### PR TITLE
l10n: Update Catalan translation

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2014-08-04 14:48+0800\n"
-"PO-Revision-Date: 2014-08-22 20:10-0700\n"
+"POT-Creation-Date: 2014-11-01 07:46+0800\n"
+"PO-Revision-Date: 2014-11-17 13:16-0700\n"
 "Last-Translator: Alex Henrie <alexhenrie24@gmail.com>\n"
 "Language-Team: Catalan\n"
 "Language: ca\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 1.6.10\n"
 
 #: advice.c:55
 #, c-format
@@ -26,193 +26,191 @@ msgstr "indirecta: %.*s\n"
 #: advice.c:88
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
-"as appropriate to mark resolution and make a commit, or use\n"
-"'git commit -a'."
+"as appropriate to mark resolution and make a commit."
 msgstr ""
-"Arregleu-los en l'arbre de treball, i després utilitzeu\n"
-"'git add/rm <fitxer>' segons sigui apropiat per marcar la\n"
-"resolució i feu una comissió, o utilitzeu 'git commit -a'."
+"Arregleu-los en l'arbre de treball, i després useu\n"
+"'git add/rm <fitxer>' segons sigui apropiat per a marcar la\n"
+"resolució i feu una comissió."
 
-#: archive.c:10
+#: archive.c:11
 msgid "git archive [options] <tree-ish> [<path>...]"
 msgstr "git archive [opcions] <arbre> [<ruta>...]"
 
-#: archive.c:11
+#: archive.c:12
 msgid "git archive --list"
 msgstr "git archive --list"
 
-#: archive.c:12
+#: archive.c:13
 msgid ""
 "git archive --remote <repo> [--exec <cmd>] [options] <tree-ish> [<path>...]"
 msgstr ""
-"git archive --remote <repositori> [--exec <ordre>] [opcions] <arbre> "
-"[<ruta>...]"
+"git archive --remote <dipòsit> [--exec <ordre>] [opcions] <arbre> [<ruta>...]"
 
-#: archive.c:13
+#: archive.c:14
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
-msgstr "git archive --remote <repositori> [--exec <ordre>] --list"
+msgstr "git archive --remote <dipòsit> [--exec <ordre>] --list"
 
-#: archive.c:243 builtin/add.c:136 builtin/add.c:427 builtin/rm.c:328
+#: archive.c:334 builtin/add.c:137 builtin/add.c:427 builtin/rm.c:328
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "L'especificació de ruta '%s' no ha concordat amb cap fitxer"
 
-#: archive.c:328
+#: archive.c:419
 msgid "fmt"
 msgstr "format"
 
-#: archive.c:328
+#: archive.c:419
 msgid "archive format"
 msgstr "format d'arxiu"
 
-#: archive.c:329 builtin/log.c:1201
+#: archive.c:420 builtin/log.c:1204
 msgid "prefix"
 msgstr "prefix"
 
-#: archive.c:330
+#: archive.c:421
 msgid "prepend prefix to each pathname in the archive"
 msgstr "anteposa el prefix a cada nom de ruta en l'arxiu"
 
-#: archive.c:331 builtin/archive.c:88 builtin/blame.c:2517
-#: builtin/blame.c:2518 builtin/config.c:57 builtin/fast-export.c:709
-#: builtin/fast-export.c:711 builtin/grep.c:712 builtin/hash-object.c:77
-#: builtin/ls-files.c:489 builtin/ls-files.c:492 builtin/notes.c:412
-#: builtin/notes.c:569 builtin/read-tree.c:108 parse-options.h:151
+#: archive.c:422 builtin/archive.c:88 builtin/blame.c:2517
+#: builtin/blame.c:2518 builtin/config.c:57 builtin/fast-export.c:986
+#: builtin/fast-export.c:988 builtin/grep.c:712 builtin/hash-object.c:101
+#: builtin/ls-files.c:489 builtin/ls-files.c:492 builtin/notes.c:411
+#: builtin/notes.c:568 builtin/read-tree.c:109 parse-options.h:151
 msgid "file"
 msgstr "fitxer"
 
-#: archive.c:332 builtin/archive.c:89
+#: archive.c:423 builtin/archive.c:89
 msgid "write the archive to this file"
 msgstr "escriu l'arxiu a aquest fitxer"
 
-#: archive.c:334
+#: archive.c:425
 msgid "read .gitattributes in working directory"
 msgstr "llegeix .gitattributes en el directori de treball"
 
-#: archive.c:335
+#: archive.c:426
 msgid "report archived files on stderr"
 msgstr "informa de fitxers arxivats en stderr"
 
-#: archive.c:336
+#: archive.c:427
 msgid "store only"
 msgstr "només emmagatzemar"
 
-#: archive.c:337
+#: archive.c:428
 msgid "compress faster"
 msgstr "comprimeix més ràpid"
 
-#: archive.c:345
+#: archive.c:436
 msgid "compress better"
 msgstr "comprimeix millor"
 
-#: archive.c:348
+#: archive.c:439
 msgid "list supported archive formats"
 msgstr "allista els formats d'arxiu suportats"
 
-#: archive.c:350 builtin/archive.c:90 builtin/clone.c:84
+#: archive.c:441 builtin/archive.c:90 builtin/clone.c:85
 msgid "repo"
-msgstr "repositori"
+msgstr "dipòsit"
 
-#: archive.c:351 builtin/archive.c:91
+#: archive.c:442 builtin/archive.c:91
 msgid "retrieve the archive from remote repository <repo>"
-msgstr "recupera l'arxiu del repositori remot <repositori>"
+msgstr "recupera l'arxiu del dipòsit remot <dipòsit>"
 
-#: archive.c:352 builtin/archive.c:92 builtin/notes.c:491
+#: archive.c:443 builtin/archive.c:92 builtin/notes.c:490
 msgid "command"
 msgstr "ordre"
 
-#: archive.c:353 builtin/archive.c:93
+#: archive.c:444 builtin/archive.c:93
 msgid "path to the remote git-upload-archive command"
 msgstr "ruta a l'ordre git-upload-archive remot"
 
-#: attr.c:259
+#: attr.c:258
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
 msgstr ""
 "Els patrons negatius s'ignoren en els atributes de git\n"
-"Utilitzeu '\\!' per exclamació capdavantera literal."
+"Useu '\\!' per exclamació capdavantera literal."
 
 #: branch.c:60
 #, c-format
 msgid "Not setting branch %s as its own upstream."
-msgstr "No establint la rama %s com la seva pròpia font."
+msgstr "No establint la rama %s com a la seva pròpia font."
 
 #: branch.c:83
 #, c-format
 msgid "Branch %s set up to track remote branch %s from %s by rebasing."
 msgstr ""
-"La rama %s està configurada per seguir la rama remota %s de %s per rebasar."
+"La rama %s està configurada per a seguir la rama remota %s de %s per rebasar."
 
 #: branch.c:84
 #, c-format
 msgid "Branch %s set up to track remote branch %s from %s."
-msgstr "La rama %s està configurada per seguir la rama remota %s de %s."
+msgstr "La rama %s està configurada per a seguir la rama remota %s de %s."
 
 #: branch.c:88
 #, c-format
 msgid "Branch %s set up to track local branch %s by rebasing."
-msgstr "La rama %s està configurada per seguir la rama local %s per rebasar."
+msgstr "La rama %s està configurada per a seguir la rama local %s per rebasar."
 
 #: branch.c:89
 #, c-format
 msgid "Branch %s set up to track local branch %s."
-msgstr "La rama %s està configurada per seguir la rama local %s."
+msgstr "La rama %s està configurada per a seguir la rama local %s."
 
 #: branch.c:94
 #, c-format
 msgid "Branch %s set up to track remote ref %s by rebasing."
 msgstr ""
-"La rama %s està configurada per seguir la referència remota %s per rebasar."
+"La rama %s està configurada per a seguir la referència remota %s per rebasar."
 
 #: branch.c:95
 #, c-format
 msgid "Branch %s set up to track remote ref %s."
-msgstr "La rama %s està configurada per seguir la referència remota %s."
+msgstr "La rama %s està configurada per a seguir la referència remota %s."
 
 #: branch.c:99
 #, c-format
 msgid "Branch %s set up to track local ref %s by rebasing."
 msgstr ""
-"La rama %s està configurada per seguir la referència local %s per rebasar."
+"La rama %s està configurada per a seguir la referència local %s per rebasar."
 
 #: branch.c:100
 #, c-format
 msgid "Branch %s set up to track local ref %s."
-msgstr "La rama %s està configurada per seguir la referència local %s."
+msgstr "La rama %s està configurada per a seguir la referència local %s."
 
 #: branch.c:133
 #, c-format
 msgid "Not tracking: ambiguous information for ref %s"
 msgstr "No seguint: informació ambigua per a la referència %s"
 
-#: branch.c:178
+#: branch.c:162
 #, c-format
 msgid "'%s' is not a valid branch name."
 msgstr "'%s' no és un nom de rama vàlid."
 
-#: branch.c:183
+#: branch.c:167
 #, c-format
 msgid "A branch named '%s' already exists."
 msgstr "Una rama amb nom '%s' ja existeix."
 
-#: branch.c:191
+#: branch.c:175
 msgid "Cannot force update the current branch."
 msgstr "No es pot actualitzar la rama actual a la força."
 
-#: branch.c:211
+#: branch.c:195
 #, c-format
 msgid "Cannot setup tracking information; starting point '%s' is not a branch."
 msgstr ""
-"No es pot configurar la informació de seguimiento; el punt inicial '%s' no "
-"és una rama."
+"No es pot configurar la informació de seguiment; el punt inicial '%s' no és "
+"una rama."
 
-#: branch.c:213
+#: branch.c:197
 #, c-format
 msgid "the requested upstream branch '%s' does not exist"
 msgstr "la rama font demanada '%s' no existeix"
 
-#: branch.c:215
+#: branch.c:199
 msgid ""
 "\n"
 "If you are planning on basing your work on an upstream\n"
@@ -226,113 +224,111 @@ msgstr ""
 "\n"
 "Si planeu basar el teu treball en una rama font que ja\n"
 "existeix al remot, pot que necessiteu executar\n"
-"\"git fetch\" per obtenir-la.\n"
+"\"git fetch\" per a obtenir-la.\n"
 "\n"
 "Si planeu pujar una rama local nova que seguirà la seva\n"
-"contrapart remota, pot que voleu utilitzar\n"
+"contrapart remota, pot que voleu usar\n"
 "\"git push -u\" per establir la configuració font mentre\n"
 "pugeu."
 
-#: branch.c:260
+#: branch.c:243
 #, c-format
 msgid "Not a valid object name: '%s'."
 msgstr "No és un nom d'objecte vàlid: '%s'."
 
-#: branch.c:280
+#: branch.c:263
 #, c-format
 msgid "Ambiguous object name: '%s'."
 msgstr "Nom d'objecte ambigu: '%s'."
 
-#: branch.c:285
+#: branch.c:268
 #, c-format
 msgid "Not a valid branch point: '%s'."
 msgstr "No és un punt de ramificació vàlid: '%s'."
 
-#: branch.c:291
-msgid "Failed to lock ref for update"
-msgstr "S'ha fallat al bloquejar la referència per actualització"
-
-#: branch.c:309
-msgid "Failed to write ref"
-msgstr "S'ha fallat al escriure la referència"
-
-#: bundle.c:33
+#: bundle.c:34
 #, c-format
 msgid "'%s' does not look like a v2 bundle file"
 msgstr "'%s' no sembla a un fitxer d'embolic v2"
 
-#: bundle.c:60
+#: bundle.c:61
 #, c-format
 msgid "unrecognized header: %s%s (%d)"
 msgstr "capçalera no reconeguda: %s%s (%d)"
 
-#: bundle.c:86 builtin/commit.c:755
+#: bundle.c:87 builtin/commit.c:788
 #, c-format
 msgid "could not open '%s'"
 msgstr "no s'ha pogut obrir '%s'"
 
-#: bundle.c:138
+#: bundle.c:139
 msgid "Repository lacks these prerequisite commits:"
-msgstr "Al repositori manquen aquestes comissions prerequisits:"
+msgstr "Al dipòsit li manquen aquestes comissions prerequisits:"
 
-#: bundle.c:162 sequencer.c:630 sequencer.c:1085 builtin/log.c:330
-#: builtin/log.c:821 builtin/log.c:1428 builtin/log.c:1665 builtin/merge.c:357
+#: bundle.c:163 sequencer.c:641 sequencer.c:1096 builtin/blame.c:2706
+#: builtin/branch.c:652 builtin/commit.c:1085 builtin/log.c:330
+#: builtin/log.c:823 builtin/log.c:1432 builtin/log.c:1669 builtin/merge.c:357
 #: builtin/shortlog.c:158
 msgid "revision walk setup failed"
 msgstr "la configuració del passeig per revisions ha fallat"
 
-#: bundle.c:184
+#: bundle.c:185
 #, c-format
 msgid "The bundle contains this ref:"
 msgid_plural "The bundle contains these %d refs:"
 msgstr[0] "L'embolic conté aquesta referència:"
 msgstr[1] "L'embolic conté aquestes %d referències:"
 
-#: bundle.c:191
+#: bundle.c:192
 msgid "The bundle records a complete history."
 msgstr "L'embolic registra una història completa."
 
-#: bundle.c:193
+#: bundle.c:194
 #, c-format
 msgid "The bundle requires this ref:"
 msgid_plural "The bundle requires these %d refs:"
 msgstr[0] "L'embolic requereix aquesta referència:"
 msgstr[1] "L'embolic requereix aquestes %d referències:"
 
-#: bundle.c:289
+#: bundle.c:292
 msgid "rev-list died"
 msgstr "El rev-list s'ha mort"
 
-#: bundle.c:295 builtin/log.c:1339 builtin/shortlog.c:261
+#: bundle.c:298 builtin/log.c:153 builtin/log.c:1342 builtin/shortlog.c:261
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "paràmetre no reconegut: %s"
 
-#: bundle.c:330
+#: bundle.c:333
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
-msgstr "la referència '%s' s'exclou per les opcions de rev-list"
+msgstr "les opcions de la llista de revisions exclouen la referència '%s'"
 
-#: bundle.c:375
+#: bundle.c:378
 msgid "Refusing to create empty bundle."
 msgstr "Refusant crear un embolic buit."
 
-#: bundle.c:390
+#: bundle.c:393
 msgid "Could not spawn pack-objects"
 msgstr "No s'ha pogut executar el pack-objects"
 
-#: bundle.c:408
+#: bundle.c:411
 msgid "pack-objects died"
 msgstr "El pack-objects s'ha mort"
 
-#: bundle.c:411
+#: bundle.c:414
 #, c-format
 msgid "cannot create '%s'"
 msgstr "no es pot crear '%s'"
 
-#: bundle.c:433
+#: bundle.c:435
 msgid "index-pack died"
 msgstr "L'index-pack s'ha mort"
+
+#: color.c:157
+#, c-format
+msgid "invalid color value: %.*s"
+msgstr "valor de color invàlid: %.*s"
 
 #: commit.c:40
 #, c-format
@@ -348,19 +344,73 @@ msgstr "%s %s no és una comissió!"
 msgid "memory exhausted"
 msgstr "memòria esgotada"
 
-#: connected.c:70
+#: config.c:469 config.c:471
+#, c-format
+msgid "bad config file line %d in %s"
+msgstr "línia de fitxer de configuració dolenta %d en %s"
+
+#: config.c:587
+#, c-format
+msgid "bad numeric config value '%s' for '%s' in %s: %s"
+msgstr "valor de configuració numèrica dolent '%s' per '%s' en %s: %s"
+
+#: config.c:589
+#, c-format
+msgid "bad numeric config value '%s' for '%s': %s"
+msgstr "valor de configuració numèrica dolent '%s' per '%s': %s"
+
+#: config.c:674
+#, c-format
+msgid "failed to expand user dir in: '%s'"
+msgstr "s'ha fallat en expandir el directori d'usuari en '%s'"
+
+#: config.c:752 config.c:763
+#, c-format
+msgid "bad zlib compression level %d"
+msgstr "nivell de compressió de zlib dolent %d"
+
+#: config.c:885
+#, c-format
+msgid "invalid mode for object creation: %s"
+msgstr "mode de creació d'objecte invàlid: %s"
+
+#: config.c:1201
+msgid "unable to parse command-line config"
+msgstr "incapaç de analitzar la configuració de la línia d'ordres"
+
+#: config.c:1262
+msgid "unknown error occured while reading the configuration files"
+msgstr ""
+"s'ha ocorregut un error desconegut en llegir els fitxers de configuració"
+
+#: config.c:1586
+#, c-format
+msgid "unable to parse '%s' from command-line config"
+msgstr "incapaç d'analitzar '%s' de la configuració de la línia d'ordres"
+
+#: config.c:1588
+#, c-format
+msgid "bad config variable '%s' in file '%s' at line %d"
+msgstr "variable de configuració dolent '%s' en el fitxer '%s' a la línia %d"
+
+#: config.c:1647
+#, c-format
+msgid "%s has multiple values"
+msgstr "%s té múltiples valors"
+
+#: connected.c:69
 msgid "Could not run 'git rev-list'"
 msgstr "No s'ha pogut executar 'git rev-list'"
 
-#: connected.c:90
+#: connected.c:89
 #, c-format
 msgid "failed write to rev-list: %s"
 msgstr "escriptura fallada al rev-list: %s"
 
-#: connected.c:98
+#: connected.c:97
 #, c-format
 msgid "failed to close rev-list's stdin: %s"
-msgstr "s'ha fallat al tancar el stdin del rev-list: %s"
+msgstr "s'ha fallat en tancar l'stdin del rev-list: %s"
 
 #: date.c:95
 msgid "in the future"
@@ -433,16 +483,16 @@ msgstr[1] "fa %lu anys"
 #: diffcore-order.c:24
 #, c-format
 msgid "failed to read orderfile '%s'"
-msgstr "s'ha fallat al llegir el fitxer d'ordres '%s'"
+msgstr "s'ha fallat en llegir el fitxer d'ordres '%s'"
 
-#: diffcore-rename.c:514
+#: diffcore-rename.c:516
 msgid "Performing inexact rename detection"
-msgstr "Realitzant detecció inexacte de canvi de nom"
+msgstr "Realitzant detecció inexacte de canvis de nom"
 
 #: diff.c:114
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
-msgstr "  S'ha fallat al analitzar el percentatge limitant de dirstat '%s'\n"
+msgstr "  S'ha fallat en analitzar el percentatge limitant de dirstat '%s'\n"
 
 #: diff.c:119
 #, c-format
@@ -455,7 +505,7 @@ msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr ""
 "Valor desconegut del variable de configuració de 'diff.submodule': '%s'"
 
-#: diff.c:267
+#: diff.c:266
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -464,65 +514,65 @@ msgstr ""
 "Errors trobat en el variable de configuració 'diff.dirstat':\n"
 "%s"
 
-#: diff.c:2934
+#: diff.c:2957
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "El diff external s'ha mort, aturant a %s"
 
-#: diff.c:3329
+#: diff.c:3352
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow requereix exactament una especificació de ruta"
 
-#: diff.c:3492
+#: diff.c:3515
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
 "%s"
 msgstr ""
-"S'ha fallat al analitzar el paràmetre d'opció de --dirstat/-X:\n"
+"S'ha fallat en analitzar el paràmetre d'opció de --dirstat/-X:\n"
 "%s"
 
-#: diff.c:3506
+#: diff.c:3529
 #, c-format
 msgid "Failed to parse --submodule option parameter: '%s'"
-msgstr "S'ha fallat al analitzar el paràmetre d'opció de --submodule: %s"
+msgstr "S'ha fallat en analitzar el paràmetre d'opció de --submodule: %s"
 
-#: gpg-interface.c:73 gpg-interface.c:145
+#: gpg-interface.c:129 gpg-interface.c:200
 msgid "could not run gpg."
 msgstr "no s'ha pogut executar el gpg."
 
-#: gpg-interface.c:85
+#: gpg-interface.c:141
 msgid "gpg did not accept the data"
 msgstr "El gpg no ha acceptat les dades"
 
-#: gpg-interface.c:96
+#: gpg-interface.c:152
 msgid "gpg failed to sign the data"
-msgstr "gpg ha fallat al firmar les dades"
+msgstr "gpg ha fallat en firmar les dades"
 
-#: gpg-interface.c:129
+#: gpg-interface.c:185
 #, c-format
 msgid "could not create temporary file '%s': %s"
 msgstr "no s'ha pogut crear el fitxer temporal '%s': %s"
 
-#: gpg-interface.c:132
+#: gpg-interface.c:188
 #, c-format
 msgid "failed writing detached signature to '%s': %s"
-msgstr "s'ha fallat al escriure la firma separada a '%s': %s"
+msgstr "s'ha fallat en escriure la firma separada a '%s': %s"
 
-#: grep.c:1703
+#: grep.c:1718
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': incapaç de llegir %s"
 
-#: grep.c:1720
+#: grep.c:1735
 #, c-format
 msgid "'%s': %s"
 msgstr "'%s': %s"
 
-#: grep.c:1731
+#: grep.c:1746
 #, c-format
 msgid "'%s': short read %s"
-msgstr "'%s': lectura corta %s"
+msgstr "'%s': lectura curta %s"
 
 #: help.c:207
 #, c-format
@@ -535,7 +585,7 @@ msgstr "ordres de git disponibles d'altres llocs en la vostra $PATH"
 
 #: help.c:230
 msgid "The most commonly used git commands are:"
-msgstr "Els ordres de git més freqüentment utilitzats són:"
+msgstr "Els ordres de git més freqüentment usats són:"
 
 #: help.c:289
 #, c-format
@@ -588,87 +638,95 @@ msgstr[1] ""
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: merge.c:40
+#: lockfile.c:275
+msgid "BUG: reopen a lockfile that is still open"
+msgstr "BUG: reobrir un fitxer de bloqueig que encara està obert"
+
+#: lockfile.c:277
+msgid "BUG: reopen a lockfile that has been committed"
+msgstr "BUG: reobrir un fitxer de bloqueig que s'ha comès"
+
+#: merge.c:41
 msgid "failed to read the cache"
-msgstr "s'ha fallat al llegir la memòria cau"
+msgstr "s'ha fallat en llegir la memòria cau"
 
-#: merge.c:93 builtin/checkout.c:356 builtin/checkout.c:556
-#: builtin/clone.c:661
+#: merge.c:94 builtin/checkout.c:356 builtin/checkout.c:562
+#: builtin/clone.c:659
 msgid "unable to write new index file"
-msgstr "incapaç d'escriure un nou fitxer d'índex"
+msgstr "incapaç d'escriure un fitxer d'índex nou"
 
-#: merge-recursive.c:190
+#: merge-recursive.c:189
 #, c-format
 msgid "(bad commit)\n"
 msgstr "(comissió dolenta)\n"
 
-#: merge-recursive.c:210
+#: merge-recursive.c:209
 #, c-format
 msgid "addinfo_cache failed for path '%s'"
 msgstr "addinfo_cache ha fallat per a la ruta '%s'"
 
-#: merge-recursive.c:271
+#: merge-recursive.c:270
 msgid "error building trees"
-msgstr "error al construir arbres"
+msgstr "error en construir arbres"
 
-#: merge-recursive.c:692
+#: merge-recursive.c:691
 #, c-format
 msgid "failed to create path '%s'%s"
-msgstr "s'ha fallat al crear la ruta '%s' %s"
+msgstr "s'ha fallat en crear la ruta '%s' %s"
 
-#: merge-recursive.c:703
+#: merge-recursive.c:702
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
-msgstr "Traient %s per fer espai per al subdirectori\n"
+msgstr "Traient %s per a fer espai per al subdirectori\n"
 
-#: merge-recursive.c:717 merge-recursive.c:738
+#: merge-recursive.c:716 merge-recursive.c:737
 msgid ": perhaps a D/F conflict?"
 msgstr ": potser un conflicte D/F?"
 
-#: merge-recursive.c:728
+#: merge-recursive.c:727
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
-msgstr "refusant perdre el fitxer seguit a '%s'"
+msgstr "refusant perdre el fitxer no seguit a '%s'"
 
-#: merge-recursive.c:768
+#: merge-recursive.c:767
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "no es pot llegir l'objecte %s '%s'"
 
-#: merge-recursive.c:770
+#: merge-recursive.c:769
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "blob esperat per a %s '%s'"
 
-#: merge-recursive.c:793 builtin/clone.c:317
+#: merge-recursive.c:792 builtin/clone.c:318
 #, c-format
 msgid "failed to open '%s'"
-msgstr "s'ha fallat al obrir '%s'"
+msgstr "s'ha fallat en obrir '%s'"
 
-#: merge-recursive.c:801
+#: merge-recursive.c:800
 #, c-format
 msgid "failed to symlink '%s'"
-msgstr "s'ha fallat al fer l'enllaç simbòlic '%s'"
+msgstr "s'ha fallat en fer l'enllaç simbòlic '%s'"
 
-#: merge-recursive.c:804
+#: merge-recursive.c:803
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "no es sap què fer amb %06o %s '%s'"
 
-#: merge-recursive.c:942
+#: merge-recursive.c:941
 msgid "Failed to execute internal merge"
-msgstr "S'ha fallat al executar la fusió interna"
+msgstr "S'ha fallat en executar la fusió interna"
 
-#: merge-recursive.c:946
+#: merge-recursive.c:945
 #, c-format
 msgid "Unable to add %s to database"
-msgstr "Incapaç d'afegir %s al base de dades"
+msgstr "Incapaç d'afegir %s a la base de dades"
 
-#: merge-recursive.c:962
+#: merge-recursive.c:961
 msgid "unsupported object type in the tree"
 msgstr "tipus d'objecte no suportat en l'arbre"
 
-#: merge-recursive.c:1037 merge-recursive.c:1051
+#: merge-recursive.c:1036 merge-recursive.c:1050
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -677,7 +735,7 @@ msgstr ""
 "CONFLICTE: (%s/supressió): %s suprimit en %s i %s en %s. La versió %s de %s "
 "s'ha deixat en l'arbre."
 
-#: merge-recursive.c:1043 merge-recursive.c:1056
+#: merge-recursive.c:1042 merge-recursive.c:1055
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -686,20 +744,20 @@ msgstr ""
 "CONFLICTE: (%s/supressió): %s suprimit en %s i %s en %s. La versió %s de %s "
 "s'ha deixat en l'arbre a %s."
 
-#: merge-recursive.c:1097
+#: merge-recursive.c:1096
 msgid "rename"
 msgstr "canvia de nom"
 
-#: merge-recursive.c:1097
+#: merge-recursive.c:1096
 msgid "renamed"
 msgstr "canviat de nom"
 
-#: merge-recursive.c:1153
+#: merge-recursive.c:1152
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
-msgstr "%s és un directori en %s; afegint com %s en lloc"
+msgstr "%s és un directori en %s; afegint com a %s en lloc"
 
-#: merge-recursive.c:1175
+#: merge-recursive.c:1174
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -708,151 +766,152 @@ msgstr ""
 "CONFLICTE (canvi de nom/canvi de nom): Canvi de nom \"%s\"->\"%s\" en la "
 "rama \"%s\" canvi de nom \"%s\"->\"%s\" en \"%s\"%s"
 
-#: merge-recursive.c:1180
+#: merge-recursive.c:1179
 msgid " (left unresolved)"
 msgstr " (deixat sense resolució)"
 
-#: merge-recursive.c:1234
+#: merge-recursive.c:1233
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "CONFLICTE (canvi de nom/canvi de nom): Canvi de nom %s->%s en %s. Canvi de "
 "nom %s->%s en %s"
 
-#: merge-recursive.c:1264
+#: merge-recursive.c:1263
 #, c-format
 msgid "Renaming %s to %s and %s to %s instead"
 msgstr "Canviant el nom de %s a %s i %s a %s en lloc"
 
-#: merge-recursive.c:1463
+#: merge-recursive.c:1462
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s. %s added in %s"
 msgstr ""
 "CONFLICTE (supressió/afegiment): Canvi de nom %s->%s en %s. %s afegit en %s"
 
-#: merge-recursive.c:1473
+#: merge-recursive.c:1472
 #, c-format
 msgid "Adding merged %s"
 msgstr "Afegint %s fusionat"
 
-#: merge-recursive.c:1478 merge-recursive.c:1676
+#: merge-recursive.c:1477 merge-recursive.c:1675
 #, c-format
 msgid "Adding as %s instead"
-msgstr "Afegint com %s en lloc"
+msgstr "Afegint com a %s en lloc"
 
-#: merge-recursive.c:1529
+#: merge-recursive.c:1528
 #, c-format
 msgid "cannot read object %s"
 msgstr "no es pot llegir l'objecte %s"
 
-#: merge-recursive.c:1532
+#: merge-recursive.c:1531
 #, c-format
 msgid "object %s is not a blob"
 msgstr "L'objecte %s no és un blob"
 
-#: merge-recursive.c:1580
+#: merge-recursive.c:1579
 msgid "modify"
 msgstr "modifica"
 
-#: merge-recursive.c:1580
+#: merge-recursive.c:1579
 msgid "modified"
 msgstr "modificat"
 
-#: merge-recursive.c:1590
+#: merge-recursive.c:1589
 msgid "content"
 msgstr "contingut"
 
-#: merge-recursive.c:1597
+#: merge-recursive.c:1596
 msgid "add/add"
-msgstr "afegeix/afegeix"
+msgstr "afegiment/afegiment"
 
-#: merge-recursive.c:1631
+#: merge-recursive.c:1630
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "%s saltat (el fusionat és igual a l'existent)"
 
-#: merge-recursive.c:1645
+#: merge-recursive.c:1644
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Autofusionant %s"
 
-#: merge-recursive.c:1649 git-submodule.sh:1150
+#: merge-recursive.c:1648 git-submodule.sh:1150
 msgid "submodule"
 msgstr "submòdul"
 
-#: merge-recursive.c:1650
+#: merge-recursive.c:1649
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "CONFLICTE (%s): Conflicte de fusió en %s"
 
-#: merge-recursive.c:1740
+#: merge-recursive.c:1735
 #, c-format
 msgid "Removing %s"
 msgstr "Traient %s"
 
-#: merge-recursive.c:1765
+#: merge-recursive.c:1760
 msgid "file/directory"
 msgstr "fitxer/directori"
 
-#: merge-recursive.c:1771
+#: merge-recursive.c:1766
 msgid "directory/file"
 msgstr "directori/fitxer"
 
-#: merge-recursive.c:1776
+#: merge-recursive.c:1771
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
-msgstr "CONFLICTE (%s=: Hi ha un directori amb nom %s en %s. Afegint %s com %s"
+msgstr ""
+"CONFLICTE (%s=: Hi ha un directori amb nom %s en %s. Afegint %s com a %s"
 
-#: merge-recursive.c:1786
+#: merge-recursive.c:1781
 #, c-format
 msgid "Adding %s"
 msgstr "Afegint %s"
 
-#: merge-recursive.c:1803
+#: merge-recursive.c:1798
 msgid "Fatal merge failure, shouldn't happen."
 msgstr "Fallat de fusió fatal; això no ha de passar."
 
-#: merge-recursive.c:1822
+#: merge-recursive.c:1817
 msgid "Already up-to-date!"
-msgstr "Ja actualitzat!"
+msgstr "Ja al dia!"
 
-#: merge-recursive.c:1831
+#: merge-recursive.c:1826
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "la fusió dels arbres %s i %s ha fallat"
 
-#: merge-recursive.c:1861
+#: merge-recursive.c:1856
 #, c-format
 msgid "Unprocessed path??? %s"
 msgstr "Ruta no processat??? %s"
 
-#: merge-recursive.c:1906
+#: merge-recursive.c:1901
 msgid "Merging:"
 msgstr "Fusionant:"
 
-#: merge-recursive.c:1919
+#: merge-recursive.c:1914
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
-msgstr[0] "%u avantpassat trobat:"
-msgstr[1] "%u avantpassats trobats:"
+msgstr[0] "s'ha trobat %u avantpassat:"
+msgstr[1] "s'han trobat %u avantpassats:"
 
-#: merge-recursive.c:1956
+#: merge-recursive.c:1951
 msgid "merge returned no commit"
 msgstr "la fusió no ha retornat cap comissió"
 
-#: merge-recursive.c:2013
+#: merge-recursive.c:2008
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "No s'ha pogut analitzar l'objecte '%s'"
 
-#: merge-recursive.c:2024 builtin/merge.c:666
+#: merge-recursive.c:2019 builtin/merge.c:666
 msgid "Unable to write index."
 msgstr "Incapaç d'escriure l'índex."
 
 #: notes-utils.c:41
 msgid "Cannot commit uninitialized/unreferenced notes tree"
-msgstr "No es pot cometre un arbre de notes no inicialitzat/no referenciat"
+msgstr "No es pot cometre un arbre de notes no inicialitzat / no referenciat"
 
 #: notes-utils.c:83
 #, c-format
@@ -871,33 +930,33 @@ msgstr "Refusant reescriure les notes en %s (fora de refs/notes/)"
 msgid "Bad %s value: '%s'"
 msgstr "Valor dolent de %s: '%s'"
 
-#: object.c:234
+#: object.c:241
 #, c-format
 msgid "unable to parse object: %s"
 msgstr "incapaç d'analitzar l'objecte: %s"
 
-#: parse-options.c:534
+#: parse-options.c:546
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:552
+#: parse-options.c:564
 #, c-format
 msgid "usage: %s"
 msgstr "ús: %s"
 
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation
-#: parse-options.c:556
+#: parse-options.c:568
 #, c-format
 msgid "   or: %s"
 msgstr "   o: %s"
 
-#: parse-options.c:559
+#: parse-options.c:571
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:593
+#: parse-options.c:605
 msgid "-NUM"
 msgstr "-NUM"
 
@@ -942,12 +1001,12 @@ msgstr "%s: 'literal' i 'glob' són incompatibles"
 #: pathspec.c:241
 #, c-format
 msgid "%s: '%s' is outside repository"
-msgstr "%s: '%s' està fora del repositori"
+msgstr "%s: '%s' és fora del dipòsit"
 
 #: pathspec.c:291
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
-msgstr "L'especificació '%s' està en el submòdul '%.*s'"
+msgstr "L'especificació '%s' és en el submòdul '%.*s'"
 
 #: pathspec.c:353
 #, c-format
@@ -957,84 +1016,87 @@ msgstr "%s: aquest ordre no suporta la màgica d'especificació de ruta: %s"
 #: pathspec.c:432
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
-msgstr "l'especificació de ruta '%s' està més allà d'un enllaç simbòlic"
+msgstr "l'especificació de ruta '%s' és més allà d'un enllaç simbòlic"
 
 #: pathspec.c:441
 msgid ""
 "There is nothing to exclude from by :(exclude) patterns.\n"
 "Perhaps you forgot to add either ':/' or '.' ?"
 msgstr ""
-"No hi ha res que excloure per patrons :(exclusió).\n"
+"No hi ha res a excloure per patrons :(exclusió).\n"
 "Potser heu oblidat afegir o ':/' o '.' ?"
+
+#: pretty.c:968
+msgid "unable to parse --pretty format"
+msgstr "incapaç d'analitzar el format --pretty"
 
 #: progress.c:225
 msgid "done"
 msgstr "fet"
 
-#: read-cache.c:1260
+#: read-cache.c:1261
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 "index.version establert, però el valor és invàlid.\n"
-"Utilitzant la versió %i"
+"Usant la versió %i"
 
-#: read-cache.c:1270
+#: read-cache.c:1271
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 "GIT_INDEX_VERSION establert, però el valor és invàlid.\n"
-"Utilitzant la versió %i"
+"Usant la versió %i"
 
-#: remote.c:753
+#: remote.c:782
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "No és pot obtenir ambdós %s i %s a %s"
 
-#: remote.c:757
+#: remote.c:786
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s generalment segueix %s, no %s"
 
-#: remote.c:761
+#: remote.c:790
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s segueix ambdós %s i %s"
 
-#: remote.c:769
+#: remote.c:798
 msgid "Internal error"
 msgstr "Error intern"
 
-#: remote.c:1943
+#: remote.c:1968
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
-msgstr "La teva rama està basada en '%s', però la font no està.\n"
+msgstr "La teva rama està basada en '%s', però la font no és.\n"
 
-#: remote.c:1947
+#: remote.c:1972
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
-msgstr "  (utilitzeu \"git branch --unset-upstream\" per arreglar)\n"
+msgstr "  (useu \"git branch --unset-upstream\" per a arreglar)\n"
 
-#: remote.c:1950
+#: remote.c:1975
 #, c-format
 msgid "Your branch is up-to-date with '%s'.\n"
-msgstr "La vostra rama està actualitzada amb '%s'.\n"
+msgstr "La vostra rama està al dia amb '%s'.\n"
 
-#: remote.c:1954
+#: remote.c:1979
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "La vostra rama està davant de '%s' per %d comissions.\n"
 msgstr[1] "La vostra rama està davant de '%s' per %d comissions.\n"
 
-#: remote.c:1960
+#: remote.c:1985
 msgid "  (use \"git push\" to publish your local commits)\n"
-msgstr ""
-"  (utilitzeu \"git push\" per publicar els vostres comissions locals)\n"
+msgstr "  (useu \"git push\" per a publicar les vostres comissions locals)\n"
 
-#: remote.c:1963
+#: remote.c:1988
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -1046,11 +1108,11 @@ msgstr[1] ""
 "La vostra rama està darrere de '%s' per %d comissions, i pot avançar-se "
 "ràpidament.\n"
 
-#: remote.c:1971
+#: remote.c:1996
 msgid "  (use \"git pull\" to update your local branch)\n"
-msgstr " (utilitzeu \"git pull\" per actualitzar la vostra rama local)\n"
+msgstr " (useu \"git pull\" per a actualitzar la vostra rama local)\n"
 
-#: remote.c:1974
+#: remote.c:1999
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -1065,114 +1127,118 @@ msgstr[1] ""
 "La vostra rama i '%s' s'han divergit,\n"
 "i tenen %d i %d comissions distintes cada una, respectivament.\n"
 
-#: remote.c:1984
+#: remote.c:2009
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
-msgstr "  (utilitzeu \"git pull\" per fusionar la rama remota a la vostra)\n"
+msgstr "  (useu \"git pull\" per a fusionar la rama remota a la vostra)\n"
 
-#: run-command.c:80
+#: run-command.c:87
 msgid "open /dev/null failed"
-msgstr "s'ha fallat al obrir /dev/null"
+msgstr "s'ha fallat en obrir /dev/null"
 
-#: run-command.c:82
+#: run-command.c:89
 #, c-format
 msgid "dup2(%d,%d) failed"
-msgstr "dup2(%d,%d) s'ha fallat"
+msgstr "dup2(%d,%d) ha fallat"
 
-#: sequencer.c:171 builtin/merge.c:782 builtin/merge.c:893
-#: builtin/merge.c:1003 builtin/merge.c:1013
+#: send-pack.c:265
+msgid "failed to sign the push certificate"
+msgstr "s'ha fallat en firmar el certificat de pujada"
+
+#: send-pack.c:322
+msgid "the receiving end does not support --signed push"
+msgstr "el destí rebent no suporta el pujar --signed"
+
+#: sequencer.c:172 builtin/merge.c:781 builtin/merge.c:892
+#: builtin/merge.c:1002 builtin/merge.c:1012
 #, c-format
 msgid "Could not open '%s' for writing"
 msgstr "No s'ha pogut obrir '%s' per a escriptura"
 
-#: sequencer.c:173 builtin/merge.c:343 builtin/merge.c:785
-#: builtin/merge.c:1005 builtin/merge.c:1018
+#: sequencer.c:174 builtin/merge.c:343 builtin/merge.c:784
+#: builtin/merge.c:1004 builtin/merge.c:1017
 #, c-format
 msgid "Could not write to '%s'"
 msgstr "No s'ha pogut escriure al '%s'"
 
-#: sequencer.c:194
+#: sequencer.c:195
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
 msgstr ""
 "després de resoldre els conflictes, marqueu les rutes\n"
-"corregides amb 'git add <paths>' o 'git rm <paths>'"
+"corregides amb 'git add <rutes>' o 'git rm <rutes>'"
 
-#: sequencer.c:197
+#: sequencer.c:198
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
 "and commit the result with 'git commit'"
 msgstr ""
 "després de resoldre els conflictes, marqueu les rutes\n"
-"corregides amb 'git add <paths>' o 'git rm <paths>'\n"
+"corregides amb 'git add <rutes>' o 'git rm <rutes>'\n"
 "i cometeu el resultat amb 'git commit'"
 
-#: sequencer.c:210 sequencer.c:841 sequencer.c:924
+#: sequencer.c:211 sequencer.c:852 sequencer.c:935
 #, c-format
 msgid "Could not write to %s"
 msgstr "No s'ha pogut escriure a %s"
 
-#: sequencer.c:213
+#: sequencer.c:214
 #, c-format
 msgid "Error wrapping up %s"
-msgstr "Error terminant %s"
+msgstr "Error en terminar %s"
 
-#: sequencer.c:228
+#: sequencer.c:229
 msgid "Your local changes would be overwritten by cherry-pick."
 msgstr "Els vostres canvis locals es sobreescriurien pel recull de cireres."
 
-#: sequencer.c:230
+#: sequencer.c:231
 msgid "Your local changes would be overwritten by revert."
 msgstr "Els vostres canvis locals es sobreescriurien per la reversió."
 
-#: sequencer.c:233
+#: sequencer.c:234
 msgid "Commit your changes or stash them to proceed."
-msgstr "Cometeu els vostres canvis o emmagatzemeu-los per procedir."
-
-#: sequencer.c:250
-msgid "Failed to lock HEAD during fast_forward_to"
-msgstr "S'ha fallat al bloquejar HEAD durant fast_forward_to"
+msgstr "Cometeu els vostres canvis o emmagatzemeu-los per a procedir."
 
 #. TRANSLATORS: %s will be "revert" or "cherry-pick"
-#: sequencer.c:293
+#: sequencer.c:304
 #, c-format
 msgid "%s: Unable to write new index file"
-msgstr "%s: Incapaç d'escriure un nou fitxer d'índex"
+msgstr "%s: Incapaç d'escriure un fitxer d'índex nou"
 
-#: sequencer.c:324
+#: sequencer.c:335
 msgid "Could not resolve HEAD commit\n"
 msgstr "No s'ha pogut resoldre la comissió HEAD\n"
 
-#: sequencer.c:344
+#: sequencer.c:355
 msgid "Unable to update cache tree\n"
 msgstr "Incapaç d'actualitzar l'arbre cau\n"
 
-#: sequencer.c:391
+#: sequencer.c:402
 #, c-format
 msgid "Could not parse commit %s\n"
 msgstr "No s'ha pogut analitzar la comissió %s\n"
 
-#: sequencer.c:396
+#: sequencer.c:407
 #, c-format
 msgid "Could not parse parent commit %s\n"
 msgstr "No s'ha pogut analitzar la comissió pare %s\n"
 
-#: sequencer.c:462
+#: sequencer.c:473
 msgid "Your index file is unmerged."
 msgstr "El vostre fitxer d'índex està sense fusionar."
 
-#: sequencer.c:481
+#: sequencer.c:492
 #, c-format
 msgid "Commit %s is a merge but no -m option was given."
 msgstr "La comissió %s és una fusió però cap opció -m s'ha donat."
 
-#: sequencer.c:489
+#: sequencer.c:500
 #, c-format
 msgid "Commit %s does not have parent %d"
 msgstr "La comissió %s no té pare %d"
 
-#: sequencer.c:493
+#: sequencer.c:504
 #, c-format
 msgid "Mainline was specified but commit %s is not a merge."
 msgstr ""
@@ -1180,158 +1246,158 @@ msgstr ""
 
 #. TRANSLATORS: The first %s will be "revert" or
 #. "cherry-pick", the second %s a SHA1
-#: sequencer.c:506
+#: sequencer.c:517
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: no es pot analitzar la comissió pare %s"
 
-#: sequencer.c:510
+#: sequencer.c:521
 #, c-format
 msgid "Cannot get commit message for %s"
 msgstr "No es pot obtenir el missatge de comissió de %s"
 
-#: sequencer.c:596
+#: sequencer.c:607
 #, c-format
 msgid "could not revert %s... %s"
-msgstr "no s'ha pogut revertir %s... %s"
+msgstr "no s'ha pogut revertir %s...%s"
 
-#: sequencer.c:597
+#: sequencer.c:608
 #, c-format
 msgid "could not apply %s... %s"
-msgstr "no s'ha pogut aplicar %s... %s"
+msgstr "no s'ha pogut aplicar %s...%s"
 
-#: sequencer.c:633
+#: sequencer.c:644
 msgid "empty commit set passed"
 msgstr "conjunt de comissions buit passat"
 
-#: sequencer.c:641
+#: sequencer.c:652
 #, c-format
 msgid "git %s: failed to read the index"
-msgstr "git %s: s'ha fallat al llegir l'índex"
+msgstr "git %s: s'ha fallat en llegir l'índex"
 
-#: sequencer.c:645
+#: sequencer.c:656
 #, c-format
 msgid "git %s: failed to refresh the index"
-msgstr "git %s: s'ha fallat al actualitzar l'índex"
+msgstr "git %s: s'ha fallat en actualitzar l'índex"
 
-#: sequencer.c:705
+#: sequencer.c:716
 #, c-format
 msgid "Cannot %s during a %s"
 msgstr "No es pot %s durant un %s"
 
-#: sequencer.c:727
+#: sequencer.c:738
 #, c-format
 msgid "Could not parse line %d."
 msgstr "No s'ha pogut analitzar la línia %d."
 
-#: sequencer.c:732
+#: sequencer.c:743
 msgid "No commits parsed."
 msgstr "Cap comissió analitzada."
 
-#: sequencer.c:745
+#: sequencer.c:756
 #, c-format
 msgid "Could not open %s"
 msgstr "No s'ha pogut obrir %s"
 
-#: sequencer.c:749
+#: sequencer.c:760
 #, c-format
 msgid "Could not read %s."
 msgstr "No s'ha pogut llegir %s."
 
-#: sequencer.c:756
+#: sequencer.c:767
 #, c-format
 msgid "Unusable instruction sheet: %s"
-msgstr "Full d'instruccions inutilitzable: %s"
+msgstr "Full d'instruccions inusable: %s"
 
-#: sequencer.c:786
+#: sequencer.c:797
 #, c-format
 msgid "Invalid key: %s"
 msgstr "Clau invàlid: %s"
 
-#: sequencer.c:789
+#: sequencer.c:800
 #, c-format
 msgid "Invalid value for %s: %s"
 msgstr "Valor invàlid per a %s: %s"
 
-#: sequencer.c:801
+#: sequencer.c:812
 #, c-format
 msgid "Malformed options sheet: %s"
 msgstr "Full d'opcions malformat: %s"
 
-#: sequencer.c:822
+#: sequencer.c:833
 msgid "a cherry-pick or revert is already in progress"
 msgstr "un recull de cireres o una reversió ja està en curs"
 
-#: sequencer.c:823
+#: sequencer.c:834
 msgid "try \"git cherry-pick (--continue | --quit | --abort)\""
 msgstr "intenteu \"git cherry-pick (--continue | --quit | --abort)\""
 
-#: sequencer.c:827
+#: sequencer.c:838
 #, c-format
 msgid "Could not create sequencer directory %s"
 msgstr "No s'ha pogut crear el directori de seqüenciador %s"
 
-#: sequencer.c:843 sequencer.c:928
+#: sequencer.c:854 sequencer.c:939
 #, c-format
 msgid "Error wrapping up %s."
-msgstr "Error al terminar %s."
+msgstr "Error en terminar %s."
 
-#: sequencer.c:862 sequencer.c:998
+#: sequencer.c:873 sequencer.c:1009
 msgid "no cherry-pick or revert in progress"
-msgstr "cap recull de cireres o reversió en curs"
+msgstr "ni recull de cireres ni una reversió està en curs"
 
-#: sequencer.c:864
+#: sequencer.c:875
 msgid "cannot resolve HEAD"
 msgstr "no es pot resoldre HEAD"
 
-#: sequencer.c:866
+#: sequencer.c:877
 msgid "cannot abort from a branch yet to be born"
 msgstr "no es pot avortar des d'una rama que encara ha de nàixer"
 
-#: sequencer.c:888 builtin/apply.c:4062
+#: sequencer.c:899 builtin/apply.c:4128
 #, c-format
 msgid "cannot open %s: %s"
 msgstr "no es pot obrir %s: %s"
 
-#: sequencer.c:891
+#: sequencer.c:902
 #, c-format
 msgid "cannot read %s: %s"
 msgstr "no es pot llegir %s: %s"
 
-#: sequencer.c:892
+#: sequencer.c:903
 msgid "unexpected end of file"
 msgstr "fin de fitxer inesperat"
 
-#: sequencer.c:898
+#: sequencer.c:909
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr ""
 "el fitxer HEAD emmagatzemat abans del recull de cirers '%s' és corrupte"
 
-#: sequencer.c:921
+#: sequencer.c:932
 #, c-format
 msgid "Could not format %s."
 msgstr "No s'ha pogut formatar %s."
 
-#: sequencer.c:1066
+#: sequencer.c:1077
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: no es pot recollir com cirera un %s"
 
-#: sequencer.c:1069
+#: sequencer.c:1080
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: revisió dolenta"
 
-#: sequencer.c:1103
+#: sequencer.c:1114
 msgid "Can't revert as initial commit"
-msgstr "No es pot revertir com comissió inicial"
+msgstr "No es pot revertir com a comissió inicial"
 
-#: sequencer.c:1104
+#: sequencer.c:1115
 msgid "Can't cherry-pick into empty head"
 msgstr "No es pot recollir cireres en un cap buit"
 
-#: sha1_name.c:439
+#: sha1_name.c:440
 msgid ""
 "Git normally never creates a ref that ends with 40 hex characters\n"
 "because it will be ignored when you just specify 40-hex. These refs\n"
@@ -1355,24 +1421,24 @@ msgstr ""
 "suprimiu-les. Desactiva aquest missatge per executar\n"
 "\"git config advice.objectNameWarning false\""
 
-#: sha1_name.c:1060
+#: sha1_name.c:1068
 msgid "HEAD does not point to a branch"
 msgstr "HEAD no assenyala cap rama"
 
-#: sha1_name.c:1063
+#: sha1_name.c:1071
 #, c-format
 msgid "No such branch: '%s'"
-msgstr "Cap rama així: '%s'"
+msgstr "No hi ha tal rama: '%s'"
 
-#: sha1_name.c:1065
+#: sha1_name.c:1073
 #, c-format
 msgid "No upstream configured for branch '%s'"
 msgstr "Cap font configurada per a la rama '%s'"
 
-#: sha1_name.c:1069
+#: sha1_name.c:1077
 #, c-format
 msgid "Upstream branch '%s' not stored as a remote-tracking branch"
-msgstr "La rama font '%s' no s'emmagatzema com rama que segueixi al remot"
+msgstr "La rama font '%s' no s'emmagatzema com a rama que segueixi al remot"
 
 #: submodule.c:64 submodule.c:98
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
@@ -1399,15 +1465,40 @@ msgstr "No s'ha pogut treure l'entrada de .gitmodules per a %s"
 msgid "staging updated .gitmodules failed"
 msgstr "L'allistament del .gitmodules actualitzat ha fallat"
 
-#: submodule.c:1118 builtin/init-db.c:363
+#: submodule.c:1111 builtin/init-db.c:363
 #, c-format
 msgid "Could not create git link %s"
 msgstr "No s'ha pogut crear l'enllaç de git %s"
 
-#: submodule.c:1129
+#: submodule.c:1122
 #, c-format
 msgid "Could not set core.worktree in %s"
 msgstr "No s'ha pogut establir core.worktree en %s"
+
+#: trailer.c:500 trailer.c:504 trailer.c:508 trailer.c:562 trailer.c:566
+#: trailer.c:570
+#, c-format
+msgid "unknown value '%s' for key '%s'"
+msgstr "valor desconegut '%s' per a la clau '%s'"
+
+#: trailer.c:552 trailer.c:557 builtin/remote.c:288
+#, c-format
+msgid "more than one %s"
+msgstr "més d'un %s"
+
+#: trailer.c:587
+#, c-format
+msgid "empty trailer token in trailer '%s'"
+msgstr "fitxa de remolc buida en el remolc '%s'"
+
+#: trailer.c:706
+#, c-format
+msgid "could not read input file '%s'"
+msgstr "no s'ha pogut llegir el fitxer d'entrada '%s'"
+
+#: trailer.c:709
+msgid "could not read from stdin"
+msgstr "No s'ha pogut llegir des d'stdin"
 
 #: unpack-trees.c:202
 msgid "Checking out files"
@@ -1415,7 +1506,7 @@ msgstr "Agafant fitxers"
 
 #: urlmatch.c:120
 msgid "invalid URL scheme name or missing '://' suffix"
-msgstr "esquema d'URL invàlida o manca el sufix '://'"
+msgstr "l'esquema d'URL és invàlida o li manca el sufix '://'"
 
 #: urlmatch.c:144 urlmatch.c:297 urlmatch.c:356
 #, c-format
@@ -1428,11 +1519,11 @@ msgstr "manca l'host i l'esquema no és 'file:'"
 
 #: urlmatch.c:189
 msgid "a 'file:' URL may not have a port number"
-msgstr "un URL 'file:' no pot tenir un número de port"
+msgstr "un URL 'file:' no pot tenir número de port"
 
 #: urlmatch.c:199
 msgid "invalid characters in host name"
-msgstr "caràcters invàlids en nom de host"
+msgstr "hi ha caràcters invàlids en el nom de host"
 
 #: urlmatch.c:244 urlmatch.c:255
 msgid "invalid port number"
@@ -1442,24 +1533,28 @@ msgstr "número de port invàlid"
 msgid "invalid '..' path segment"
 msgstr "segment de ruta '..' invàlid"
 
-#: wrapper.c:460
+#: wrapper.c:509
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "incapaç d'accedir a '%s': %s"
 
-#: wrapper.c:481
+#: wrapper.c:530
 #, c-format
 msgid "unable to access '%s'"
 msgstr "incapaç d'accedir a '%s'"
 
-#: wrapper.c:492
+#: wrapper.c:541
 #, c-format
 msgid "unable to look up current user in the passwd file: %s"
 msgstr "incapaç de trobar l'usuari actual en el fitxer passwd: %s"
 
-#: wrapper.c:493
+#: wrapper.c:542
 msgid "no such user"
-msgstr "cap usuari així"
+msgstr "no hi ha tal usuari"
+
+#: wrapper.c:550
+msgid "unable to get current working directory"
+msgstr "incapaç d'obtenir el directori de treball actual"
 
 #: wt-status.c:150
 msgid "Unmerged paths:"
@@ -1468,29 +1563,29 @@ msgstr "Rutes sense fusionar:"
 #: wt-status.c:177 wt-status.c:204
 #, c-format
 msgid "  (use \"git reset %s <file>...\" to unstage)"
-msgstr "  (utilitzeu \"git reset %s <fitxer>...\" per desallistar)"
+msgstr "  (useu \"git reset %s <fitxer>...\" per a desallistar)"
 
 #: wt-status.c:179 wt-status.c:206
 msgid "  (use \"git rm --cached <file>...\" to unstage)"
-msgstr "  (utilitzeu \"git rm --cached <fitxer>...\" per desallistar)"
+msgstr "  (useu \"git rm --cached <fitxer>...\" per a desallistar)"
 
 #: wt-status.c:183
 msgid "  (use \"git add <file>...\" to mark resolution)"
-msgstr "  (utilitzeu \"git add <file>...\" per senyalar resolució)"
+msgstr "  (useu \"git add <fitxer>...\" per a senyalar resolució)"
 
 #: wt-status.c:185 wt-status.c:189
 msgid "  (use \"git add/rm <file>...\" as appropriate to mark resolution)"
 msgstr ""
-"  (utilitzeu \"git add/rm <file>...\" segons sigui apropiat per senyalar "
+"  (useu \"git add/rm <fitxer>...\" segons sigui apropiat per a senyalar "
 "resolució)"
 
 #: wt-status.c:187
 msgid "  (use \"git rm <file>...\" to mark resolution)"
-msgstr "  (utilitzeu \"git rm <file>...\" per senyalar resolució)"
+msgstr "  (useu \"git rm <fitxer>...\" per a senyalar resolució)"
 
 #: wt-status.c:198
 msgid "Changes to be committed:"
-msgstr "Canvis que cometre:"
+msgstr "Canvis a cometre:"
 
 #: wt-status.c:216
 msgid "Changes not staged for commit:"
@@ -1498,17 +1593,17 @@ msgstr "Canvis no allistats per a cometre:"
 
 #: wt-status.c:220
 msgid "  (use \"git add <file>...\" to update what will be committed)"
-msgstr "  (utilitzeu \"git add <file>...\" per actualitzar què es cometrà)"
+msgstr "  (useu \"git add <fitxer>...\" per a actualitzar què es cometrà)"
 
 #: wt-status.c:222
 msgid "  (use \"git add/rm <file>...\" to update what will be committed)"
-msgstr "  (utilitzeu \"git add/rm <file>...\" per actualitzar què es cometrà)"
+msgstr "  (useu \"git add/rm <fitxer>...\" per a actualitzar què es cometrà)"
 
 #: wt-status.c:223
 msgid ""
 "  (use \"git checkout -- <file>...\" to discard changes in working directory)"
 msgstr ""
-"  (utilitzeu \"git checkout -- <file>...\" per descartar els canvis en el "
+"  (useu \"git checkout -- <fitxer>...\" per a descartar els canvis en el "
 "directori de treball)"
 
 #: wt-status.c:225
@@ -1519,7 +1614,7 @@ msgstr ""
 #: wt-status.c:237
 #, c-format
 msgid "  (use \"git %s <file>...\" to include in what will be committed)"
-msgstr "  (utilitzeu \"git %s <file>...\" per incloure en què es cometrà)"
+msgstr "  (useu \"git %s <fitxer>...\" per a incloure-ho en què es cometrà)"
 
 #: wt-status.c:252
 msgid "both deleted:"
@@ -1531,11 +1626,11 @@ msgstr "afegit per nosaltres:"
 
 #: wt-status.c:256
 msgid "deleted by them:"
-msgstr "suprimit per ells:"
+msgstr "suprimit pels:"
 
 #: wt-status.c:258
 msgid "added by them:"
-msgstr "afegit per ells:"
+msgstr "afegit pels:"
 
 #: wt-status.c:260
 msgid "deleted by us:"
@@ -1603,206 +1698,207 @@ msgstr "contingut no seguit, "
 msgid "bug: unhandled diff status %c"
 msgstr "bug: estat de diferència no manejat %c"
 
-#: wt-status.c:764
+#: wt-status.c:761
 msgid "Submodules changed but not updated:"
 msgstr "Submòduls canviats però no actualitzats:"
 
-#: wt-status.c:766
+#: wt-status.c:763
 msgid "Submodule changes to be committed:"
-msgstr "Canvis de submòdul que cometre:"
+msgstr "Canvis de submòdul a cometre:"
 
-#: wt-status.c:845
+#: wt-status.c:842
 msgid ""
 "Do not touch the line above.\n"
 "Everything below will be removed."
 msgstr ""
-"No toquis la línia amunt.\n"
+"No toqueu la línia amunt.\n"
 "Tot a baix es traurà."
 
-#: wt-status.c:936
+#: wt-status.c:933
 msgid "You have unmerged paths."
 msgstr "Teniu rutes sense fusionar."
 
-#: wt-status.c:939
+#: wt-status.c:936
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (arregleu els conflictes i executeu \"git commit\")"
 
-#: wt-status.c:942
+#: wt-status.c:939
 msgid "All conflicts fixed but you are still merging."
-msgstr "Tots els conflictes arreglats però encara esteu fusionant."
+msgstr "Tots els conflictes estan arreglats però encara esteu fusionant."
 
-#: wt-status.c:945
+#: wt-status.c:942
 msgid "  (use \"git commit\" to conclude merge)"
-msgstr "  (utilitzeu \"git commit\" per concloure la fusió)"
+msgstr "  (useu \"git commit\" per a concloure la fusió)"
 
-#: wt-status.c:955
+#: wt-status.c:952
 msgid "You are in the middle of an am session."
 msgstr "Esteu en el medi d'una sessió am."
 
-#: wt-status.c:958
+#: wt-status.c:955
 msgid "The current patch is empty."
 msgstr "El pedaç actual està buit."
 
-#: wt-status.c:962
+#: wt-status.c:959
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (arregleu els conflictes i després executeu \"git am --continue\")"
 
-#: wt-status.c:964
+#: wt-status.c:961
 msgid "  (use \"git am --skip\" to skip this patch)"
-msgstr "  (utilitzeu \"git am --skip\" per saltar aquest pedaç)"
+msgstr "  (useu \"git am --skip\" per a saltar aquest pedaç)"
 
-#: wt-status.c:966
+#: wt-status.c:963
 msgid "  (use \"git am --abort\" to restore the original branch)"
-msgstr "  (utilitzeu \"git am --abort\" per restaurar la rama original)"
+msgstr "  (useu \"git am --abort\" per a restaurar la rama original)"
 
-#: wt-status.c:1026 wt-status.c:1043
+#: wt-status.c:1023 wt-status.c:1040
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Actualment esteu rebasant la rama '%s' en '%s'."
 
-#: wt-status.c:1031 wt-status.c:1048
+#: wt-status.c:1028 wt-status.c:1045
 msgid "You are currently rebasing."
 msgstr "Actualment esteu rebasant."
 
-#: wt-status.c:1034
+#: wt-status.c:1031
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr ""
 "  (arregleu els conflictes i després executeu \"git rebase --continue\")"
 
-#: wt-status.c:1036
+#: wt-status.c:1033
 msgid "  (use \"git rebase --skip\" to skip this patch)"
-msgstr "  (utlitizeu \"git rebase --skip\" per saltar aquest pedaç)"
+msgstr "  (useu \"git rebase --skip\" per a saltar aquest pedaç)"
 
-#: wt-status.c:1038
+#: wt-status.c:1035
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
-msgstr "  (utilitzeu \"git rebase --abort\" per agafar la rama original)"
+msgstr "  (useu \"git rebase --abort\" per a agafar la rama original)"
 
-#: wt-status.c:1051
+#: wt-status.c:1048
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (tots els conflictes arreglats: executeu \"git rebase --continue\")"
 
-#: wt-status.c:1055
+#: wt-status.c:1052
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Actualment esteu dividint una comissió mentre rebasant la rama '%s' en '%s'."
 
-#: wt-status.c:1060
+#: wt-status.c:1057
 msgid "You are currently splitting a commit during a rebase."
-msgstr "Actualment esteu dividint una comissió durant un rebase."
+msgstr "Actualment esteu dividint una comissió durant una rebase."
 
-#: wt-status.c:1063
+#: wt-status.c:1060
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Una vegada que el vostre directori de treball sigui net, executeu \"git "
 "rebase --continue\")"
 
-#: wt-status.c:1067
+#: wt-status.c:1064
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Actualment esteu editant una comissió mentre rebasant la rama '%s' en '%s'."
 
-#: wt-status.c:1072
+#: wt-status.c:1069
 msgid "You are currently editing a commit during a rebase."
-msgstr "Actualment esteu editant una comissió durant un rebase."
+msgstr "Actualment esteu editant una comissió durant una rebase."
 
-#: wt-status.c:1075
+#: wt-status.c:1072
 msgid "  (use \"git commit --amend\" to amend the current commit)"
-msgstr "  (utilitzeu \"git commit --amend\" per esmenar la comissió actual)"
+msgstr "  (useu \"git commit --amend\" per a esmenar la comissió actual)"
 
-#: wt-status.c:1077
+#: wt-status.c:1074
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
-"  (utilitzeu \"git rebase --continue\" una vegada que sigueu satisfet amb "
-"els vostres canvis)"
+"  (useu \"git rebase --continue\" una vegada que esteu satisfet amb els "
+"vostres canvis)"
 
-#: wt-status.c:1087
+#: wt-status.c:1084
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Actualment esteu recollint com cirera la comissió %s."
 
-#: wt-status.c:1092
+#: wt-status.c:1089
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (arregleu els conflictes i executeu \"git cherry-pick --continue\")"
 
-#: wt-status.c:1095
+#: wt-status.c:1092
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (tots els conflictes arreglats: executeu \"git cherry-pick --continue\")"
 
-#: wt-status.c:1097
+#: wt-status.c:1094
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
-"  (utilitzeu \"git cherry-pick --abort\" per cancel·lar l'operació de recull "
-"de cireres)"
+"  (useu \"git cherry-pick --abort\" per a cancel·lar l'operació de recull de "
+"cireres)"
 
-#: wt-status.c:1106
+#: wt-status.c:1103
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Actualment esteu revertint la comissió %s."
 
-#: wt-status.c:1111
+#: wt-status.c:1108
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (arregleu els conflictes i executeu \"git revert --continue\")"
 
-#: wt-status.c:1114
+#: wt-status.c:1111
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
-msgstr "  (tots els conflictes arreglats: executeu \"git revert --continue\")"
+msgstr ""
+"  (tots els conflictes estan arreglats: executeu \"git revert --continue\")"
 
-#: wt-status.c:1116
+#: wt-status.c:1113
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr ""
-"  (utilitzeu \"git revert --abort\" per cancel·lar l'operació de reversió)"
+"  (useu \"git revert --abort\" per a cancel·lar l'operació de reversió)"
 
-#: wt-status.c:1127
+#: wt-status.c:1124
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Actualment esteu bisecant, heu començat des de la rama '%s'."
 
-#: wt-status.c:1131
+#: wt-status.c:1128
 msgid "You are currently bisecting."
 msgstr "Actualment esteu bisecant."
 
-#: wt-status.c:1134
+#: wt-status.c:1131
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
-msgstr "  (utilitzeu \"git bisect reset\" per tornar a la rama original)"
+msgstr "  (useu \"git bisect reset\" per a tornar a la rama original)"
 
-#: wt-status.c:1309
+#: wt-status.c:1306
 msgid "On branch "
 msgstr "En la rama "
 
-#: wt-status.c:1316
+#: wt-status.c:1313
 msgid "rebase in progress; onto "
 msgstr "rebase en progrés; en "
 
-#: wt-status.c:1323
+#: wt-status.c:1320
 msgid "HEAD detached at "
 msgstr "HEAD separat a"
 
-#: wt-status.c:1325
+#: wt-status.c:1322
 msgid "HEAD detached from "
 msgstr "HEAD separat de"
 
-#: wt-status.c:1328
+#: wt-status.c:1325
 msgid "Not currently on any branch."
 msgstr "Actualment no en cap rama."
 
-#: wt-status.c:1345
+#: wt-status.c:1342
 msgid "Initial commit"
 msgstr "Comissió inicial"
 
-#: wt-status.c:1359
+#: wt-status.c:1356
 msgid "Untracked files"
 msgstr "Fitxers no seguits"
 
-#: wt-status.c:1361
+#: wt-status.c:1358
 msgid "Ignored files"
 msgstr "Fitxers ignorats"
 
-#: wt-status.c:1365
+#: wt-status.c:1362
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -1814,130 +1910,131 @@ msgstr ""
 "oblidar afegir fitxers nous per vós mateix (veu\n"
 "'git help status')."
 
-#: wt-status.c:1371
+#: wt-status.c:1368
 #, c-format
 msgid "Untracked files not listed%s"
-msgstr "Fitxers no seguits no llistats%s"
+msgstr "Els fitxers no seguits no estan llistats%s"
 
-#: wt-status.c:1373
+#: wt-status.c:1370
 msgid " (use -u option to show untracked files)"
-msgstr " (utilitzeu l'opció -u per mostrar fitxers no seguits)"
+msgstr " (useu l'opció -u per a mostrar els fitxers no seguits)"
 
-#: wt-status.c:1379
+#: wt-status.c:1376
 msgid "No changes"
 msgstr "Sense canvis"
 
-#: wt-status.c:1384
+#: wt-status.c:1381
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
-"cap canvi afegit que cometre (afegeix \"git add\" o \"git commit -a\")\n"
+"no hi ha canvis afegits a cometre (useu \"git add\" o \"git commit -a\")\n"
 
-#: wt-status.c:1387
+#: wt-status.c:1384
 #, c-format
 msgid "no changes added to commit\n"
-msgstr "cap canvi afegit que cometre\n"
+msgstr "no hi ha canvis afegits a cometre\n"
 
-#: wt-status.c:1390
+#: wt-status.c:1387
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
 "track)\n"
 msgstr ""
-"res afegit que cometre però fitxers no seguits estan presents (utilitzeu "
-"\"git add\" per seguir-los)\n"
+"no hi ha res afegit a cometre però fitxers no seguits estan presents (useu "
+"\"git add\" per a seguir-los)\n"
+
+#: wt-status.c:1390
+#, c-format
+msgid "nothing added to commit but untracked files present\n"
+msgstr "no hi ha res afegit a cometre però fitxers no seguits estan presents\n"
 
 #: wt-status.c:1393
 #, c-format
-msgid "nothing added to commit but untracked files present\n"
-msgstr "res afegit que cometre però fitxers no seguits estan presents\n"
-
-#: wt-status.c:1396
-#, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
-"res que cometre (creeu/copieu fitxers i utilitzeu \"git add\" per seguir-"
+"no hi ha res a cometre (creeu/copieu fitxers i useu \"git add\" per a seguir-"
 "los)\n"
 
-#: wt-status.c:1399 wt-status.c:1404
+#: wt-status.c:1396 wt-status.c:1401
 #, c-format
 msgid "nothing to commit\n"
-msgstr "res que cometre\n"
+msgstr "no hi ha res a cometre\n"
 
-#: wt-status.c:1402
+#: wt-status.c:1399
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
-msgstr "res que cometre (utilitzeu -u per mostrar fitxers no seguits)\n"
+msgstr ""
+"no hi ha res a cometre (useu -u per a mostrar els fitxers no seguits)\n"
 
-#: wt-status.c:1406
+#: wt-status.c:1403
 #, c-format
 msgid "nothing to commit, working directory clean\n"
-msgstr "res que cometre, directori de treball net\n"
+msgstr "no hi ha res a cometre, directori de treball net\n"
 
-#: wt-status.c:1515
+#: wt-status.c:1512
 msgid "HEAD (no branch)"
 msgstr "HEAD (sense rama)"
 
-#: wt-status.c:1521
+#: wt-status.c:1518
 msgid "Initial commit on "
 msgstr "Comissió inicial en "
 
-#: wt-status.c:1553
+#: wt-status.c:1550
 msgid "gone"
-msgstr "no està"
+msgstr "no és"
 
-#: wt-status.c:1555 wt-status.c:1563
+#: wt-status.c:1552 wt-status.c:1560
 msgid "behind "
 msgstr "darrere "
 
-#: compat/precompose_utf8.c:55 builtin/clone.c:356
+#: compat/precompose_utf8.c:55 builtin/clone.c:357
 #, c-format
 msgid "failed to unlink '%s'"
-msgstr "s'ha fallat al desenllaçar '%s'"
+msgstr "s'ha fallat en desenllaçar '%s'"
 
-#: builtin/add.c:21
+#: builtin/add.c:22
 msgid "git add [options] [--] <pathspec>..."
 msgstr "git add [opcions] [--] <especificació-de-ruta>..."
 
-#: builtin/add.c:64
+#: builtin/add.c:65
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "estat de diff inesperat %c"
 
-#: builtin/add.c:69 builtin/commit.c:261
+#: builtin/add.c:70 builtin/commit.c:275
 msgid "updating files failed"
-msgstr "s'ha fallat al actualitzar els fitxers"
+msgstr "s'ha fallat en actualitzar els fitxers"
 
-#: builtin/add.c:79
+#: builtin/add.c:80
 #, c-format
 msgid "remove '%s'\n"
 msgstr "treu '%s'\n"
 
-#: builtin/add.c:133
+#: builtin/add.c:134
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Canvis no allistats després d'actualitzar l'índex:"
 
-#: builtin/add.c:193 builtin/rev-parse.c:781
+#: builtin/add.c:194 builtin/rev-parse.c:785
 msgid "Could not read the index"
 msgstr "No s'ha pogut llegir l'índex"
 
-#: builtin/add.c:204
+#: builtin/add.c:205
 #, c-format
 msgid "Could not open '%s' for writing."
 msgstr "No s'ha pogut obrir '%s' per a escriptura."
 
-#: builtin/add.c:208
+#: builtin/add.c:209
 msgid "Could not write patch"
 msgstr "No s'ha pogut escriure el pedaç"
 
-#: builtin/add.c:213
+#: builtin/add.c:214
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "No s'ha pogut fer stat a '%s'"
 
-#: builtin/add.c:215
+#: builtin/add.c:216
 msgid "Empty patch. Aborted."
-msgstr "Pedaç buit. Avortat."
+msgstr "El pedaç és buit. Avortat."
 
 #: builtin/add.c:221
 #, c-format
@@ -1948,15 +2045,15 @@ msgstr "No s'ha pogut aplicar '%s'"
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "Les rutes següents s'ignoren per un dels vostres fitxers .gitignore:\n"
 
-#: builtin/add.c:248 builtin/clean.c:875 builtin/fetch.c:108 builtin/mv.c:70
-#: builtin/prune-packed.c:77 builtin/push.c:488 builtin/remote.c:1367
+#: builtin/add.c:248 builtin/clean.c:875 builtin/fetch.c:108 builtin/mv.c:110
+#: builtin/prune-packed.c:55 builtin/push.c:499 builtin/remote.c:1375
 #: builtin/rm.c:269
 msgid "dry run"
 msgstr "marxa en sec"
 
-#: builtin/add.c:249 builtin/apply.c:4411 builtin/check-ignore.c:19
-#: builtin/commit.c:1328 builtin/count-objects.c:95 builtin/fsck.c:606
-#: builtin/log.c:1613 builtin/mv.c:69 builtin/read-tree.c:113
+#: builtin/add.c:249 builtin/apply.c:4415 builtin/check-ignore.c:19
+#: builtin/commit.c:1362 builtin/count-objects.c:63 builtin/fsck.c:608
+#: builtin/log.c:1617 builtin/mv.c:109 builtin/read-tree.c:114
 msgid "be verbose"
 msgstr "sigues verbós"
 
@@ -1964,13 +2061,13 @@ msgstr "sigues verbós"
 msgid "interactive picking"
 msgstr "recull interactiu"
 
-#: builtin/add.c:252 builtin/checkout.c:1102 builtin/reset.c:285
+#: builtin/add.c:252 builtin/checkout.c:1108 builtin/reset.c:286
 msgid "select hunks interactively"
 msgstr "selecciona els trossos interactivament"
 
 #: builtin/add.c:253
 msgid "edit current diff and apply"
-msgstr "edita la diferència actual i aplica"
+msgstr "edita la diferència actual i aplica'l"
 
 #: builtin/add.c:254
 msgid "allow adding otherwise ignored files"
@@ -2003,12 +2100,12 @@ msgstr "només salta els fitxers que no es poden afegir a causa d'errors"
 #: builtin/add.c:264
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
-"comproveu si els fitxers - encara els mancants - s'ignoran en marxa en sec"
+"comproveu si els fitxers - encara els mancants - s'ignoren en marxa en sec"
 
 #: builtin/add.c:286
 #, c-format
 msgid "Use -f if you really want to add them.\n"
-msgstr "Utilitzeu -f si realment els voleu afegir.\n"
+msgstr "Useu -f si realment els voleu afegir.\n"
 
 #: builtin/add.c:287
 msgid "no files added"
@@ -2024,7 +2121,7 @@ msgstr "-A i -u són mutualment incompatibles"
 
 #: builtin/add.c:336
 msgid "Option --ignore-missing can only be used together with --dry-run"
-msgstr "L'opció --ignore-missing només es pot utilitzar junt amb --dry-run"
+msgstr "L'opció --ignore-missing només es pot usar junt amb --dry-run"
 
 #: builtin/add.c:357
 #, c-format
@@ -2037,77 +2134,77 @@ msgid "Maybe you wanted to say 'git add .'?\n"
 msgstr "Potser volíeu dir 'git add .'?\n"
 
 #: builtin/add.c:363 builtin/check-ignore.c:172 builtin/clean.c:919
-#: builtin/commit.c:319 builtin/mv.c:90 builtin/reset.c:234 builtin/rm.c:299
+#: builtin/commit.c:333 builtin/mv.c:130 builtin/reset.c:235 builtin/rm.c:299
 msgid "index file corrupt"
 msgstr "fitxer d'índex malmès"
 
-#: builtin/add.c:446 builtin/apply.c:4506 builtin/mv.c:280 builtin/rm.c:431
+#: builtin/add.c:446 builtin/apply.c:4510 builtin/mv.c:279 builtin/rm.c:431
 msgid "Unable to write new index file"
-msgstr "Incapaç d'escriure un nou fitxer d'índex"
+msgstr "Incapaç d'escriure un fitxer d'índex nou"
 
-#: builtin/apply.c:57
+#: builtin/apply.c:58
 msgid "git apply [options] [<patch>...]"
 msgstr "git apply [opcions] [<pedaç>...]"
 
-#: builtin/apply.c:110
+#: builtin/apply.c:111
 #, c-format
 msgid "unrecognized whitespace option '%s'"
 msgstr "opció d'espai en blanc '%s' no reconeguda"
 
-#: builtin/apply.c:125
+#: builtin/apply.c:126
 #, c-format
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr "opció d'ignoral d'espai en blanc '%s' no reconeguda"
 
-#: builtin/apply.c:825
+#: builtin/apply.c:826
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
 msgstr "No es pot preparar l'expressió regular de marca de temps %s"
 
-#: builtin/apply.c:834
+#: builtin/apply.c:835
 #, c-format
 msgid "regexec returned %d for input: %s"
 msgstr "regexec ha retornat %d per l'entrada: %s"
 
-#: builtin/apply.c:915
+#: builtin/apply.c:916
 #, c-format
 msgid "unable to find filename in patch at line %d"
 msgstr "incapaç de trobar el nom de fitxer en el pedaç a la línia %d"
 
-#: builtin/apply.c:947
+#: builtin/apply.c:948
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
 msgstr ""
 "git apply: git-diff dolent - /dev/null esperat, %s rebut en la línia %d"
 
-#: builtin/apply.c:951
+#: builtin/apply.c:952
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
 "git apply: git-diff dolent - nom de fitxer nou inconsistent en la línia %d"
 
-#: builtin/apply.c:952
+#: builtin/apply.c:953
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr ""
 "git apply: git-diff dolent - nom de fitxer antic inconsistent en la línia %d"
 
-#: builtin/apply.c:959
+#: builtin/apply.c:960
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null on line %d"
 msgstr "git apply: git-diff dolent - /dev/null esperat en la línia %d"
 
-#: builtin/apply.c:1422
+#: builtin/apply.c:1423
 #, c-format
 msgid "recount: unexpected line: %.*s"
 msgstr "recompte: línia inesperada: %.*s"
 
-#: builtin/apply.c:1479
+#: builtin/apply.c:1480
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
 msgstr "fragment de pedaç sense capçalera a la línia %d: %.*s"
 
-#: builtin/apply.c:1496
+#: builtin/apply.c:1497
 #, c-format
 msgid ""
 "git diff header lacks filename information when removing %d leading pathname "
@@ -2116,83 +2213,83 @@ msgid_plural ""
 "git diff header lacks filename information when removing %d leading pathname "
 "components (line %d)"
 msgstr[0] ""
-"a la capçalera de git diff li manca informació de nom de fitxer al treure %d "
+"a la capçalera de git diff li manca informació de nom de fitxer en treure %d "
 "component de nom de ruta inicial (línia %d)"
 msgstr[1] ""
-"a la capçalera de git diff li manca informació de nom de fitxer al treure %d "
+"a la capçalera de git diff li manca informació de nom de fitxer en treure %d "
 "components de nom de ruta inicial (línia %d)"
 
-#: builtin/apply.c:1656
+#: builtin/apply.c:1657
 msgid "new file depends on old contents"
 msgstr "el fitxer nou depèn dels continguts antics"
 
-#: builtin/apply.c:1658
+#: builtin/apply.c:1659
 msgid "deleted file still has contents"
 msgstr "el fitxer suprimit encara té continguts"
 
-#: builtin/apply.c:1684
+#: builtin/apply.c:1685
 #, c-format
 msgid "corrupt patch at line %d"
-msgstr "pedaç malmès a la línia %d"
+msgstr "el pedaç és malmès a la línia %d"
 
-#: builtin/apply.c:1720
+#: builtin/apply.c:1721
 #, c-format
 msgid "new file %s depends on old contents"
 msgstr "el fitxer nou %s depèn dels continguts antics"
 
-#: builtin/apply.c:1722
+#: builtin/apply.c:1723
 #, c-format
 msgid "deleted file %s still has contents"
 msgstr "el fitxer suprimit %s encara té continguts"
 
-#: builtin/apply.c:1725
+#: builtin/apply.c:1726
 #, c-format
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "** avís: el fitxer %s es buida però no es suprimeix"
 
-#: builtin/apply.c:1871
+#: builtin/apply.c:1872
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "pedaç binari malmès a la línia %d: %.*s"
 
-#: builtin/apply.c:1900
+#: builtin/apply.c:1901
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "pedaç binari no reconegut a la línia %d"
 
-#: builtin/apply.c:1986
+#: builtin/apply.c:2052
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "pedaç amb només escombraries a la línia %d"
 
-#: builtin/apply.c:2076
+#: builtin/apply.c:2142
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "incapaç de llegir l'enllaç simbòlic %s"
 
-#: builtin/apply.c:2080
+#: builtin/apply.c:2146
 #, c-format
 msgid "unable to open or read %s"
 msgstr "incapaç d'obrir o llegir %s"
 
-#: builtin/apply.c:2688
+#: builtin/apply.c:2754
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "inici de línia no vàlid: '%c'"
 
-#: builtin/apply.c:2806
+#: builtin/apply.c:2872
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
 msgstr[0] "El tros #%d ha tingut éxit a %d (desplaçament %d línia)."
 msgstr[1] "El tros #%d ha tingut éxit a %d (desplaçament %d línies)."
 
-#: builtin/apply.c:2818
+#: builtin/apply.c:2884
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
-msgstr "Context reduït a (%ld/%ld) per a aplicar el fragment a %d"
+msgstr "El context s'ha reduït a (%ld/%ld) per a aplicar el fragment a %d"
 
-#: builtin/apply.c:2824
+#: builtin/apply.c:2890
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -2201,322 +2298,323 @@ msgstr ""
 "mentre cercant:\n"
 "%.*s"
 
-#: builtin/apply.c:2843
+#: builtin/apply.c:2909
 #, c-format
 msgid "missing binary patch data for '%s'"
-msgstr "manca els dades de pedaç binari de '%s'"
+msgstr "manquen els dades de pedaç binari de '%s'"
 
-#: builtin/apply.c:2944
+#: builtin/apply.c:3010
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "el pedaç binari no s'aplica a '%s'"
 
-#: builtin/apply.c:2950
+#: builtin/apply.c:3016
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "el pedaç binari a '%s' crea un resultat incorrecte (esperant %s, %s rebut)"
 
-#: builtin/apply.c:2971
+#: builtin/apply.c:3037
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "el pedaç ha fallat: %s:%ld"
 
-#: builtin/apply.c:3095
+#: builtin/apply.c:3161
 #, c-format
 msgid "cannot checkout %s"
 msgstr "no es pot agafar %s"
 
-#: builtin/apply.c:3140 builtin/apply.c:3149 builtin/apply.c:3194
+#: builtin/apply.c:3206 builtin/apply.c:3215 builtin/apply.c:3260
 #, c-format
 msgid "read of %s failed"
 msgstr "la lectura de %s ha fallat"
 
-#: builtin/apply.c:3174 builtin/apply.c:3396
+#: builtin/apply.c:3240 builtin/apply.c:3462
 #, c-format
 msgid "path %s has been renamed/deleted"
-msgstr "la ruta %s s'ha canviat de nom/suprimit"
+msgstr "la ruta %s s'ha canviat de nom / s'ha suprimit"
 
-#: builtin/apply.c:3255 builtin/apply.c:3410
+#: builtin/apply.c:3321 builtin/apply.c:3476
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: no existeix en l'índex"
 
-#: builtin/apply.c:3259 builtin/apply.c:3402 builtin/apply.c:3424
+#: builtin/apply.c:3325 builtin/apply.c:3468 builtin/apply.c:3490
 #, c-format
 msgid "%s: %s"
 msgstr "%s: %s"
 
-#: builtin/apply.c:3264 builtin/apply.c:3418
+#: builtin/apply.c:3330 builtin/apply.c:3484
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: no coincideix amb l'índex"
 
-#: builtin/apply.c:3366
+#: builtin/apply.c:3432
 msgid "removal patch leaves file contents"
 msgstr "el pedaç de treta deixa els continguts dels fitxers"
 
-#: builtin/apply.c:3435
+#: builtin/apply.c:3501
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: tipus erroni"
 
-#: builtin/apply.c:3437
+#: builtin/apply.c:3503
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s és del tipus %o, %o esperat"
 
-#: builtin/apply.c:3538
+#: builtin/apply.c:3604
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: ja existeix en l'índex"
 
-#: builtin/apply.c:3541
+#: builtin/apply.c:3607
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: ja existeix en el directori de treball"
 
-#: builtin/apply.c:3561
+#: builtin/apply.c:3627
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "el mode nou (%o) de %s no coincideix amb el mode antic (%o)"
 
-#: builtin/apply.c:3566
+#: builtin/apply.c:3632
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "el mode nou (%o) de %s no coincideix amb el mode antic (%o) de %s"
 
-#: builtin/apply.c:3574
+#: builtin/apply.c:3640
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: el pedaç no aplica"
 
-#: builtin/apply.c:3587
+#: builtin/apply.c:3653
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Comprovant el pedaç %s..."
 
-#: builtin/apply.c:3680 builtin/checkout.c:213 builtin/reset.c:134
+#: builtin/apply.c:3746 builtin/checkout.c:213 builtin/reset.c:135
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry ha fallat per a la ruta '%s'"
 
-#: builtin/apply.c:3823
+#: builtin/apply.c:3889
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "incapaç de treure %s de l'índex"
 
-#: builtin/apply.c:3852
+#: builtin/apply.c:3918
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "pedaç corrupte per al submòdul %s"
 
-#: builtin/apply.c:3856
+#: builtin/apply.c:3922
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "incapaç de fer stat al fitxer novament creat '%s'"
 
-#: builtin/apply.c:3861
+#: builtin/apply.c:3927
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
 "incapaç de crear un magatzem de recolzament per al fitxer novament creat %s"
 
-#: builtin/apply.c:3864 builtin/apply.c:3972
+#: builtin/apply.c:3930 builtin/apply.c:4038
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "incapaç d'afegir una entrada de cau per a %s"
 
-#: builtin/apply.c:3897
+#: builtin/apply.c:3963
 #, c-format
 msgid "closing file '%s'"
 msgstr "tancant el fitxer '%s'"
 
-#: builtin/apply.c:3946
+#: builtin/apply.c:4012
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "incapaç d'escriure el fitxer '%s' mode %o"
 
-#: builtin/apply.c:4033
+#: builtin/apply.c:4099
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "El pedaç %s s'ha aplicat netament."
 
-#: builtin/apply.c:4041
+#: builtin/apply.c:4107
 msgid "internal error"
 msgstr "error intern"
 
-#: builtin/apply.c:4044
+#: builtin/apply.c:4110
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Aplicant el pedaç %%s amb %d rebuig"
 msgstr[1] "Aplicant el pedaç %%s amb %d rebuitjos"
 
-#: builtin/apply.c:4054
+#: builtin/apply.c:4120
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "truncant el nom del fitxer .rej a %.*s.rej"
 
-#: builtin/apply.c:4075
+#: builtin/apply.c:4141
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "El tros #%d s'ha aplicat netament."
 
-#: builtin/apply.c:4078
+#: builtin/apply.c:4144
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "S'ha rebutjat el tros #%d."
 
-#: builtin/apply.c:4228
+#: builtin/apply.c:4234
 msgid "unrecognized input"
 msgstr "entrada no reconegut"
 
-#: builtin/apply.c:4239
+#: builtin/apply.c:4245
 msgid "unable to read index file"
 msgstr "incapaç de llegir el fitxer d'índex"
 
-#: builtin/apply.c:4358 builtin/apply.c:4361 builtin/clone.c:90
+#: builtin/apply.c:4362 builtin/apply.c:4365 builtin/clone.c:91
 #: builtin/fetch.c:93
 msgid "path"
 msgstr "ruta"
 
-#: builtin/apply.c:4359
+#: builtin/apply.c:4363
 msgid "don't apply changes matching the given path"
-msgstr "no apliquis canvis que coincideixen amb la ruta donada"
+msgstr "no apliquis els canvis que coincideixin amb la ruta donada"
 
-#: builtin/apply.c:4362
+#: builtin/apply.c:4366
 msgid "apply changes matching the given path"
-msgstr "aplica els canvis que coincideixen amb la ruta donada"
+msgstr "aplica els canvis que coincideixin amb la ruta donada"
 
-#: builtin/apply.c:4364
+#: builtin/apply.c:4368
 msgid "num"
 msgstr "número"
 
-#: builtin/apply.c:4365
+#: builtin/apply.c:4369
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 "treu <nombre> barres obliqües inicials de les rutes de diferència "
 "tradicionals"
 
-#: builtin/apply.c:4368
+#: builtin/apply.c:4372
 msgid "ignore additions made by the patch"
 msgstr "ignora afegiments fets pel pedaç"
 
-#: builtin/apply.c:4370
+#: builtin/apply.c:4374
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "en lloc d'aplicar el pedaç, emet les estadístiques de diferència de l'entrada"
 
-#: builtin/apply.c:4374
+#: builtin/apply.c:4378
 msgid "show number of added and deleted lines in decimal notation"
 msgstr "mostra el nombre de línies afegides i suprimides en notació decimal"
 
-#: builtin/apply.c:4376
+#: builtin/apply.c:4380
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "en lloc d'aplicar el pedaç, emet un resum de l'entrada"
 
-#: builtin/apply.c:4378
+#: builtin/apply.c:4382
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "en lloc d'aplicar el pedaç, veges si el pedaç és aplicable"
 
-#: builtin/apply.c:4380
+#: builtin/apply.c:4384
 msgid "make sure the patch is applicable to the current index"
 msgstr "assegura que el pedaç sigui aplicable a l'índex actual"
 
-#: builtin/apply.c:4382
+#: builtin/apply.c:4386
 msgid "apply a patch without touching the working tree"
 msgstr "aplica un pedaç sense tocar l'arbre de treball"
 
-#: builtin/apply.c:4384
+#: builtin/apply.c:4388
 msgid "also apply the patch (use with --stat/--summary/--check)"
-msgstr "aplica el pedaç també (utilitzeu amb --stat/--summary/--check)"
+msgstr "aplica el pedaç també (useu amb --stat/--summary/--check)"
 
-#: builtin/apply.c:4386
+#: builtin/apply.c:4390
 msgid "attempt three-way merge if a patch does not apply"
 msgstr "intenta una fusió de tres vies si el pedaç no s'aplica"
 
-#: builtin/apply.c:4388
+#: builtin/apply.c:4392
 msgid "build a temporary index based on embedded index information"
 msgstr "construeix un índex temporal basat en la informació d'índex incrustada"
 
-#: builtin/apply.c:4390 builtin/checkout-index.c:198 builtin/ls-files.c:455
+#: builtin/apply.c:4394 builtin/checkout-index.c:198 builtin/ls-files.c:455
 msgid "paths are separated with NUL character"
 msgstr "rutes es separen amb el caràcter NUL"
 
-#: builtin/apply.c:4393
+#: builtin/apply.c:4397
 msgid "ensure at least <n> lines of context match"
 msgstr "assegura que almenys <n> línies de context coincideixin"
 
-#: builtin/apply.c:4394
+#: builtin/apply.c:4398
 msgid "action"
 msgstr "acció"
 
-#: builtin/apply.c:4395
+#: builtin/apply.c:4399
 msgid "detect new or modified lines that have whitespace errors"
-msgstr "detecta línies noves o modificades que tenen errors d'espai en blanc"
+msgstr ""
+"detecta les línies noves o modificades que tinguin errors d'espai en blanc"
 
-#: builtin/apply.c:4398 builtin/apply.c:4401
+#: builtin/apply.c:4402 builtin/apply.c:4405
 msgid "ignore changes in whitespace when finding context"
 msgstr "ignora els canvis d'espai en blanc al cercar context"
 
-#: builtin/apply.c:4404
+#: builtin/apply.c:4408
 msgid "apply the patch in reverse"
 msgstr "aplica el pedaç al revés"
 
-#: builtin/apply.c:4406
+#: builtin/apply.c:4410
 msgid "don't expect at least one line of context"
 msgstr "no esperis almenys una línia de context"
 
-#: builtin/apply.c:4408
+#: builtin/apply.c:4412
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "deixa els trossos rebutjats en fitxers *.reg coresspondents"
 
-#: builtin/apply.c:4410
+#: builtin/apply.c:4414
 msgid "allow overlapping hunks"
 msgstr "permet trossos encavalcants"
 
-#: builtin/apply.c:4413
+#: builtin/apply.c:4417
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "tolera una línia nova incorrectament detectada al final del fitxer"
 
-#: builtin/apply.c:4416
+#: builtin/apply.c:4420
 msgid "do not trust the line counts in the hunk headers"
 msgstr "no confiïs en els recomptes de línia en les capçaleres dels trossos"
 
-#: builtin/apply.c:4418
+#: builtin/apply.c:4422
 msgid "root"
 msgstr "arrel"
 
-#: builtin/apply.c:4419
+#: builtin/apply.c:4423
 msgid "prepend <root> to all filenames"
 msgstr "anteposa <arrel> a tots els noms de fitxer"
 
-#: builtin/apply.c:4441
+#: builtin/apply.c:4445
 msgid "--3way outside a repository"
-msgstr "--3way fora d'un repositori"
+msgstr "--3way fora d'un dipòsit"
 
-#: builtin/apply.c:4449
+#: builtin/apply.c:4453
 msgid "--index outside a repository"
-msgstr "--index fora d'un repositori"
+msgstr "--index fora d'un dipòsit"
 
-#: builtin/apply.c:4452
+#: builtin/apply.c:4456
 msgid "--cached outside a repository"
-msgstr "--cached fora d'un repositori"
+msgstr "--cached fora d'un dipòsit"
 
-#: builtin/apply.c:4468
+#: builtin/apply.c:4472
 #, c-format
 msgid "can't open patch '%s'"
 msgstr "no es pot obrir el pedaç '%s'"
 
-#: builtin/apply.c:4482
+#: builtin/apply.c:4486
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "%d error d'espai en blanc omès"
 msgstr[1] "%d errors d'espai en blanc omesos"
 
-#: builtin/apply.c:4488 builtin/apply.c:4498
+#: builtin/apply.c:4492 builtin/apply.c:4502
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
@@ -2576,7 +2674,7 @@ msgstr "git blame [opcions] [opcions-de-revisió] [revisió] [--] fitxer"
 
 #: builtin/blame.c:35
 msgid "[rev-opts] are documented in git-rev-list(1)"
-msgstr "les [opcions-de-revisió] estàn documentades en git-rev-list(1)"
+msgstr "les [opcions-de-revisió] estan documentades en git-rev-list(1)"
 
 #: builtin/blame.c:2501
 msgid "Show blame entries as we find them, incrementally"
@@ -2584,11 +2682,13 @@ msgstr "Mostra les entrades de culpa mentre les trobem, incrementalment"
 
 #: builtin/blame.c:2502
 msgid "Show blank SHA-1 for boundary commits (Default: off)"
-msgstr "Mostra SHA-1 blanc en comissions de frontera (Per defecte: desactivat)"
+msgstr ""
+"Mostra un SHA-1 blanc peles comissions de frontera (Per defecte: desactivat)"
 
 #: builtin/blame.c:2503
 msgid "Do not treat root commits as boundaries (Default: off)"
-msgstr "No tractis les comissions d'arrel com límits (Per defecte: desactivat)"
+msgstr ""
+"No tractis les comissions d'arrel com a límits (Per defecte: desactivat)"
 
 #: builtin/blame.c:2504
 msgid "Show work cost statistics"
@@ -2617,7 +2717,7 @@ msgstr "Mostra el format de porcellana amb informació de comissió per línia"
 #: builtin/blame.c:2510
 msgid "Use the same output mode as git-annotate (Default: off)"
 msgstr ""
-"Utilitza el mateix mode de sortida que git-annotate (Per defecte: desactivat)"
+"Usa el mateix mode de sortida que git-annotate (Per defecte: desactivat)"
 
 #: builtin/blame.c:2511
 msgid "Show raw timestamp (Default: off)"
@@ -2647,11 +2747,11 @@ msgstr "Gasta cicles extres per a trobar una coincidència millora"
 
 #: builtin/blame.c:2517
 msgid "Use revisions from <file> instead of calling git-rev-list"
-msgstr "Utilitza les revisions de <file> en lloc d'invocar git-rev-list"
+msgstr "Usa les revisions de <fitxer> en lloc d'invocar git-rev-list"
 
 #: builtin/blame.c:2518
 msgid "Use <file>'s contents as the final image"
-msgstr "Utilitza els continguts de <file> com l'imatge final"
+msgstr "Usa els continguts de <fitxer> com a la imatge final"
 
 #: builtin/blame.c:2519 builtin/blame.c:2520
 msgid "score"
@@ -2659,11 +2759,11 @@ msgstr "puntuació"
 
 #: builtin/blame.c:2519
 msgid "Find line copies within and across files"
-msgstr "Troba còpies de línia dins i a través de fitxers"
+msgstr "Troba còpies de línia dins i a través dels fitxers"
 
 #: builtin/blame.c:2520
 msgid "Find line movements within and across files"
-msgstr "Troba moviments de línia dins i a través de fitxers"
+msgstr "Troba moviments de línia dins i a través dels fitxers"
 
 #: builtin/blame.c:2521
 msgid "n,m"
@@ -2671,7 +2771,7 @@ msgstr "n,m"
 
 #: builtin/blame.c:2521
 msgid "Process only line range n,m, counting from 1"
-msgstr "Processa només el rang de línies n,m, contant des de 1"
+msgstr "Processa només el rang de línies n,m, comptant des de 1"
 
 #. TRANSLATORS: This string is used to tell us the maximum
 #. display width for a relative timestamp in "git blame"
@@ -2679,7 +2779,7 @@ msgstr "Processa només el rang de línies n,m, contant des de 1"
 #. takes 22 places, is the longest among various forms of
 #. relative timestamps, but your language may need more or
 #. fewer display columns.
-#: builtin/blame.c:2599
+#: builtin/blame.c:2602
 msgid "4 years, 11 months ago"
 msgstr "fa 4 anys, 11 mesos"
 
@@ -2699,17 +2799,17 @@ msgstr "git branch [opcions] [-r] (-d | -D) <nom-de-rama>..."
 msgid "git branch [options] (-m | -M) [<oldbranch>] <newbranch>"
 msgstr "git branch [opcions] (-m | -M) [<rama-antiga>] <rama-nova>"
 
-#: builtin/branch.c:150
+#: builtin/branch.c:152
 #, c-format
 msgid ""
 "deleting branch '%s' that has been merged to\n"
 "         '%s', but not yet merged to HEAD."
 msgstr ""
 "suprimint la rama '%s' que s'ha fusionat a\n"
-"         '%s', però encara no fusionat a\n"
-"         HEAD."
+"         '%s', però encara no s'ha fusionat\n"
+"         a HEAD."
 
-#: builtin/branch.c:154
+#: builtin/branch.c:156
 #, c-format
 msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
@@ -2719,12 +2819,12 @@ msgstr ""
 "         fusionat a '%s', encara que està fusionat\n"
 "         a HEAD."
 
-#: builtin/branch.c:168
+#: builtin/branch.c:170
 #, c-format
 msgid "Couldn't look up commit object for '%s'"
 msgstr "No s'ha pogut trobar l'objecte de comissió de '%s'"
 
-#: builtin/branch.c:172
+#: builtin/branch.c:174
 #, c-format
 msgid ""
 "The branch '%s' is not fully merged.\n"
@@ -2733,350 +2833,351 @@ msgstr ""
 "La rama '%s' no està totalment fusionada.\n"
 "Si esteu segur que la voleu suprimir, executeu 'git branch -D %s'."
 
-#: builtin/branch.c:185
+#: builtin/branch.c:187
 msgid "Update of config-file failed"
 msgstr "L'actualització del fitxer de configuració ha fallat"
 
-#: builtin/branch.c:213
+#: builtin/branch.c:215
 msgid "cannot use -a with -d"
-msgstr "no es pot utilitzar -a amb -d"
+msgstr "no es pot usar -a amb -d"
 
-#: builtin/branch.c:219
+#: builtin/branch.c:221
 msgid "Couldn't look up commit object for HEAD"
 msgstr "No s'ha pogut trobar l'objecte de comissió de HEAD"
 
-#: builtin/branch.c:227
+#: builtin/branch.c:229
 #, c-format
 msgid "Cannot delete the branch '%s' which you are currently on."
 msgstr "No es pot suprimir la rama '%s' en que esteu actualment."
 
-#: builtin/branch.c:240
+#: builtin/branch.c:245
 #, c-format
 msgid "remote branch '%s' not found."
-msgstr "rama remota '%s' no trobada."
+msgstr "no s'ha trobat la rama remota '%s'."
 
-#: builtin/branch.c:241
+#: builtin/branch.c:246
 #, c-format
 msgid "branch '%s' not found."
-msgstr "rama '%s' no trobada"
+msgstr "no s'ha trobat la rama '%s'."
 
-#: builtin/branch.c:255
+#: builtin/branch.c:260
 #, c-format
 msgid "Error deleting remote branch '%s'"
-msgstr "Error al suprimir la rama remota '%s'"
+msgstr "Error en suprimir la rama remota '%s'"
 
-#: builtin/branch.c:256
+#: builtin/branch.c:261
 #, c-format
 msgid "Error deleting branch '%s'"
-msgstr "Error al suprimir la rama '%s'"
+msgstr "Error en suprimir la rama '%s'"
 
-#: builtin/branch.c:263
+#: builtin/branch.c:268
 #, c-format
 msgid "Deleted remote branch %s (was %s).\n"
 msgstr "S'ha suprimit la rama remota %s (ha estat %s).\n"
 
-#: builtin/branch.c:264
+#: builtin/branch.c:269
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
 msgstr "S'ha suprimit la rama %s (ha estat %s).\n"
 
-#: builtin/branch.c:366
+#: builtin/branch.c:370
 #, c-format
 msgid "branch '%s' does not point at a commit"
 msgstr "la rama '%s' no assenyala una comissió"
 
-#: builtin/branch.c:454
+#: builtin/branch.c:459
 #, c-format
 msgid "[%s: gone]"
-msgstr "[%s: no està]"
+msgstr "[%s: no és]"
 
-#: builtin/branch.c:459
+#: builtin/branch.c:464
 #, c-format
 msgid "[%s]"
 msgstr "[%s]"
 
-#: builtin/branch.c:464
+#: builtin/branch.c:469
 #, c-format
 msgid "[%s: behind %d]"
 msgstr "[%s: darrere per %d]"
 
-#: builtin/branch.c:466
+#: builtin/branch.c:471
 #, c-format
 msgid "[behind %d]"
 msgstr "[darrere de %d]"
 
-#: builtin/branch.c:470
+#: builtin/branch.c:475
 #, c-format
 msgid "[%s: ahead %d]"
 msgstr "[%s: davant per %d]"
 
-#: builtin/branch.c:472
+#: builtin/branch.c:477
 #, c-format
 msgid "[ahead %d]"
-msgstr "[davant per %d]"
+msgstr "[davant de %d]"
 
-#: builtin/branch.c:475
+#: builtin/branch.c:480
 #, c-format
 msgid "[%s: ahead %d, behind %d]"
-msgstr "[%s: davant %d, darrere %d]"
+msgstr "[%s: davant per %d, darrere per %d]"
 
-#: builtin/branch.c:478
+#: builtin/branch.c:483
 #, c-format
 msgid "[ahead %d, behind %d]"
 msgstr "[davant %d, darrere %d]"
 
-#: builtin/branch.c:502
+#: builtin/branch.c:496
 msgid " **** invalid ref ****"
 msgstr " **** referència invàlida ****"
 
-#: builtin/branch.c:594
+#: builtin/branch.c:587
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(cap rama, rebasant %s)"
 
-#: builtin/branch.c:597
+#: builtin/branch.c:590
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(cap rama, bisecció començada en %s)"
 
-#: builtin/branch.c:600
+#: builtin/branch.c:593
 #, c-format
 msgid "(detached from %s)"
 msgstr "(separat de %s)"
 
-#: builtin/branch.c:603
+#: builtin/branch.c:596
 msgid "(no branch)"
 msgstr "(cap rama)"
 
-#: builtin/branch.c:649
+#: builtin/branch.c:643
 #, c-format
 msgid "object '%s' does not point to a commit"
 msgstr "l'objecte '%s' no assenyala cap comissió"
 
-#: builtin/branch.c:681
+#: builtin/branch.c:691
 msgid "some refs could not be read"
-msgstr "algunes referències no s'han pogut llegir"
-
-#: builtin/branch.c:694
-msgid "cannot rename the current branch while not on any."
-msgstr "no es pot canviar el nom de la rama actual mentre no estar en ninguna."
+msgstr "no s'han pogut llegir algunes referències"
 
 #: builtin/branch.c:704
+msgid "cannot rename the current branch while not on any."
+msgstr ""
+"no es pot canviar el nom de la rama actual mentre no estant en ninguna."
+
+#: builtin/branch.c:714
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Nom de rama invàlid: '%s'"
 
-#: builtin/branch.c:719
+#: builtin/branch.c:729
 msgid "Branch rename failed"
 msgstr "El canvi de nom de rama ha fallat"
 
-#: builtin/branch.c:723
+#: builtin/branch.c:733
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "S'ha canviat el nom de la rama malanomenada '%s'"
 
-#: builtin/branch.c:727
+#: builtin/branch.c:737
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "S'ha canviat el nom de la rama a %s, però HEAD no està actualitzat!"
 
-#: builtin/branch.c:734
+#: builtin/branch.c:744
 msgid "Branch is renamed, but update of config-file failed"
 msgstr ""
 "La ramà està canviada de nom, però l'actualització del fitxer de "
 "configuració ha fallat"
 
-#: builtin/branch.c:749
+#: builtin/branch.c:759
 #, c-format
 msgid "malformed object name %s"
 msgstr "nom d'objecte %s malformat"
 
-#: builtin/branch.c:773
+#: builtin/branch.c:783
 #, c-format
 msgid "could not write branch description template: %s"
 msgstr "no s'ha pogut escriure la plantilla de descripció de rama: %s"
 
-#: builtin/branch.c:803
+#: builtin/branch.c:813
 msgid "Generic options"
 msgstr "Opcions genèriques"
 
-#: builtin/branch.c:805
+#: builtin/branch.c:815
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "mostra el hash i el tema, doneu dos vegades per la rama font"
 
-#: builtin/branch.c:806
+#: builtin/branch.c:816
 msgid "suppress informational messages"
 msgstr "omet els missatges informatius"
 
-#: builtin/branch.c:807
+#: builtin/branch.c:817
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "configura el mode de seguiment (veu git-pull(1))"
 
-#: builtin/branch.c:809
+#: builtin/branch.c:819
 msgid "change upstream info"
 msgstr "canvia la informació de font"
 
-#: builtin/branch.c:813
+#: builtin/branch.c:823
 msgid "use colored output"
-msgstr "utilitza sortida colorada"
+msgstr "usa sortida colorada"
 
-#: builtin/branch.c:814
+#: builtin/branch.c:824
 msgid "act on remote-tracking branches"
 msgstr "actua en rames amb seguiment remot"
 
-#: builtin/branch.c:817 builtin/branch.c:823 builtin/branch.c:844
-#: builtin/branch.c:850 builtin/commit.c:1573 builtin/commit.c:1574
-#: builtin/commit.c:1575 builtin/commit.c:1576 builtin/tag.c:615
-#: builtin/tag.c:621
+#: builtin/branch.c:827 builtin/branch.c:833 builtin/branch.c:854
+#: builtin/branch.c:860 builtin/commit.c:1622 builtin/commit.c:1623
+#: builtin/commit.c:1624 builtin/commit.c:1625 builtin/tag.c:616
+#: builtin/tag.c:622
 msgid "commit"
 msgstr "comissió"
 
-#: builtin/branch.c:818 builtin/branch.c:824
+#: builtin/branch.c:828 builtin/branch.c:834
 msgid "print only branches that contain the commit"
 msgstr "imprimeix només les rames que continguin la comissió"
 
-#: builtin/branch.c:830
+#: builtin/branch.c:840
 msgid "Specific git-branch actions:"
 msgstr "Accions de git-branch específiques:"
 
-#: builtin/branch.c:831
+#: builtin/branch.c:841
 msgid "list both remote-tracking and local branches"
 msgstr "llista ambdós les rames amb seguiment remot i les locals"
 
-#: builtin/branch.c:833
+#: builtin/branch.c:843
 msgid "delete fully merged branch"
-msgstr "suprimeix la rama si completament fusionada"
+msgstr "suprimeix la rama si és completament fusionada"
 
-#: builtin/branch.c:834
+#: builtin/branch.c:844
 msgid "delete branch (even if not merged)"
 msgstr "suprimeix la rama (encara que no estigui fusionada)"
 
-#: builtin/branch.c:835
+#: builtin/branch.c:845
 msgid "move/rename a branch and its reflog"
 msgstr "mou/canvia de nom una rama i el seu registre de referència"
 
-#: builtin/branch.c:836
+#: builtin/branch.c:846
 msgid "move/rename a branch, even if target exists"
 msgstr "mou/canvia de nom una rama, encara que el destí existeixi"
 
-#: builtin/branch.c:837
+#: builtin/branch.c:847
 msgid "list branch names"
 msgstr "llista els noms de rama"
 
-#: builtin/branch.c:838
+#: builtin/branch.c:848
 msgid "create the branch's reflog"
 msgstr "crea el registre de referència de la rama"
 
-#: builtin/branch.c:840
+#: builtin/branch.c:850
 msgid "edit the description for the branch"
 msgstr "edita la descripció de la rama"
 
-#: builtin/branch.c:841
+#: builtin/branch.c:851
 msgid "force creation (when already exists)"
 msgstr "força creació (quan ja existeix)"
 
-#: builtin/branch.c:844
+#: builtin/branch.c:854
 msgid "print only not merged branches"
 msgstr "imprimeix només les rames sense fusionar"
 
-#: builtin/branch.c:850
+#: builtin/branch.c:860
 msgid "print only merged branches"
 msgstr "imprimeix només les rames fusionades"
 
-#: builtin/branch.c:854
+#: builtin/branch.c:864
 msgid "list branches in columns"
 msgstr "llista les rames en columnes"
 
-#: builtin/branch.c:867
+#: builtin/branch.c:877
 msgid "Failed to resolve HEAD as a valid ref."
-msgstr "S'ha fallat al resoldre HEAD com referència vàlida."
+msgstr "S'ha fallat en resoldre HEAD com a referència vàlida."
 
-#: builtin/branch.c:872 builtin/clone.c:636
+#: builtin/branch.c:881 builtin/clone.c:634
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD no trobat baix refs/heads!"
 
-#: builtin/branch.c:896
+#: builtin/branch.c:903
 msgid "--column and --verbose are incompatible"
 msgstr "--column i --verbose són incompatibles"
 
-#: builtin/branch.c:902 builtin/branch.c:941
+#: builtin/branch.c:909 builtin/branch.c:948
 msgid "branch name required"
 msgstr "cal el nom de rama"
 
-#: builtin/branch.c:917
+#: builtin/branch.c:924
 msgid "Cannot give description to detached HEAD"
 msgstr "No es pot donar descripció a un HEAD separat"
 
-#: builtin/branch.c:922
+#: builtin/branch.c:929
 msgid "cannot edit description of more than one branch"
 msgstr "no es pot editar la descripció de més d'una rama"
 
-#: builtin/branch.c:929
+#: builtin/branch.c:936
 #, c-format
 msgid "No commit on branch '%s' yet."
-msgstr "Encara cap comissió en la rama '%s'."
+msgstr "Encara no hi ha comissió en la rama '%s'."
 
-#: builtin/branch.c:932
+#: builtin/branch.c:939
 #, c-format
 msgid "No branch named '%s'."
-msgstr "Cap rama amb nom '%s'."
+msgstr "No hi ha rama amb nom '%s'."
 
-#: builtin/branch.c:947
+#: builtin/branch.c:954
 msgid "too many branches for a rename operation"
-msgstr "massa rames per a una operació de canvi de nom"
+msgstr "hi ha massa rames per a una operació de canvi de nom"
 
-#: builtin/branch.c:952
+#: builtin/branch.c:959
 msgid "too many branches to set new upstream"
-msgstr "massa rames per a establir una nova font"
+msgstr "hi ha massa rames per a establir una nova font"
 
-#: builtin/branch.c:956
+#: builtin/branch.c:963
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
 msgstr ""
-"no s'ha pogut establir la font de HEAD com %s quan no assenyala cap rama."
+"no s'ha pogut establir la font de HEAD com a %s quan no assenyala cap rama."
 
-#: builtin/branch.c:959 builtin/branch.c:981 builtin/branch.c:1002
+#: builtin/branch.c:966 builtin/branch.c:988 builtin/branch.c:1009
 #, c-format
 msgid "no such branch '%s'"
-msgstr "cap rama així '%s'"
+msgstr "no hi ha tal rama '%s'"
 
-#: builtin/branch.c:963
+#: builtin/branch.c:970
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "la rama '%s' no existeix"
 
-#: builtin/branch.c:975
+#: builtin/branch.c:982
 msgid "too many branches to unset upstream"
-msgstr "massa rames per a desestablir la font"
+msgstr "hi ha massa rames per a desestablir la font"
 
-#: builtin/branch.c:979
+#: builtin/branch.c:986
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr "no s'ha pogut desestablir la font de HEAD quan no assenyala cap rama."
 
-#: builtin/branch.c:985
+#: builtin/branch.c:992
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "La rama '%s' no té informació de font"
 
-#: builtin/branch.c:999
+#: builtin/branch.c:1006
 msgid "it does not make sense to create 'HEAD' manually"
 msgstr "no té sentit crear 'HEAD' manualment"
 
-#: builtin/branch.c:1005
+#: builtin/branch.c:1012
 msgid "-a and -r options to 'git branch' do not make sense with a branch name"
 msgstr "les opcions -a i -r a 'git branch' no tenen sentit amb un nom de rama"
 
-#: builtin/branch.c:1008
+#: builtin/branch.c:1015
 #, c-format
 msgid ""
 "The --set-upstream flag is deprecated and will be removed. Consider using --"
 "track or --set-upstream-to\n"
 msgstr ""
-"La bandera --set-upstream està desaprovada i es traurà. Considereu utilitzar "
-"--track o --set-upstream-to\n"
+"La bandera --set-upstream està desaprovada i es traurà. Considereu usar --"
+"track o --set-upstream-to\n"
 
-#: builtin/branch.c:1025
+#: builtin/branch.c:1032
 #, c-format
 msgid ""
 "\n"
@@ -3087,12 +3188,12 @@ msgstr ""
 "Si volíeu fer '%s' seguir '%s', feu això:\n"
 "\n"
 
-#: builtin/branch.c:1026
+#: builtin/branch.c:1033
 #, c-format
 msgid "    git branch -d %s\n"
 msgstr "    git branch -d %s\n"
 
-#: builtin/branch.c:1027
+#: builtin/branch.c:1034
 #, c-format
 msgid "    git branch --set-upstream-to %s\n"
 msgstr "    git branch --set-upstream-to %s\n"
@@ -3104,50 +3205,50 @@ msgstr "%s està bé\n"
 
 #: builtin/bundle.c:56
 msgid "Need a repository to create a bundle."
-msgstr "Cal un repositori per fer un embolic."
+msgstr "Cal un dipòsit per a fer un embolic."
 
 #: builtin/bundle.c:60
 msgid "Need a repository to unbundle."
-msgstr "Cal un repositori per desembolicar."
+msgstr "Cal un dipòsit per a desembolicar."
 
-#: builtin/cat-file.c:331
+#: builtin/cat-file.c:332
 msgid "git cat-file (-t|-s|-e|-p|<type>|--textconv) <object>"
 msgstr "git cat-file (-t|-s|-e|-p|<tipus>|--textconv) <objecte>"
 
-#: builtin/cat-file.c:332
+#: builtin/cat-file.c:333
 msgid "git cat-file (--batch|--batch-check) < <list_of_objects>"
 msgstr "git cat-file (--batch|--batch-check) < <llista_de_objectes>"
 
-#: builtin/cat-file.c:369
+#: builtin/cat-file.c:370
 msgid "<type> can be one of: blob, tree, commit, tag"
 msgstr "<tipus> pot ser un de: blob, tree, commit, tag"
 
-#: builtin/cat-file.c:370
+#: builtin/cat-file.c:371
 msgid "show object type"
 msgstr "mostra el tipus de l'objecte"
 
-#: builtin/cat-file.c:371
+#: builtin/cat-file.c:372
 msgid "show object size"
 msgstr "mostra la mida de l'objecte"
 
-#: builtin/cat-file.c:373
+#: builtin/cat-file.c:374
 msgid "exit with zero when there's no error"
 msgstr "surt amb zero quan no hi ha error"
 
-#: builtin/cat-file.c:374
+#: builtin/cat-file.c:375
 msgid "pretty-print object's content"
 msgstr "imprimeix bellament el contingut de l'objecte "
 
-#: builtin/cat-file.c:376
+#: builtin/cat-file.c:377
 msgid "for blob objects, run textconv on object's content"
 msgstr "en els objectes de blob, executa textconv en el contingut de l'objecte"
 
-#: builtin/cat-file.c:378
+#: builtin/cat-file.c:379
 msgid "show info and content of objects fed from the standard input"
 msgstr ""
 "mostra la informació i contingut dels objectes rebuts de l'entrada estàndard"
 
-#: builtin/cat-file.c:381
+#: builtin/cat-file.c:382
 msgid "show info about objects fed from the standard input"
 msgstr "mostra informació sobre els objectes rebuts de l'entrada estàndard"
 
@@ -3166,23 +3267,23 @@ msgstr "informa de tots els atributs establerts en el fitxer"
 
 #: builtin/check-attr.c:20
 msgid "use .gitattributes only from the index"
-msgstr "utilitza .gitattributes només des de l'índex"
+msgstr "usa .gitattributes només des de l'índex"
 
-#: builtin/check-attr.c:21 builtin/check-ignore.c:22 builtin/hash-object.c:75
+#: builtin/check-attr.c:21 builtin/check-ignore.c:22 builtin/hash-object.c:98
 msgid "read file names from stdin"
-msgstr "llegeix els noms de fitxer de stdin"
+msgstr "llegeix els noms de fitxer d'stdin"
 
 #: builtin/check-attr.c:23 builtin/check-ignore.c:24
 msgid "terminate input and output records by a NUL character"
 msgstr "termina els registres d'entrada i de salida per un caràcter NUL"
 
-#: builtin/check-ignore.c:18 builtin/checkout.c:1083 builtin/gc.c:285
+#: builtin/check-ignore.c:18 builtin/checkout.c:1089 builtin/gc.c:274
 msgid "suppress progress reporting"
 msgstr "omet el reportatge de progrés"
 
 #: builtin/check-ignore.c:26
 msgid "show non-matching input paths"
-msgstr "mostra les rutes d'entrada que no coincideixen"
+msgstr "mostra les rutes d'entrada que no coincideixin"
 
 #: builtin/check-ignore.c:28
 msgid "ignore index when checking"
@@ -3218,7 +3319,7 @@ msgstr "git check-mailmap [opcions] <contacte>..."
 
 #: builtin/check-mailmap.c:13
 msgid "also read contacts from stdin"
-msgstr "també llegeix els contactes des de stdin"
+msgstr "també llegeix els contactes des d'stdin"
 
 #: builtin/check-mailmap.c:24
 #, c-format
@@ -3227,7 +3328,7 @@ msgstr "incapaç d'analitzar el contacte: %s"
 
 #: builtin/check-mailmap.c:47
 msgid "no contacts specified"
-msgstr "cap contacte especificat"
+msgstr "no hi ha contactes especificats"
 
 #: builtin/checkout-index.c:126
 msgid "git checkout-index [options] [--] [<file>...]"
@@ -3315,12 +3416,12 @@ msgstr "Incapaç d'afegir el resultat de fusió per a '%s'"
 #: builtin/checkout.c:240
 #, c-format
 msgid "'%s' cannot be used with updating paths"
-msgstr "'%s' no es pot utilitzar al actualitzar rutes"
+msgstr "'%s' no es pot usar amb actualització de rutes"
 
 #: builtin/checkout.c:243 builtin/checkout.c:246
 #, c-format
 msgid "'%s' cannot be used with %s"
-msgstr "'%s' no es pot utilitzar amb %s"
+msgstr "'%s' no es pot usar amb %s"
 
 #: builtin/checkout.c:249
 #, c-format
@@ -3340,46 +3441,46 @@ msgstr "la ruta '%s' està sense fusionar"
 msgid "you need to resolve your current index first"
 msgstr "heu de resoldre el vostre índex actual primer"
 
-#: builtin/checkout.c:591
+#: builtin/checkout.c:597
 #, c-format
 msgid "Can not do reflog for '%s'\n"
 msgstr "No es pot fer reflog per a '%s'\n"
 
-#: builtin/checkout.c:629
+#: builtin/checkout.c:635
 msgid "HEAD is now at"
 msgstr "HEAD ara està a"
 
-#: builtin/checkout.c:636
+#: builtin/checkout.c:642
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Restableix la rama '%s'\n"
 
-#: builtin/checkout.c:639
+#: builtin/checkout.c:645
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Ja en '%s'\n"
 
-#: builtin/checkout.c:643
+#: builtin/checkout.c:649
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
-msgstr "Rama '%s' agafat i restablit\n"
+msgstr "S'ha agafat i restablert la rama '%s'\n"
 
-#: builtin/checkout.c:645 builtin/checkout.c:1026
+#: builtin/checkout.c:651 builtin/checkout.c:1032
 #, c-format
 msgid "Switched to a new branch '%s'\n"
-msgstr "Rama nova '%s' agafada\n"
+msgstr "S'ha agafat la rama nova '%s'\n"
 
-#: builtin/checkout.c:647
+#: builtin/checkout.c:653
 #, c-format
 msgid "Switched to branch '%s'\n"
-msgstr "Rama '%s' agafada\n"
+msgstr "S'ha agafat la rama '%s'\n"
 
-#: builtin/checkout.c:699
+#: builtin/checkout.c:705
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... i %d més.\n"
 
-#: builtin/checkout.c:705
+#: builtin/checkout.c:711
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -3402,7 +3503,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:723
+#: builtin/checkout.c:729
 #, c-format
 msgid ""
 "If you want to keep them by creating a new branch, this may be a good time\n"
@@ -3411,159 +3512,159 @@ msgid ""
 " git branch new_branch_name %s\n"
 "\n"
 msgstr ""
-"Si els voleu retenir per crear una rama nova, ara pot ser una hora bona\n"
-"per fer això amb:\n"
+"Si els voleu retenir per a crear una rama nova, ara pot ser una hora bona\n"
+"per a fer això amb:\n"
 "\n"
 " git branch new_branch_name %s\n"
 "\n"
 
-#: builtin/checkout.c:753
+#: builtin/checkout.c:759
 msgid "internal error in revision walk"
 msgstr "error intern en el passeig per revisions"
 
-#: builtin/checkout.c:757
+#: builtin/checkout.c:763
 msgid "Previous HEAD position was"
 msgstr "La posició de HEAD anterior ha estat"
 
-#: builtin/checkout.c:784 builtin/checkout.c:1021
+#: builtin/checkout.c:790 builtin/checkout.c:1027
 msgid "You are on a branch yet to be born"
-msgstr "Esteu en una rama que encara ha de naixer"
+msgstr "Esteu en una rama que encara ha de nàixer"
 
-#: builtin/checkout.c:928
+#: builtin/checkout.c:934
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "només una referència esperada, %d donades."
 
-#: builtin/checkout.c:967
+#: builtin/checkout.c:973
 #, c-format
 msgid "invalid reference: %s"
 msgstr "referència invàlida: %s"
 
-#: builtin/checkout.c:996
+#: builtin/checkout.c:1002
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "la referéncia no és un arbre: %s"
 
-#: builtin/checkout.c:1035
+#: builtin/checkout.c:1041
 msgid "paths cannot be used with switching branches"
-msgstr "les rutes no es poden utilitzar amb canvi de rama"
+msgstr "les rutes no es poden usar amb canvi de rama"
 
-#: builtin/checkout.c:1038 builtin/checkout.c:1042
+#: builtin/checkout.c:1044 builtin/checkout.c:1048
 #, c-format
 msgid "'%s' cannot be used with switching branches"
-msgstr "'%s' no es pot utilitzar amb canvi de rama"
+msgstr "'%s' no es pot usar amb canvi de rama"
 
-#: builtin/checkout.c:1046 builtin/checkout.c:1049 builtin/checkout.c:1054
-#: builtin/checkout.c:1057
+#: builtin/checkout.c:1052 builtin/checkout.c:1055 builtin/checkout.c:1060
+#: builtin/checkout.c:1063
 #, c-format
 msgid "'%s' cannot be used with '%s'"
-msgstr "'%s' no es pot utilitzar amb '%s'"
+msgstr "'%s' no es pot usar amb '%s'"
 
-#: builtin/checkout.c:1062
+#: builtin/checkout.c:1068
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "No es pot canviar la rama a un no comissió '%s'"
 
-#: builtin/checkout.c:1084 builtin/checkout.c:1086 builtin/clone.c:88
+#: builtin/checkout.c:1090 builtin/checkout.c:1092 builtin/clone.c:89
 #: builtin/remote.c:159 builtin/remote.c:161
 msgid "branch"
 msgstr "rama"
 
-#: builtin/checkout.c:1085
+#: builtin/checkout.c:1091
 msgid "create and checkout a new branch"
 msgstr "crea i agafa una rama nova"
 
-#: builtin/checkout.c:1087
+#: builtin/checkout.c:1093
 msgid "create/reset and checkout a branch"
 msgstr "crea/restableix i agafa una rama"
 
-#: builtin/checkout.c:1088
+#: builtin/checkout.c:1094
 msgid "create reflog for new branch"
-msgstr "Crea un registre de referència per a la rama nova"
+msgstr "crea un registre de referència per a la rama nova"
 
-#: builtin/checkout.c:1089
+#: builtin/checkout.c:1095
 msgid "detach the HEAD at named commit"
 msgstr "separa el HEAD a la comissió anomenada"
 
-#: builtin/checkout.c:1090
+#: builtin/checkout.c:1096
 msgid "set upstream info for new branch"
 msgstr "estableix la informació de font de la rama nova"
 
-#: builtin/checkout.c:1092
+#: builtin/checkout.c:1098
 msgid "new-branch"
-msgstr "nova-rama"
+msgstr "rama-nova"
 
-#: builtin/checkout.c:1092
+#: builtin/checkout.c:1098
 msgid "new unparented branch"
-msgstr "nova rama sense pares"
+msgstr "rama nova sense pares"
 
-#: builtin/checkout.c:1093
+#: builtin/checkout.c:1099
 msgid "checkout our version for unmerged files"
-msgstr "agafa la versió nostra de fitxers sense fusionar"
+msgstr "agafa la versió nostra dels fitxers sense fusionar"
 
-#: builtin/checkout.c:1095
+#: builtin/checkout.c:1101
 msgid "checkout their version for unmerged files"
-msgstr "agafa la versió seva de fitxers sense fusionar"
+msgstr "agafa la versió seva dels fitxers sense fusionar"
 
-#: builtin/checkout.c:1097
+#: builtin/checkout.c:1103
 msgid "force checkout (throw away local modifications)"
 msgstr "agafa a la força (descarta qualsevulles modificacions locals)"
 
-#: builtin/checkout.c:1098
+#: builtin/checkout.c:1104
 msgid "perform a 3-way merge with the new branch"
 msgstr "realitza una fusió de 3 vies amb la rama nova"
 
-#: builtin/checkout.c:1099 builtin/merge.c:225
+#: builtin/checkout.c:1105 builtin/merge.c:226
 msgid "update ignored files (default)"
 msgstr "actualitza els fitxers ignorats (per defecte)"
 
-#: builtin/checkout.c:1100 builtin/log.c:1236 parse-options.h:245
+#: builtin/checkout.c:1106 builtin/log.c:1239 parse-options.h:245
 msgid "style"
 msgstr "estil"
 
-#: builtin/checkout.c:1101
+#: builtin/checkout.c:1107
 msgid "conflict style (merge or diff3)"
 msgstr "estil de conflicte (fusió o diff3)"
 
-#: builtin/checkout.c:1104
+#: builtin/checkout.c:1110
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "no limitis les especificacions de ruta a entrades escasses només"
 
-#: builtin/checkout.c:1106
+#: builtin/checkout.c:1112
 msgid "second guess 'git checkout no-such-branch'"
 msgstr "dubta 'git checkout cap-rama-així'"
 
-#: builtin/checkout.c:1129
+#: builtin/checkout.c:1135
 msgid "-b, -B and --orphan are mutually exclusive"
 msgstr "-b, -B i --orphan són mutualment exclusius"
 
-#: builtin/checkout.c:1146
+#: builtin/checkout.c:1152
 msgid "--track needs a branch name"
 msgstr "--track necessita un nom de rama"
 
-#: builtin/checkout.c:1153
+#: builtin/checkout.c:1157
 msgid "Missing branch name; try -b"
 msgstr "Manca el nom de rama; proveu -b"
 
-#: builtin/checkout.c:1190
+#: builtin/checkout.c:1194
 msgid "invalid path specification"
 msgstr "especificació de ruta invàlida"
 
-#: builtin/checkout.c:1197
+#: builtin/checkout.c:1201
 #, c-format
 msgid ""
 "Cannot update paths and switch to branch '%s' at the same time.\n"
 "Did you intend to checkout '%s' which can not be resolved as commit?"
 msgstr ""
 "No es pot actualitzar rames i canviar a la rama '%s' a la vegada.\n"
-"Volíeu agafar '%s' la qual no es pot resoldre com comissió?"
+"Volíeu agafar '%s' la qual no es pot resoldre com a comissió?"
 
-#: builtin/checkout.c:1202
+#: builtin/checkout.c:1206
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach no accepta un paràmetre de ruta '%s'"
 
-#: builtin/checkout.c:1206
+#: builtin/checkout.c:1210
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -3590,17 +3691,17 @@ msgstr "Trauria %s\n"
 #: builtin/clean.c:32
 #, c-format
 msgid "Skipping repository %s\n"
-msgstr "Saltant el repositori %s\n"
+msgstr "Saltant el dipòsit %s\n"
 
 #: builtin/clean.c:33
 #, c-format
 msgid "Would skip repository %s\n"
-msgstr "Saltaria el repositori %s\n"
+msgstr "Saltaria el dipòsit %s\n"
 
 #: builtin/clean.c:34
 #, c-format
 msgid "failed to remove %s"
-msgstr "s'ha fallat al treure %s"
+msgstr "s'ha fallat en treure %s"
 
 #: builtin/clean.c:295
 msgid ""
@@ -3642,16 +3743,16 @@ msgstr "Perdó (%s)?"
 #: builtin/clean.c:659
 #, c-format
 msgid "Input ignore patterns>> "
-msgstr "Introduïu patrons que ignorar>> "
+msgstr "Introduïu els patrons a ignorar>> "
 
 #: builtin/clean.c:696
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
-msgstr "AVÍS: No es pot trobar ítems que coincideixen amb: %s"
+msgstr "AVÍS: No es pot trobar ítems que coincideixin amb: %s"
 
 #: builtin/clean.c:717
 msgid "Select items to delete"
-msgstr "Selecciona els ítems que suprimir"
+msgstr "Selecciona els ítems a suprimir"
 
 #: builtin/clean.c:757
 #, c-format
@@ -3674,11 +3775,11 @@ msgid ""
 msgstr ""
 "clean               - comença a netejar\n"
 "filter by pattern   - exclou ítems de supressió\n"
-"select by numbers   - selecciona ítems que suprimir per números\n"
-"ask each            - confirma cada supressió (com a \"rm -i\")\n"
+"select by numbers   - selecciona ítems a suprimir per números\n"
+"ask each            - confirma cada supressió (com \"rm -i\")\n"
 "quit                - deixa de netejar\n"
 "help                - aquesta pantalla\n"
-"?                   - ajuda per selecció de l'avís"
+"?                   - ajuda de selecció de l'avís"
 
 #: builtin/clean.c:817
 msgid "*** Commands ***"
@@ -3696,7 +3797,7 @@ msgstr[1] "Trauria els ítems següents:"
 
 #: builtin/clean.c:843
 msgid "No more files to clean, exiting."
-msgstr "No hi ha més fitxers que netejar; sortint."
+msgstr "No hi ha més fitxers a netejar; sortint."
 
 #: builtin/clean.c:874
 msgid "do not print names of files removed"
@@ -3714,14 +3815,14 @@ msgstr "neteja interactiva"
 msgid "remove whole directories"
 msgstr "treu directoris enters"
 
-#: builtin/clean.c:880 builtin/describe.c:406 builtin/grep.c:714
+#: builtin/clean.c:880 builtin/describe.c:407 builtin/grep.c:714
 #: builtin/ls-files.c:486 builtin/name-rev.c:311 builtin/show-ref.c:185
 msgid "pattern"
 msgstr "patró"
 
 #: builtin/clean.c:881
 msgid "add <pattern> to ignore rules"
-msgstr "afegiu <patró> per ignorar les regles"
+msgstr "afegiu <patró> per a ignorar les regles"
 
 #: builtin/clean.c:882
 msgid "remove ignored files, too"
@@ -3733,163 +3834,163 @@ msgstr "treu només els fitxers ignorats"
 
 #: builtin/clean.c:902
 msgid "-x and -X cannot be used together"
-msgstr "-x i -X no es poden utilitzar junts"
+msgstr "-x i -X no es poden usar junts"
 
 #: builtin/clean.c:906
 msgid ""
 "clean.requireForce set to true and neither -i, -n, nor -f given; refusing to "
 "clean"
 msgstr ""
-"clean.requireForce estaberta a veritat i ni -i, -n ni -f donat; refusant "
-"netejar"
+"clean.requireForce està establerta a veritat i ni -i, -n ni -f s'ha donat; "
+"refusant netejar"
 
 #: builtin/clean.c:909
 msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
 msgstr ""
-"clean.requireForce és per defecte veritat i ni -i, -n ni -f donat; refusant "
-"netejar"
+"clean.requireForce és per defecte veritat i ni -i, -n ni -f s'ha donat; "
+"refusant netejar"
 
-#: builtin/clone.c:36
+#: builtin/clone.c:37
 msgid "git clone [options] [--] <repo> [<dir>]"
-msgstr "git clone [opcions] [--] <repositori> [<directori>]"
+msgstr "git clone [opcions] [--] <dipòsit> [<directori>]"
 
-#: builtin/clone.c:64 builtin/fetch.c:112 builtin/merge.c:222
-#: builtin/push.c:503
+#: builtin/clone.c:65 builtin/fetch.c:112 builtin/merge.c:223
+#: builtin/push.c:514
 msgid "force progress reporting"
 msgstr "força l'informe de progrés"
 
-#: builtin/clone.c:66
+#: builtin/clone.c:67
 msgid "don't create a checkout"
 msgstr "no fes una agafada"
 
-#: builtin/clone.c:67 builtin/clone.c:69 builtin/init-db.c:486
+#: builtin/clone.c:68 builtin/clone.c:70 builtin/init-db.c:488
 msgid "create a bare repository"
-msgstr "crea un repositori nu"
+msgstr "crea un dipòsit nu"
 
-#: builtin/clone.c:71
+#: builtin/clone.c:72
 msgid "create a mirror repository (implies bare)"
-msgstr "crea un repositori reflectit (implica nu)"
+msgstr "crea un dipòsit reflectit (implica bare)"
 
-#: builtin/clone.c:73
+#: builtin/clone.c:74
 msgid "to clone from a local repository"
-msgstr "per a clonar des d'un repositori local"
+msgstr "per a clonar des d'un dipòsit local"
 
-#: builtin/clone.c:75
+#: builtin/clone.c:76
 msgid "don't use local hardlinks, always copy"
-msgstr "no utilitzeu enllaços durs locals, sempre copia"
+msgstr "no usis enllaços durs locals, sempre copia"
 
-#: builtin/clone.c:77
+#: builtin/clone.c:78
 msgid "setup as shared repository"
-msgstr "configura com repositori compartit"
+msgstr "configura com a dipòsit compartit"
 
-#: builtin/clone.c:79 builtin/clone.c:81
+#: builtin/clone.c:80 builtin/clone.c:82
 msgid "initialize submodules in the clone"
 msgstr "initialitza els submòduls en el clon"
 
-#: builtin/clone.c:82 builtin/init-db.c:483
+#: builtin/clone.c:83 builtin/init-db.c:485
 msgid "template-directory"
 msgstr "directori-de-plantilla"
 
-#: builtin/clone.c:83 builtin/init-db.c:484
+#: builtin/clone.c:84 builtin/init-db.c:486
 msgid "directory from which templates will be used"
-msgstr "directori del qual les plantilles s'utilitzaran"
+msgstr "directori del qual les plantilles s'usaran"
 
-#: builtin/clone.c:85
+#: builtin/clone.c:86
 msgid "reference repository"
-msgstr "repositori de referència"
+msgstr "dipòsit de referència"
 
-#: builtin/clone.c:86 builtin/column.c:26 builtin/merge-file.c:44
+#: builtin/clone.c:87 builtin/column.c:26 builtin/merge-file.c:44
 msgid "name"
 msgstr "nom"
 
-#: builtin/clone.c:87
+#: builtin/clone.c:88
 msgid "use <name> instead of 'origin' to track upstream"
-msgstr "utilitza <nom> en lloc de 'origin' per seguir la font"
+msgstr "usa <nom> en lloc de 'origin' per a seguir la font"
 
-#: builtin/clone.c:89
+#: builtin/clone.c:90
 msgid "checkout <branch> instead of the remote's HEAD"
 msgstr "agafa <rama> en lloc del HEAD del remot"
 
-#: builtin/clone.c:91
+#: builtin/clone.c:92
 msgid "path to git-upload-pack on the remote"
 msgstr "ruta a git-upload-pack en el remot"
 
-#: builtin/clone.c:92 builtin/fetch.c:113 builtin/grep.c:659
+#: builtin/clone.c:93 builtin/fetch.c:113 builtin/grep.c:659
 msgid "depth"
 msgstr "profunditat"
 
-#: builtin/clone.c:93
+#: builtin/clone.c:94
 msgid "create a shallow clone of that depth"
 msgstr "crea un clon superficial de tal profunditat"
 
-#: builtin/clone.c:95
+#: builtin/clone.c:96
 msgid "clone only one branch, HEAD or --branch"
-msgstr "cona només una rama, HEAD o --branch"
+msgstr "clona només una rama, HEAD o --branch"
 
-#: builtin/clone.c:96 builtin/init-db.c:492
+#: builtin/clone.c:97 builtin/init-db.c:494
 msgid "gitdir"
 msgstr "directori de git"
 
-#: builtin/clone.c:97 builtin/init-db.c:493
+#: builtin/clone.c:98 builtin/init-db.c:495
 msgid "separate git dir from working tree"
 msgstr "separa el directori de git de l'arbre de treball"
 
-#: builtin/clone.c:98
+#: builtin/clone.c:99
 msgid "key=value"
 msgstr "calu=valor"
 
-#: builtin/clone.c:99
+#: builtin/clone.c:100
 msgid "set config inside the new repository"
-msgstr "estableix la configuració dins del repositori nou"
+msgstr "estableix la configuració dins del dipòsit nou"
 
-#: builtin/clone.c:252
+#: builtin/clone.c:253
 #, c-format
 msgid "reference repository '%s' is not a local repository."
-msgstr "el repositori de referència '%s' no és un repositori local."
+msgstr "el dipòsit de referència '%s' no és un dipòsit local."
 
-#: builtin/clone.c:256
+#: builtin/clone.c:257
 #, c-format
 msgid "reference repository '%s' is shallow"
-msgstr "el repositori de referència '%s' és superficial"
+msgstr "el dipòsit de referència '%s' és superficial"
 
-#: builtin/clone.c:259
+#: builtin/clone.c:260
 #, c-format
 msgid "reference repository '%s' is grafted"
-msgstr "el repositori de referència '%s' és empeltat"
+msgstr "el dipòsit de referència '%s' és empeltat"
 
-#: builtin/clone.c:321
+#: builtin/clone.c:322
 #, c-format
 msgid "failed to create directory '%s'"
-msgstr "s'ha fallat al crear el directori '%s'"
+msgstr "s'ha fallat en crear el directori '%s'"
 
-#: builtin/clone.c:323 builtin/diff.c:83
+#: builtin/clone.c:324 builtin/diff.c:84
 #, c-format
 msgid "failed to stat '%s'"
-msgstr "s'ha fallat al fer stat a '%s'"
+msgstr "s'ha fallat en fer stat a '%s'"
 
-#: builtin/clone.c:325
+#: builtin/clone.c:326
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s existeix i no és un directori"
 
-#: builtin/clone.c:339
+#: builtin/clone.c:340
 #, c-format
 msgid "failed to stat %s\n"
-msgstr "s'ha fallat al fer stat a '%s'\n"
+msgstr "s'ha fallat en fer stat a '%s'\n"
 
-#: builtin/clone.c:361
+#: builtin/clone.c:362
 #, c-format
 msgid "failed to create link '%s'"
-msgstr "s'ha fallat al crear l'enllaç '%s'"
+msgstr "s'ha fallat en crear l'enllaç '%s'"
 
-#: builtin/clone.c:365
+#: builtin/clone.c:366
 #, c-format
 msgid "failed to copy file to '%s'"
-msgstr "s'ha fallat al copiar el fitxer a '%s'"
+msgstr "s'ha fallat en copiar el fitxer a '%s'"
 
-#: builtin/clone.c:388 builtin/clone.c:565
+#: builtin/clone.c:389 builtin/clone.c:563
 #, c-format
 msgid "done.\n"
 msgstr "fet.\n"
@@ -3900,116 +4001,116 @@ msgid ""
 "You can inspect what was checked out with 'git status'\n"
 "and retry the checkout with 'git checkout -f HEAD'\n"
 msgstr ""
-"La clonació ha tingut éxit, però l'agafada ha fallat.\n"
+"La clonació ha tingut èxit, però l'agafada ha fallat.\n"
 "Podeu inspeccionar què s'ha agafat amb 'git status' i\n"
-"reintentar l'agafada amb 'git checkout -f HEAD'\n"
+"tornar a intentar l'agafada amb 'git checkout -f HEAD'\n"
 
-#: builtin/clone.c:480
+#: builtin/clone.c:478
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "No s'ha pogut trobar la rama remota %s per a clonar."
 
-#: builtin/clone.c:560
+#: builtin/clone.c:558
 #, c-format
 msgid "Checking connectivity... "
 msgstr "Provant connectivitat... "
 
-#: builtin/clone.c:563
+#: builtin/clone.c:561
 msgid "remote did not send all necessary objects"
 msgstr "el remot no ha enviat tots els objectes necessaris"
 
-#: builtin/clone.c:627
+#: builtin/clone.c:625
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "el HEAD remot es refereix a una referència que no existeix; incapaç "
 "d'agafar.\n"
 
-#: builtin/clone.c:658
+#: builtin/clone.c:656
 msgid "unable to checkout working tree"
 msgstr "incapaç d'agafar l'arbre de treball"
 
-#: builtin/clone.c:768
+#: builtin/clone.c:765
 msgid "Too many arguments."
-msgstr "Massa paràmetres."
+msgstr "Hi ha massa paràmetres."
 
-#: builtin/clone.c:772
+#: builtin/clone.c:769
 msgid "You must specify a repository to clone."
-msgstr "Heu d'especificar un repositori que clonar."
+msgstr "Heu d'especificar un dipòsit per a clonar."
 
-#: builtin/clone.c:783
+#: builtin/clone.c:780
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "les opcions --bare i --origin %s són incompatibles."
 
-#: builtin/clone.c:786
+#: builtin/clone.c:783
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "--bare i --separate-git-dir són incompatibles."
 
-#: builtin/clone.c:799
+#: builtin/clone.c:796
 #, c-format
 msgid "repository '%s' does not exist"
-msgstr "el repositori '%s' no existeix"
+msgstr "el dipòsit '%s' no existeix"
 
-#: builtin/clone.c:805 builtin/fetch.c:1143
+#: builtin/clone.c:802 builtin/fetch.c:1155
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "la profunditat %s no és nombre positiu"
 
-#: builtin/clone.c:815
+#: builtin/clone.c:812
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "la ruta destí '%s' ja existeix i no és un directori buit."
 
-#: builtin/clone.c:825
+#: builtin/clone.c:822
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "l'arbre de treball '%s' ja existeix."
 
-#: builtin/clone.c:838 builtin/clone.c:850
+#: builtin/clone.c:835 builtin/clone.c:847
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "no s'ha pogut crear els directoris inicials de '%s'"
 
-#: builtin/clone.c:841
+#: builtin/clone.c:838
 #, c-format
 msgid "could not create work tree dir '%s'."
 msgstr "no s'ha pogut crear el directori d'arbre de treball '%s'."
 
-#: builtin/clone.c:860
+#: builtin/clone.c:857
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
-msgstr "Clonant al repositori nu '%s'...\n"
+msgstr "Clonant al dipòsit nu '%s'...\n"
 
-#: builtin/clone.c:862
+#: builtin/clone.c:859
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Clonant a '%s'...\n"
 
-#: builtin/clone.c:898
+#: builtin/clone.c:895
 msgid "--depth is ignored in local clones; use file:// instead."
-msgstr "--depth s'ignora en clons locals; utilitzeu file:// en lloc."
+msgstr "--depth s'ignora en els clons locals; useu file:// en lloc."
 
-#: builtin/clone.c:901
+#: builtin/clone.c:898
 msgid "source repository is shallow, ignoring --local"
-msgstr "el repositori font és superficial, ignorant --local"
+msgstr "el dipòsit font és superficial, ignorant --local"
 
-#: builtin/clone.c:906
+#: builtin/clone.c:903
 msgid "--local is ignored"
 msgstr "--local s'ignora"
 
-#: builtin/clone.c:910
+#: builtin/clone.c:907
 #, c-format
 msgid "Don't know how to clone %s"
 msgstr "No es sap com clonar %s"
 
-#: builtin/clone.c:961 builtin/clone.c:969
+#: builtin/clone.c:958 builtin/clone.c:966
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "La rama remota %s no es troba en la font %s"
 
-#: builtin/clone.c:972
+#: builtin/clone.c:969
 msgid "You appear to have cloned an empty repository."
-msgstr "Sembla que heu clonat un repositori buit."
+msgstr "Sembla que heu clonat un dipòsit buit."
 
 #: builtin/column.c:9
 msgid "git column [options]"
@@ -4021,7 +4122,7 @@ msgstr "cerca els variables de configuració"
 
 #: builtin/column.c:27 builtin/column.c:28
 msgid "layout to use"
-msgstr "pla que utilitzar"
+msgstr "pla a usar"
 
 #: builtin/column.c:29
 msgid "Maximum width"
@@ -4043,15 +4144,42 @@ msgstr "Espai d'encoixinada entre columnes"
 msgid "--command must be the first argument"
 msgstr "--command ha de ser el primer paràmetre"
 
-#: builtin/commit.c:36
+#: builtin/commit.c:37
 msgid "git commit [options] [--] <pathspec>..."
 msgstr "git commit [opcions] [--] <especificació-de-ruta>..."
 
-#: builtin/commit.c:41
+#: builtin/commit.c:42
 msgid "git status [options] [--] <pathspec>..."
 msgstr "git status [opcions] [--] <especificació-de-ruta>..."
 
-#: builtin/commit.c:46
+#: builtin/commit.c:47
+msgid ""
+"Your name and email address were configured automatically based\n"
+"on your username and hostname. Please check that they are accurate.\n"
+"You can suppress this message by setting them explicitly. Run the\n"
+"following command and follow the instructions in your editor to edit\n"
+"your configuration file:\n"
+"\n"
+"    git config --global --edit\n"
+"\n"
+"After doing this, you may fix the identity used for this commit with:\n"
+"\n"
+"    git commit --amend --reset-author\n"
+msgstr ""
+"S'han configurat el vostre nom i adreça de correu electrònic\n"
+"automàticament basats en el vostre nom d'usuari i nom de host. Si us\n"
+"plau, comproveu que siguin correctes. Podeu suprimir aquest missatge\n"
+"per establir-los explícitament. Executeu l'ordre següent i seguiu les\n"
+"instruccions en el vostre editor per editar el vostre fitxer de\n"
+"configuració:\n"
+"\n"
+"    git config --global --edit\n"
+"Després de fer això, podeu arreglar la identitat usada per a aquesta\n"
+"comissió amb:\n"
+"\n"
+"    git commit --amend --reset-author\n"
+
+#: builtin/commit.c:60
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -4072,12 +4200,12 @@ msgstr ""
 "    git config --global user.name \"El Vostre Nom\"\n"
 "    git config --global user.email tu@example.com\n"
 "\n"
-"Després de fer això, podeu arreglar la identitat utilitzada per a\n"
-"aquesta comissió amb:\n"
+"Després de fer això, podeu arreglar la identitat usada per a aquesta\n"
+"comissió amb:\n"
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: builtin/commit.c:58
+#: builtin/commit.c:72
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -4087,7 +4215,7 @@ msgstr ""
 "buida. Podeu repetir el vostre ordre amb --allow-empty, o podeu\n"
 "treure la comissió per complet amb \"git reset HEAD^\".\n"
 
-#: builtin/commit.c:63
+#: builtin/commit.c:77
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -4097,16 +4225,16 @@ msgid ""
 msgstr ""
 "El recull de cireres previ ja està buit, possiblement a causa de resolució "
 "de conflicte.\n"
-"Si el voleu cometre de totes maneres, utilitzeu:\n"
+"Si el voleu cometre de totes maneres, useu:\n"
 "\n"
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:70
+#: builtin/commit.c:84
 msgid "Otherwise, please use 'git reset'\n"
-msgstr "D'altra manera, si us plau, utilitzeu 'git reset'\n"
+msgstr "D'altra manera, si us plau, useu 'git reset'\n"
 
-#: builtin/commit.c:73
+#: builtin/commit.c:87
 msgid ""
 "If you wish to skip this commit, use:\n"
 "\n"
@@ -4115,109 +4243,126 @@ msgid ""
 "Then \"git cherry-pick --continue\" will resume cherry-picking\n"
 "the remaining commits.\n"
 msgstr ""
-"Si voleu saltar aquesta comissió, utilitzeu:\n"
+"Si voleu saltar aquesta comissió, useu:\n"
 "\n"
 "    git reset\n"
 "\n"
 "Llavors \"git cherry-pick --continue\" reprendrà recollint\n"
 "com cireres les comissions restants.\n"
 
-#: builtin/commit.c:288
+#: builtin/commit.c:302
 msgid "failed to unpack HEAD tree object"
-msgstr "s'ha fallat al desempaquetar l'objecte d'arbre HEAD"
+msgstr "s'ha fallat en desempaquetar l'objecte d'arbre HEAD"
 
-#: builtin/commit.c:328
+#: builtin/commit.c:342
 msgid "unable to create temporary index"
 msgstr "incapaç de crear un índex temporal"
 
-#: builtin/commit.c:334
+#: builtin/commit.c:348
 msgid "interactive add failed"
 msgstr "l'afegiment interactiu ha fallat"
 
-#: builtin/commit.c:366 builtin/commit.c:387 builtin/commit.c:435
+#: builtin/commit.c:359
+msgid "unable to write index file"
+msgstr "incapaç d'escriure el fitxer d'índex"
+
+#: builtin/commit.c:361
+msgid "unable to update temporary index"
+msgstr "incapaç de actualitzar l'índex temporal"
+
+#: builtin/commit.c:363
+msgid "Failed to update main cache tree"
+msgstr "S'ha fallat en actualitzar l'arbre principal de memòria cau"
+
+#: builtin/commit.c:387 builtin/commit.c:412 builtin/commit.c:461
 msgid "unable to write new_index file"
 msgstr "incapaç d'escriure el fitxer new_index"
 
-#: builtin/commit.c:418
+#: builtin/commit.c:443
 msgid "cannot do a partial commit during a merge."
 msgstr "no es pot fer una comissió parcial durant una fusió."
 
-#: builtin/commit.c:420
+#: builtin/commit.c:445
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr "no es pot fer una comissió parcial durant un recull de cireres."
 
-#: builtin/commit.c:429
+#: builtin/commit.c:454
 msgid "cannot read the index"
 msgstr "no es pot llegir l'índex"
 
-#: builtin/commit.c:447
+#: builtin/commit.c:473
 msgid "unable to write temporary index file"
 msgstr "incapaç d'escriure un fitxer d'índex temporal"
 
-#: builtin/commit.c:557 builtin/commit.c:563
+#: builtin/commit.c:592
 #, c-format
-msgid "invalid commit: %s"
-msgstr "comissió invàlida: %s"
+msgid "commit '%s' lacks author header"
+msgstr "a la comissió '%s' li manca la capçalera d'autor"
 
-#: builtin/commit.c:585
+#: builtin/commit.c:594
+#, c-format
+msgid "commit '%s' has malformed author line"
+msgstr "la comissió '%s' té una línia d'autor malformada"
+
+#: builtin/commit.c:613
 msgid "malformed --author parameter"
 msgstr "paràmetre --author malformat"
 
-#: builtin/commit.c:592
+#: builtin/commit.c:621
 #, c-format
 msgid "invalid date format: %s"
 msgstr "format de data invàlid: %s"
 
-#: builtin/commit.c:609
+#: builtin/commit.c:642
 #, c-format
 msgid "Malformed ident string: '%s'"
 msgstr "Cadena d'identificació malformada: '%s'"
 
-#: builtin/commit.c:642
+#: builtin/commit.c:675
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
 msgstr ""
 "incapaç de seleccionar un caràcter de comentari que\n"
-"no sigui utilitzat en el missatge de comissió actual"
+"no sigui usat en el missatge de comissió actual"
 
-#: builtin/commit.c:679 builtin/commit.c:712 builtin/commit.c:1086
+#: builtin/commit.c:712 builtin/commit.c:745 builtin/commit.c:1120
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "no s'ha pogut trobar la comissió %s"
 
-#: builtin/commit.c:691 builtin/shortlog.c:273
+#: builtin/commit.c:724 builtin/shortlog.c:273
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(llegint el missatge de registre de l'entrada estàndard)\n"
 
-#: builtin/commit.c:693
+#: builtin/commit.c:726
 msgid "could not read log from standard input"
 msgstr "no s'ha pogut llegir de l'entrada estàndard"
 
-#: builtin/commit.c:697
+#: builtin/commit.c:730
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "no s'ha pogut llegir el fitxer de registre '%s'"
 
-#: builtin/commit.c:719
+#: builtin/commit.c:752
 msgid "could not read MERGE_MSG"
 msgstr "no s'ha pogut llegir MERGE_MSG"
 
-#: builtin/commit.c:723
+#: builtin/commit.c:756
 msgid "could not read SQUASH_MSG"
 msgstr "no s'ha pogur llegir SQUASH_MSG"
 
-#: builtin/commit.c:727
+#: builtin/commit.c:760
 #, c-format
 msgid "could not read '%s'"
 msgstr "no s'ha pogut llegir '%s'"
 
-#: builtin/commit.c:798
+#: builtin/commit.c:831
 msgid "could not write commit template"
 msgstr "no s'ha pogut escriure la plantilla de comissió"
 
-#: builtin/commit.c:816
+#: builtin/commit.c:849
 #, c-format
 msgid ""
 "\n"
@@ -4232,7 +4377,7 @@ msgstr ""
 "\t%s\n"
 "i intenteu de nou.\n"
 
-#: builtin/commit.c:821
+#: builtin/commit.c:854
 #, c-format
 msgid ""
 "\n"
@@ -4247,7 +4392,7 @@ msgstr ""
 "\t%s\n"
 "i intenteu de nou.\n"
 
-#: builtin/commit.c:834
+#: builtin/commit.c:867
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -4257,7 +4402,7 @@ msgstr ""
 "S'ignoraran les línies començant amb '%c', i un missatge de\n"
 "comissió buit avorta la comissió.\n"
 
-#: builtin/commit.c:841
+#: builtin/commit.c:874
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -4268,148 +4413,146 @@ msgstr ""
 "Es retindran les línies començants amb '%c'; podeu treure'ls per vós\n"
 "mateix si voleu. Un missatge buit avorta la comissió.\n"
 
-#: builtin/commit.c:855
+#: builtin/commit.c:888
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sAutor:    %.*s <%.*s>"
 
-#: builtin/commit.c:863
+#: builtin/commit.c:896
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sData:      %s"
 
-#: builtin/commit.c:870
+#: builtin/commit.c:903
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sComitent: %.*s <%.*s>"
 
-#: builtin/commit.c:888
+#: builtin/commit.c:921
 msgid "Cannot read index"
 msgstr "No es pot llegir l'índex"
 
-#: builtin/commit.c:945
+#: builtin/commit.c:978
 msgid "Error building trees"
-msgstr "Error al construir arbres"
+msgstr "Error en construir arbres"
 
-#: builtin/commit.c:960 builtin/tag.c:495
+#: builtin/commit.c:993 builtin/tag.c:495
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
-msgstr ""
-"Si us plau, proveïu el missatge utilitzant l'opció o -m o l'opció -F.\n"
+msgstr "Si us plau, proveïu el missatge per usar o l'opció -m o l'opció -F.\n"
 
-#: builtin/commit.c:1061
+#: builtin/commit.c:1095
 #, c-format
 msgid "No existing author found with '%s'"
 msgstr "Cap autor existent trobat amb '%s'"
 
-#: builtin/commit.c:1076 builtin/commit.c:1316
+#: builtin/commit.c:1110 builtin/commit.c:1350
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Mode de fitxers no seguits invàlid '%s'"
 
-#: builtin/commit.c:1113
+#: builtin/commit.c:1147
 msgid "--long and -z are incompatible"
 msgstr "--long i -z són incompatibles"
 
-#: builtin/commit.c:1143
+#: builtin/commit.c:1177
 msgid "Using both --reset-author and --author does not make sense"
-msgstr "Utilitzar ambdós --reset-author i --author no té sentit"
+msgstr "Usar ambdós --reset-author i --author no té sentit"
 
-#: builtin/commit.c:1152
+#: builtin/commit.c:1186
 msgid "You have nothing to amend."
-msgstr "No teniu res que esmenar."
+msgstr "No teniu res a esmenar."
 
-#: builtin/commit.c:1155
+#: builtin/commit.c:1189
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Esteu en el medi d'una fusió -- no es pot esmenar."
 
-#: builtin/commit.c:1157
+#: builtin/commit.c:1191
 msgid "You are in the middle of a cherry-pick -- cannot amend."
-msgstr "Esteu en el medi d'una cherry-pick -- no es pot esmenar."
+msgstr "Esteu en el medi d'un recull de cireres -- no es pot esmenar."
 
-#: builtin/commit.c:1160
+#: builtin/commit.c:1194
 msgid "Options --squash and --fixup cannot be used together"
-msgstr "Les opcions --squash i --fixup no es poden utilitzar junts"
+msgstr "Les opcions --squash i --fixup no es poden usar junts"
 
-#: builtin/commit.c:1170
+#: builtin/commit.c:1204
 msgid "Only one of -c/-C/-F/--fixup can be used."
-msgstr "Només un de -c/-C/-F/--fixup es pot utilitzar."
+msgstr "Només un de -c/-C/-F/--fixup es pot usar."
 
-#: builtin/commit.c:1172
+#: builtin/commit.c:1206
 msgid "Option -m cannot be combined with -c/-C/-F/--fixup."
 msgstr "L'opció -m no es pot combinar amb -c/-C/-F/--fixup."
 
-#: builtin/commit.c:1180
+#: builtin/commit.c:1214
 msgid "--reset-author can be used only with -C, -c or --amend."
-msgstr "--reset-author només es pot utilitzar amb -C, -c o --amend."
+msgstr "--reset-author només es pot usar amb -C, -c o --amend."
 
-#: builtin/commit.c:1197
+#: builtin/commit.c:1231
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
-msgstr ""
-"Només un de --include/--only/--all/--interactive/--patch es pot utilitzar."
+msgstr "Només un de --include/--only/--all/--interactive/--patch es pot usar."
 
-#: builtin/commit.c:1199
+#: builtin/commit.c:1233
 msgid "No paths with --include/--only does not make sense."
 msgstr "--include/--only no té sentit sense ruta."
 
-#: builtin/commit.c:1201
+#: builtin/commit.c:1235
 msgid "Clever... amending the last one with dirty index."
-msgstr "Intel·ligent... esmenant el últim amb índex brut"
+msgstr "Intel·ligent...esmenant el últim amb índex brut."
 
-#: builtin/commit.c:1203
+#: builtin/commit.c:1237
 msgid "Explicit paths specified without -i or -o; assuming --only paths..."
 msgstr ""
-"Rutes explícites especificades sense -i o -o; presumint rutes --only..."
+"S'han especificat rutes explícites sense -i o -o; presumint rutes --only..."
 
-#: builtin/commit.c:1215 builtin/tag.c:727
+#: builtin/commit.c:1249 builtin/tag.c:728
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Mode de neteja invàlid %s"
 
-#: builtin/commit.c:1220
+#: builtin/commit.c:1254
 msgid "Paths with -a does not make sense."
 msgstr "-a no té sentit amb rutes."
 
-#: builtin/commit.c:1330 builtin/commit.c:1595
+#: builtin/commit.c:1364 builtin/commit.c:1644
 msgid "show status concisely"
 msgstr "mostra l'estat concisament"
 
-#: builtin/commit.c:1332 builtin/commit.c:1597
+#: builtin/commit.c:1366 builtin/commit.c:1646
 msgid "show branch information"
 msgstr "mostra la informació de rama"
 
-#: builtin/commit.c:1334 builtin/commit.c:1599 builtin/push.c:489
+#: builtin/commit.c:1368 builtin/commit.c:1648 builtin/push.c:500
 msgid "machine-readable output"
 msgstr "sortida llegible per màquina"
 
-#: builtin/commit.c:1337 builtin/commit.c:1601
+#: builtin/commit.c:1371 builtin/commit.c:1650
 msgid "show status in long format (default)"
 msgstr "mostra l'estat en format llarg (per defecte)"
 
-#: builtin/commit.c:1340 builtin/commit.c:1604
+#: builtin/commit.c:1374 builtin/commit.c:1653
 msgid "terminate entries with NUL"
 msgstr "termina les entrades amb NUL"
 
-#: builtin/commit.c:1342 builtin/commit.c:1607 builtin/fast-export.c:703
-#: builtin/fast-export.c:706 builtin/tag.c:602
+#: builtin/commit.c:1376 builtin/commit.c:1656 builtin/fast-export.c:980
+#: builtin/fast-export.c:983 builtin/tag.c:603
 msgid "mode"
 msgstr "mode"
 
-#: builtin/commit.c:1343 builtin/commit.c:1607
+#: builtin/commit.c:1377 builtin/commit.c:1656
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "mostra els fitxers no seguits, modes opcional: all, normal, no. (Per "
 "defecte: all)"
 
-#: builtin/commit.c:1346
+#: builtin/commit.c:1380
 msgid "show ignored files"
 msgstr "mostra els fitxers ignorats"
 
-#: builtin/commit.c:1347 parse-options.h:153
+#: builtin/commit.c:1381 parse-options.h:153
 msgid "when"
 msgstr "quan"
 
-#: builtin/commit.c:1348
+#: builtin/commit.c:1382
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -4417,227 +4560,219 @@ msgstr ""
 "ignora els canvis als submòduls, opcional quan: all, dirty, untracked. (Per "
 "defecte: all)"
 
-#: builtin/commit.c:1350
+#: builtin/commit.c:1384
 msgid "list untracked files in columns"
 msgstr "mostra els fitxers no seguits en columnes"
 
-#: builtin/commit.c:1419
+#: builtin/commit.c:1471
 msgid "couldn't look up newly created commit"
 msgstr "no s'ha pogut trobar la comissió novament creat"
 
-#: builtin/commit.c:1421
+#: builtin/commit.c:1473
 msgid "could not parse newly created commit"
 msgstr "no s'ha pogut analitzar la comissió novament creat"
 
-#: builtin/commit.c:1469
+#: builtin/commit.c:1518
 msgid "detached HEAD"
 msgstr "HEAD separat"
 
-#: builtin/commit.c:1471
+#: builtin/commit.c:1521
 msgid " (root-commit)"
 msgstr " (comissió d'arrel)"
 
-#: builtin/commit.c:1565
+#: builtin/commit.c:1614
 msgid "suppress summary after successful commit"
 msgstr "omet el resum després d'una comissió reexita"
 
-#: builtin/commit.c:1566
+#: builtin/commit.c:1615
 msgid "show diff in commit message template"
 msgstr "mostra la diferència en la plantilla de missatge de comissió"
 
-#: builtin/commit.c:1568
+#: builtin/commit.c:1617
 msgid "Commit message options"
 msgstr "Opcions de missatge de comissió"
 
-#: builtin/commit.c:1569 builtin/tag.c:600
+#: builtin/commit.c:1618 builtin/tag.c:601
 msgid "read message from file"
 msgstr "llegiu el missatge des d'un fitxer"
 
-#: builtin/commit.c:1570
+#: builtin/commit.c:1619
 msgid "author"
 msgstr "autor"
 
-#: builtin/commit.c:1570
+#: builtin/commit.c:1619
 msgid "override author for commit"
 msgstr "autor corregit de la comissió"
 
-#: builtin/commit.c:1571 builtin/gc.c:286
+#: builtin/commit.c:1620 builtin/gc.c:275
 msgid "date"
 msgstr "data"
 
-#: builtin/commit.c:1571
+#: builtin/commit.c:1620
 msgid "override date for commit"
 msgstr "data corregida de la comissió"
 
-#: builtin/commit.c:1572 builtin/merge.c:216 builtin/notes.c:409
-#: builtin/notes.c:566 builtin/tag.c:598
+#: builtin/commit.c:1621 builtin/merge.c:217 builtin/notes.c:408
+#: builtin/notes.c:565 builtin/tag.c:599
 msgid "message"
 msgstr "missatge"
 
-#: builtin/commit.c:1572
+#: builtin/commit.c:1621
 msgid "commit message"
 msgstr "missatge de comissió"
 
-#: builtin/commit.c:1573
+#: builtin/commit.c:1622
 msgid "reuse and edit message from specified commit"
-msgstr "reutilitza i edit el missatge de la comissió especificada"
+msgstr "reusa i edita el missatge de la comissió especificada"
 
-#: builtin/commit.c:1574
+#: builtin/commit.c:1623
 msgid "reuse message from specified commit"
-msgstr "reutilitza el missatge de la comissió especificada"
+msgstr "reusa el missatge de la comissió especificada"
 
-#: builtin/commit.c:1575
+#: builtin/commit.c:1624
 msgid "use autosquash formatted message to fixup specified commit"
 msgstr ""
-"utilitza el missatge formatat d'aixafada automàtica per arreglar la comissió "
+"usa el missatge formatat d'aixafada automàtica per a arreglar la comissió "
 "especificada"
 
-#: builtin/commit.c:1576
+#: builtin/commit.c:1625
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
-"utilitza el missatge formatat d'aixafada automàtica per aixafar la comissió "
+"usa el missatge formatat d'aixafada automàtica per a aixafar la comissió "
 "especificada"
 
-#: builtin/commit.c:1577
+#: builtin/commit.c:1626
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
-msgstr "l'autor de la comissió ja sóc jo (utilitzat amb -C/-c/--amend)"
+msgstr "l'autor de la comissió ja sóc jo (usat amb -C/-c/--amend)"
 
-#: builtin/commit.c:1578 builtin/log.c:1188 builtin/revert.c:86
+#: builtin/commit.c:1627 builtin/log.c:1191 builtin/revert.c:86
 msgid "add Signed-off-by:"
 msgstr "afegeix Signed-off-by:"
 
-#: builtin/commit.c:1579
+#: builtin/commit.c:1628
 msgid "use specified template file"
-msgstr "utilitza el fitxer de plantilla especificat"
+msgstr "usa el fitxer de plantilla especificat"
 
-#: builtin/commit.c:1580
+#: builtin/commit.c:1629
 msgid "force edit of commit"
-msgstr "edició de la comissió a la força"
+msgstr "força l'edició de la comissió"
 
-#: builtin/commit.c:1581
+#: builtin/commit.c:1630
 msgid "default"
 msgstr "per defecte"
 
-#: builtin/commit.c:1581 builtin/tag.c:603
+#: builtin/commit.c:1630 builtin/tag.c:604
 msgid "how to strip spaces and #comments from message"
 msgstr "com despullar els espais i #comentaris del missatge"
 
-#: builtin/commit.c:1582
+#: builtin/commit.c:1631
 msgid "include status in commit message template"
 msgstr "inclou l'estat en la plantilla de missatge de comissió"
 
-#: builtin/commit.c:1583 builtin/merge.c:223 builtin/revert.c:92
-#: builtin/tag.c:604
+#: builtin/commit.c:1632 builtin/merge.c:224 builtin/revert.c:92
+#: builtin/tag.c:605
 msgid "key-id"
 msgstr "ID de clau"
 
-#: builtin/commit.c:1584 builtin/merge.c:224 builtin/revert.c:93
+#: builtin/commit.c:1633 builtin/merge.c:225 builtin/revert.c:93
 msgid "GPG sign commit"
 msgstr "firma la comissió amb GPG"
 
-#: builtin/commit.c:1587
+#: builtin/commit.c:1636
 msgid "Commit contents options"
 msgstr "Opcions dels continguts de les comissions"
 
-#: builtin/commit.c:1588
+#: builtin/commit.c:1637
 msgid "commit all changed files"
 msgstr "comet tots els fitxers canviats"
 
-#: builtin/commit.c:1589
+#: builtin/commit.c:1638
 msgid "add specified files to index for commit"
 msgstr "afegeix els fitxers especificats a l'índex per a cometre"
 
-#: builtin/commit.c:1590
+#: builtin/commit.c:1639
 msgid "interactively add files"
 msgstr "afegeix els fitxers interactivament"
 
-#: builtin/commit.c:1591
+#: builtin/commit.c:1640
 msgid "interactively add changes"
 msgstr "afegeix els canvis interactivament"
 
-#: builtin/commit.c:1592
+#: builtin/commit.c:1641
 msgid "commit only specified files"
 msgstr "comet només els fitxers especificats"
 
-#: builtin/commit.c:1593
+#: builtin/commit.c:1642
 msgid "bypass pre-commit hook"
 msgstr "evita el ganxo de precomissió"
 
-#: builtin/commit.c:1594
+#: builtin/commit.c:1643
 msgid "show what would be committed"
 msgstr "mostra què es cometria"
 
-#: builtin/commit.c:1605
+#: builtin/commit.c:1654
 msgid "amend previous commit"
 msgstr "esmena la comissió anterior"
 
-#: builtin/commit.c:1606
+#: builtin/commit.c:1655
 msgid "bypass post-rewrite hook"
 msgstr "evita el ganxo de postreescriure"
 
-#: builtin/commit.c:1611
+#: builtin/commit.c:1660
 msgid "ok to record an empty change"
-msgstr "bé registrar un canvi buit"
+msgstr "està bé registrar un canvi buit"
 
-#: builtin/commit.c:1613
+#: builtin/commit.c:1662
 msgid "ok to record a change with an empty message"
-msgstr "bé registrar un canvi amb missatge buit"
+msgstr "està bé registrar un canvi amb missatge buit"
 
-#: builtin/commit.c:1641
+#: builtin/commit.c:1691
 msgid "could not parse HEAD commit"
 msgstr "no s'ha pogut analitzar la comissió HEAD"
 
-#: builtin/commit.c:1680 builtin/merge.c:518
+#: builtin/commit.c:1730 builtin/merge.c:518
 #, c-format
 msgid "could not open '%s' for reading"
-msgstr "no s'ha pogut obrir '%s' per lectura"
+msgstr "no s'ha pogut obrir '%s' per a lectura"
 
-#: builtin/commit.c:1687
+#: builtin/commit.c:1737
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Fitxer MERGE_HEAD corrupte (%s)"
 
-#: builtin/commit.c:1694
+#: builtin/commit.c:1744
 msgid "could not read MERGE_MODE"
 msgstr "no s'ha pogut llegir MERGE_MODE"
 
-#: builtin/commit.c:1713
+#: builtin/commit.c:1763
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "no s'ha pogut llegir el missatge de comissió: %s"
 
-#: builtin/commit.c:1724
+#: builtin/commit.c:1774
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Avortant la comissió; no heu editat el missatge.\n"
 
-#: builtin/commit.c:1729
+#: builtin/commit.c:1779
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Avortant la comissió a causa d'un missatge de comissió buit.\n"
 
-#: builtin/commit.c:1744 builtin/merge.c:851 builtin/merge.c:876
+#: builtin/commit.c:1794 builtin/merge.c:850 builtin/merge.c:875
 msgid "failed to write commit object"
-msgstr "s'ha fallat al escriure l'objecte de comissió"
+msgstr "s'ha fallat en escriure l'objecte de comissió"
 
-#: builtin/commit.c:1756
-msgid "cannot lock HEAD ref"
-msgstr "no es pot bloquejar la referència HEAD"
-
-#: builtin/commit.c:1769
-msgid "cannot update HEAD ref"
-msgstr "no es pot actualitzar la referència HEAD"
-
-#: builtin/commit.c:1780
+#: builtin/commit.c:1827
 msgid ""
 "Repository has been updated, but unable to write\n"
-"new_index file. Check that disk is not full or quota is\n"
+"new_index file. Check that disk is not full and quota is\n"
 "not exceeded, and then \"git reset HEAD\" to recover."
 msgstr ""
-"S'ha actualitzat el repositori, però no es pot escriure\n"
-"el fitxer new_index. Comproveu que el disc no estigui\n"
-"ple i la quota no estigui excedit, i després\n"
-"\"git reset HEAD\" per recuperar."
+"S'ha actualitzat el dipòsit, però no es pot escriure el\n"
+"fitxer new_index. Comproveu que el disc no estigui ple i\n"
+"que la quota no estigui excedit, i després\n"
+"\"git reset HEAD\" per a recuperar."
 
 #: builtin/config.c:8
 msgid "git config [options]"
@@ -4649,19 +4784,19 @@ msgstr "Ubicació del fitxer de configuració"
 
 #: builtin/config.c:54
 msgid "use global config file"
-msgstr "utilitza el fitxer de configuració global"
+msgstr "usa el fitxer de configuració global"
 
 #: builtin/config.c:55
 msgid "use system config file"
-msgstr "utilitza el fitxer de configuració del sistema"
+msgstr "usa el fitxer de configuració del sistema"
 
 #: builtin/config.c:56
 msgid "use repository config file"
-msgstr "utilitza el fitxer de configuració del repositori"
+msgstr "usa el fitxer de configuració del dipòsit"
 
 #: builtin/config.c:57
 msgid "use given config file"
-msgstr "utilitza el fitxer de configuració donat"
+msgstr "usa el fitxer de configuració donat"
 
 #: builtin/config.c:58
 msgid "blob-id"
@@ -4742,19 +4877,19 @@ msgstr "Tipus"
 
 #: builtin/config.c:75
 msgid "value is \"true\" or \"false\""
-msgstr "valor és \"true\" o \"false\""
+msgstr "el valor és \"true\" o \"false\""
 
 #: builtin/config.c:76
 msgid "value is decimal number"
-msgstr "valor és un nombre decimal"
+msgstr "el valor és un nombre decimal"
 
 #: builtin/config.c:77
 msgid "value is --bool or --int"
-msgstr "valor és --bool o --int"
+msgstr "el valor és --bool o --int"
 
 #: builtin/config.c:78
 msgid "value is a path (file or directory name)"
-msgstr "valor és un path (nom de fitxer o directori)"
+msgstr "el valor és una ruta (nom de fitxer o directori)"
 
 #: builtin/config.c:79
 msgid "Other"
@@ -4768,63 +4903,87 @@ msgstr "termina els valors amb un octet NUL"
 msgid "respect include directives on lookup"
 msgstr "respecta les directives d'inclusió al cercar"
 
-#: builtin/count-objects.c:82
+#: builtin/config.c:315
+msgid "unable to parse default color value"
+msgstr "incapaç d'analitzar el valor de color per defecte"
+
+#: builtin/config.c:455
+#, c-format
+msgid ""
+"# This is Git's per-user configuration file.\n"
+"[core]\n"
+"# Please adapt and uncomment the following lines:\n"
+"#\tuser = %s\n"
+"#\temail = %s\n"
+msgstr ""
+"# Això és el fitxer de configuració del Git del usuari.\n"
+"[core]\n"
+"# Si us plau, adapteu i descomenteu les línies següentes:\n"
+"#\tuser = %s\n"
+"#\temail = %s\n"
+
+#: builtin/config.c:590
+#, c-format
+msgid "cannot create configuration file %s"
+msgstr "no es pot crear el fitxer de configuració '%s'"
+
+#: builtin/count-objects.c:55
 msgid "git count-objects [-v] [-H | --human-readable]"
 msgstr "git count-objects [-v] [-H | --human-readable]"
 
-#: builtin/count-objects.c:97
+#: builtin/count-objects.c:65
 msgid "print sizes in human readable format"
 msgstr "imprimeix les mides en un format llegible per humans"
 
-#: builtin/describe.c:16
+#: builtin/describe.c:17
 msgid "git describe [options] <commit-ish>*"
 msgstr "git describe [opcions] <comissió>*"
 
-#: builtin/describe.c:17
+#: builtin/describe.c:18
 msgid "git describe [options] --dirty"
 msgstr "git describe [opcions] --dirty"
 
-#: builtin/describe.c:216
+#: builtin/describe.c:217
 #, c-format
 msgid "annotated tag %s not available"
 msgstr "l'etiqueta anotada %s no és disponible"
 
-#: builtin/describe.c:220
+#: builtin/describe.c:221
 #, c-format
 msgid "annotated tag %s has no embedded name"
 msgstr "l'etiqueta anotada %s no té nom incrustat"
 
-#: builtin/describe.c:222
+#: builtin/describe.c:223
 #, c-format
 msgid "tag '%s' is really '%s' here"
 msgstr "l'etiqueta '%s' realment és '%s' aquí"
 
-#: builtin/describe.c:249
+#: builtin/describe.c:250 builtin/log.c:452
 #, c-format
 msgid "Not a valid object name %s"
 msgstr "%s no és un nom d'objecte vàlid"
 
-#: builtin/describe.c:252
+#: builtin/describe.c:253
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s no és un objecte de '%s' vàlid"
 
-#: builtin/describe.c:269
+#: builtin/describe.c:270
 #, c-format
 msgid "no tag exactly matches '%s'"
 msgstr "cap etiqueta coincideix exactament amb '%s'"
 
-#: builtin/describe.c:271
+#: builtin/describe.c:272
 #, c-format
 msgid "searching to describe %s\n"
-msgstr "cercant per descriure %s\n"
+msgstr "cercant per a descriure %s\n"
 
-#: builtin/describe.c:318
+#: builtin/describe.c:319
 #, c-format
 msgid "finished search at %s\n"
-msgstr "cerca terminada a %s\n"
+msgstr "s'ha terminat la cerca a %s\n"
 
-#: builtin/describe.c:345
+#: builtin/describe.c:346
 #, c-format
 msgid ""
 "No annotated tags can describe '%s'.\n"
@@ -4833,7 +4992,7 @@ msgstr ""
 "Cap etiqueta anotada pot descriure '%s'.\n"
 "No obstant, hi havia etiquetes no anotades: proveu --tags."
 
-#: builtin/describe.c:349
+#: builtin/describe.c:350
 #, c-format
 msgid ""
 "No tags can describe '%s'.\n"
@@ -4842,162 +5001,165 @@ msgstr ""
 "Cap etiqueta pot descriure '%s'.\n"
 "Proveu --always, o creeu algunes etiquetes."
 
-#: builtin/describe.c:370
+#: builtin/describe.c:371
 #, c-format
 msgid "traversed %lu commits\n"
 msgstr "%lu comissions travessades\n"
 
-#: builtin/describe.c:373
+#: builtin/describe.c:374
 #, c-format
 msgid ""
 "more than %i tags found; listed %i most recent\n"
 "gave up search at %s\n"
 msgstr ""
 "s'ha trobat més de %i etiquetes: s'ha llistat les %i més recents\n"
-"cerca renunciada a %s\n"
+"s'ha renunciat la cerca a %s\n"
 
-#: builtin/describe.c:395
+#: builtin/describe.c:396
 msgid "find the tag that comes after the commit"
 msgstr "troba l'etiqueta que vingui després de la comissió"
 
-#: builtin/describe.c:396
+#: builtin/describe.c:397
 msgid "debug search strategy on stderr"
 msgstr "estratègia de cerca de depuració en stderr"
 
-#: builtin/describe.c:397
-msgid "use any ref"
-msgstr "utilitza qualsevulla referència"
-
 #: builtin/describe.c:398
-msgid "use any tag, even unannotated"
-msgstr "utilitza qualsevulla etiqueta, encara les sense anotar"
+msgid "use any ref"
+msgstr "usa qualsevulla referència"
 
 #: builtin/describe.c:399
-msgid "always use long format"
-msgstr "sempre utilitza el format llarg"
+msgid "use any tag, even unannotated"
+msgstr "usa qualsevulla etiqueta, encara les sense anotar"
 
 #: builtin/describe.c:400
+msgid "always use long format"
+msgstr "sempre usa el format llarg"
+
+#: builtin/describe.c:401
 msgid "only follow first parent"
 msgstr "només segueix el primer pare"
 
-#: builtin/describe.c:403
+#: builtin/describe.c:404
 msgid "only output exact matches"
 msgstr "emet només coincidències exactes"
 
-#: builtin/describe.c:405
+#: builtin/describe.c:406
 msgid "consider <n> most recent tags (default: 10)"
 msgstr "considera les <n> etiquetes més recents (per defecte: 10)"
 
-#: builtin/describe.c:407
+#: builtin/describe.c:408
 msgid "only consider tags matching <pattern>"
 msgstr "només considera les etiquetes que coincideixen amb <patró>"
 
-#: builtin/describe.c:409 builtin/name-rev.c:318
+#: builtin/describe.c:410 builtin/name-rev.c:318
 msgid "show abbreviated commit object as fallback"
-msgstr "mostra l'objecte de comissió abreviat com retrocediment"
+msgstr "mostra l'objecte de comissió abreviat com a retrocediment"
 
-#: builtin/describe.c:410
+#: builtin/describe.c:411
 msgid "mark"
 msgstr "marca"
 
-#: builtin/describe.c:411
+#: builtin/describe.c:412
 msgid "append <mark> on dirty working tree (default: \"-dirty\")"
 msgstr "annexa <marca> en l'arbre de treball brut (per defecte: \"-dirty\")"
 
-#: builtin/describe.c:429
+#: builtin/describe.c:430
 msgid "--long is incompatible with --abbrev=0"
 msgstr "--long és incompatible amb --abbrev=0"
 
-#: builtin/describe.c:455
+#: builtin/describe.c:456
 msgid "No names found, cannot describe anything."
 msgstr "Cap nom trobat, no es pot descriure res."
 
-#: builtin/describe.c:475
+#: builtin/describe.c:476
 msgid "--dirty is incompatible with commit-ishes"
 msgstr "--dirty és incompatible amb les comissions"
 
-#: builtin/diff.c:85
+#: builtin/diff.c:86
 #, c-format
 msgid "'%s': not a regular file or symlink"
-msgstr "'%s': no és un fitxer regular ni enllaç simbòlic"
+msgstr "'%s': no és ni fitxer regular ni enllaç simbòlic"
 
-#: builtin/diff.c:236
+#: builtin/diff.c:237
 #, c-format
 msgid "invalid option: %s"
 msgstr "opció invàlida: %s"
 
-#: builtin/diff.c:357
+#: builtin/diff.c:358
 msgid "Not a git repository"
-msgstr "No és un repositori de git"
+msgstr "No és un dipòsit de git"
 
-#: builtin/diff.c:400
+#: builtin/diff.c:401
 #, c-format
 msgid "invalid object '%s' given."
-msgstr "objecte invàlid '%s' donat."
+msgstr "s'ha donat un objecte invàlid '%s'."
 
-#: builtin/diff.c:409
+#: builtin/diff.c:410
 #, c-format
 msgid "more than two blobs given: '%s'"
-msgstr "més de dos blobs donats: '%s'"
+msgstr "s'ha donat més de dos blobs: '%s"
 
-#: builtin/diff.c:416
+#: builtin/diff.c:417
 #, c-format
 msgid "unhandled object '%s' given."
-msgstr "objecte no manejat '%s' donat."
+msgstr "s'ha donat l'objecte no manejat '%s'."
 
-#: builtin/fast-export.c:23
+#: builtin/fast-export.c:24
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [opcions-de-llista-de-revisions]"
 
-#: builtin/fast-export.c:702
+#: builtin/fast-export.c:979
 msgid "show progress after <n> objects"
 msgstr "mostra el progrés després de <n> objectes"
 
-#: builtin/fast-export.c:704
+#: builtin/fast-export.c:981
 msgid "select handling of signed tags"
 msgstr "selecciona el manejament de les etiquetes firmades"
 
-#: builtin/fast-export.c:707
+#: builtin/fast-export.c:984
 msgid "select handling of tags that tag filtered objects"
 msgstr ""
-"selecciona el manejament de les etiquetes que etiqueten objectes filtrats"
+"selecciona el manejament de les etiquetes que etiquetin objectes filtrats"
 
-#: builtin/fast-export.c:710
+#: builtin/fast-export.c:987
 msgid "Dump marks to this file"
 msgstr "Bolcar les marques a aquest fitxer"
 
-#: builtin/fast-export.c:712
+#: builtin/fast-export.c:989
 msgid "Import marks from this file"
-msgstr "Importa marques d'aquest fitxer"
+msgstr "Importa les marques d'aquest fitxer"
 
-#: builtin/fast-export.c:714
+#: builtin/fast-export.c:991
 msgid "Fake a tagger when tags lack one"
-msgstr "Fingeix un etiquetador quan als etiquetes lis manca un"
+msgstr "Fingeix un etiquetador quan un lis manca a les etiquetes"
 
-#: builtin/fast-export.c:716
+#: builtin/fast-export.c:993
 msgid "Output full tree for each commit"
-msgstr "Imprimeix l'arbre complet per cada comissió"
+msgstr "Imprimeix l'arbre complet de cada comissió"
 
-#: builtin/fast-export.c:718
+#: builtin/fast-export.c:995
 msgid "Use the done feature to terminate the stream"
-msgstr "Utilitza la característica done per terminar el corrent"
+msgstr "Usa la característica done per a terminar el corrent"
 
-#: builtin/fast-export.c:719
+#: builtin/fast-export.c:996
 msgid "Skip output of blob data"
 msgstr "Salta l'emissió de dades de blob"
 
-#: builtin/fast-export.c:720
+#: builtin/fast-export.c:997
 msgid "refspec"
 msgstr "especificació de referència"
 
-#: builtin/fast-export.c:721
+#: builtin/fast-export.c:998
 msgid "Apply refspec to exported refs"
 msgstr "Aplica l'especificació de referència a les referències exportades"
 
+#: builtin/fast-export.c:999
+msgid "anonymize output"
+msgstr "anonimitza la sortida"
+
 #: builtin/fetch.c:20
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
-msgstr ""
-"git fetch [<opcions>] [<repositori> [<especificació-de-referència>...]]"
+msgstr "git fetch [<opcions>] [<dipòsit> [<especificació-de-referència>...]]"
 
 #: builtin/fetch.c:21
 msgid "git fetch [<options>] <group>"
@@ -5005,7 +5167,7 @@ msgstr "git fetch [<opcions>] <grup>"
 
 #: builtin/fetch.c:22
 msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
-msgstr "git fetch --multiple [<opcions>] [(<repositori> | <grup>)...]"
+msgstr "git fetch --multiple [<opcions>] [(<dipòsit> | <grup>)...]"
 
 #: builtin/fetch.c:23
 msgid "git fetch --all [<options>]"
@@ -5041,7 +5203,7 @@ msgstr "no obtingues les etiquetes (--no-tags)"
 
 #: builtin/fetch.c:103
 msgid "prune remote-tracking branches no longer on remote"
-msgstr "poda les rames amb seguiment remot que ja no estan en el remot"
+msgstr "poda les rames amb seguiment remot que ja no estiguin en el remot"
 
 #: builtin/fetch.c:104
 msgid "on-demand"
@@ -5061,13 +5223,13 @@ msgstr "permet l'actualització de la referència HEAD"
 
 #: builtin/fetch.c:114
 msgid "deepen history of shallow clone"
-msgstr "aprofundeix la història del clon superficial"
+msgstr "aprofundeix la història d'un clon superficial"
 
 #: builtin/fetch.c:116
 msgid "convert to a complete repository"
-msgstr "converteix en un repositori complet"
+msgstr "converteix en un dipòsit complet"
 
-#: builtin/fetch.c:118 builtin/log.c:1205
+#: builtin/fetch.c:118 builtin/log.c:1208
 msgid "dir"
 msgstr "directori"
 
@@ -5081,7 +5243,7 @@ msgstr "mode de recursivitat per defecte"
 
 #: builtin/fetch.c:124
 msgid "accept refs that update .git/shallow"
-msgstr "accepta referències que actualitzin .git/shallow"
+msgstr "accepta les referències que actualitzin .git/shallow"
 
 #: builtin/fetch.c:125
 msgid "refmap"
@@ -5095,169 +5257,169 @@ msgstr "mostra el mapa de referències d'obteniment"
 msgid "Couldn't find remote ref HEAD"
 msgstr "No s'ha pogut trobar la referència HEAD remota"
 
-#: builtin/fetch.c:440
+#: builtin/fetch.c:454
 #, c-format
 msgid "object %s not found"
 msgstr "objecte %s no trobat"
 
-#: builtin/fetch.c:445
-msgid "[up to date]"
-msgstr "[actualitzat]"
-
 #: builtin/fetch.c:459
+msgid "[up to date]"
+msgstr "[al dia]"
+
+#: builtin/fetch.c:473
 #, c-format
 msgid "! %-*s %-*s -> %s  (can't fetch in current branch)"
 msgstr "! %-*s %-*s -> %s  (no es pot obtenir en la rama actual)"
 
-#: builtin/fetch.c:460 builtin/fetch.c:546
+#: builtin/fetch.c:474 builtin/fetch.c:560
 msgid "[rejected]"
 msgstr "[rebutjat]"
 
-#: builtin/fetch.c:471
+#: builtin/fetch.c:485
 msgid "[tag update]"
 msgstr "[actualització d'etiqueta]"
 
-#: builtin/fetch.c:473 builtin/fetch.c:508 builtin/fetch.c:526
+#: builtin/fetch.c:487 builtin/fetch.c:522 builtin/fetch.c:540
 msgid "  (unable to update local ref)"
 msgstr "  (incapaç d'actualitzar la referència local)"
 
-#: builtin/fetch.c:491
+#: builtin/fetch.c:505
 msgid "[new tag]"
 msgstr "[etiqueta nova]"
 
-#: builtin/fetch.c:494
+#: builtin/fetch.c:508
 msgid "[new branch]"
 msgstr "[rama nova]"
 
-#: builtin/fetch.c:497
+#: builtin/fetch.c:511
 msgid "[new ref]"
 msgstr "[referència nova]"
 
-#: builtin/fetch.c:542
+#: builtin/fetch.c:556
 msgid "unable to update local ref"
 msgstr "incapaç d'actualitzar la referència local"
 
-#: builtin/fetch.c:542
+#: builtin/fetch.c:556
 msgid "forced update"
 msgstr "actualització forçada"
 
-#: builtin/fetch.c:548
+#: builtin/fetch.c:562
 msgid "(non-fast-forward)"
 msgstr "(sense avanç ràpid)"
 
-#: builtin/fetch.c:581 builtin/fetch.c:814
+#: builtin/fetch.c:595 builtin/fetch.c:828
 #, c-format
 msgid "cannot open %s: %s\n"
 msgstr "no és pot obrir %s: %s\n"
 
-#: builtin/fetch.c:590
+#: builtin/fetch.c:604
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s no ha enviat tots els objectes necessaris\n"
 
-#: builtin/fetch.c:608
+#: builtin/fetch.c:622
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr ""
 "rebutja %s perquè no es permet que els arrels superficials s'actualitzin"
 
-#: builtin/fetch.c:696 builtin/fetch.c:779
+#: builtin/fetch.c:710 builtin/fetch.c:793
 #, c-format
 msgid "From %.*s\n"
 msgstr "De %.*s\n"
 
-#: builtin/fetch.c:707
+#: builtin/fetch.c:721
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
 " 'git remote prune %s' to remove any old, conflicting branches"
 msgstr ""
 "algunes referències locals no s'han pogut actualitzar;\n"
-" intenteu executar 'git remote prune %s' per treure\n"
+" intenteu executar 'git remote prune %s' per a treure\n"
 " qualsevulla rama antiga o conflictiva"
 
-#: builtin/fetch.c:759
+#: builtin/fetch.c:773
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s es tornarà penjant)"
 
-#: builtin/fetch.c:760
+#: builtin/fetch.c:774
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s s'ha tornat penjant)"
 
-#: builtin/fetch.c:784
+#: builtin/fetch.c:798
 msgid "[deleted]"
 msgstr "[suprimit]"
 
-#: builtin/fetch.c:785 builtin/remote.c:1059
+#: builtin/fetch.c:799 builtin/remote.c:1063
 msgid "(none)"
 msgstr "(cap)"
 
-#: builtin/fetch.c:804
+#: builtin/fetch.c:818
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
-msgstr "Refusar obtenir a la rama actual %s d'un repositori no nu"
+msgstr "Refusant obtenir en la rama actual %s d'un dipòsit no nu"
 
-#: builtin/fetch.c:823
+#: builtin/fetch.c:837
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "L'opció \"%s\" amb valor \"%s\" no és vàlida per a %s"
 
-#: builtin/fetch.c:826
+#: builtin/fetch.c:840
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "S'ignora l'opció \"%s\" per a %s\n"
 
-#: builtin/fetch.c:882
+#: builtin/fetch.c:896
 #, c-format
 msgid "Don't know how to fetch from %s"
 msgstr "No es sap com obtenir de %s"
 
-#: builtin/fetch.c:1044
+#: builtin/fetch.c:1058
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Obtenint %s\n"
 
-#: builtin/fetch.c:1046 builtin/remote.c:90
+#: builtin/fetch.c:1060 builtin/remote.c:90
 #, c-format
 msgid "Could not fetch %s"
 msgstr "No s'ha pogut obtenir %s"
 
-#: builtin/fetch.c:1064
+#: builtin/fetch.c:1078
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
 msgstr ""
-"Cap repositori remot especificat. Si us plau, especifiqueu o un\n"
-"URL o un nom remot del qual es deuen obtenir les revisions noves."
+"Cap dipòsit remot especificat. Si us plau, especifiqueu o un URL o\n"
+"un nom remot del qual es deuen obtenir les revisions noves."
 
-#: builtin/fetch.c:1087
+#: builtin/fetch.c:1101
 msgid "You need to specify a tag name."
 msgstr "Necessiteu especificar un nom d'etiqueta."
 
-#: builtin/fetch.c:1131
+#: builtin/fetch.c:1143
 msgid "--depth and --unshallow cannot be used together"
-msgstr "--depth i --unshallow no es poden utilitzar junts"
+msgstr "--depth i --unshallow no es poden usar junts"
 
-#: builtin/fetch.c:1133
+#: builtin/fetch.c:1145
 msgid "--unshallow on a complete repository does not make sense"
-msgstr "--unshallow en un repositori complet no té sentit"
+msgstr "--unshallow en un dipòsit complet no té sentit"
 
-#: builtin/fetch.c:1156
+#: builtin/fetch.c:1168
 msgid "fetch --all does not take a repository argument"
-msgstr "fetch --all no accepta un paràmetre de repositori"
+msgstr "fetch --all no accepta un paràmetre de dipòsit"
 
-#: builtin/fetch.c:1158
+#: builtin/fetch.c:1170
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all no té sentit amb especificacions de referència"
 
-#: builtin/fetch.c:1169
+#: builtin/fetch.c:1181
 #, c-format
 msgid "No such remote or remote group: %s"
-msgstr "Cap remot o grup remot així: %s"
+msgstr "No hi ha tal remot ni tal grup remot: %s"
 
-#: builtin/fetch.c:1177
+#: builtin/fetch.c:1189
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr "Obtenir un grup i especificar referències no té sentit"
 
@@ -5267,8 +5429,8 @@ msgstr ""
 "git fmt-merge-msg [-m <missatge>] [--log[=<n>]|--no-log] [--file <fitxer>]"
 
 #: builtin/fmt-merge-msg.c:663 builtin/fmt-merge-msg.c:666 builtin/grep.c:698
-#: builtin/merge.c:196 builtin/repack.c:179 builtin/repack.c:183
-#: builtin/show-branch.c:654 builtin/show-ref.c:178 builtin/tag.c:589
+#: builtin/merge.c:197 builtin/repack.c:179 builtin/repack.c:183
+#: builtin/show-branch.c:654 builtin/show-ref.c:178 builtin/tag.c:590
 #: parse-options.h:132 parse-options.h:239
 msgid "n"
 msgstr "n"
@@ -5287,168 +5449,172 @@ msgstr "text"
 
 #: builtin/fmt-merge-msg.c:671
 msgid "use <text> as start of message"
-msgstr "utilitza <text> com inici de missatge"
+msgstr "usa <text> com a inici de missatge"
 
 #: builtin/fmt-merge-msg.c:672
 msgid "file to read from"
 msgstr "fitxer del qual llegir"
 
-#: builtin/for-each-ref.c:1051
+#: builtin/for-each-ref.c:676
+msgid "unable to parse format"
+msgstr "incapaç d'analitzar el format"
+
+#: builtin/for-each-ref.c:1057
 msgid "git for-each-ref [options] [<pattern>]"
 msgstr "git for-each-ref [opcions] [<patró>]"
 
-#: builtin/for-each-ref.c:1066
+#: builtin/for-each-ref.c:1072
 msgid "quote placeholders suitably for shells"
 msgstr ""
 "posa els marcadors de posició entre cometes adequades per als terminals"
 
-#: builtin/for-each-ref.c:1068
+#: builtin/for-each-ref.c:1074
 msgid "quote placeholders suitably for perl"
 msgstr "posa els marcadors de posició entre cometes adequades per a perl"
 
-#: builtin/for-each-ref.c:1070
+#: builtin/for-each-ref.c:1076
 msgid "quote placeholders suitably for python"
 msgstr "posa els marcadors de posició entre cometes adequades per a python"
 
-#: builtin/for-each-ref.c:1072
+#: builtin/for-each-ref.c:1078
 msgid "quote placeholders suitably for tcl"
 msgstr "posa els marcadors de posició entre cometes adequades per a tcl"
 
-#: builtin/for-each-ref.c:1075
+#: builtin/for-each-ref.c:1081
 msgid "show only <n> matched refs"
 msgstr "mostra només <n> referències coincidents"
 
-#: builtin/for-each-ref.c:1076 builtin/replace.c:435
+#: builtin/for-each-ref.c:1082 builtin/replace.c:438
 msgid "format"
 msgstr "format"
 
-#: builtin/for-each-ref.c:1076
+#: builtin/for-each-ref.c:1082
 msgid "format to use for the output"
-msgstr "format que utilitzar per a la sortida"
+msgstr "format a usar en la sortida"
 
-#: builtin/for-each-ref.c:1077
+#: builtin/for-each-ref.c:1083
 msgid "key"
 msgstr "clau"
 
-#: builtin/for-each-ref.c:1078
+#: builtin/for-each-ref.c:1084
 msgid "field name to sort on"
 msgstr "nom de camp en el qual ordenar"
 
-#: builtin/fsck.c:147 builtin/prune.c:172
+#: builtin/fsck.c:147 builtin/prune.c:136
 msgid "Checking connectivity"
 msgstr "Comprovant connectivitat"
 
-#: builtin/fsck.c:538
+#: builtin/fsck.c:540
 msgid "Checking object directories"
 msgstr "Comprovant els directoris d'objecte"
 
-#: builtin/fsck.c:601
+#: builtin/fsck.c:603
 msgid "git fsck [options] [<object>...]"
 msgstr "git fsck [opcions] [<objecte>...]"
 
-#: builtin/fsck.c:607
+#: builtin/fsck.c:609
 msgid "show unreachable objects"
-msgstr "mostra els objects inabastable"
+msgstr "mostra els objectes inabastables"
 
-#: builtin/fsck.c:608
+#: builtin/fsck.c:610
 msgid "show dangling objects"
 msgstr "mostra els objectes penjants"
 
-#: builtin/fsck.c:609
+#: builtin/fsck.c:611
 msgid "report tags"
 msgstr "informa de les etiquetes"
 
-#: builtin/fsck.c:610
+#: builtin/fsck.c:612
 msgid "report root nodes"
 msgstr "informa dels nodes d'arrel"
 
-#: builtin/fsck.c:611
+#: builtin/fsck.c:613
 msgid "make index objects head nodes"
 msgstr "fes els objectes d'índex nodes de cap"
 
-#: builtin/fsck.c:612
+#: builtin/fsck.c:614
 msgid "make reflogs head nodes (default)"
-msgstr "fes notes de cap de registres de referències (per defecte)"
+msgstr "fes que els registres de referències siguin nodes de cap (per defecte)"
 
-#: builtin/fsck.c:613
+#: builtin/fsck.c:615
 msgid "also consider packs and alternate objects"
 msgstr "també considera els paquets i els objectes alternatius"
 
-#: builtin/fsck.c:614
-msgid "enable more strict checking"
-msgstr "habilita comprovació més estricta"
-
 #: builtin/fsck.c:616
+msgid "enable more strict checking"
+msgstr "habilita la comprovació més estricta"
+
+#: builtin/fsck.c:618
 msgid "write dangling objects in .git/lost-found"
 msgstr "escriu objectes penjants a .git/lost-found"
 
-#: builtin/fsck.c:617 builtin/prune.c:144
+#: builtin/fsck.c:619 builtin/prune.c:108
 msgid "show progress"
-msgstr "mostra progrés"
+msgstr "mostra el progrés"
 
-#: builtin/fsck.c:667
+#: builtin/fsck.c:669
 msgid "Checking objects"
-msgstr "Comprovant objectes"
+msgstr "Comprovant els objectes"
 
 #: builtin/gc.c:24
 msgid "git gc [options]"
 msgstr "git gc [opcions]"
 
-#: builtin/gc.c:91
+#: builtin/gc.c:79
 #, c-format
-msgid "Invalid %s: '%s'"
-msgstr "%s invàlid: '%s'"
+msgid "Invalid gc.pruneexpire: '%s'"
+msgstr "gc.pruneexpire invàlid: %s"
 
-#: builtin/gc.c:118
+#: builtin/gc.c:107
 #, c-format
 msgid "insanely long object directory %.*s"
 msgstr "directori d'objectes increïblement llarga %.*s"
 
-#: builtin/gc.c:287
+#: builtin/gc.c:276
 msgid "prune unreferenced objects"
 msgstr "poda objectes sense referència"
 
-#: builtin/gc.c:289
+#: builtin/gc.c:278
 msgid "be more thorough (increased runtime)"
 msgstr "siguis més exhaustiu (temps d'execució augmentat)"
 
-#: builtin/gc.c:290
+#: builtin/gc.c:279
 msgid "enable auto-gc mode"
-msgstr "habilita mode de recollida d'escombraries automàtica"
+msgstr "habilita el mode de recollida d'escombraries automàtica"
 
-#: builtin/gc.c:291
+#: builtin/gc.c:280
 msgid "force running gc even if there may be another gc running"
-msgstr "força l'execució de gc encara que hi pugui haver altre gc executant"
+msgstr "força l'execució de gc encara que hi pugui haver un altre gc executant"
 
-#: builtin/gc.c:332
+#: builtin/gc.c:321
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
-"Empaquetant automàticament el repositori en el fons per rendiment optim.\n"
+"Empaquetant automàticament el dipòsit en el fons per rendiment òptim.\n"
 
-#: builtin/gc.c:334
+#: builtin/gc.c:323
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
-msgstr "Empaquetant automàticament el repositori per rendiment optim.\n"
+msgstr "Empaquetant automàticament el dipòsit per rendiment òptim.\n"
 
-#: builtin/gc.c:335
+#: builtin/gc.c:324
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Veu \"git help gc\" per neteja manual.\n"
 
-#: builtin/gc.c:353
+#: builtin/gc.c:342
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
 msgstr ""
-"gc ja està executant en la màquina '%s' pid %<PRIuMAX> (utilitzeu --force si "
-"no)"
+"gc ja està executant en la màquina '%s' pid %<PRIuMAX> (useu --force si no)"
 
-#: builtin/gc.c:375
+#: builtin/gc.c:364
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
-"Hi ha massa objectes solts inabastables; executeu 'git prune' per treure'ls."
+"Hi ha massa objectes solts inabastables; executeu 'git prune' per a "
+"treure'ls."
 
 #: builtin/grep.c:23
 msgid "git grep [options] [-e] <pattern> [<rev>...] [[--] <path>...]"
@@ -5457,7 +5623,7 @@ msgstr "git grep [opcions] [-e] <patró> [<revisió>...] [[--] <ruta>...]"
 #: builtin/grep.c:218
 #, c-format
 msgid "grep: failed to create thread: %s"
-msgstr "grep: s'ha fallat al crear fil: %s"
+msgstr "grep: s'ha fallat en crear fil: %s"
 
 #: builtin/grep.c:441 builtin/grep.c:476
 #, c-format
@@ -5509,7 +5675,7 @@ msgstr "coincideix amb els patrons només als límits de paraula"
 
 #: builtin/grep.c:653
 msgid "process binary files as text"
-msgstr "processa els fitxers binaris com text"
+msgstr "processa els fitxers binaris com a text"
 
 #: builtin/grep.c:655
 msgid "don't match patterns in binary files"
@@ -5521,23 +5687,23 @@ msgstr "processa els fitxers binaris amb filtres de textconv"
 
 #: builtin/grep.c:660
 msgid "descend at most <depth> levels"
-msgstr "descendeix al màxim <profunditat> nivells"
+msgstr "descendeix com a màxim <profunditat> nivells"
 
 #: builtin/grep.c:664
 msgid "use extended POSIX regular expressions"
-msgstr "utilitza expressions regulars POSIX esteses"
+msgstr "usa les expressions regulars POSIX esteses"
 
 #: builtin/grep.c:667
 msgid "use basic POSIX regular expressions (default)"
-msgstr "utilitza expressions regulars POSIX bàsiques (per defecte)"
+msgstr "usa les expressions regulars POSIX bàsiques (per defecte)"
 
 #: builtin/grep.c:670
 msgid "interpret patterns as fixed strings"
-msgstr "interpreta els patrons com cadenes fixades"
+msgstr "interpreta els patrons com a cadenes fixades"
 
 #: builtin/grep.c:673
 msgid "use Perl-compatible regular expressions"
-msgstr "utilitza expressions regulars compatibles amb Perl"
+msgstr "usa les expressions regulars compatibles amb Perl"
 
 #: builtin/grep.c:676
 msgid "show line numbers"
@@ -5553,7 +5719,7 @@ msgstr "mostra els noms de fitxer"
 
 #: builtin/grep.c:680
 msgid "show filenames relative to top directory"
-msgstr "mostra els noms de fitxer relatiu al directori superior"
+msgstr "mostra els noms de fitxer relatius al directori superior"
 
 #: builtin/grep.c:682
 msgid "show only filenames instead of matching lines"
@@ -5627,7 +5793,7 @@ msgstr "combina els patrons especificats amb -e"
 
 #: builtin/grep.c:729
 msgid "indicate hit with exit status without output"
-msgstr "indica coincidència amb estat de sortida sense sortida de text"
+msgstr "indica coincidència amb estat de sortida sense sortida textual"
 
 #: builtin/grep.c:731
 msgid "show only matches from files that match all patterns"
@@ -5665,22 +5831,21 @@ msgstr "--open-files-in-pager només funciona en l'arbre de treball"
 
 #: builtin/grep.c:892
 msgid "--cached or --untracked cannot be used with --no-index."
-msgstr "--cached o --untracked no es pot utilitzar amb --no-index."
+msgstr "--cached o --untracked no es pot usar amb --no-index."
 
 #: builtin/grep.c:897
 msgid "--no-index or --untracked cannot be used with revs."
-msgstr "--no-index o --untracked no es poden utilitzar amb revisions."
+msgstr "--no-index o --untracked no es pot usar amb revisions."
 
 #: builtin/grep.c:900
 msgid "--[no-]exclude-standard cannot be used for tracked contents."
-msgstr ""
-"--[no-]exclude-standard no es pot utilitzar per als continguts seguits."
+msgstr "--[no-]exclude-standard no es pot usar per als continguts seguits."
 
 #: builtin/grep.c:908
 msgid "both --cached and trees are given."
-msgstr "s'ha donat ambdós --caches i arbres."
+msgstr "s'han donat ambdós --caches i arbres."
 
-#: builtin/hash-object.c:60
+#: builtin/hash-object.c:82
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin] [--] "
 "<file>..."
@@ -5688,31 +5853,38 @@ msgstr ""
 "git hash-object [-t <tipus>] [-w] [--path=<fitxer>|--no-filters] [--stdin] "
 "[--] <fitxer>..."
 
-#: builtin/hash-object.c:61
+#: builtin/hash-object.c:83
 msgid "git hash-object  --stdin-paths < <list-of-paths>"
 msgstr "git hash-object  --stdin-paths < <llista-de-rutes>"
 
-#: builtin/hash-object.c:72 builtin/tag.c:609
+#: builtin/hash-object.c:94 builtin/tag.c:610
 msgid "type"
 msgstr "tipus"
 
-#: builtin/hash-object.c:72
+#: builtin/hash-object.c:94
 msgid "object type"
 msgstr "tipus d'objecte"
 
-#: builtin/hash-object.c:73
+#: builtin/hash-object.c:95
 msgid "write the object into the object database"
-msgstr "escriu l'objecte al base de dades d'objectes"
+msgstr "escriu l'objecte a la base de dades d'objectes"
 
-#: builtin/hash-object.c:74
+#: builtin/hash-object.c:97
 msgid "read the object from stdin"
-msgstr "llegiu l'objecte des de stdin"
+msgstr "llegiu l'objecte des d'stdin"
 
-#: builtin/hash-object.c:76
+#: builtin/hash-object.c:99
 msgid "store file as is without filters"
 msgstr "emmagatzema el fitxer tal com és sense filtres"
 
-#: builtin/hash-object.c:77
+#: builtin/hash-object.c:100
+msgid ""
+"just hash any random garbage to create corrupt objects for debugging Git"
+msgstr ""
+"només sumar qualsevulla brossa aleatòria per a crear objectes corruptes per "
+"a depurar al Git"
+
+#: builtin/hash-object.c:101
 msgid "process file as it were from this path"
 msgstr "processa el fitxer com si fos d'aquesta ruta"
 
@@ -5745,58 +5917,62 @@ msgstr "git help [--all] [--guides] [--man|--web|--info] [ordre]"
 msgid "unrecognized help format '%s'"
 msgstr "format d'ajuda no reconegut '%s'"
 
-#: builtin/help.c:92
+#: builtin/help.c:91
 msgid "Failed to start emacsclient."
-msgstr "S'ha fallat al iniciar emacsclient."
+msgstr "S'ha fallat en iniciar emacsclient."
 
-#: builtin/help.c:105
+#: builtin/help.c:104
 msgid "Failed to parse emacsclient version."
-msgstr "S'ha fallat al analitzar la versió d'emacsclint."
+msgstr "S'ha fallat en analitzar la versió d'emacsclint."
 
-#: builtin/help.c:113
+#: builtin/help.c:112
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "la versió d'emacsclient '%d' és massa vella (< 22)."
 
-#: builtin/help.c:131 builtin/help.c:159 builtin/help.c:168 builtin/help.c:176
+#: builtin/help.c:130 builtin/help.c:158 builtin/help.c:167 builtin/help.c:175
 #, c-format
 msgid "failed to exec '%s': %s"
-msgstr "s'ha fallat al executar '%s': %s"
+msgstr "s'ha fallat en executar '%s': %s"
 
-#: builtin/help.c:216
+#: builtin/help.c:215
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
 "Please consider using 'man.<tool>.cmd' instead."
 msgstr ""
-"'%s': ruta d'un visualitzador de manuals no suportat.\n"
-"Si us plau, considereu utilitzar 'man.<tool>.cmd' en lloc."
+"'%s': ruta a un visualitzador de manuals no suportat.\n"
+"Si us plau, considereu usar 'man.<eine>.cmd' en lloc."
 
-#: builtin/help.c:228
+#: builtin/help.c:227
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
 "Please consider using 'man.<tool>.path' instead."
 msgstr ""
 "'%s': ordre per un visualitzador de manuals suportat.\n"
-"Si us plau, considereu utilitzar 'man.<tool>.path' en lloc."
+"Si us plau, considereu usar 'man.<eine>.path' en lloc."
 
-#: builtin/help.c:353
+#: builtin/help.c:352
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "'%s': visualitzador de manuals desconegut"
 
-#: builtin/help.c:370
+#: builtin/help.c:369
 msgid "no man viewer handled the request"
 msgstr "cap visualitzador de manuals ha manejat la sol·licitud"
 
-#: builtin/help.c:378
+#: builtin/help.c:377
 msgid "no info viewer handled the request"
 msgstr "cap visualitzador d'informació ha manejat la sol·licitud"
 
-#: builtin/help.c:424
+#: builtin/help.c:423
 msgid "Defining attributes per path"
 msgstr "La definició d'atributs per ruta"
+
+#: builtin/help.c:424
+msgid "Everyday Git With 20 Commands Or So"
+msgstr "Git quotidià amb més o menys 20 ordres"
 
 #: builtin/help.c:425
 msgid "A Git glossary"
@@ -5804,19 +5980,19 @@ msgstr "Un glossari de Git"
 
 #: builtin/help.c:426
 msgid "Specifies intentionally untracked files to ignore"
-msgstr "Especifica fitxers intencionalment no seguits que ignorar"
+msgstr "Especifica els fitxers intencionalment no seguits a ignorar"
 
 #: builtin/help.c:427
 msgid "Defining submodule properties"
-msgstr "La definició dels propietats de submòduls"
+msgstr "La definició de les propietats de submòduls"
 
 #: builtin/help.c:428
 msgid "Specifying revisions and ranges for Git"
-msgstr "L'especificació de revisions i rangs per a Git"
+msgstr "L'especificació de revisions i rangs per al Git"
 
 #: builtin/help.c:429
 msgid "A tutorial introduction to Git (for version 1.5.1 or newer)"
-msgstr "Una introducció tutorial a Git (per a la versió 1.5.1 o més nou)"
+msgstr "Una introducció tutorial al Git (per a la versió 1.5.1 o més nou)"
 
 #: builtin/help.c:430
 msgid "An overview of recommended workflows with Git"
@@ -5836,293 +6012,293 @@ msgstr "ús: %s%s"
 msgid "`git %s' is aliased to `%s'"
 msgstr "`git %s' és àlies a `%s'"
 
-#: builtin/index-pack.c:145
+#: builtin/index-pack.c:150
 #, c-format
 msgid "unable to open %s"
 msgstr "incapaç d'obrir %s"
 
-#: builtin/index-pack.c:191
+#: builtin/index-pack.c:200
 #, c-format
 msgid "object type mismatch at %s"
-msgstr "discordança de tipus d'objecte a %s"
+msgstr "hi ha una discordança de tipus d'objecte a %s"
 
-#: builtin/index-pack.c:211
+#: builtin/index-pack.c:220
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "no s'ha rebut l'objecte esperat %s"
 
-#: builtin/index-pack.c:214
+#: builtin/index-pack.c:223
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "objecte %s: tipus %s esperat, %s trobat"
 
-#: builtin/index-pack.c:256
+#: builtin/index-pack.c:265
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "no es pot omplir %d octet"
 msgstr[1] "no es pot omplir %d octets"
 
-#: builtin/index-pack.c:266
+#: builtin/index-pack.c:275
 msgid "early EOF"
 msgstr "EOF aviat"
 
-#: builtin/index-pack.c:267
+#: builtin/index-pack.c:276
 msgid "read error on input"
 msgstr "error de lectura d'entrada"
 
-#: builtin/index-pack.c:279
+#: builtin/index-pack.c:288
 msgid "used more bytes than were available"
-msgstr "més octets utilitzats que estaven disponibles"
+msgstr "s'han usat més octets que estaven disponibles"
 
-#: builtin/index-pack.c:286
+#: builtin/index-pack.c:295
 msgid "pack too large for current definition of off_t"
 msgstr "paquet massa gran per a la definició actual d'off_t"
 
-#: builtin/index-pack.c:302
+#: builtin/index-pack.c:311
 #, c-format
 msgid "unable to create '%s'"
 msgstr "no es pot crear '%s'"
 
-#: builtin/index-pack.c:307
+#: builtin/index-pack.c:316
 #, c-format
 msgid "cannot open packfile '%s'"
 msgstr "no es pot obrir el fitxer de paquet '%s'"
 
-#: builtin/index-pack.c:321
+#: builtin/index-pack.c:330
 msgid "pack signature mismatch"
-msgstr "discordança de firma de paquet"
+msgstr "hi ha una discordança de firma de paquet"
 
-#: builtin/index-pack.c:323
+#: builtin/index-pack.c:332
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
-msgstr "versió de paquet %<PRIu32> no suportada"
+msgstr "la versió de paquet %<PRIu32> no es suporta"
 
-#: builtin/index-pack.c:341
+#: builtin/index-pack.c:350
 #, c-format
 msgid "pack has bad object at offset %lu: %s"
 msgstr "el paquet té un objecte dolent a desplaçament %lu: %s"
 
-#: builtin/index-pack.c:462
+#: builtin/index-pack.c:471
 #, c-format
 msgid "inflate returned %d"
 msgstr "la inflació ha retornat %d"
 
-#: builtin/index-pack.c:511
+#: builtin/index-pack.c:520
 msgid "offset value overflow for delta base object"
 msgstr "desbordament de valor de desplaçament per a l'objecte base de delta"
 
-#: builtin/index-pack.c:519
+#: builtin/index-pack.c:528
 msgid "delta base offset is out of bound"
-msgstr "desplaçament de base de delta està fora de límits"
+msgstr "el desplaçament de base de delta està fora de límits"
 
-#: builtin/index-pack.c:527
+#: builtin/index-pack.c:536
 #, c-format
 msgid "unknown object type %d"
 msgstr "tipus d'objecte desconegut %d"
 
-#: builtin/index-pack.c:558
+#: builtin/index-pack.c:567
 msgid "cannot pread pack file"
-msgstr "no es pot fer pread en en fitxer de paquet"
+msgstr "no es pot fer pread en el fitxer de paquet"
 
-#: builtin/index-pack.c:560
+#: builtin/index-pack.c:569
 #, c-format
 msgid "premature end of pack file, %lu byte missing"
 msgid_plural "premature end of pack file, %lu bytes missing"
 msgstr[0] "fin prematur de fitxer de paquet, manca %lu octet"
 msgstr[1] "fin prematur de fitxer de paquet, manquen %lu octets"
 
-#: builtin/index-pack.c:586
+#: builtin/index-pack.c:595
 msgid "serious inflate inconsistency"
-msgstr "inconsistència d'inflació seria"
+msgstr "hi ha una inconsistència seria d'inflació"
 
-#: builtin/index-pack.c:677 builtin/index-pack.c:683 builtin/index-pack.c:706
-#: builtin/index-pack.c:740 builtin/index-pack.c:749
+#: builtin/index-pack.c:686 builtin/index-pack.c:692 builtin/index-pack.c:715
+#: builtin/index-pack.c:749 builtin/index-pack.c:758
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
-msgstr "COL·LISIÓ SHA1 TROBAT AMB %s !"
+msgstr "S'HA TROBAT UNA COL·LISIÓ SHA1 AMB %s !"
 
-#: builtin/index-pack.c:680 builtin/pack-objects.c:162
-#: builtin/pack-objects.c:254
+#: builtin/index-pack.c:689 builtin/pack-objects.c:164
+#: builtin/pack-objects.c:256
 #, c-format
 msgid "unable to read %s"
 msgstr "incapaç de llegir %s"
 
-#: builtin/index-pack.c:746
+#: builtin/index-pack.c:755
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "no es pot llegir l'objecte existent %s"
 
-#: builtin/index-pack.c:760
+#: builtin/index-pack.c:769
 #, c-format
 msgid "invalid blob object %s"
 msgstr "objecte de blob invàlid %s"
 
-#: builtin/index-pack.c:774
+#: builtin/index-pack.c:783
 #, c-format
 msgid "invalid %s"
 msgstr "%s invàlid"
 
-#: builtin/index-pack.c:777
+#: builtin/index-pack.c:787
 msgid "Error in object"
 msgstr "Error en objecte"
 
-#: builtin/index-pack.c:779
+#: builtin/index-pack.c:789
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "No tots els objectes fills de %s són abastables"
 
-#: builtin/index-pack.c:851 builtin/index-pack.c:881
+#: builtin/index-pack.c:861 builtin/index-pack.c:890
 msgid "failed to apply delta"
-msgstr "s'ha fallat al aplicar delta"
+msgstr "s'ha fallat en aplicar la delta"
 
-#: builtin/index-pack.c:1022
+#: builtin/index-pack.c:1055
 msgid "Receiving objects"
 msgstr "Rebent objectes"
 
-#: builtin/index-pack.c:1022
+#: builtin/index-pack.c:1055
 msgid "Indexing objects"
 msgstr "Indexant objectes"
 
-#: builtin/index-pack.c:1048
+#: builtin/index-pack.c:1081
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "el paquet és corromput (discordança SHA1)"
 
-#: builtin/index-pack.c:1053
+#: builtin/index-pack.c:1086
 msgid "cannot fstat packfile"
-msgstr "no es pot fer fstat en en fitxer de paquet"
+msgstr "no es pot fer fstat en el fitxer de paquet"
 
-#: builtin/index-pack.c:1056
+#: builtin/index-pack.c:1089
 msgid "pack has junk at the end"
-msgstr "el paquet té brossa al final"
+msgstr "el paquet té brossa al seu fin"
 
-#: builtin/index-pack.c:1067
+#: builtin/index-pack.c:1100
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "confusió més enllà de la insanitat en parse_pack_objects()"
 
-#: builtin/index-pack.c:1090
+#: builtin/index-pack.c:1123
 msgid "Resolving deltas"
 msgstr "Resolent les deltes"
 
-#: builtin/index-pack.c:1100
+#: builtin/index-pack.c:1133
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "incapaç de crear fil: %s"
 
-#: builtin/index-pack.c:1142
+#: builtin/index-pack.c:1175
 msgid "confusion beyond insanity"
 msgstr "confusió més enllà de la insanitat"
 
-#: builtin/index-pack.c:1150
+#: builtin/index-pack.c:1181
 #, c-format
 msgid "completed with %d local objects"
-msgstr "terminat amb %d objectes locals"
+msgstr "s'ha terminat amb %d objectes locals"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1191
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Suma de verificació final no esperada per a %s (corrupció de disc?)"
 
-#: builtin/index-pack.c:1164
+#: builtin/index-pack.c:1195
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "El paquet té %d delta no resolta"
 msgstr[1] "El paquet té %d deltes no resoltes"
 
-#: builtin/index-pack.c:1189
+#: builtin/index-pack.c:1220
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "incapaç de desinflar l'objecte annexat (%d)"
 
-#: builtin/index-pack.c:1268
+#: builtin/index-pack.c:1299
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "l'objecte local %s és corrupte"
 
-#: builtin/index-pack.c:1292
+#: builtin/index-pack.c:1323
 msgid "error while closing pack file"
-msgstr "error al tancar el fitxer de paquet"
+msgstr "error en tancar el fitxer de paquet"
 
-#: builtin/index-pack.c:1305
+#: builtin/index-pack.c:1336
 #, c-format
 msgid "cannot write keep file '%s'"
-msgstr "no es pot escriure el fitxer que retenir '%s'"
+msgstr "no es pot escriure el fitxer a retenir '%s'"
 
-#: builtin/index-pack.c:1313
+#: builtin/index-pack.c:1344
 #, c-format
 msgid "cannot close written keep file '%s'"
-msgstr "no es pot tancar el fitxer que retenir escrit '%s'"
+msgstr "no es pot tancar el fitxer escrit a retenir '%s'"
 
-#: builtin/index-pack.c:1326
+#: builtin/index-pack.c:1357
 msgid "cannot store pack file"
 msgstr "no es pot emmagatzemar el fitxer de paquet"
 
-#: builtin/index-pack.c:1337
+#: builtin/index-pack.c:1368
 msgid "cannot store index file"
 msgstr "no es pot emmagatzemar el fitxer d'índex"
 
-#: builtin/index-pack.c:1370
+#: builtin/index-pack.c:1401
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "pack.indexversion=%<PRIu32> dolent"
 
-#: builtin/index-pack.c:1376
+#: builtin/index-pack.c:1407
 #, c-format
 msgid "invalid number of threads specified (%d)"
-msgstr "nombre de fils invàlid especificat (%d)"
+msgstr "s'ha especificat un nombre de fils invàlid (%d)"
 
-#: builtin/index-pack.c:1380 builtin/index-pack.c:1559
+#: builtin/index-pack.c:1411 builtin/index-pack.c:1590
 #, c-format
 msgid "no threads support, ignoring %s"
-msgstr "cap suport de fils, ignorant %s"
+msgstr "no hi ha suport de fils, ignorant %s"
 
-#: builtin/index-pack.c:1438
+#: builtin/index-pack.c:1469
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "No es pot obrir el fitxer de paquet existent '%s'"
 
-#: builtin/index-pack.c:1440
+#: builtin/index-pack.c:1471
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "No es pot obrir el fitxer d'índex de paquets existent de '%s'"
 
-#: builtin/index-pack.c:1487
+#: builtin/index-pack.c:1518
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "sense delta: %d objecte"
 msgstr[1] "sense delta: %d objectes"
 
-#: builtin/index-pack.c:1494
+#: builtin/index-pack.c:1525
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "longitud de cadena = %d: %lu objecte"
 msgstr[1] "longitud de cadena = %d: %lu objectes"
 
-#: builtin/index-pack.c:1523
+#: builtin/index-pack.c:1554
 msgid "Cannot come back to cwd"
 msgstr "No es pot tornar al directori de treball actual"
 
-#: builtin/index-pack.c:1571 builtin/index-pack.c:1574
-#: builtin/index-pack.c:1586 builtin/index-pack.c:1590
+#: builtin/index-pack.c:1602 builtin/index-pack.c:1605
+#: builtin/index-pack.c:1617 builtin/index-pack.c:1621
 #, c-format
 msgid "bad %s"
 msgstr "%s dolent"
 
-#: builtin/index-pack.c:1604
+#: builtin/index-pack.c:1635
 msgid "--fix-thin cannot be used without --stdin"
-msgstr "--fix-thin no es pot utilitzar sense --stdin"
+msgstr "--fix-thin no es pot usar sense --stdin"
 
-#: builtin/index-pack.c:1608 builtin/index-pack.c:1617
+#: builtin/index-pack.c:1639 builtin/index-pack.c:1648
 #, c-format
 msgid "packfile name '%s' does not end with '.pack'"
 msgstr "el nom de fitxer de paquet '%s' no termina amb '.pack'"
 
-#: builtin/index-pack.c:1625
+#: builtin/index-pack.c:1656
 msgid "--verify with no packfile name given"
-msgstr "--verify donat sense nom de fitxer de paquet"
+msgstr "s'ha donat --verify sense nom de fitxer de paquet"
 
 #: builtin/init-db.c:35
 #, c-format
@@ -6177,12 +6353,12 @@ msgstr "ignorant la plantilla %s"
 #: builtin/init-db.c:133
 #, c-format
 msgid "insanely long template path %s"
-msgstr "enllaç ruta de plantilla %s"
+msgstr "ruta de plantilla insanament llarg %s"
 
 #: builtin/init-db.c:141
 #, c-format
 msgid "templates not found %s"
-msgstr "plantilles no trobades %s"
+msgstr "no s'han trobat les plantilles %s"
 
 #: builtin/init-db.c:154
 #, c-format
@@ -6215,25 +6391,21 @@ msgstr "incapaç de moure %s a %s"
 #: builtin/init-db.c:418
 #, c-format
 msgid "%s%s Git repository in %s%s\n"
-msgstr "%s%s repositori de Git en %s%s\n"
+msgstr "%s%s dipòsit de Git en %s%s\n"
 
 #: builtin/init-db.c:419
 msgid "Reinitialized existing"
-msgstr "Reinicialitzat existent"
+msgstr "S'ha reinicialitzat un existent"
 
 #: builtin/init-db.c:419
 msgid "Initialized empty"
-msgstr "Inicialitzat buit"
+msgstr "S'ha inicialitzat un buit"
 
 #: builtin/init-db.c:420
 msgid " shared"
 msgstr " compartit"
 
-#: builtin/init-db.c:439
-msgid "cannot tell cwd"
-msgstr "no es pot determinar el directori de treball actual"
-
-#: builtin/init-db.c:465
+#: builtin/init-db.c:467
 msgid ""
 "git init [-q | --quiet] [--bare] [--template=<template-directory>] [--"
 "shared[=<permissions>]] [directory]"
@@ -6241,30 +6413,29 @@ msgstr ""
 "git init [-q | --quiet] [--bare] [--template=<directori-de-plantilla>] [--"
 "shared[=<permisos>]] [directori]"
 
-#: builtin/init-db.c:488
+#: builtin/init-db.c:490
 msgid "permissions"
 msgstr "permisos"
 
-#: builtin/init-db.c:489
+#: builtin/init-db.c:491
 msgid "specify that the git repository is to be shared amongst several users"
-msgstr ""
-"especifica que el repositori de git es compartirà entre diversos usuaris"
+msgstr "especifica que el dipòsit de git es compartirà entre diversos usuaris"
 
-#: builtin/init-db.c:491 builtin/prune-packed.c:79 builtin/repack.c:172
+#: builtin/init-db.c:493 builtin/prune-packed.c:57 builtin/repack.c:172
 msgid "be quiet"
 msgstr "calla"
 
-#: builtin/init-db.c:523 builtin/init-db.c:528
+#: builtin/init-db.c:525 builtin/init-db.c:530
 #, c-format
 msgid "cannot mkdir %s"
 msgstr "no es pot mkdir %s"
 
-#: builtin/init-db.c:532
+#: builtin/init-db.c:534
 #, c-format
 msgid "cannot chdir to %s"
 msgstr "no es pot chdir a %s"
 
-#: builtin/init-db.c:554
+#: builtin/init-db.c:555
 #, c-format
 msgid ""
 "%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
@@ -6273,14 +6444,30 @@ msgstr ""
 "no es permet %s (o --work-tree=<directori>) sense especificar %s (o --git-"
 "dir=<directori>)"
 
-#: builtin/init-db.c:578
-msgid "Cannot access current working directory"
-msgstr "No es pot accedir al directori de treball corrent"
-
-#: builtin/init-db.c:585
+#: builtin/init-db.c:583
 #, c-format
 msgid "Cannot access work tree '%s'"
 msgstr "No es pot accedir al arbre de treball '%s'"
+
+#: builtin/interpret-trailers.c:15
+msgid ""
+"git interpret-trailers [--trim-empty] [(--trailer <token>[(=|:)<value>])...] "
+"[<file>...]"
+msgstr ""
+"git interpret-trailers [--trim-empty] [(--trailer <fitxa>[(=|:)<valor>])...] "
+"[<fitxer>...]"
+
+#: builtin/interpret-trailers.c:25
+msgid "trim empty trailers"
+msgstr "escurça els remolcs buits"
+
+#: builtin/interpret-trailers.c:26
+msgid "trailer"
+msgstr "remolc"
+
+#: builtin/interpret-trailers.c:27
+msgid "trailer(s) to add"
+msgstr "remolcs a afegir"
 
 #: builtin/log.c:41
 msgid "git log [<options>] [<revision range>] [[--] <path>...]\n"
@@ -6289,6 +6476,11 @@ msgstr "git log [<opcions>] [<rang de revisions>] [[--] <ruta>...]\n"
 #: builtin/log.c:42
 msgid "   or: git show [options] <object>..."
 msgstr "   o: git show [opcions] <objecte>..."
+
+#: builtin/log.c:81
+#, c-format
+msgid "invalid --decorate option: %s"
+msgstr "opció --decorate invàlida: %s"
 
 #: builtin/log.c:127
 msgid "suppress diff output"
@@ -6300,247 +6492,256 @@ msgstr "mostra el fons"
 
 #: builtin/log.c:129
 msgid "Use mail map file"
-msgstr "Utilitza fitxer de mapa de correu"
+msgstr "Usa el fitxer de mapa de correu"
 
 #: builtin/log.c:130
 msgid "decorate options"
 msgstr "opcions de decoració"
+
+#: builtin/log.c:133
+msgid "Process line range n,m in file, counting from 1"
+msgstr "Processa el rang de línies n,m en el fitxer, comptant des de 1"
 
 #: builtin/log.c:229
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Sortida final: %d %s\n"
 
-#: builtin/log.c:470 builtin/log.c:562
+#: builtin/log.c:458
+#, c-format
+msgid "git show %s: bad file"
+msgstr "git show %s: fitxer dolent"
+
+#: builtin/log.c:472 builtin/log.c:564
 #, c-format
 msgid "Could not read object %s"
 msgstr "No es pot llegir l'objecte %s"
 
-#: builtin/log.c:586
+#: builtin/log.c:588
 #, c-format
 msgid "Unknown type: %d"
 msgstr "Tipus desconegut: %d"
 
-#: builtin/log.c:687
+#: builtin/log.c:689
 msgid "format.headers without value"
 msgstr "format.headers sense valor"
 
-#: builtin/log.c:771
+#: builtin/log.c:773
 msgid "name of output directory is too long"
 msgstr "el nom del directori de sortida és massa llarg"
 
-#: builtin/log.c:787
+#: builtin/log.c:789
 #, c-format
 msgid "Cannot open patch file %s"
 msgstr "No es pot obrir el fitxer de pedaç %s"
 
-#: builtin/log.c:801
+#: builtin/log.c:803
 msgid "Need exactly one range."
 msgstr "Cal exactament un rang."
 
-#: builtin/log.c:809
+#: builtin/log.c:811
 msgid "Not a range."
 msgstr "No és un rang."
 
-#: builtin/log.c:916
+#: builtin/log.c:919
 msgid "Cover letter needs email format"
 msgstr "La carta de presentació necessita el format de correu electrònic"
 
-#: builtin/log.c:995
+#: builtin/log.c:998
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "in-reply-to boig: %s"
 
-#: builtin/log.c:1023
+#: builtin/log.c:1026
 msgid "git format-patch [options] [<since> | <revision range>]"
 msgstr "git format-patch [opcions] [<des de> | <rang de revisions>]"
 
-#: builtin/log.c:1068
+#: builtin/log.c:1071
 msgid "Two output directories?"
 msgstr "Dos directoris de sortida?"
 
-#: builtin/log.c:1183
-msgid "use [PATCH n/m] even with a single patch"
-msgstr "utilitza [PATCH n/m] encara amb un pedaç solter"
-
 #: builtin/log.c:1186
+msgid "use [PATCH n/m] even with a single patch"
+msgstr "usa [PATCH n/m] encara amb un pedaç solter"
+
+#: builtin/log.c:1189
 msgid "use [PATCH] even with multiple patches"
-msgstr "utilitza [PATCH] encara amb múltiples pedaços"
+msgstr "usa [PATCH] encara amb múltiples pedaços"
 
-#: builtin/log.c:1190
+#: builtin/log.c:1193
 msgid "print patches to standard out"
-msgstr "imprimeix els pedaços al sortida estàndard"
+msgstr "imprimeix els pedaços a la sortida estàndard"
 
-#: builtin/log.c:1192
+#: builtin/log.c:1195
 msgid "generate a cover letter"
 msgstr "genera una carta de presentació"
 
-#: builtin/log.c:1194
+#: builtin/log.c:1197
 msgid "use simple number sequence for output file names"
-msgstr "utilitza una seqüència de números per als noms dels fitxers de sortida"
+msgstr "usa una seqüència de números per als noms dels fitxers de sortida"
 
-#: builtin/log.c:1195
+#: builtin/log.c:1198
 msgid "sfx"
 msgstr "sufix"
 
-#: builtin/log.c:1196
+#: builtin/log.c:1199
 msgid "use <sfx> instead of '.patch'"
-msgstr "utilitza <sufix> en lloc de '.patch'"
+msgstr "usa <sufix> en lloc de '.patch'"
 
-#: builtin/log.c:1198
+#: builtin/log.c:1201
 msgid "start numbering patches at <n> instead of 1"
 msgstr "comença nombrant els pedaços a <n> en lloc d'1"
 
-#: builtin/log.c:1200
+#: builtin/log.c:1203
 msgid "mark the series as Nth re-roll"
-msgstr "marca la sèrie com la Nª llançada"
-
-#: builtin/log.c:1202
-msgid "Use [<prefix>] instead of [PATCH]"
-msgstr "Utilitza [<prefix>] en lloc de [PATCH]"
+msgstr "marca la sèrie com a la Nª llançada"
 
 #: builtin/log.c:1205
+msgid "Use [<prefix>] instead of [PATCH]"
+msgstr "Usa [<prefix>] en lloc de [PATCH]"
+
+#: builtin/log.c:1208
 msgid "store resulting files in <dir>"
 msgstr "emmagatzema els fitxers resultants en <directori>"
 
-#: builtin/log.c:1208
+#: builtin/log.c:1211
 msgid "don't strip/add [PATCH]"
 msgstr "no despullis/afegeixis [PATCH]"
 
-#: builtin/log.c:1211
+#: builtin/log.c:1214
 msgid "don't output binary diffs"
 msgstr "no emetis diferències binàries"
 
-#: builtin/log.c:1213
+#: builtin/log.c:1216
 msgid "don't include a patch matching a commit upstream"
-msgstr "no incloguis un pedaç que coincideixi amb una comissió a la font"
+msgstr "no incloguis pedaços que coincideixin amb comissions a la font"
 
-#: builtin/log.c:1215
+#: builtin/log.c:1218
 msgid "show patch format instead of default (patch + stat)"
 msgstr ""
 "mostra el format de pedaç en lloc del per defecte (pedaç + estadístiques)"
 
-#: builtin/log.c:1217
+#: builtin/log.c:1220
 msgid "Messaging"
 msgstr "Missatgeria"
 
-#: builtin/log.c:1218
+#: builtin/log.c:1221
 msgid "header"
 msgstr "capçalera"
 
-#: builtin/log.c:1219
+#: builtin/log.c:1222
 msgid "add email header"
-msgstr "afegeix capçalera de correu electrònic"
+msgstr "afegeix una capçalera de correu electrònic"
 
-#: builtin/log.c:1220 builtin/log.c:1222
+#: builtin/log.c:1223 builtin/log.c:1225
 msgid "email"
 msgstr "correu electrònic"
 
-#: builtin/log.c:1220
+#: builtin/log.c:1223
 msgid "add To: header"
-msgstr "afegeix capçalera To:"
+msgstr "afegeix la capçalera To:"
 
-#: builtin/log.c:1222
+#: builtin/log.c:1225
 msgid "add Cc: header"
-msgstr "afegeix capçalera Cc:"
+msgstr "afegeix la capçalera Cc:"
 
-#: builtin/log.c:1224
+#: builtin/log.c:1227
 msgid "ident"
 msgstr "identitat"
 
-#: builtin/log.c:1225
+#: builtin/log.c:1228
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "estableix l'adreça From a <identitat> (o la identitat del comitent si absent)"
 
-#: builtin/log.c:1227
+#: builtin/log.c:1230
 msgid "message-id"
 msgstr "ID de missatge"
 
-#: builtin/log.c:1228
+#: builtin/log.c:1231
 msgid "make first mail a reply to <message-id>"
 msgstr "fes el primer missatge una resposta a <ID de missatge>"
 
-#: builtin/log.c:1229 builtin/log.c:1232
+#: builtin/log.c:1232 builtin/log.c:1235
 msgid "boundary"
 msgstr "límit"
 
-#: builtin/log.c:1230
+#: builtin/log.c:1233
 msgid "attach the patch"
 msgstr "ajunta el pedaç"
 
-#: builtin/log.c:1233
+#: builtin/log.c:1236
 msgid "inline the patch"
 msgstr "posa el pedaç en el cos"
 
-#: builtin/log.c:1237
+#: builtin/log.c:1240
 msgid "enable message threading, styles: shallow, deep"
 msgstr "habilita l'enfilada de missatges, estils: shallow, deep"
 
-#: builtin/log.c:1239
+#: builtin/log.c:1242
 msgid "signature"
 msgstr "firma"
 
-#: builtin/log.c:1240
+#: builtin/log.c:1243
 msgid "add a signature"
 msgstr "afegeix una firma"
 
-#: builtin/log.c:1242
+#: builtin/log.c:1245
 msgid "add a signature from a file"
 msgstr "afegeix una firma des d'un fitxer"
 
-#: builtin/log.c:1243
+#: builtin/log.c:1246
 msgid "don't print the patch filenames"
 msgstr "no imprimeixis els noms de fitxer del pedaç"
 
-#: builtin/log.c:1317
+#: builtin/log.c:1320
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "línia d'identitat invàlida: %s"
 
-#: builtin/log.c:1332
+#: builtin/log.c:1335
 msgid "-n and -k are mutually exclusive."
 msgstr "-n i -k són mutualment exclusius."
 
-#: builtin/log.c:1334
+#: builtin/log.c:1337
 msgid "--subject-prefix and -k are mutually exclusive."
 msgstr "--subject-prefix i -k són mutualment exclusius."
 
-#: builtin/log.c:1342
+#: builtin/log.c:1345
 msgid "--name-only does not make sense"
 msgstr "--name-only no té sentit"
 
-#: builtin/log.c:1344
+#: builtin/log.c:1347
 msgid "--name-status does not make sense"
 msgstr "--name-status no té sentit"
 
-#: builtin/log.c:1346
+#: builtin/log.c:1349
 msgid "--check does not make sense"
 msgstr "--check no té sentit"
 
-#: builtin/log.c:1369
+#: builtin/log.c:1372
 msgid "standard output, or directory, which one?"
-msgstr "sortida estàndard, o directori, qual?"
+msgstr "sortida estàndard, o directori, qual dels dos?"
 
-#: builtin/log.c:1371
+#: builtin/log.c:1374
 #, c-format
 msgid "Could not create directory '%s'"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: builtin/log.c:1468
+#: builtin/log.c:1472
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "incapaç de llegir el fitxer de firma '%s'"
 
-#: builtin/log.c:1531
+#: builtin/log.c:1535
 msgid "Failed to create output files"
-msgstr "S'ha fallat al crear fitxers de sortida"
+msgstr "S'ha fallat en crear els fitxers de sortida"
 
-#: builtin/log.c:1579
+#: builtin/log.c:1583
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<font> [<cap> [<límit>]]]"
 
-#: builtin/log.c:1634
+#: builtin/log.c:1638
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -6548,7 +6749,7 @@ msgstr ""
 "No s'ha pogut trobar una rama remota seguida, si us plau, especifiqueu "
 "<font> manualment.\n"
 
-#: builtin/log.c:1647 builtin/log.c:1649 builtin/log.c:1661
+#: builtin/log.c:1651 builtin/log.c:1653 builtin/log.c:1665
 #, c-format
 msgid "Unknown commit %s"
 msgstr "Comissió desconeguda %s"
@@ -6563,7 +6764,7 @@ msgstr "identifica l'estat de fitxer amb etiquetes"
 
 #: builtin/ls-files.c:460
 msgid "use lowercase letters for 'assume unchanged' files"
-msgstr "utilitza lletres minúscules per als fitxers 'assume unchanged'"
+msgstr "usa lletres minúscules per als fitxers 'assume unchanged'"
 
 #: builtin/ls-files.c:462
 msgid "show cached files in the output (default)"
@@ -6594,12 +6795,12 @@ msgid "show files on the filesystem that need to be removed"
 msgstr "mostra els fitxers en el sistema de fitxers que s'han de treure"
 
 #: builtin/ls-files.c:477
-msgid "show 'other' directories' name only"
+msgid "show 'other' directories' names only"
 msgstr "mostra només els noms dels directoris 'other'"
 
 #: builtin/ls-files.c:480
 msgid "don't show empty directories"
-msgstr "no mostris directoris buits"
+msgstr "no mostris els directoris buits"
 
 #: builtin/ls-files.c:483
 msgid "show unmerged files in the output"
@@ -6619,7 +6820,7 @@ msgstr "els patrons d'exclusió es llegeixen de <fitxer>"
 
 #: builtin/ls-files.c:493
 msgid "read additional per-directory exclude patterns in <file>"
-msgstr "llegeix els patrons d'exclusió per directori addicionals en <fitxer>"
+msgstr "llegeix els patrons addicionals d'exclusió per directori en <fitxer>"
 
 #: builtin/ls-files.c:495
 msgid "add the standard git exclusions"
@@ -6631,7 +6832,7 @@ msgstr "fes que la sortida sigui relativa al directori superior del project"
 
 #: builtin/ls-files.c:501
 msgid "if any <file> is not in the index, treat this as an error"
-msgstr "si qualsevol <fitxer> no està en l'índex, tracta això com error"
+msgstr "si qualsevol <fitxer> no és en l'índex, tracta això com a error"
 
 #: builtin/ls-files.c:502
 msgid "tree-ish"
@@ -6640,11 +6841,11 @@ msgstr "arbre"
 #: builtin/ls-files.c:503
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
-"pretenguis que les rutes tretes deprés de <arbre> encara estiguin presents"
+"pretenguis que les rutes tretes després de <arbre> encara estiguin presents"
 
 #: builtin/ls-files.c:505
 msgid "show debugging data"
-msgstr "mostra dades de depuració"
+msgstr "mostra les dades de depuració"
 
 #: builtin/ls-tree.c:28
 msgid "git ls-tree [<options>] <tree-ish> [<path>...]"
@@ -6656,7 +6857,7 @@ msgstr "mostra només els arbres"
 
 #: builtin/ls-tree.c:128
 msgid "recurse into subtrees"
-msgstr "recursa a subarbres"
+msgstr "recursa als subarbres"
 
 #: builtin/ls-tree.c:130
 msgid "show trees when recursing"
@@ -6672,110 +6873,110 @@ msgstr "mida de l'objecte d'inclusió"
 
 #: builtin/ls-tree.c:136 builtin/ls-tree.c:138
 msgid "list only filenames"
-msgstr "llista només noms de fitxer"
+msgstr "llista només els noms de fitxer"
 
 #: builtin/ls-tree.c:141
 msgid "use full path names"
-msgstr "utilitza noms de ruta compets"
+msgstr "usa els noms de ruta complets"
 
 #: builtin/ls-tree.c:143
 msgid "list entire tree; not just current directory (implies --full-name)"
 msgstr "llista l'arbre enter; no sol el directori actual (implica --full-name)"
 
-#: builtin/merge.c:43
+#: builtin/merge.c:44
 msgid "git merge [options] [<commit>...]"
 msgstr "git merge [opcions] [<comissió>...]"
 
-#: builtin/merge.c:44
+#: builtin/merge.c:45
 msgid "git merge [options] <msg> HEAD <commit>"
 msgstr "git merge [opcions] <missatge> HEAD <comissió>"
 
-#: builtin/merge.c:45
+#: builtin/merge.c:46
 msgid "git merge --abort"
 msgstr "git merge --abort"
 
-#: builtin/merge.c:98
+#: builtin/merge.c:99
 msgid "switch `m' requires a value"
 msgstr "l'opció `m' requereix un valor"
 
-#: builtin/merge.c:135
+#: builtin/merge.c:136
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "No s'ha pogut trobar l'estratègia de fusió '%s'.\n"
 
-#: builtin/merge.c:136
+#: builtin/merge.c:137
 #, c-format
 msgid "Available strategies are:"
 msgstr "Les estratègies disponibles són:"
 
-#: builtin/merge.c:141
+#: builtin/merge.c:142
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Les estratègies personalitzades disponibles són:"
 
-#: builtin/merge.c:191
+#: builtin/merge.c:192
 msgid "do not show a diffstat at the end of the merge"
 msgstr "no mostris les estadístiques de diferència al final de la fusió"
 
-#: builtin/merge.c:194
+#: builtin/merge.c:195
 msgid "show a diffstat at the end of the merge"
 msgstr "mostra les estadístiques de diferència al final de la fusió"
 
-#: builtin/merge.c:195
+#: builtin/merge.c:196
 msgid "(synonym to --stat)"
 msgstr "(sinònim de --stat)"
 
-#: builtin/merge.c:197
+#: builtin/merge.c:198
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
-"afegeix (com màxim <n>) entrades del registre curt per fusionar el missatge "
-"de comissió"
+"afegeix (com a màxim <n>) entrades del registre curt per a fusionar el "
+"missatge de comissió"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 msgid "create a single commit instead of doing a merge"
 msgstr "crea una comissió soltera en lloc de fusionar"
 
-#: builtin/merge.c:202
+#: builtin/merge.c:203
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "realitza una comissió si la fusió té èxit (per defecte)"
 
-#: builtin/merge.c:204
+#: builtin/merge.c:205
 msgid "edit message before committing"
 msgstr "edita el missatge abans de cometre"
 
-#: builtin/merge.c:205
+#: builtin/merge.c:206
 msgid "allow fast-forward (default)"
 msgstr "permet l'avanç ràpid (per defecte)"
 
-#: builtin/merge.c:207
+#: builtin/merge.c:208
 msgid "abort if fast-forward is not possible"
 msgstr "avorta si l'avanç ràpid no és possible"
 
-#: builtin/merge.c:211
+#: builtin/merge.c:212
 msgid "Verify that the named commit has a valid GPG signature"
-msgstr "Verifica que la comissió anomenada té una firma GPG vàlida"
+msgstr "Verifica que la comissió anomenada tingui una firma GPG vàlida"
 
-#: builtin/merge.c:212 builtin/notes.c:742 builtin/revert.c:89
+#: builtin/merge.c:213 builtin/notes.c:741 builtin/revert.c:89
 msgid "strategy"
 msgstr "estratègia"
 
-#: builtin/merge.c:213
-msgid "merge strategy to use"
-msgstr "estratègia de fusió que utilitzar"
-
 #: builtin/merge.c:214
+msgid "merge strategy to use"
+msgstr "estratègia de fusió a usar"
+
+#: builtin/merge.c:215
 msgid "option=value"
 msgstr "opció=valor"
 
-#: builtin/merge.c:215
+#: builtin/merge.c:216
 msgid "option for selected merge strategy"
 msgstr "opció per a l'estratègia de fusió seleccionada"
 
-#: builtin/merge.c:217
+#: builtin/merge.c:218
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "missatge de comissió de fusió (per a una fusió no de avanç ràpid)"
 
-#: builtin/merge.c:221
+#: builtin/merge.c:222
 msgid "abort the current in-progress merge"
 msgstr "avorta la fusió en curs actual"
 
@@ -6790,7 +6991,7 @@ msgstr "L'emmagatzemament ha fallat."
 #: builtin/merge.c:260
 #, c-format
 msgid "not a valid object: %s"
-msgstr "no és un objecte vàlid: %s"
+msgstr "no és objecte vàlid: %s"
 
 #: builtin/merge.c:279 builtin/merge.c:296
 msgid "read-tree failed"
@@ -6798,7 +6999,7 @@ msgstr "read-tree ha fallat"
 
 #: builtin/merge.c:326
 msgid " (nothing to squash)"
-msgstr " (res que aixafar)"
+msgstr " (res a aixafar)"
 
 #: builtin/merge.c:339
 #, c-format
@@ -6830,33 +7031,33 @@ msgstr "Cadena branch.%s.mergeoptions dolenta: %s"
 
 #: builtin/merge.c:653
 msgid "git write-tree failed to write a tree"
-msgstr "git write-tree ha fallat al escriure un arbre"
+msgstr "git write-tree ha fallat en escriure un arbre"
 
-#: builtin/merge.c:678
+#: builtin/merge.c:677
 msgid "Not handling anything other than two heads merge."
 msgstr "No manejant res apart de la fusió de dos caps."
 
-#: builtin/merge.c:692
+#: builtin/merge.c:691
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Opció desconeguda de merge-recursive: -X%s"
 
-#: builtin/merge.c:705
+#: builtin/merge.c:704
 #, c-format
 msgid "unable to write %s"
 msgstr "incapaç d'escriure %s"
 
-#: builtin/merge.c:794
+#: builtin/merge.c:793
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "No s'ha pogut llegir de '%s'"
 
-#: builtin/merge.c:803
+#: builtin/merge.c:802
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
-msgstr "No comitent la fusió; utilitzeu 'git commit' per terminar la fusió.\n"
+msgstr "No comitent la fusió; useu 'git commit' per a terminar la fusió.\n"
 
-#: builtin/merge.c:809
+#: builtin/merge.c:808
 #, c-format
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
@@ -6872,167 +7073,169 @@ msgstr ""
 "S'ignoraran les línies que comencin amb '%c', i un missatge buit\n"
 "avorta la comissió.\n"
 
-#: builtin/merge.c:833
+#: builtin/merge.c:832
 msgid "Empty commit message."
 msgstr "Missatge de comissió buit."
 
-#: builtin/merge.c:845
+#: builtin/merge.c:844
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Meravellós.\n"
 
-#: builtin/merge.c:908
+#: builtin/merge.c:907
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "La fusió automàtica ha fallat; arregleu els conflictes i després cometeu el "
 "resultat.\n"
 
-#: builtin/merge.c:924
+#: builtin/merge.c:923
 #, c-format
 msgid "'%s' is not a commit"
 msgstr "'%s' no és una comissió"
 
-#: builtin/merge.c:965
+#: builtin/merge.c:964
 msgid "No current branch."
 msgstr "Cap rama actual."
 
-#: builtin/merge.c:967
+#: builtin/merge.c:966
 msgid "No remote for the current branch."
 msgstr "Cap remot per a la rama actual."
 
-#: builtin/merge.c:969
+#: builtin/merge.c:968
 msgid "No default upstream defined for the current branch."
 msgstr "Cap font per defecte definida per a la rama actual."
 
-#: builtin/merge.c:974
+#: builtin/merge.c:973
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
-msgstr "Cap rama de seguiment remot per a %s a %s"
+msgstr "Cap rama de seguiment remot per a %s de %s"
 
-#: builtin/merge.c:1130
+#: builtin/merge.c:1129
 msgid "There is no merge to abort (MERGE_HEAD missing)."
-msgstr "No hi ha fusió que avortar (manca MERGE_HEAD)."
+msgstr "No hi ha fusió a avortar (manca MERGE_HEAD)."
 
-#: builtin/merge.c:1146 git-pull.sh:31
+#: builtin/merge.c:1145
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
-"Please, commit your changes before you can merge."
+"Please, commit your changes before you merge."
 msgstr ""
 "No heu terminat la vostra fusió (MERGE_HEAD existeix).\n"
 "Si us plau, cometeu els vostres canvis abans de fusionar."
 
-#: builtin/merge.c:1149 git-pull.sh:34
+#: builtin/merge.c:1148 git-pull.sh:34
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "No heu terminat la vostra fusió (MERGE_HEAD existeix)."
 
-#: builtin/merge.c:1153
+#: builtin/merge.c:1152
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
-"Please, commit your changes before you can merge."
+"Please, commit your changes before you merge."
 msgstr ""
 "No heu terminat el vostre recull de cireres (CHERRY_PICK_HEAD existeix).\n"
 "Si us plau, cometeu els vostres canvis abans de fusionar."
 
-#: builtin/merge.c:1156
+#: builtin/merge.c:1155
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "No heu terminat el vostre recull de cireres (CHERRY_PICK_HEAD existeix)."
 
-#: builtin/merge.c:1165
+#: builtin/merge.c:1164
 msgid "You cannot combine --squash with --no-ff."
 msgstr "No podeu combinar --squash amb --no-ff."
 
-#: builtin/merge.c:1174
+#: builtin/merge.c:1173
 msgid "No commit specified and merge.defaultToUpstream not set."
-msgstr "Cap comissió especificada i merge.defaultToUpstream no establert."
+msgstr ""
+"No hi ha una comissió especificada i merge.defaultToUpstream no està "
+"establert."
 
-#: builtin/merge.c:1206
+#: builtin/merge.c:1205
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Es pot fusionar només exactament una comissió a un cap buit"
 
-#: builtin/merge.c:1209
+#: builtin/merge.c:1208
 msgid "Squash commit into empty head not supported yet"
 msgstr "Aixafar una comissió a un cap buit encara no es suporta"
 
-#: builtin/merge.c:1211
+#: builtin/merge.c:1210
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Una comissió no d'avanç ràpid no té sentit a un cap buit"
 
-#: builtin/merge.c:1216
+#: builtin/merge.c:1215
 #, c-format
 msgid "%s - not something we can merge"
-msgstr "%s - no és cosa que podem fusionar"
+msgstr "%s - no és cosa que puguem fusionar"
 
-#: builtin/merge.c:1267
+#: builtin/merge.c:1266
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr "La comissió %s té una firma GPG no confiada, suposadament de %s."
 
-#: builtin/merge.c:1270
+#: builtin/merge.c:1269
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
-msgstr "La comissió %s té una firma GPG dolenta suposadament per %s."
+msgstr "La comissió %s té una firma GPG dolenta suposadament de %s."
 
-#: builtin/merge.c:1273
+#: builtin/merge.c:1272
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "La comissió %s no té firma GPG."
 
-#: builtin/merge.c:1276
+#: builtin/merge.c:1275
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
-msgstr "La comissió %s té una firma GPG bona per %s\n"
+msgstr "La comissió %s té una firma GPG bona de %s\n"
 
-#: builtin/merge.c:1357
+#: builtin/merge.c:1356
 #, c-format
 msgid "Updating %s..%s\n"
-msgstr "Actualizant %s..%s\n"
+msgstr "Actualitzant %s..%s\n"
 
-#: builtin/merge.c:1396
+#: builtin/merge.c:1395
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
-msgstr "Intentant una fusió realment trivial en l'índex...\n"
+msgstr "Intentant una fusió molt trivial en l'índex...\n"
 
-#: builtin/merge.c:1403
+#: builtin/merge.c:1402
 #, c-format
 msgid "Nope.\n"
 msgstr "No.\n"
 
-#: builtin/merge.c:1435
+#: builtin/merge.c:1434
 msgid "Not possible to fast-forward, aborting."
 msgstr "No és possible avançar ràpidament, avortant."
 
-#: builtin/merge.c:1458 builtin/merge.c:1537
+#: builtin/merge.c:1457 builtin/merge.c:1536
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
-msgstr "Rebobinant l'arbre a la prístina...\n"
+msgstr "Rebobinant l'arbre a la pristina...\n"
 
-#: builtin/merge.c:1462
+#: builtin/merge.c:1461
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Intentant l'estratègia de fusió %s...\n"
 
-#: builtin/merge.c:1528
+#: builtin/merge.c:1527
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Cap estratègia de fusió ha manejat la fusió.\n"
 
-#: builtin/merge.c:1530
+#: builtin/merge.c:1529
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "L'estratègia de fusió %s ha fallat.\n"
 
-#: builtin/merge.c:1539
+#: builtin/merge.c:1538
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
-msgstr "Utilitzant el %s per preparar la resolució a mà.\n"
+msgstr "Usant el %s per a preparar la resolució a mà.\n"
 
-#: builtin/merge.c:1551
+#: builtin/merge.c:1550
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
-"La fusió automàtica ha sortit bé; aturat abans de cometre com demanat\n"
+"La fusió automàtica ha sortit bé; aturat abans de cometre segons demanat\n"
 
 #: builtin/merge-base.c:29
 msgid "git merge-base [-a|--all] <commit> <commit>..."
@@ -7060,7 +7263,7 @@ msgstr "emet tots els avantpassats comuns"
 
 #: builtin/merge-base.c:216
 msgid "find ancestors for a single n-way merge"
-msgstr "troba els avantpassats per a una fusió de n vies soltera"
+msgstr "troba els avantpassats per a una fusió soltera de n vies"
 
 #: builtin/merge-base.c:218
 msgid "list revs not reachable from others"
@@ -7068,7 +7271,7 @@ msgstr "llista les revisions no abastables d'altres"
 
 #: builtin/merge-base.c:220
 msgid "is the first one ancestor of the other?"
-msgstr "és el primer avantpassat de l'altre?"
+msgstr "és el primer un avantpassat de l'altre?"
 
 #: builtin/merge-base.c:222
 msgid "find where <commit> forked from reflog of <ref>"
@@ -7089,23 +7292,23 @@ msgstr "envia els resultats a la sortida estàndard"
 
 #: builtin/merge-file.c:34
 msgid "use a diff3 based merge"
-msgstr "utilitza una fusió basada en diff3"
+msgstr "usa una fusió basada en diff3"
 
 #: builtin/merge-file.c:35
 msgid "for conflicts, use our version"
-msgstr "en conflictes, utilitza la versió nostra"
+msgstr "en conflictes, usa la versió nostra"
 
 #: builtin/merge-file.c:37
 msgid "for conflicts, use their version"
-msgstr "en conflictes, utilitza la versió seva"
+msgstr "en conflictes, usa la versió seva"
 
 #: builtin/merge-file.c:39
 msgid "for conflicts, use a union version"
-msgstr "en conflictes, utilitza una versió d'unió"
+msgstr "en conflictes, usa una versió d'unió"
 
 #: builtin/merge-file.c:42
 msgid "for conflicts, use this marker size"
-msgstr "en conflicte, utilitza aquesta mida de marcador"
+msgstr "en conflictes, usa aquesta mida de marcador"
 
 #: builtin/merge-file.c:43
 msgid "do not warn about conflicts"
@@ -7113,7 +7316,7 @@ msgstr "no avisis de conflictes"
 
 #: builtin/merge-file.c:45
 msgid "set labels for file1/orig_file/file2"
-msgstr "estableix les etiquetes per a file1/orig_file/file2"
+msgstr "estableix les etiquetes per a fitxer1/fitxer_original/fitxer2"
 
 #: builtin/mktree.c:64
 msgid "git mktree [-z] [--missing] [--batch]"
@@ -7133,89 +7336,94 @@ msgstr "permet la creació de més d'un arbre"
 
 #: builtin/mv.c:15
 msgid "git mv [options] <source>... <destination>"
-msgstr "git mv [opcions] <fons>... <destí>"
+msgstr "git mv [opcions] <font>... <destí>"
+
+#: builtin/mv.c:69
+#, c-format
+msgid "Directory %s is in index and no submodule?"
+msgstr "El directori %s està en l'índex i no hi ha submòdul?"
 
 #: builtin/mv.c:71
-msgid "force move/rename even if target exists"
-msgstr "força moviment/canvi de nom encara que el destí existeixi"
-
-#: builtin/mv.c:72
-msgid "skip move/rename errors"
-msgstr "salta els error de moviment/canvi de nom"
-
-#: builtin/mv.c:122
-#, c-format
-msgid "Checking rename of '%s' to '%s'\n"
-msgstr "Comprovant el canvi de nom de '%s' a '%s'\n"
-
-#: builtin/mv.c:126
-msgid "bad source"
-msgstr "font dolenta"
-
-#: builtin/mv.c:129
-msgid "can not move directory into itself"
-msgstr "no es pot moure un directori al seu mateix"
-
-#: builtin/mv.c:132
-msgid "cannot move directory over file"
-msgstr "no es pot moure un directori sobre un fitxer"
-
-#: builtin/mv.c:138
-#, c-format
-msgid "Huh? Directory %s is in index and no submodule?"
-msgstr "Perdó? El directori %s està en l'índex i no hi ha submòdul?"
-
-#: builtin/mv.c:140 builtin/rm.c:318
-msgid "Please, stage your changes to .gitmodules or stash them to proceed"
+msgid "Please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "Si us plau, allisteu els vostres canvis a .gitmodules o emmagatzemeu-los per "
 "a procedir"
 
-#: builtin/mv.c:156
+#: builtin/mv.c:89
 #, c-format
-msgid "Huh? %.*s is in index?"
-msgstr "Perdó? %.*s està en l'índex?"
+msgid "%.*s is in index"
+msgstr "%.*s està en l'índex"
+
+#: builtin/mv.c:111
+msgid "force move/rename even if target exists"
+msgstr "força el moviment / canvi de nom encara que el destí existeixi"
+
+#: builtin/mv.c:112
+msgid "skip move/rename errors"
+msgstr "salta els error de moviment / canvi de nom"
+
+#: builtin/mv.c:151
+#, c-format
+msgid "destination '%s' is not a directory"
+msgstr "el destí '%s' no és un directori"
+
+#: builtin/mv.c:162
+#, c-format
+msgid "Checking rename of '%s' to '%s'\n"
+msgstr "Comprovant el canvi de nom de '%s' a '%s'\n"
+
+#: builtin/mv.c:166
+msgid "bad source"
+msgstr "font dolenta"
 
 #: builtin/mv.c:169
+msgid "can not move directory into itself"
+msgstr "no es pot moure un directori al seu mateix"
+
+#: builtin/mv.c:172
+msgid "cannot move directory over file"
+msgstr "no es pot moure un directori sobre un fitxer"
+
+#: builtin/mv.c:181
 msgid "source directory is empty"
 msgstr "el directori font està buit"
 
-#: builtin/mv.c:205
+#: builtin/mv.c:206
 msgid "not under version control"
-msgstr "no baix control de versions"
+msgstr "no està baix control de versions"
 
-#: builtin/mv.c:208
+#: builtin/mv.c:209
 msgid "destination exists"
 msgstr "el destí existeix"
 
-#: builtin/mv.c:216
+#: builtin/mv.c:217
 #, c-format
 msgid "overwriting '%s'"
 msgstr "sobreescrivint '%s'"
 
-#: builtin/mv.c:219
+#: builtin/mv.c:220
 msgid "Cannot overwrite"
 msgstr "No es pot sobreescriure"
 
-#: builtin/mv.c:222
+#: builtin/mv.c:223
 msgid "multiple sources for the same target"
 msgstr "múltiples fonts per al mateix destí"
 
-#: builtin/mv.c:224
+#: builtin/mv.c:225
 msgid "destination directory does not exist"
 msgstr "el directori destí no existeix"
 
-#: builtin/mv.c:244
+#: builtin/mv.c:232
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, origen=%s, destí=%s"
 
-#: builtin/mv.c:254
+#: builtin/mv.c:253
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Canviant el nom de %s a %s\n"
 
-#: builtin/mv.c:257 builtin/remote.c:725 builtin/repack.c:358
+#: builtin/mv.c:256 builtin/remote.c:726 builtin/repack.c:358
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "el canvi del nom de '%s' ha fallat"
@@ -7234,15 +7442,15 @@ msgstr "git name-rev [opcions] --stdin"
 
 #: builtin/name-rev.c:309
 msgid "print only names (no SHA-1)"
-msgstr "imprimeix només els noms (cap SHA-1)"
+msgstr "imprimeix només els noms (sense SHA-1)"
 
 #: builtin/name-rev.c:310
 msgid "only use tags to name the commits"
-msgstr "només utilitza etiquetes per anomenar les comissions"
+msgstr "només usa les etiquetes per a anomenar les comissions"
 
 #: builtin/name-rev.c:312
 msgid "only use refs matching <pattern>"
-msgstr "només utilitza les referències que coincideixen amb <patró>"
+msgstr "només usa les referències que coincideixin amb <patró>"
 
 #: builtin/name-rev.c:314
 msgid "list all commits reachable from all refs"
@@ -7250,11 +7458,11 @@ msgstr "llista totes les comissions abastables de totes les referències"
 
 #: builtin/name-rev.c:315
 msgid "read from stdin"
-msgstr "llegeix de stdin"
+msgstr "llegeix d'stdin"
 
 #: builtin/name-rev.c:316
 msgid "allow to print `undefined` names (default)"
-msgstr "permet imprimir noms `undefined` (per defecte)"
+msgstr "permet imprimir els noms `undefined` (per defecte)"
 
 #: builtin/name-rev.c:322
 msgid "dereference tags in the input (internal use)"
@@ -7372,414 +7580,422 @@ msgstr "git notes prune [<opcions>]"
 msgid "git notes get-ref"
 msgstr "git notes get-ref"
 
-#: builtin/notes.c:137
+#: builtin/notes.c:136
 #, c-format
 msgid "unable to start 'show' for object '%s'"
-msgstr "incapaç d'iniciar 'show' per al objecte '%s'"
+msgstr "incapaç d'iniciar 'show' per a l'objecte '%s'"
 
-#: builtin/notes.c:141
+#: builtin/notes.c:140
 msgid "could not read 'show' output"
 msgstr "no s'ha pogut llegir la sortida de 'show'"
 
-#: builtin/notes.c:149
+#: builtin/notes.c:148
 #, c-format
 msgid "failed to finish 'show' for object '%s'"
-msgstr "s'ha fallat al terminar 'show' per al objecte '%s'"
+msgstr "s'ha fallat en terminar 'show' per a l'objecte '%s'"
 
-#: builtin/notes.c:167 builtin/tag.c:477
+#: builtin/notes.c:166 builtin/tag.c:477
 #, c-format
 msgid "could not create file '%s'"
 msgstr "no s'ha pogut crear el fitxer '%s'"
 
-#: builtin/notes.c:186
+#: builtin/notes.c:185
 msgid "Please supply the note contents using either -m or -F option"
 msgstr ""
-"Si us plau, proveïu els continguts de la nota utilitzant o l'opció -m o "
+"Si us plau, proveïu els continguts de la nota per usar o l'opció -m o "
 "l'opció -F"
 
-#: builtin/notes.c:207 builtin/notes.c:848
+#: builtin/notes.c:206 builtin/notes.c:847
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Traient la nota de l'objecte %s\n"
 
-#: builtin/notes.c:212
+#: builtin/notes.c:211
 msgid "unable to write note object"
 msgstr "incapaç d'escriure l'objecte de nota"
 
-#: builtin/notes.c:214
+#: builtin/notes.c:213
 #, c-format
-msgid "The note contents has been left in %s"
+msgid "The note contents have been left in %s"
 msgstr "Els continguts de la nota s'han deixat en %s"
 
-#: builtin/notes.c:248 builtin/tag.c:692
+#: builtin/notes.c:247 builtin/tag.c:693
 #, c-format
 msgid "cannot read '%s'"
 msgstr "no es pot llegir '%s'"
 
-#: builtin/notes.c:250 builtin/tag.c:695
+#: builtin/notes.c:249 builtin/tag.c:696
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "no s'ha pogut obrir ni llegir '%s'"
 
-#: builtin/notes.c:269 builtin/notes.c:320 builtin/notes.c:322
-#: builtin/notes.c:382 builtin/notes.c:436 builtin/notes.c:519
-#: builtin/notes.c:524 builtin/notes.c:599 builtin/notes.c:641
-#: builtin/notes.c:843 builtin/tag.c:708
+#: builtin/notes.c:268 builtin/notes.c:319 builtin/notes.c:321
+#: builtin/notes.c:381 builtin/notes.c:435 builtin/notes.c:518
+#: builtin/notes.c:523 builtin/notes.c:598 builtin/notes.c:640
+#: builtin/notes.c:842 builtin/tag.c:709
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
-msgstr "S'ha fallat al resoldre '%s' com referència vàlida."
+msgstr "S'ha fallat en resoldre '%s' com a referència vàlida."
 
-#: builtin/notes.c:272
+#: builtin/notes.c:271
 #, c-format
 msgid "Failed to read object '%s'."
-msgstr "S'ha fallat al llegir l'objecte '%s'."
+msgstr "S'ha fallat en llegir l'objecte '%s'."
 
-#: builtin/notes.c:276
+#: builtin/notes.c:275
 #, c-format
 msgid "Cannot read note data from non-blob object '%s'."
-msgstr "No es pot llegir dades de node de l'objecte no de blob '%s'."
+msgstr "No es pot llegir les dades de node de l'objecte no de blob '%s'."
 
-#: builtin/notes.c:316
+#: builtin/notes.c:315
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Línia d'entrada malformada: '%s'."
 
-#: builtin/notes.c:331
+#: builtin/notes.c:330
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
-msgstr "S'ha fallat al copiar les notes de '%s' a '%s'"
+msgstr "S'ha fallat en copiar les notes de '%s' a '%s'"
 
-#: builtin/notes.c:375 builtin/notes.c:429 builtin/notes.c:502
-#: builtin/notes.c:514 builtin/notes.c:587 builtin/notes.c:634
-#: builtin/notes.c:908
+#: builtin/notes.c:374 builtin/notes.c:428 builtin/notes.c:501
+#: builtin/notes.c:513 builtin/notes.c:586 builtin/notes.c:633
+#: builtin/notes.c:907
 msgid "too many parameters"
 msgstr "massa paràmetres"
 
-#: builtin/notes.c:388 builtin/notes.c:647
+#: builtin/notes.c:387 builtin/notes.c:646
 #, c-format
 msgid "No note found for object %s."
 msgstr "Cap nota trobada per a l'objecte %s."
 
-#: builtin/notes.c:410 builtin/notes.c:567
+#: builtin/notes.c:409 builtin/notes.c:566
 msgid "note contents as a string"
-msgstr "nota els continguta com cadena"
+msgstr "nota els continguts com a cadena"
 
-#: builtin/notes.c:413 builtin/notes.c:570
+#: builtin/notes.c:412 builtin/notes.c:569
 msgid "note contents in a file"
 msgstr "nota els continguts en un fitxer"
 
-#: builtin/notes.c:415 builtin/notes.c:418 builtin/notes.c:572
-#: builtin/notes.c:575 builtin/tag.c:627
+#: builtin/notes.c:414 builtin/notes.c:417 builtin/notes.c:571
+#: builtin/notes.c:574 builtin/tag.c:628
 msgid "object"
 msgstr "objecte"
 
-#: builtin/notes.c:416 builtin/notes.c:573
+#: builtin/notes.c:415 builtin/notes.c:572
 msgid "reuse and edit specified note object"
-msgstr "reutilitza i edita l'objecte de nota especificat"
+msgstr "reusa i edita l'objecte de nota especificat"
 
-#: builtin/notes.c:419 builtin/notes.c:576
+#: builtin/notes.c:418 builtin/notes.c:575
 msgid "reuse specified note object"
-msgstr "reutilitza l'objecte de nota especificat"
+msgstr "reusa l'objecte de nota especificat"
 
-#: builtin/notes.c:421 builtin/notes.c:489
+#: builtin/notes.c:420 builtin/notes.c:488
 msgid "replace existing notes"
-msgstr "reemplaça notes existents"
+msgstr "reemplaça les notes existents"
 
-#: builtin/notes.c:455
+#: builtin/notes.c:454
 #, c-format
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
 "No es pot afegir les notes. S'ha trobat notes existents de l'objecte %s. "
-"Utilitza '-f' per sobreescriure les notes existents."
+"Useu '-f' per a sobreescriure les notes existents."
 
-#: builtin/notes.c:460 builtin/notes.c:537
+#: builtin/notes.c:459 builtin/notes.c:536
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Sobreescrivint les notes existents de l'objecte %s\n"
 
-#: builtin/notes.c:490
+#: builtin/notes.c:489
 msgid "read objects from stdin"
-msgstr "llegeix els objects des de stdin"
+msgstr "llegeix els objectes des d'stdin"
 
-#: builtin/notes.c:492
+#: builtin/notes.c:491
 msgid "load rewriting config for <command> (implies --stdin)"
-msgstr "carrega configuració de reescriptura per a <ordre> (implica --stdin)"
+msgstr ""
+"carrega la configuració de reescriptura per a <ordre> (implica --stdin)"
 
-#: builtin/notes.c:510
+#: builtin/notes.c:509
 msgid "too few parameters"
-msgstr "massa pocs paràmetres"
+msgstr "hi ha massa pocs paràmetres"
 
-#: builtin/notes.c:531
+#: builtin/notes.c:530
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
-"No es pot copiar les notes. S'ha trobat notes existents de l'objecte %s. "
-"Utilitza '-f' per sobreescriure les notes existents."
+"No es pot copiar les notes. S'han trobat notes existents de l'objecte %s. "
+"Useu '-f' per a sobreescriure les notes existents."
 
-#: builtin/notes.c:543
+#: builtin/notes.c:542
 #, c-format
 msgid "Missing notes on source object %s. Cannot copy."
-msgstr "Manquen notes en l'objecte font %s. No es pot copiar."
+msgstr "Manquen notes a l'objecte font %s. No es pot copiar."
 
-#: builtin/notes.c:592
+#: builtin/notes.c:591
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
 "Please use 'git notes add -f -m/-F/-c/-C' instead.\n"
 msgstr ""
 "S'han desaprovat les opcions -m/-F/-c/-C del subordre 'edit'.\n"
-"Si us plau, utilitzeu 'git notes add -f -m/-F/-c/-C' en lloc.\n"
+"Si us plau, useu 'git notes add -f -m/-F/-c/-C' en lloc.\n"
 
-#: builtin/notes.c:739
+#: builtin/notes.c:738
 msgid "General options"
 msgstr "Opcions generals"
 
-#: builtin/notes.c:741
+#: builtin/notes.c:740
 msgid "Merge options"
 msgstr "Opcions de fusió"
 
-#: builtin/notes.c:743
+#: builtin/notes.c:742
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
 msgstr ""
-"resol conflictes de nota utilitzant l'estratègia donada (manual/ours/theirs/"
+"resol conflictes de nota per usar l'estratègia donada (manual/ours/theirs/"
 "union/cat_sort_uniq)"
 
-#: builtin/notes.c:745
+#: builtin/notes.c:744
 msgid "Committing unmerged notes"
 msgstr "Cometent les notes sense fusionar"
 
-#: builtin/notes.c:747
+#: builtin/notes.c:746
 msgid "finalize notes merge by committing unmerged notes"
 msgstr "finalitza la fusió de notes per cometre les notes sense fusionar"
 
-#: builtin/notes.c:749
+#: builtin/notes.c:748
 msgid "Aborting notes merge resolution"
 msgstr "Avortant la resolució de fusió de notes"
 
-#: builtin/notes.c:751
+#: builtin/notes.c:750
 msgid "abort notes merge"
-msgstr "avorta fusió de notes"
+msgstr "avorta la fusió de notes"
 
-#: builtin/notes.c:846
+#: builtin/notes.c:845
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "L'objecte %s no té cap nota\n"
 
-#: builtin/notes.c:858
+#: builtin/notes.c:857
 msgid "attempt to remove non-existent note is not an error"
-msgstr "L'intent de treure una nota no existent no és un error"
+msgstr "l'intent de treure una nota no existent no és un error"
 
-#: builtin/notes.c:861
+#: builtin/notes.c:860
 msgid "read object names from the standard input"
 msgstr "llegeix els noms d'objecte des de l'entrada estàndard"
 
-#: builtin/notes.c:942
+#: builtin/notes.c:941
 msgid "notes-ref"
 msgstr "referència de notes"
 
-#: builtin/notes.c:943
+#: builtin/notes.c:942
 msgid "use notes from <notes_ref>"
-msgstr "utilitza les notes de <referència de notes>"
+msgstr "usa les notes de <referència de notes>"
 
-#: builtin/notes.c:978 builtin/remote.c:1616
+#: builtin/notes.c:977 builtin/remote.c:1624
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Subordre desconegut: %s"
 
-#: builtin/pack-objects.c:25
+#: builtin/pack-objects.c:28
 msgid "git pack-objects --stdout [options...] [< ref-list | < object-list]"
 msgstr ""
 "git pack-objects --stdout [opcions...] [< llista-de-referències | < llista-"
 "de-objectes]"
 
-#: builtin/pack-objects.c:26
+#: builtin/pack-objects.c:29
 msgid "git pack-objects [options...] base-name [< ref-list | < object-list]"
 msgstr ""
-"git pack-objects [opcions...] base-name [< llista-de-referències | < llista-"
+"git pack-objects [opcions...] nom-base [< llista-de-referències | < llista-"
 "de-objectes]"
 
-#: builtin/pack-objects.c:175 builtin/pack-objects.c:178
+#: builtin/pack-objects.c:177 builtin/pack-objects.c:180
 #, c-format
 msgid "deflate error (%d)"
 msgstr "error de deflació (%d)"
 
-#: builtin/pack-objects.c:771
+#: builtin/pack-objects.c:773
 msgid "Writing objects"
-msgstr "Escrivint objectes"
+msgstr "Escrivint els objectes"
 
-#: builtin/pack-objects.c:1012
+#: builtin/pack-objects.c:1015
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "deshabilitant l'escriptura de mapes de bits, perquè alguns objectes no "
 "s'estan empaquetant"
 
-#: builtin/pack-objects.c:2174
+#: builtin/pack-objects.c:2175
 msgid "Compressing objects"
 msgstr "Comprimint objectes"
 
-#: builtin/pack-objects.c:2526
+#: builtin/pack-objects.c:2572
 #, c-format
 msgid "unsupported index version %s"
 msgstr "versió d'índex no suportada %s"
 
-#: builtin/pack-objects.c:2530
+#: builtin/pack-objects.c:2576
 #, c-format
 msgid "bad index version '%s'"
 msgstr "versió d'índex dolenta '%s'"
 
-#: builtin/pack-objects.c:2553
+#: builtin/pack-objects.c:2599
 #, c-format
 msgid "option %s does not accept negative form"
-msgstr "l'opció %s no accepta el forma negatiu"
+msgstr "l'opció %s no accepta la forma negativa"
 
-#: builtin/pack-objects.c:2557
+#: builtin/pack-objects.c:2603
 #, c-format
 msgid "unable to parse value '%s' for option %s"
 msgstr "incapaç d'analitzar el valor '%s' per a l'opció %s"
 
-#: builtin/pack-objects.c:2576
+#: builtin/pack-objects.c:2622
 msgid "do not show progress meter"
 msgstr "no mostris l'indicador de progrés"
 
-#: builtin/pack-objects.c:2578
+#: builtin/pack-objects.c:2624
 msgid "show progress meter"
-msgstr "mostra indicador de progrés"
+msgstr "mostra l'indicador de progrés"
 
-#: builtin/pack-objects.c:2580
+#: builtin/pack-objects.c:2626
 msgid "show progress meter during object writing phase"
-msgstr "mostra indicador de progrés durant el fase d'escriptura d'objectes"
+msgstr "mostra l'indicador de progrés durant el fase d'escriptura d'objectes"
 
-#: builtin/pack-objects.c:2583
+#: builtin/pack-objects.c:2629
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "similar a --all-progress quan l'indicador de progrés es mostra"
 
-#: builtin/pack-objects.c:2584
+#: builtin/pack-objects.c:2630
 msgid "version[,offset]"
 msgstr "versió[,desplaçament]"
 
-#: builtin/pack-objects.c:2585
+#: builtin/pack-objects.c:2631
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 "escriu el fitxer d'índex de paquet en la versió de format d'índex "
 "especificada"
 
-#: builtin/pack-objects.c:2588
+#: builtin/pack-objects.c:2634
 msgid "maximum size of each output pack file"
 msgstr "mida màxima de cada fitxer de paquet de sortida"
 
-#: builtin/pack-objects.c:2590
+#: builtin/pack-objects.c:2636
 msgid "ignore borrowed objects from alternate object store"
 msgstr ""
 "ignora els objectes prestats d'un emmagatzemament d'objectes alternatiu"
 
-#: builtin/pack-objects.c:2592
+#: builtin/pack-objects.c:2638
 msgid "ignore packed objects"
-msgstr "ignora objectes empaquetats"
+msgstr "ignora els objectes empaquetats"
 
-#: builtin/pack-objects.c:2594
+#: builtin/pack-objects.c:2640
 msgid "limit pack window by objects"
-msgstr "limita la finestra de paquete per objectes"
+msgstr "limita la finestra d'empaquetament per objectes"
 
-#: builtin/pack-objects.c:2596
+#: builtin/pack-objects.c:2642
 msgid "limit pack window by memory in addition to object limit"
-msgstr "limita la finestra de paquet per memòria a més del límit d'objectes"
+msgstr ""
+"limita la finestra d'empaquetament per memòria a més del límit d'objectes"
 
-#: builtin/pack-objects.c:2598
+#: builtin/pack-objects.c:2644
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr "longitud màxima de la cadena de deltes permesa en el paquet resultat"
 
-#: builtin/pack-objects.c:2600
+#: builtin/pack-objects.c:2646
 msgid "reuse existing deltas"
-msgstr "reutilitza deltes existents"
+msgstr "reusa les deltes existents"
 
-#: builtin/pack-objects.c:2602
+#: builtin/pack-objects.c:2648
 msgid "reuse existing objects"
-msgstr "reutilitza objectes existents"
+msgstr "reusa els objectes existents"
 
-#: builtin/pack-objects.c:2604
+#: builtin/pack-objects.c:2650
 msgid "use OFS_DELTA objects"
-msgstr "utilitza objectes OFS_DELTA"
+msgstr "usa objectes OFS_DELTA"
 
-#: builtin/pack-objects.c:2606
+#: builtin/pack-objects.c:2652
 msgid "use threads when searching for best delta matches"
-msgstr "utilitza fils al cercar les millores coincidències de delta"
+msgstr "usa fils en cercar les millores coincidències de delta"
 
-#: builtin/pack-objects.c:2608
+#: builtin/pack-objects.c:2654
 msgid "do not create an empty pack output"
-msgstr "no creis una emissió de paquet buida"
+msgstr "no creïs una emissió de paquet buida"
 
-#: builtin/pack-objects.c:2610
+#: builtin/pack-objects.c:2656
 msgid "read revision arguments from standard input"
 msgstr "llegeix els paràmetres de revisió des de l'entrada estàndard"
 
-#: builtin/pack-objects.c:2612
+#: builtin/pack-objects.c:2658
 msgid "limit the objects to those that are not yet packed"
 msgstr "limita els objectes als que encara no s'hagin empaquetat"
 
-#: builtin/pack-objects.c:2615
+#: builtin/pack-objects.c:2661
 msgid "include objects reachable from any reference"
 msgstr "inclou els objectes abastables de qualsevulla referència"
 
-#: builtin/pack-objects.c:2618
+#: builtin/pack-objects.c:2664
 msgid "include objects referred by reflog entries"
-msgstr "inclou els objectes referits per entrades del registre de referències"
+msgstr ""
+"inclou els objectes als quals les entrades del registre de referències "
+"refereixin"
 
-#: builtin/pack-objects.c:2621
+#: builtin/pack-objects.c:2667
+msgid "include objects referred to by the index"
+msgstr "inclou els objectes als quals l'índex refereixi"
+
+#: builtin/pack-objects.c:2670
 msgid "output pack to stdout"
 msgstr "emet el paquet a stdout"
 
-#: builtin/pack-objects.c:2623
+#: builtin/pack-objects.c:2672
 msgid "include tag objects that refer to objects to be packed"
 msgstr ""
 "inclou els objectes d'etiqueta que refereixin als objectes que empaquetar"
 
-#: builtin/pack-objects.c:2625
+#: builtin/pack-objects.c:2674
 msgid "keep unreachable objects"
-msgstr "reté objectes inabastables"
+msgstr "reté els objectes inabastables"
 
-#: builtin/pack-objects.c:2626 parse-options.h:140
+#: builtin/pack-objects.c:2675 parse-options.h:140
 msgid "time"
 msgstr "hora"
 
-#: builtin/pack-objects.c:2627
+#: builtin/pack-objects.c:2676
 msgid "unpack unreachable objects newer than <time>"
 msgstr "desempaquetar els objectes inabastables més nous que <hora>"
 
-#: builtin/pack-objects.c:2630
+#: builtin/pack-objects.c:2679
 msgid "create thin packs"
 msgstr "crea paquets prims"
 
-#: builtin/pack-objects.c:2632
+#: builtin/pack-objects.c:2681
 msgid "ignore packs that have companion .keep file"
 msgstr "ignora els paquets que tinguin un fitxer .keep de company"
 
-#: builtin/pack-objects.c:2634
+#: builtin/pack-objects.c:2683
 msgid "pack compression level"
 msgstr "nivell de compressió de paquet"
 
-#: builtin/pack-objects.c:2636
+#: builtin/pack-objects.c:2685
 msgid "do not hide commits by grafts"
 msgstr "no amaguis les comissions per empelt"
 
-#: builtin/pack-objects.c:2638
+#: builtin/pack-objects.c:2687
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
-"utilitza un índex de mapa de bits, si disponible, per accelerar el recompte "
+"usa un índex de mapa de bits, si disponible, per a accelerar el recompte "
 "d'objectes"
 
-#: builtin/pack-objects.c:2640
+#: builtin/pack-objects.c:2689
 msgid "write a bitmap index together with the pack index"
 msgstr "escriu un índex de mapa de bits junt amb l'índex de paquet"
 
-#: builtin/pack-objects.c:2719
+#: builtin/pack-objects.c:2778
 msgid "Counting objects"
-msgstr "Comptant objectes"
+msgstr "Comptant els objectes"
 
 #: builtin/pack-refs.c:6
 msgid "git pack-refs [options]"
@@ -7791,13 +8007,13 @@ msgstr "empaqueta tot"
 
 #: builtin/pack-refs.c:15
 msgid "prune loose refs (default)"
-msgstr "poda referències soltes (per defecte)"
+msgstr "poda les referències soltes (per defecte)"
 
 #: builtin/prune-packed.c:7
 msgid "git prune-packed [-n|--dry-run] [-q|--quiet]"
 msgstr "git prune-packed [-n|--dry-run] [-q|--quiet]"
 
-#: builtin/prune-packed.c:49
+#: builtin/prune-packed.c:40
 msgid "Removing duplicate objects"
 msgstr "Traient objectes duplicats"
 
@@ -7805,25 +8021,25 @@ msgstr "Traient objectes duplicats"
 msgid "git prune [-n] [-v] [--expire <time>] [--] [<head>...]"
 msgstr "git prune [-n] [-v] [--expire <hora>] [--] [<cap>...]"
 
-#: builtin/prune.c:142
+#: builtin/prune.c:106
 msgid "do not remove, show only"
 msgstr "no treguis, només mostra"
 
-#: builtin/prune.c:143
+#: builtin/prune.c:107
 msgid "report pruned objects"
 msgstr "informa d'objectes podats"
 
-#: builtin/prune.c:146
+#: builtin/prune.c:110
 msgid "expire objects older than <time>"
-msgstr "caduca els objectes majors que <hora>"
+msgstr "caduca els objectes més vells que <hora>"
 
 #: builtin/push.c:14
 msgid "git push [<options>] [<repository> [<refspec>...]]"
-msgstr "git push [<options>] [<repositori> [<especificació-de-referència>...]]"
+msgstr "git push [<opcions>] [<dipòsit> [<especificació-de-referència>...]]"
 
 #: builtin/push.c:85
 msgid "tag shorthand without <tag>"
-msgstr "abreviatura d'etiqueta sense <etiqueta>"
+msgstr "abreviatura d'etiqueta sense <tag>"
 
 #: builtin/push.c:95
 msgid "--delete only accepts plain target ref names"
@@ -7835,7 +8051,7 @@ msgid ""
 "To choose either option permanently, see push.default in 'git help config'."
 msgstr ""
 "\n"
-"Per triar qualsevulla opció permanentment, veu push.default en 'git help "
+"Per a triar qualsevulla opció permanentment, veu push.default en 'git help "
 "config'."
 
 #: builtin/push.c:142
@@ -7853,12 +8069,12 @@ msgid ""
 "%s"
 msgstr ""
 "La rama font de la vostra rama actual no coincideix amb\n"
-"el nom de la vostra rama actual. Per pujar-la a la rama font\n"
-"en el remot, utilitzeu\n"
+"el nom de la vostra rama actual. Per a pujar-la a la rama font\n"
+"en el remot, useu\n"
 "\n"
 "    git push %s HEAD:%s\n"
 "\n"
-"Per pujar a la rama de la mateixa nom en el remot, utilitzeu\n"
+"Per a pujar a la rama de la mateixa nom en el remot, useu\n"
 "\n"
 "    git push %s %s\n"
 "%s"
@@ -7872,9 +8088,9 @@ msgid ""
 "\n"
 "    git push %s HEAD:<name-of-remote-branch>\n"
 msgstr ""
-"Actualment no esteu en una rama.\n"
-"Per pujar la història que condueix a l'estat actual (HEAD\n"
-"separat) ara, utilitzeu\n"
+"Actualment no esteu en cap rama.\n"
+"Per a pujar la història que condueix a l'estat actual\n"
+"(HEAD separat) ara, useu\n"
 "\n"
 "    git push %s HEAD:<nom-de-rama-remota>\n"
 
@@ -7887,7 +8103,7 @@ msgid ""
 "    git push --set-upstream %s %s\n"
 msgstr ""
 "La rama actual %s no té rama font.\n"
-"Per pujar la rama actual i estableix el remot com font, utilitzeu\n"
+"Per a pujar la rama actual i estableix el remot com a font, useu\n"
 "\n"
 "    git push --set-upstream %s %s\n"
 
@@ -7904,7 +8120,7 @@ msgid ""
 "to update which remote branch."
 msgstr ""
 "Esteu pujant al remot '%s', que no és la font de la vostra\n"
-"rama actual '%s', sense dir-me què pujar per actualitzar\n"
+"rama actual '%s', sense dir-me què pujar per a actualitzar\n"
 "quina rama remota."
 
 #: builtin/push.c:205
@@ -7931,35 +8147,34 @@ msgid ""
 "(the 'simple' mode was introduced in Git 1.7.11. Use the similar mode\n"
 "'current' instead of 'simple' if you sometimes use older versions of Git)"
 msgstr ""
-"push.default no està estabert; el seu valor implícit s'ha\n"
-"canviat en Git 2.0 de 'matching' a 'simple'. Per suprimir\n"
-"aquest missatge i mantenir el compartament tradicional,\n"
-"utilitzeu:\n"
+"push.default no està establert; el seu valor implícit s'ha\n"
+"canviat en el Git 2.0 de 'matching' a 'simple'. Per a suprimir\n"
+"aquest missatge i mantenir el comportament tradicional,\n"
+"useu:\n"
 "\n"
 "  git config --global push.default matching\n"
 "\n"
-"Per suprimir aquest missatge i adoptar el comportament nou ara, utilitzeu:\n"
+"Per a suprimir aquest missatge i adoptar el comportament nou ara, useu:\n"
 "\n"
 "  git config --global push.default simple\n"
 "\n"
 "Quan push.default és 'matching', git pujarà les rames locals a les\n"
 "rames remotes que ja existeixen amb el mateix nom.\n"
 "\n"
-"Des de Git 2.0, Git per defecte té el comportament més\n"
+"Des del Git 2.0, el Git per defecte té el comportament més\n"
 "conservatiu 'simple', que només puja la rama actual a la rama\n"
-"corresponent que 'git pull' utilitza per actualitzar la rama\n"
-"actual.\n"
+"corresponent que 'git pull' usa per actualitzar la rama actual.\n"
 "\n"
 "Veu 'git help config' i cerqueu 'push.default' per més informació.\n"
-"(s'ha introduït el mode 'simple' en Git 1.7.11. Utilitzeu el mode similar\n"
+"(s'ha introduït el mode 'simple' en el Git 1.7.11. Useu el mode similar\n"
 "'current' en lloc de 'simple' si a vegades utilitzeu versions més\n"
-"antigues de Git)"
+"antigues del Git)"
 
 #: builtin/push.c:272
 msgid ""
 "You didn't specify any refspecs to push, and push.default is \"nothing\"."
 msgstr ""
-"No heu especificat cap especificació de referència que pujar, i push.default "
+"No heu especificat cap especificació de referència a pujar, i push.default "
 "és \"nothing\"."
 
 #: builtin/push.c:279
@@ -7970,7 +8185,7 @@ msgid ""
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
 "S'han rebutjat les actualitzacions perquè el punt de la vostra rama\n"
-"actual està darrerre de la seva contrapart remota. Integreu els canvis\n"
+"actual està darrere de la seva contrapart remota. Integreu els canvis\n"
 "remots (per exemple, 'git pull ...') abans de pujar de nou.\n"
 "Veu la 'Nota sobre avances ràpids' en 'git push --help' per detalls."
 
@@ -7982,7 +8197,7 @@ msgid ""
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
 "S'han rebutjat les actualitzacions perquè un punt de rama pujada està\n"
-"darrere de la seva contraparte remota. Agafeu aquesta rama i integreu\n"
+"darrere de la seva contrapart remota. Agafeu aquesta rama i integreu\n"
 "els canvis remots (per exemple, 'git pull ...') abans de pujar de nou.\n"
 "Veu la 'Nota sobre avances ràpids' en 'git push --help' per detalls."
 
@@ -7995,8 +8210,8 @@ msgid ""
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
 "S'han rebutjat les actualitzacions perquè el remot conté treball que\n"
-"no teniu localment. Això usualment es causa per altre repositori\n"
-"havent pujant a la mateixa referència. Podeu voler primer integar els\n"
+"no teniu localment. Això usualment es causa per un altre dipòsit\n"
+"havent pujat a la mateixa referència. Podeu voler primer integrar els\n"
 "canvis remots (per exemple, 'git pull ...') abans de pujar de nou.\n"
 "Veu la 'Nota sobre avances ràpids' en 'git push --help' per detalls."
 
@@ -8013,8 +8228,8 @@ msgid ""
 msgstr ""
 "No podeu actualitzar una referència remota que assenyala un\n"
 "objecte no de comissió, ni actualitzar una referència remota per\n"
-"fer que assenyali un objecte no de comissió, sense utilitzar\n"
-"l'opció '--force'.\n"
+"fer que assenyali un objecte no de comissió, sense usar l'opció\n"
+"'--force'.\n"
 
 #: builtin/push.c:360
 #, c-format
@@ -8024,12 +8239,12 @@ msgstr "Pujant a %s\n"
 #: builtin/push.c:364
 #, c-format
 msgid "failed to push some refs to '%s'"
-msgstr "s'ha fallat al pujar algunes referències a '%s'"
+msgstr "s'ha fallat en pujar algunes referències a '%s'"
 
 #: builtin/push.c:394
 #, c-format
 msgid "bad repository '%s'"
-msgstr "repositori dolent '%s'"
+msgstr "dipòsit dolent '%s'"
 
 #: builtin/push.c:395
 msgid ""
@@ -8044,14 +8259,14 @@ msgid ""
 "    git push <name>\n"
 msgstr ""
 "Cap destí de pujada configurada.\n"
-"O especifiqueu l'URL des de la línia d'ordres o configura un repositori "
-"remot utilitzant\n"
+"O especifiqueu l'URL des de la línia d'ordres o configureu un dipòsit remot "
+"per usar\n"
 "\n"
-"    git remote add <name> <url>\n"
+"    git remote add <nom> <url>\n"
 "\n"
-"i després pujeu utilitzant el nom remot\n"
+"i després pujeu per usar el nom remot\n"
 "\n"
-"    git push <name>\n"
+"    git push <nom>\n"
 
 #: builtin/push.c:410
 msgid "--all and --tags are incompatible"
@@ -8073,79 +8288,83 @@ msgstr "--mirror no es pot combinar amb especificacions de referència"
 msgid "--all and --mirror are incompatible"
 msgstr "--all i --mirror són incompatibles"
 
-#: builtin/push.c:482
+#: builtin/push.c:493
 msgid "repository"
-msgstr "repositori"
+msgstr "dipòsit"
 
-#: builtin/push.c:483
+#: builtin/push.c:494
 msgid "push all refs"
 msgstr "envia totes les referències"
 
-#: builtin/push.c:484
+#: builtin/push.c:495
 msgid "mirror all refs"
 msgstr "reflecteix totes les referències"
 
-#: builtin/push.c:486
+#: builtin/push.c:497
 msgid "delete refs"
 msgstr "suprimeix les referències"
 
-#: builtin/push.c:487
+#: builtin/push.c:498
 msgid "push tags (can't be used with --all or --mirror)"
-msgstr "envia les etiquetes (no es pot utilitzar amb --all o --mirror)"
+msgstr "envia les etiquetes (no es pot usar amb --all o --mirror)"
 
-#: builtin/push.c:490
+#: builtin/push.c:501
 msgid "force updates"
 msgstr "força actualitzacions"
 
-#: builtin/push.c:492
+#: builtin/push.c:503
 msgid "refname>:<expect"
 msgstr "nom-de-referència>:<esperat"
 
-#: builtin/push.c:493
+#: builtin/push.c:504
 msgid "require old value of ref to be at this value"
 msgstr "requereix que el valor antic de la referència sigui d'aquest valor"
 
-#: builtin/push.c:495
+#: builtin/push.c:506
 msgid "check"
 msgstr "comprova"
 
-#: builtin/push.c:496
+#: builtin/push.c:507
 msgid "control recursive pushing of submodules"
-msgstr "controla la pujada recursiva de submòduls"
+msgstr "controla la pujada recursiva dels submòduls"
 
-#: builtin/push.c:498
+#: builtin/push.c:509
 msgid "use thin pack"
-msgstr "utilitza el paquet prim"
+msgstr "usa el paquet prim"
 
-#: builtin/push.c:499 builtin/push.c:500
+#: builtin/push.c:510 builtin/push.c:511
 msgid "receive pack program"
 msgstr "programa que rep els paquets"
 
-#: builtin/push.c:501
+#: builtin/push.c:512
 msgid "set upstream for git pull/status"
 msgstr "estableix la font per a git pull/status"
 
-#: builtin/push.c:504
+#: builtin/push.c:515
 msgid "prune locally removed refs"
 msgstr "poda les referències localment tretes"
 
-#: builtin/push.c:506
+#: builtin/push.c:517
 msgid "bypass pre-push hook"
 msgstr "evita el ganxo de prepujada"
 
-#: builtin/push.c:507
+#: builtin/push.c:518
 msgid "push missing but relevant tags"
 msgstr "puja les etiquetes mancants però relevants"
 
-#: builtin/push.c:517
+#: builtin/push.c:520
+msgid "GPG sign the push"
+msgstr "firma la pujada amb GPG"
+
+#: builtin/push.c:529
 msgid "--delete is incompatible with --all, --mirror and --tags"
 msgstr "--delete és incompatible amb --all, --mirror i --tags"
 
-#: builtin/push.c:519
+#: builtin/push.c:531
 msgid "--delete doesn't make sense without any refs"
 msgstr "--delete no té sentit sense referències"
 
-#: builtin/read-tree.c:36
+#: builtin/read-tree.c:37
 msgid ""
 "git read-tree [[-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>] "
 "[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
@@ -8155,74 +8374,74 @@ msgstr ""
 "[-u [--exclude-per-directory=<ignoral-de-git>] | -i]] [--no-sparse-checkout] "
 "[--index-output=<fitxer>] (--empty | <arbre1> [<arbre2> [<arbre3>]])"
 
-#: builtin/read-tree.c:109
+#: builtin/read-tree.c:110
 msgid "write resulting index to <file>"
 msgstr "escriu l'índex resultant al <fitxer>"
 
-#: builtin/read-tree.c:112
+#: builtin/read-tree.c:113
 msgid "only empty the index"
 msgstr "només buida l'índex"
 
-#: builtin/read-tree.c:114
+#: builtin/read-tree.c:115
 msgid "Merging"
 msgstr "Fusionant"
 
-#: builtin/read-tree.c:116
+#: builtin/read-tree.c:117
 msgid "perform a merge in addition to a read"
 msgstr "realitza una fusió a més d'una lectura"
 
-#: builtin/read-tree.c:118
+#: builtin/read-tree.c:119
 msgid "3-way merge if no file level merging required"
 msgstr "fusió de 3 vies si no cal fusió a la nivell de fitxers"
 
-#: builtin/read-tree.c:120
+#: builtin/read-tree.c:121
 msgid "3-way merge in presence of adds and removes"
 msgstr "fusió de 3 vies en presència d'afegiments i tretes"
 
-#: builtin/read-tree.c:122
+#: builtin/read-tree.c:123
 msgid "same as -m, but discard unmerged entries"
 msgstr "el mateix que -m, però descarta les entrades no fusionades"
 
-#: builtin/read-tree.c:123
+#: builtin/read-tree.c:124
 msgid "<subdirectory>/"
 msgstr "<subdirectori>/"
 
-#: builtin/read-tree.c:124
+#: builtin/read-tree.c:125
 msgid "read the tree into the index under <subdirectory>/"
 msgstr "llegiu l'arbre a l'índex baix <subdirectori>/"
 
-#: builtin/read-tree.c:127
+#: builtin/read-tree.c:128
 msgid "update working tree with merge result"
 msgstr "actualitza l'arbre de treball amb el resultat de fusió"
 
-#: builtin/read-tree.c:129
+#: builtin/read-tree.c:130
 msgid "gitignore"
 msgstr "ignoral de git"
 
-#: builtin/read-tree.c:130
+#: builtin/read-tree.c:131
 msgid "allow explicitly ignored files to be overwritten"
 msgstr "permet que els fitxers explícitament ignorats es sobreescriguin"
 
-#: builtin/read-tree.c:133
+#: builtin/read-tree.c:134
 msgid "don't check the working tree after merging"
 msgstr "no comprovis l'arbre de treball després de fusionar"
 
-#: builtin/read-tree.c:134
+#: builtin/read-tree.c:135
 msgid "don't update the index or the work tree"
 msgstr "no actualitzis l'índex ni l'arbre de treball"
 
-#: builtin/read-tree.c:136
+#: builtin/read-tree.c:137
 msgid "skip applying sparse checkout filter"
 msgstr "salta l'aplicació del filtre d'agafament escàs"
 
-#: builtin/read-tree.c:138
+#: builtin/read-tree.c:139
 msgid "debug unpack-trees"
 msgstr "depura unpack-trees"
 
 #: builtin/reflog.c:499
 #, c-format
 msgid "%s' for '%s' is not a valid timestamp"
-msgstr "%s' per '%s' no és una marca de temps vàlida"
+msgstr "%s' per a '%s' no és una marca de temps vàlida"
 
 #: builtin/reflog.c:615 builtin/reflog.c:620
 #, c-format
@@ -8321,8 +8540,8 @@ msgid ""
 "--mirror is dangerous and deprecated; please\n"
 "\t use --mirror=fetch or --mirror=push instead"
 msgstr ""
-"--mirror és peligrós i desaprovat; si us\n"
-"\t plau, utilitzeu --mirror=fetch o\t --mirror=push en lloc"
+"--mirror és perillós i desaprovat; si us\n"
+"\t plau, useu --mirror=fetch o\t --mirror=push en lloc"
 
 #: builtin/remote.c:137
 #, c-format
@@ -8335,15 +8554,15 @@ msgstr "obtén les rames remotes"
 
 #: builtin/remote.c:155
 msgid "import all tags and associated objects when fetching"
-msgstr "importa totes les etiquetes i tos els objectes al obtenir"
+msgstr "en obtenir, importa totes les etiquetes i tos els objectes"
 
 #: builtin/remote.c:158
 msgid "or do not fetch any tag at all (--no-tags)"
-msgstr "o no obtén cap etiqueta (--no-tags)"
+msgstr "o no obtinguis cap etiqueta (--no-tags)"
 
 #: builtin/remote.c:160
 msgid "branch(es) to track"
-msgstr "rames que seguir"
+msgstr "rames a seguir"
 
 #: builtin/remote.c:161
 msgid "master branch"
@@ -8355,7 +8574,7 @@ msgstr "push|fetch"
 
 #: builtin/remote.c:163
 msgid "set up remote as a mirror to push to or fetch from"
-msgstr "estableix remot com mirall a que pujar o de que obtenir"
+msgstr "estableix el remot com a mirall a que pujar o de que obtenir"
 
 #: builtin/remote.c:175
 msgid "specifying a master branch makes no sense with --mirror"
@@ -8363,14 +8582,15 @@ msgstr "especificar una rama mestra no té sentit amb --mirror"
 
 #: builtin/remote.c:177
 msgid "specifying branches to track makes sense only with fetch mirrors"
-msgstr "especificar rames que seguir té sentit només amb miralls d'obteniment"
+msgstr ""
+"especificar les rames a seguir té sentit només amb miralls d'obteniment"
 
-#: builtin/remote.c:185 builtin/remote.c:640
+#: builtin/remote.c:185 builtin/remote.c:641
 #, c-format
 msgid "remote %s already exists."
 msgstr "el remot %s ja existeix."
 
-#: builtin/remote.c:189 builtin/remote.c:644
+#: builtin/remote.c:189 builtin/remote.c:645
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' no és un nom de remot vàlid"
@@ -8379,11 +8599,6 @@ msgstr "'%s' no és un nom de remot vàlid"
 #, c-format
 msgid "Could not setup master '%s'"
 msgstr "No s'ha pogut configurar el mestre '%s'"
-
-#: builtin/remote.c:288
-#, c-format
-msgid "more than one %s"
-msgstr "més d'un %s"
 
 #: builtin/remote.c:333
 #, c-format
@@ -8400,27 +8615,27 @@ msgstr "(coincident)"
 msgid "(delete)"
 msgstr "(suprimir)"
 
-#: builtin/remote.c:589 builtin/remote.c:595 builtin/remote.c:601
+#: builtin/remote.c:590 builtin/remote.c:596 builtin/remote.c:602
 #, c-format
 msgid "Could not append '%s' to '%s'"
 msgstr "No s'ha pogut annexar '%s' a '%s'"
 
-#: builtin/remote.c:633 builtin/remote.c:794 builtin/remote.c:894
+#: builtin/remote.c:634 builtin/remote.c:798 builtin/remote.c:898
 #, c-format
 msgid "No such remote: %s"
-msgstr "Cap remot així: %s"
+msgstr "No hi ha tal remot: %s"
 
-#: builtin/remote.c:650
+#: builtin/remote.c:651
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "No s'ha pogut canviar el nom de la secció de configuració '%s' a '%s'"
 
-#: builtin/remote.c:656 builtin/remote.c:846
+#: builtin/remote.c:657 builtin/remote.c:850
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "No s'ha pogut treure la secció de configuració '%s'"
 
-#: builtin/remote.c:671
+#: builtin/remote.c:672
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -8431,32 +8646,32 @@ msgstr ""
 "\t%s\n"
 "\tSi us plau, actualitzeu la configuració manualment si és necessari."
 
-#: builtin/remote.c:677
+#: builtin/remote.c:678
 #, c-format
 msgid "Could not append '%s'"
 msgstr "No s'ha pogut annexar '%s'"
 
-#: builtin/remote.c:688
+#: builtin/remote.c:689
 #, c-format
 msgid "Could not set '%s'"
 msgstr "No s'ha pogut establir '%s'"
 
-#: builtin/remote.c:710
+#: builtin/remote.c:711
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "la supressió de '%s' ha fallat"
 
-#: builtin/remote.c:744
+#: builtin/remote.c:745
 #, c-format
 msgid "creating '%s' failed"
 msgstr "la creació de '%s' ha fallat"
 
-#: builtin/remote.c:765
+#: builtin/remote.c:769
 #, c-format
 msgid "Could not remove branch %s"
 msgstr "No s'ha pogut treure la rama %s"
 
-#: builtin/remote.c:832
+#: builtin/remote.c:836
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -8465,270 +8680,270 @@ msgid_plural ""
 "to delete them, use:"
 msgstr[0] ""
 "Nota: Una rama fora de la jerarquia refs/remotes/ no s'ha tret;\n"
-"per suprimir-la, utilitzeu:"
+"per a suprimir-la, useu:"
 msgstr[1] ""
 "Nota: Unes rames fora de la jerarquia refs/remotes/ no s'han tret;\n"
-"per suprimir-les, utilitzeu:"
+"per a suprimir-les, useu:"
 
-#: builtin/remote.c:947
+#: builtin/remote.c:951
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " nou (el pròxim obteniment emmagatzemarà en remotes/%s)"
 
-#: builtin/remote.c:950
+#: builtin/remote.c:954
 msgid " tracked"
 msgstr " seguit"
 
-#: builtin/remote.c:952
+#: builtin/remote.c:956
 msgid " stale (use 'git remote prune' to remove)"
-msgstr " ranci (utilitzeu 'git remote prune' per treure)"
+msgstr " ranci (useu 'git remote prune' per a treure)"
 
-#: builtin/remote.c:954
+#: builtin/remote.c:958
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:995
+#: builtin/remote.c:999
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr "branch.%s.merge invàlid; no es pot rebasar en > 1 rama"
 
-#: builtin/remote.c:1002
+#: builtin/remote.c:1006
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "es rebasa en el remot %s"
 
-#: builtin/remote.c:1005
+#: builtin/remote.c:1009
 #, c-format
 msgid " merges with remote %s"
 msgstr "es fusiona amb el remot %s"
 
-#: builtin/remote.c:1006
+#: builtin/remote.c:1010
 msgid "    and with remote"
 msgstr "    i amb el remot"
 
-#: builtin/remote.c:1008
+#: builtin/remote.c:1012
 #, c-format
 msgid "merges with remote %s"
 msgstr "es fusiona amb el remot %s"
 
-#: builtin/remote.c:1009
+#: builtin/remote.c:1013
 msgid "   and with remote"
 msgstr "   i amb el remot"
 
-#: builtin/remote.c:1055
+#: builtin/remote.c:1059
 msgid "create"
 msgstr "crea"
 
-#: builtin/remote.c:1058
+#: builtin/remote.c:1062
 msgid "delete"
 msgstr "suprimeix"
 
-#: builtin/remote.c:1062
+#: builtin/remote.c:1066
 msgid "up to date"
-msgstr "actualitzat"
+msgstr "al dia"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1069
 msgid "fast-forwardable"
 msgstr "avanç ràpid possible"
 
-#: builtin/remote.c:1068
+#: builtin/remote.c:1072
 msgid "local out of date"
 msgstr "local no actualitzat"
 
-#: builtin/remote.c:1075
+#: builtin/remote.c:1079
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s força a %-*s (%s)"
 
-#: builtin/remote.c:1078
+#: builtin/remote.c:1082
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s puja a %-*s (%s)"
 
-#: builtin/remote.c:1082
+#: builtin/remote.c:1086
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s força a %s"
 
-#: builtin/remote.c:1085
+#: builtin/remote.c:1089
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s puja a %s"
 
-#: builtin/remote.c:1153
+#: builtin/remote.c:1157
 msgid "do not query remotes"
 msgstr "no consultis els remots"
 
-#: builtin/remote.c:1180
+#: builtin/remote.c:1184
 #, c-format
 msgid "* remote %s"
 msgstr "* remot %s"
 
-#: builtin/remote.c:1181
+#: builtin/remote.c:1185
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL d'obteniment: %s"
 
-#: builtin/remote.c:1182 builtin/remote.c:1329
+#: builtin/remote.c:1186 builtin/remote.c:1333
 msgid "(no URL)"
 msgstr "(sense URL)"
 
-#: builtin/remote.c:1191 builtin/remote.c:1193
+#: builtin/remote.c:1195 builtin/remote.c:1197
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL de pujada: %s"
 
-#: builtin/remote.c:1195 builtin/remote.c:1197 builtin/remote.c:1199
+#: builtin/remote.c:1199 builtin/remote.c:1201 builtin/remote.c:1203
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Rama de HEAD: %s"
 
-#: builtin/remote.c:1201
+#: builtin/remote.c:1205
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr "  Rama de HEAD (el HEAD remot és ambigu, pot ser un dels següents):\n"
 
-#: builtin/remote.c:1213
+#: builtin/remote.c:1217
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Rama remota:%s"
 msgstr[1] "  Rames remotes:%s"
 
-#: builtin/remote.c:1216 builtin/remote.c:1243
+#: builtin/remote.c:1220 builtin/remote.c:1247
 msgid " (status not queried)"
 msgstr " (estat no consultat)"
 
-#: builtin/remote.c:1225
+#: builtin/remote.c:1229
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Rama local configurada per a 'git pull':"
 msgstr[1] "  Rames locals configurades per a 'git pull':"
 
-#: builtin/remote.c:1233
+#: builtin/remote.c:1237
 msgid "  Local refs will be mirrored by 'git push'"
-msgstr "  'git push' reflectira les referències locals"
+msgstr "  'git push' reflectirà les referències locals"
 
-#: builtin/remote.c:1240
+#: builtin/remote.c:1244
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Referència local configurada per a 'git push'%s:"
 msgstr[1] "  Referències locals configurades per a 'git push'%s:"
 
-#: builtin/remote.c:1261
+#: builtin/remote.c:1265
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "estableix refs/remotes/<name>/HEAD segons el remot"
 
-#: builtin/remote.c:1263
+#: builtin/remote.c:1267
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "suprimeix refs/remotes/<name>/HEAD"
 
-#: builtin/remote.c:1278
+#: builtin/remote.c:1282
 msgid "Cannot determine remote HEAD"
 msgstr "No es pot determinar el HEAD remot"
 
-#: builtin/remote.c:1280
+#: builtin/remote.c:1284
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr ""
 "Múltiples rames de HEAD remotes. Si us plau, trieu una explícitament amb:"
 
-#: builtin/remote.c:1290
+#: builtin/remote.c:1294
 #, c-format
 msgid "Could not delete %s"
 msgstr "No s'ha pogut suprimir %s"
 
-#: builtin/remote.c:1298
+#: builtin/remote.c:1302
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "No és una referència vàlida: %s"
 
-#: builtin/remote.c:1300
+#: builtin/remote.c:1304
 #, c-format
 msgid "Could not setup %s"
 msgstr "No s'ha pogut configurar %s"
 
-#: builtin/remote.c:1318
+#: builtin/remote.c:1322
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s es tornarà en penjant!"
 
-#: builtin/remote.c:1319
+#: builtin/remote.c:1323
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s s'ha tornat en penjant!"
 
-#: builtin/remote.c:1325
+#: builtin/remote.c:1329
 #, c-format
 msgid "Pruning %s"
 msgstr "Podant %s"
 
-#: builtin/remote.c:1326
+#: builtin/remote.c:1330
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1349
+#: builtin/remote.c:1357
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [podaria] %s"
 
-#: builtin/remote.c:1352
+#: builtin/remote.c:1360
 #, c-format
 msgid " * [pruned] %s"
 msgstr " * [podat] %s"
 
-#: builtin/remote.c:1397
+#: builtin/remote.c:1405
 msgid "prune remotes after fetching"
 msgstr "poda els remots després d'obtenir-los"
 
-#: builtin/remote.c:1463 builtin/remote.c:1537
+#: builtin/remote.c:1471 builtin/remote.c:1545
 #, c-format
 msgid "No such remote '%s'"
-msgstr "Cap remot així '%s'"
+msgstr "No hi ha tal remot '%s'"
 
-#: builtin/remote.c:1483
+#: builtin/remote.c:1491
 msgid "add branch"
 msgstr "afegeix rama"
 
-#: builtin/remote.c:1490
+#: builtin/remote.c:1498
 msgid "no remote specified"
 msgstr "cap remot especificat"
 
-#: builtin/remote.c:1512
+#: builtin/remote.c:1520
 msgid "manipulate push URLs"
 msgstr "manipula els URL de pujada"
 
-#: builtin/remote.c:1514
+#: builtin/remote.c:1522
 msgid "add URL"
 msgstr "afegeix URL"
 
-#: builtin/remote.c:1516
+#: builtin/remote.c:1524
 msgid "delete URLs"
 msgstr "suprimeix URLs"
 
-#: builtin/remote.c:1523
+#: builtin/remote.c:1531
 msgid "--add --delete doesn't make sense"
 msgstr "--add --delete no té sentit"
 
-#: builtin/remote.c:1563
+#: builtin/remote.c:1571
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "Patró d'URL antic invàlid: %s"
 
-#: builtin/remote.c:1571
+#: builtin/remote.c:1579
 #, c-format
 msgid "No such URL found: %s"
-msgstr "Cap URL així trobat: %s"
+msgstr "No s'ha trobat tal URL: %s"
 
-#: builtin/remote.c:1573
+#: builtin/remote.c:1581
 msgid "Will not delete all non-push URLs"
 msgstr "Suprimirà tots els URL no de pujada"
 
-#: builtin/remote.c:1587
+#: builtin/remote.c:1595
 msgid "be verbose; must be placed before a subcommand"
-msgstr "sigues verbós; s'ha de col·locar abans d'un subordre"
+msgstr "siguis verbós; s'ha de col·locar abans d'un subordre"
 
 #: builtin/repack.c:17
 msgid "git repack [options]"
@@ -8748,7 +8963,7 @@ msgstr "tragueu els paquets redundants, i executeu git-prune-packed"
 
 #: builtin/repack.c:167
 msgid "pass --no-reuse-delta to git-pack-objects"
-msgstr "passa --no-resuse-delta a git-pack-objects"
+msgstr "passa --no-reuse-delta a git-pack-objects"
 
 #: builtin/repack.c:169
 msgid "pass --no-reuse-object to git-pack-objects"
@@ -8772,11 +8987,11 @@ msgstr "aproximat"
 
 #: builtin/repack.c:178
 msgid "with -A, do not loosen objects older than this"
-msgstr "amb -A, no soltis objectes majors que aquest"
+msgstr "amb -A, no soltis els objectes més vells que aquest"
 
 #: builtin/repack.c:180
 msgid "size of the window used for delta compression"
-msgstr "mida de la ventana utilitzada per compressió de deltes"
+msgstr "mida de la ventana que s'usa per a compressió de deltes"
 
 #: builtin/repack.c:181 builtin/repack.c:185
 msgid "bytes"
@@ -8785,12 +9000,12 @@ msgstr "octets"
 #: builtin/repack.c:182
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
-"ex mateix que l'anterior, però limita la mida de memòria en lloc del "
+"el mateix que l'anterior, però limita la mida de memòria en lloc del "
 "recompte d'entrades"
 
 #: builtin/repack.c:184
 msgid "limits the maximum delta depth"
-msgstr "limita la profunditat màxima dels deltes"
+msgstr "limita la profunditat màxima de les deltes"
 
 #: builtin/repack.c:186
 msgid "maximum size of each packfile"
@@ -8825,71 +9040,71 @@ msgstr "git replace -d <objecte>..."
 msgid "git replace [--format=<format>] [-l [<pattern>]]"
 msgstr "git replace [--format=<format>] [-l [<patró>]]"
 
-#: builtin/replace.c:322 builtin/replace.c:360 builtin/replace.c:388
+#: builtin/replace.c:325 builtin/replace.c:363 builtin/replace.c:391
 #, c-format
 msgid "Not a valid object name: '%s'"
 msgstr "No és un nom d'objecte vàlid: '%s'"
 
-#: builtin/replace.c:352
+#: builtin/replace.c:355
 #, c-format
 msgid "bad mergetag in commit '%s'"
 msgstr "etiqueta de fusió dolenta en la comissió '%s'"
 
-#: builtin/replace.c:354
+#: builtin/replace.c:357
 #, c-format
 msgid "malformed mergetag in commit '%s'"
 msgstr "etiqueta de fusió malformada en la comissió '%s'"
 
-#: builtin/replace.c:365
+#: builtin/replace.c:368
 #, c-format
 msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
 "instead of --graft"
 msgstr ""
 "la comissió original '%s' conté l'etiqueta de fusió '%s' que es descarta; "
-"utilitzeu --edit en lloc de --graft"
+"useu --edit en lloc de --graft"
 
-#: builtin/replace.c:398
+#: builtin/replace.c:401
 #, c-format
 msgid "the original commit '%s' has a gpg signature."
 msgstr "la comissió original '%s' té una firma gpg."
 
-#: builtin/replace.c:399
+#: builtin/replace.c:402
 msgid "the signature will be removed in the replacement commit!"
 msgstr "la firma es traurà en la comissió de reemplaçament!"
 
-#: builtin/replace.c:405
+#: builtin/replace.c:408
 #, c-format
 msgid "could not write replacement commit for: '%s'"
 msgstr "no s'ha pogut escriure la comissió de reemplaçament per a: '%s'"
 
-#: builtin/replace.c:429
+#: builtin/replace.c:432
 msgid "list replace refs"
 msgstr "llista les referències reemplaçades"
 
-#: builtin/replace.c:430
+#: builtin/replace.c:433
 msgid "delete replace refs"
 msgstr "suprimeix les referències reemplaçades"
 
-#: builtin/replace.c:431
+#: builtin/replace.c:434
 msgid "edit existing object"
 msgstr "edita un objecte existent"
 
-#: builtin/replace.c:432
+#: builtin/replace.c:435
 msgid "change a commit's parents"
 msgstr "canvia els pares d'una comissió"
 
-#: builtin/replace.c:433
+#: builtin/replace.c:436
 msgid "replace the ref if it exists"
 msgstr "reemplaça la referència si existeix"
 
-#: builtin/replace.c:434
+#: builtin/replace.c:437
 msgid "do not pretty-print contents for --edit"
 msgstr "no imprimeixis bellament els continguts per a --edit"
 
-#: builtin/replace.c:435
+#: builtin/replace.c:438
 msgid "use this format"
-msgstr "utilitza aquest format"
+msgstr "usa aquest format"
 
 #: builtin/rerere.c:12
 msgid "git rerere [clear | forget path... | status | remaining | diff | gc]"
@@ -8899,155 +9114,155 @@ msgstr "git rerere [clear | forget path... | status | remaining | diff | gc]"
 msgid "register clean resolutions in index"
 msgstr "registre les resolucions netes en l'índex"
 
-#: builtin/reset.c:25
+#: builtin/reset.c:26
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 msgstr ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<comissió>]"
 
-#: builtin/reset.c:26
+#: builtin/reset.c:27
 msgid "git reset [-q] <tree-ish> [--] <paths>..."
 msgstr "git reset [-q] <arbre> [--] <rutes>..."
 
-#: builtin/reset.c:27
+#: builtin/reset.c:28
 msgid "git reset --patch [<tree-ish>] [--] [<paths>...]"
 msgstr "git reset --patch [<arbre>] [--] [<rutes>...]"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "mixed"
 msgstr "mixt"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "soft"
 msgstr "suau"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "hard"
 msgstr "dur"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "merge"
 msgstr "fusió"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "keep"
 msgstr "reteniment"
 
-#: builtin/reset.c:73
+#: builtin/reset.c:74
 msgid "You do not have a valid HEAD."
 msgstr "No teniu un HEAD vàlid."
 
-#: builtin/reset.c:75
+#: builtin/reset.c:76
 msgid "Failed to find tree of HEAD."
-msgstr "S'ha fallat al trobar l'arbre de HEAD."
+msgstr "S'ha fallat en trobar l'arbre de HEAD."
 
-#: builtin/reset.c:81
+#: builtin/reset.c:82
 #, c-format
 msgid "Failed to find tree of %s."
-msgstr "S'ha fallat al trobar l'arbre de %s."
+msgstr "S'ha fallat en trobar l'arbre de %s."
 
-#: builtin/reset.c:99
+#: builtin/reset.c:100
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD ara està a %s"
 
-#: builtin/reset.c:182
+#: builtin/reset.c:183
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "No es pot fer un restabliment de %s en el medi d'una fusió."
 
-#: builtin/reset.c:275
+#: builtin/reset.c:276
 msgid "be quiet, only report errors"
 msgstr "calla, només informa d'errors"
 
-#: builtin/reset.c:277
+#: builtin/reset.c:278
 msgid "reset HEAD and index"
 msgstr "restableix HEAD i l'índex"
 
-#: builtin/reset.c:278
+#: builtin/reset.c:279
 msgid "reset only HEAD"
 msgstr "restablex només HEAD"
 
-#: builtin/reset.c:280 builtin/reset.c:282
+#: builtin/reset.c:281 builtin/reset.c:283
 msgid "reset HEAD, index and working tree"
 msgstr "restableix HEAD, l'índex i l'arbre de treball"
 
-#: builtin/reset.c:284
+#: builtin/reset.c:285
 msgid "reset HEAD but keep local changes"
 msgstr "restableix HEAD però reté els canvis locals"
 
-#: builtin/reset.c:287
+#: builtin/reset.c:288
 msgid "record only the fact that removed paths will be added later"
-msgstr "registre només el fet de que les rutes tretes s'afegiran després"
+msgstr "registra només el fet de que les rutes tretes s'afegiran després"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:305
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
-msgstr "S'ha fallat al resoldre '%s' com revisió vàlida."
+msgstr "S'ha fallat en resoldre '%s' com a revisió vàlida."
 
-#: builtin/reset.c:307 builtin/reset.c:315
+#: builtin/reset.c:308 builtin/reset.c:316
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "No s'ha pogut analitzar l'objecte '%s'."
 
-#: builtin/reset.c:312
+#: builtin/reset.c:313
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
-msgstr "S'ha fallat al resoldre '%s' com arbre vàlid."
+msgstr "S'ha fallat en resoldre '%s' com a arbre vàlid."
 
-#: builtin/reset.c:321
+#: builtin/reset.c:322
 msgid "--patch is incompatible with --{hard,mixed,soft}"
 msgstr "--patch és incompatible amb --{hard,mixed,soft}"
 
-#: builtin/reset.c:330
+#: builtin/reset.c:331
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
-"--mixed amb rutes es desaprovat; utilitzeu 'git reset -- <paths>' en lloc."
+"--mixed amb rutes està desaprovat; useu 'git reset -- <rutes>' en lloc."
 
-#: builtin/reset.c:332
+#: builtin/reset.c:333
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "No es pot fer reinici de %s amb rutes."
 
-#: builtin/reset.c:342
+#: builtin/reset.c:343
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
-msgstr "reset de %s no és permet en un repositori nu"
+msgstr "el reinici de %s no es permet en un dipòsit nu"
 
-#: builtin/reset.c:346
+#: builtin/reset.c:347
 msgid "-N can only be used with --mixed"
-msgstr "-N només es pot utilitzar amb --mixed"
+msgstr "-N només es pot usar amb --mixed"
 
-#: builtin/reset.c:363
+#: builtin/reset.c:364
 msgid "Unstaged changes after reset:"
 msgstr "Canvis no allistats després de restabliment:"
 
-#: builtin/reset.c:369
+#: builtin/reset.c:370
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "No s'ha pogut restablir el fitxer d'índex a la revisió '%s'."
 
-#: builtin/reset.c:373
+#: builtin/reset.c:374
 msgid "Could not write new index file."
 msgstr "No s'ha pogut escriure el fitxer d'índex nou."
 
-#: builtin/rev-parse.c:360
+#: builtin/rev-parse.c:361
 msgid "git rev-parse --parseopt [options] -- [<args>...]"
 msgstr "git rev-parse --parseopt [opcions] -- [<paràmetres>...]"
 
-#: builtin/rev-parse.c:365
+#: builtin/rev-parse.c:366
 msgid "keep the `--` passed as an arg"
-msgstr "reté el `--` passat com paràmetre"
+msgstr "reté el `--` passat com a paràmetre"
 
-#: builtin/rev-parse.c:367
+#: builtin/rev-parse.c:368
 msgid "stop parsing after the first non-option argument"
 msgstr "deixa d'analitzar després del primer paràmetre no d'opció"
 
-#: builtin/rev-parse.c:370
+#: builtin/rev-parse.c:371
 msgid "output in stuck long form"
 msgstr "emet en forma llarga enganxada"
 
-#: builtin/rev-parse.c:498
+#: builtin/rev-parse.c:499
 msgid ""
 "git rev-parse --parseopt [options] -- [<args>...]\n"
 "   or: git rev-parse --sq-quote [<arg>...]\n"
@@ -9059,7 +9274,7 @@ msgstr ""
 "   or: git rev-parse --sq-quote [<paràmetre>...]\n"
 "   or: git rev-parse [opcions] [<paràmetre>...]\n"
 "\n"
-"Executeu \"git rev-parse --parseopt -h\"  per més informació sobre l'ús "
+"Executeu \"git rev-parse --parseopt -h\" per més informació sobre l'ús "
 "inicial."
 
 #: builtin/revert.c:22
@@ -9081,19 +9296,19 @@ msgstr "git cherry-pick <subordre>"
 #: builtin/revert.c:71
 #, c-format
 msgid "%s: %s cannot be used with %s"
-msgstr "%s: %s no es pot utilitzar amb %s"
+msgstr "%s: %s no es pot usar amb %s"
 
 #: builtin/revert.c:80
 msgid "end revert or cherry-pick sequence"
-msgstr "termina la seqüència de reversió o recull de cireres"
+msgstr "termina la seqüència de reversió o el recull de cireres"
 
 #: builtin/revert.c:81
 msgid "resume revert or cherry-pick sequence"
-msgstr "reprèn la seqüència de reversió o recull de cireres"
+msgstr "reprèn la seqüència de reversió o el recull de cireres"
 
 #: builtin/revert.c:82
 msgid "cancel revert or cherry-pick sequence"
-msgstr "cancel·la la seqüència de reversió o recull de cireres"
+msgstr "cancel·la la seqüència de reversió o el recull de cireres"
 
 #: builtin/revert.c:83
 msgid "don't automatically commit"
@@ -9121,7 +9336,7 @@ msgstr "opció d'estratègia de fusió"
 
 #: builtin/revert.c:104
 msgid "append commit name"
-msgstr "nom de la comissió que annexar"
+msgstr "nom de la comissió a annexar"
 
 #: builtin/revert.c:105
 msgid "allow fast-forward"
@@ -9160,14 +9375,14 @@ msgid ""
 "the following submodule (or one of its nested submodules)\n"
 "uses a .git directory:"
 msgid_plural ""
-"the following submodules (or one of its nested submodules)\n"
+"the following submodules (or one of their nested submodules)\n"
 "use a .git directory:"
 msgstr[0] ""
 "el submòdul següent (o un dels seus submòduls niats)\n"
-"utilitza un directori .git:"
+"usa un directori .git:"
 msgstr[1] ""
 "els submòduls següents (o un dels seus submòduls niats)\n"
-"utilitza un directori .git:"
+"usa un directori .git:"
 
 #: builtin/rm.c:71
 msgid ""
@@ -9175,7 +9390,7 @@ msgid ""
 "(use 'rm -rf' if you really want to remove it including all of its history)"
 msgstr ""
 "\n"
-"(utilitzeu 'rm -rf' si realment voleu treure'l, inclòs tota la seva història)"
+"(useu 'rm -rf' si realment voleu treure'l, inclòs tota la seva història)"
 
 #: builtin/rm.c:231
 msgid ""
@@ -9197,7 +9412,7 @@ msgid ""
 "(use -f to force removal)"
 msgstr ""
 "\n"
-"(utilitzeu -f per forçar la treta)"
+"(useu -f per a forçar la treta)"
 
 #: builtin/rm.c:240
 msgid "the following file has changes staged in the index:"
@@ -9211,7 +9426,7 @@ msgid ""
 "(use --cached to keep the file, or -f to force removal)"
 msgstr ""
 "\n"
-"(utilitzeu --cached per desar el fitxer, o -f per forçar la treta)"
+"(useu --cached per a desar el fitxer, o -f per a forçar la treta)"
 
 #: builtin/rm.c:252
 msgid "the following file has local modifications:"
@@ -9229,15 +9444,21 @@ msgstr "només treu de l'índex"
 
 #: builtin/rm.c:272
 msgid "override the up-to-date check"
-msgstr "passa per dalt la comprovació d'actualització"
+msgstr "passa per dalt la comprovació d'actualitat"
 
 #: builtin/rm.c:273
 msgid "allow recursive removal"
-msgstr "permet treta recursiva"
+msgstr "permet la treta recursiva"
 
 #: builtin/rm.c:275
 msgid "exit with a zero status even if nothing matched"
 msgstr "surt amb estat zero encara que res hagi coincidit"
+
+#: builtin/rm.c:318
+msgid "Please, stage your changes to .gitmodules or stash them to proceed"
+msgstr ""
+"Si us plau, allisteu els vostres canvis a .gitmodules o emmagatzemeu-los per "
+"a procedir"
 
 #: builtin/rm.c:336
 #, c-format
@@ -9287,7 +9508,7 @@ msgid ""
 "<glob>)...]"
 msgstr ""
 "git show-branch [-a|--all] [-r|--remotes] [--topo-order | --date-order] [--"
-"current] [--color[=<when>] | --no-color] [--sparse] [--more=<n> | --list | --"
+"current] [--color[=<quan>] | --no-color] [--sparse] [--more=<n> | --list | --"
 "independent | --merge-base] [--no-name | --sha1-name] [--topics] [(<revisió> "
 "| <glob>)...]"
 
@@ -9329,7 +9550,7 @@ msgstr "anomena les comissions amb els seus noms d'objecte"
 
 #: builtin/show-branch.c:664
 msgid "show possible merge bases"
-msgstr "mostra els bases de fusió possibles"
+msgstr "mostra les bases de fusió possibles"
 
 #: builtin/show-branch.c:666
 msgid "show refs unreachable from any other ref"
@@ -9341,7 +9562,7 @@ msgstr "mostra les comissions en ordre topològic"
 
 #: builtin/show-branch.c:671
 msgid "show only commits not on the first branch"
-msgstr "mostra només les comissions no en la primera rama"
+msgstr "mostra només les comissions que no siguin en la primera rama"
 
 #: builtin/show-branch.c:673
 msgid "show merges reachable from only one tip"
@@ -9357,7 +9578,7 @@ msgstr "<n>[,<base>]"
 
 #: builtin/show-branch.c:679
 msgid "show <n> most recent ref-log entries starting at base"
-msgstr "mostra les <n> entrades més recents començant al base"
+msgstr "mostra les <n> entrades més recents començant a la base"
 
 #: builtin/show-ref.c:10
 msgid ""
@@ -9373,11 +9594,11 @@ msgstr "git show-ref --exclude-existing[=pattern] < llista-de-referències"
 
 #: builtin/show-ref.c:168
 msgid "only show tags (can be combined with heads)"
-msgstr "mostra només les etiquetes (pot combinar-se amb heads)"
+msgstr "mostra només les etiquetes (es pot combinar amb heads)"
 
 #: builtin/show-ref.c:169
 msgid "only show heads (can be combined with tags)"
-msgstr "mostra només els caps (pot combinar-se amb etiquetes)"
+msgstr "mostra només els caps (es pot combinar amb tags)"
 
 #: builtin/show-ref.c:170
 msgid "stricter reference checking, requires exact ref path"
@@ -9395,7 +9616,7 @@ msgstr "dereferencia les etiquetes a IDs d'objecte"
 
 #: builtin/show-ref.c:179
 msgid "only show SHA1 hash using <n> digits"
-msgstr "mostra el hash SHA1 només utilitzant <n> xifres"
+msgstr "mostra el hash SHA1 usant només <n> xifres"
 
 #: builtin/show-ref.c:183
 msgid "do not print results to stdout (useful with --verify)"
@@ -9403,7 +9624,7 @@ msgstr "no imprimeixis els resultats a stdout (útil amb --verify)"
 
 #: builtin/show-ref.c:185
 msgid "show refs from stdin that aren't in local repository"
-msgstr "mostra les referència de stdin que no estan en el repositori local"
+msgstr "mostra les referència d'stdin que no siguin en el dipòsit local"
 
 #: builtin/symbolic-ref.c:7
 msgid "git symbolic-ref [options] name [ref]"
@@ -9425,11 +9646,11 @@ msgstr "suprimeix la referència simbòlica"
 msgid "shorten ref output"
 msgstr "escurça la sortida de referències"
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:349
+#: builtin/symbolic-ref.c:43 builtin/update-ref.c:362
 msgid "reason"
 msgstr "raó"
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:349
+#: builtin/symbolic-ref.c:43 builtin/update-ref.c:362
 msgid "reason of the update"
 msgstr "raó de l'actualització"
 
@@ -9490,9 +9711,9 @@ msgid ""
 "Lines starting with '%c' will be ignored.\n"
 msgstr ""
 "\n"
-"Escrui el missatge de l'etiqueta:\n"
+"Escriviu el missatge de l'etiqueta:\n"
 "  %s\n"
-"Les línies que comencen amb '%c' s'ignoraran.\n"
+"Les línies que comencin amb '%c' s'ignoraran.\n"
 
 #: builtin/tag.c:347
 #, c-format
@@ -9504,10 +9725,10 @@ msgid ""
 "want to.\n"
 msgstr ""
 "\n"
-"Escriu el missatge de l'etiqueta:\n"
+"Escriviu el missatge de l'etiqueta:\n"
 "  %s\n"
-"Les línies començant amb '%c' es retindran; podeu treure'ls per vós mateix "
-"si voleu.\n"
+"Les línies que comencin amb '%c' es retindran; podeu treure'ls per vós "
+"mateix si voleu.\n"
 
 #: builtin/tag.c:371
 #, c-format
@@ -9553,240 +9774,230 @@ msgstr "l'opció 'points-at' requereix un objecte"
 msgid "malformed object name '%s'"
 msgstr "nom d'objecte malformat '%s'"
 
-#: builtin/tag.c:588
+#: builtin/tag.c:589
 msgid "list tag names"
 msgstr "llista els noms d'etiqueta"
 
-#: builtin/tag.c:590
+#: builtin/tag.c:591
 msgid "print <n> lines of each tag message"
 msgstr "imprimeix <n> línies de cada missatge d'etiqueta"
 
-#: builtin/tag.c:592
-msgid "delete tags"
-msgstr "suprimeix etiquetes"
-
 #: builtin/tag.c:593
-msgid "verify tags"
-msgstr "verifica etiquetes"
+msgid "delete tags"
+msgstr "suprimeix les etiquetes"
 
-#: builtin/tag.c:595
+#: builtin/tag.c:594
+msgid "verify tags"
+msgstr "verifica les etiquetes"
+
+#: builtin/tag.c:596
 msgid "Tag creation options"
 msgstr "Opcions de creació d'etiquetes"
 
-#: builtin/tag.c:597
+#: builtin/tag.c:598
 msgid "annotated tag, needs a message"
 msgstr "etiqueta anotada, necessita un missatge"
 
-#: builtin/tag.c:599
+#: builtin/tag.c:600
 msgid "tag message"
 msgstr "missatge d'etiqueta"
 
-#: builtin/tag.c:601
+#: builtin/tag.c:602
 msgid "annotated and GPG-signed tag"
 msgstr "etiqueta anotada i firmada per GPG"
 
-#: builtin/tag.c:605
-msgid "use another key to sign the tag"
-msgstr "utilitza altra clau per firmar l'etiqueta"
-
 #: builtin/tag.c:606
-msgid "replace the tag if exists"
-msgstr "reempaça l'etiqueta si existeix"
+msgid "use another key to sign the tag"
+msgstr "usa una altra clau per a firmar l'etiqueta"
 
 #: builtin/tag.c:607
+msgid "replace the tag if exists"
+msgstr "reemplaça l'etiqueta si existeix"
+
+#: builtin/tag.c:608
 msgid "show tag list in columns"
 msgstr "mostra la llista d'etiquetes en columnes"
 
-#: builtin/tag.c:609
+#: builtin/tag.c:610
 msgid "sort tags"
 msgstr "ordena les etiquetes"
 
-#: builtin/tag.c:613
+#: builtin/tag.c:614
 msgid "Tag listing options"
 msgstr "Opcions de llistament d'etiquetes"
 
-#: builtin/tag.c:616 builtin/tag.c:622
+#: builtin/tag.c:617 builtin/tag.c:623
 msgid "print only tags that contain the commit"
 msgstr "imprimeix només les etiquetes que continguin la comissió"
 
-#: builtin/tag.c:628
+#: builtin/tag.c:629
 msgid "print only tags of the object"
-msgstr "imprimeix només les etiquets de l'objecte"
+msgstr "imprimeix només les etiquetes de l'objecte"
 
-#: builtin/tag.c:654
+#: builtin/tag.c:655
 msgid "--column and -n are incompatible"
 msgstr "--column i -n són incompatibles"
 
-#: builtin/tag.c:666
+#: builtin/tag.c:667
 msgid "--sort and -n are incompatible"
 msgstr "--sort i -n són incompatibles"
 
-#: builtin/tag.c:673
+#: builtin/tag.c:674
 msgid "-n option is only allowed with -l."
 msgstr "es permet l'opció -n només amb -l."
 
-#: builtin/tag.c:675
+#: builtin/tag.c:676
 msgid "--contains option is only allowed with -l."
 msgstr "es permet l'opció --contains només amb -l."
 
-#: builtin/tag.c:677
+#: builtin/tag.c:678
 msgid "--points-at option is only allowed with -l."
 msgstr "es permet --points-at option només amb -l."
 
-#: builtin/tag.c:685
+#: builtin/tag.c:686
 msgid "only one -F or -m option is allowed."
 msgstr "només una opció -F o -m es permet."
 
-#: builtin/tag.c:705
+#: builtin/tag.c:706
 msgid "too many params"
 msgstr "massa paràmetres"
 
-#: builtin/tag.c:711
+#: builtin/tag.c:712
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "'%s' no és un nom d'etiqueta vàlid."
 
-#: builtin/tag.c:716
+#: builtin/tag.c:717
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "l'etiqueta '%s' ja existeix"
 
-#: builtin/tag.c:734
-#, c-format
-msgid "%s: cannot lock the ref"
-msgstr "%s: no es pot bloquejar la referència"
-
-#: builtin/tag.c:736
-#, c-format
-msgid "%s: cannot update the ref"
-msgstr "%s: no es pot actualitzar la referència"
-
-#: builtin/tag.c:738
+#: builtin/tag.c:741
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Etiqueta '%s' actualitzada (ha estat %s)\n"
 
-#: builtin/unpack-objects.c:483
+#: builtin/unpack-objects.c:489
 msgid "Unpacking objects"
 msgstr "Desempaquetant objectes"
 
-#: builtin/update-index.c:402
+#: builtin/update-index.c:403
 msgid "git update-index [options] [--] [<file>...]"
 msgstr "git update-index [opcions] [--] [<fitxer>...]"
 
-#: builtin/update-index.c:755
+#: builtin/update-index.c:756
 msgid "continue refresh even when index needs update"
 msgstr ""
 "continua l'actualització encara que l'índex necessiti una actualització"
 
-#: builtin/update-index.c:758
+#: builtin/update-index.c:759
 msgid "refresh: ignore submodules"
 msgstr "actualitza: ignora els submòduls"
 
-#: builtin/update-index.c:761
+#: builtin/update-index.c:762
 msgid "do not ignore new files"
-msgstr "no ignoris fitxers nous"
+msgstr "no ignoris els fitxers nous"
 
-#: builtin/update-index.c:763
+#: builtin/update-index.c:764
 msgid "let files replace directories and vice-versa"
-msgstr "deixa que els fitxer reemplacin els directoris i viceversa"
+msgstr "deixa que els fitxers reemplacin els directoris i viceversa"
 
-#: builtin/update-index.c:765
+#: builtin/update-index.c:766
 msgid "notice files missing from worktree"
 msgstr "nota els fitxers mancants de l'arbre de treball"
 
-#: builtin/update-index.c:767
+#: builtin/update-index.c:768
 msgid "refresh even if index contains unmerged entries"
 msgstr "actualitza encara que l'índex contingui entrades no fusionades"
 
-#: builtin/update-index.c:770
+#: builtin/update-index.c:771
 msgid "refresh stat information"
 msgstr "actualitza la informació d'estadístiques"
 
-#: builtin/update-index.c:774
+#: builtin/update-index.c:775
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr "com --refresh, però ignora l'ajust assume-unchanged"
 
-#: builtin/update-index.c:778
+#: builtin/update-index.c:779
 msgid "<mode>,<object>,<path>"
 msgstr "<mode>,<objecte>,<ruta>"
 
-#: builtin/update-index.c:779
+#: builtin/update-index.c:780
 msgid "add the specified entry to the index"
 msgstr "afegeix l'entrada especificada a l'índex"
 
-#: builtin/update-index.c:783
+#: builtin/update-index.c:784
 msgid "(+/-)x"
 msgstr "(+/-)x"
 
-#: builtin/update-index.c:784
+#: builtin/update-index.c:785
 msgid "override the executable bit of the listed files"
 msgstr "passa per dalt el bit executable dels fitxers llistats"
 
-#: builtin/update-index.c:788
+#: builtin/update-index.c:789
 msgid "mark files as \"not changing\""
-msgstr "marca els fitxers com \"not changing\""
+msgstr "marca els fitxers com a \"not changing\""
 
-#: builtin/update-index.c:791
+#: builtin/update-index.c:792
 msgid "clear assumed-unchanged bit"
 msgstr "neteja el bit assumed-unchanged"
 
-#: builtin/update-index.c:794
+#: builtin/update-index.c:795
 msgid "mark files as \"index-only\""
-msgstr "marca els fitxers com \"index-only\""
+msgstr "marca els fitxers com a \"index-only\""
 
-#: builtin/update-index.c:797
+#: builtin/update-index.c:798
 msgid "clear skip-worktree bit"
 msgstr "neteja el bit skip-worktree"
 
-#: builtin/update-index.c:800
+#: builtin/update-index.c:801
 msgid "add to index only; do not add content to object database"
 msgstr ""
-"només afegeix a l'índex; no afegeixis el contingut al base de dades "
+"només afegeix a l'índex; no afegeixis el contingut a la base de dades "
 "d'objectes"
 
-#: builtin/update-index.c:802
+#: builtin/update-index.c:803
 msgid "remove named paths even if present in worktree"
 msgstr ""
 "treu les rutes anomenades encara que estiguin presents en l'arbre de treball"
 
-#: builtin/update-index.c:804
+#: builtin/update-index.c:805
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr "amb --stdin: les línies d'entrada es terminen per octets nuls"
 
-#: builtin/update-index.c:806
+#: builtin/update-index.c:807
 msgid "read list of paths to be updated from standard input"
-msgstr "llegeix la llista de rutes que actualitzar des de l'entrada estàndard"
+msgstr "llegeix la llista de rutes a actualitzar des de l'entrada estàndard"
 
-#: builtin/update-index.c:810
+#: builtin/update-index.c:811
 msgid "add entries from standard input to the index"
 msgstr "afegeix les entrades de l'entrada estàndard a l'índex"
 
-#: builtin/update-index.c:814
+#: builtin/update-index.c:815
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr "reemplena les etapes #2 i #3 per a les rutes llistades"
 
-#: builtin/update-index.c:818
+#: builtin/update-index.c:819
 msgid "only update entries that differ from HEAD"
 msgstr "només actualitza les entrades que difereixin de HEAD"
 
-#: builtin/update-index.c:822
+#: builtin/update-index.c:823
 msgid "ignore files missing from worktree"
 msgstr "ignora els fitxers que manquin a l'arbre de treball"
 
-#: builtin/update-index.c:825
+#: builtin/update-index.c:826
 msgid "report actions to standard output"
 msgstr "informa de les accions en la sortida estàndard"
 
-#: builtin/update-index.c:827
+#: builtin/update-index.c:828
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr "(per porcellanes) oblida't dels conflictes no resolts ni desats"
 
-#: builtin/update-index.c:831
+#: builtin/update-index.c:832
 msgid "write index in this format"
 msgstr "escriu l'índex en aquest format"
 
-#: builtin/update-index.c:833
+#: builtin/update-index.c:834
 msgid "enable or disable split index"
 msgstr "habilita o deshabilita l'índex dividit"
 
@@ -9803,21 +10014,21 @@ msgstr ""
 msgid "git update-ref [options] --stdin [-z]"
 msgstr "git update-ref [opcions] --stdin [-z]"
 
-#: builtin/update-ref.c:350
+#: builtin/update-ref.c:363
 msgid "delete the reference"
 msgstr "suprimeix la referència"
 
-#: builtin/update-ref.c:352
+#: builtin/update-ref.c:365
 msgid "update <refname> not the one it points to"
 msgstr "actualitza <nom de referència>, no la a que assenyali"
 
-#: builtin/update-ref.c:353
+#: builtin/update-ref.c:366
 msgid "stdin has NUL-terminated arguments"
 msgstr "stdin té paràmetres terminats per NUL"
 
-#: builtin/update-ref.c:354
+#: builtin/update-ref.c:367
 msgid "read updates from stdin"
-msgstr "llegeix actualitzacions des de stdin"
+msgstr "llegeix les actualitzacions des d'stdin"
 
 #: builtin/update-server-info.c:6
 msgid "git update-server-info [--force]"
@@ -9835,15 +10046,15 @@ msgstr "git verify-commit [-v|--verbose] <comissió>..."
 msgid "print commit contents"
 msgstr "imprimeix els continguts de la comissió"
 
-#: builtin/verify-pack.c:55
+#: builtin/verify-pack.c:54
 msgid "git verify-pack [-v|--verbose] [-s|--stat-only] <pack>..."
 msgstr "git verify-pack [-v|--verbose] [-s|--stat-only] <paquet>..."
 
-#: builtin/verify-pack.c:65
+#: builtin/verify-pack.c:64
 msgid "verbose"
 msgstr "verbós"
 
-#: builtin/verify-pack.c:67
+#: builtin/verify-pack.c:66
 msgid "show statistics only"
 msgstr "mostra només estadístiques"
 
@@ -9853,7 +10064,7 @@ msgstr "git verify-tag [-v|--verbose] <etiqueta>..."
 
 #: builtin/verify-tag.c:73
 msgid "print tag contents"
-msgstr "imprimeix els continguits de l'etiqueta"
+msgstr "imprimeix els continguts de l'etiqueta"
 
 #: builtin/write-tree.c:13
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
@@ -9869,46 +10080,30 @@ msgstr "escriu l'objecte d'arbre per a un subdirectori <prefix>"
 
 #: builtin/write-tree.c:30
 msgid "only useful for debugging"
-msgstr "només útil per la depuració"
+msgstr "només útil per a la depuració"
+
+#: credential-cache--daemon.c:267
+msgid "print debugging messages to stderr"
+msgstr "imprimeix els missatges de depuració a stderr"
 
 #: git.c:17
 msgid ""
-"'git help -a' and 'git help -g' lists available subcommands and some\n"
+"'git help -a' and 'git help -g' list available subcommands and some\n"
 "concept guides. See 'git help <command>' or 'git help <concept>'\n"
 "to read about a specific subcommand or concept."
 msgstr ""
 "'git help -a' i 'git help -g' llisten subordres disponibles i\n"
-"algunes guies de concepte. Veu 'git help <command>' o\n"
-"'git help <concept>' per llegir sobre un subordre o concepte\n"
+"algunes guies de concepte. Veu 'git help <ordre>' o\n"
+"'git help <concepte>' per a llegir sobre un subordre o concepte\n"
 "específic."
-
-#: parse-options.h:143
-msgid "expiry-date"
-msgstr "data-de-caducitat"
-
-#: parse-options.h:158
-msgid "no-op (backward compatibility)"
-msgstr "operació nul·la (compatibilitat amb versions anteriors)"
-
-#: parse-options.h:232
-msgid "be more verbose"
-msgstr "siguis més verbós"
-
-#: parse-options.h:234
-msgid "be more quiet"
-msgstr "siguis més callat"
-
-#: parse-options.h:240
-msgid "use <n> digits to display SHA-1s"
-msgstr "utilitza <n> xifres per presentar els SHA-1"
 
 #: common-cmds.h:8
 msgid "Add file contents to the index"
-msgstr "Afegeix els continguts de fitxers a l'índex"
+msgstr "Afegeix els continguts dels fitxers a l'índex"
 
 #: common-cmds.h:9
 msgid "Find by binary search the change that introduced a bug"
-msgstr "Troba per cerca binària el canvi que ha introduït un defecte"
+msgstr "Troba per cerca binària el canvi que hagi introduït un defecte"
 
 #: common-cmds.h:10
 msgid "List, create, or delete branches"
@@ -9920,20 +10115,20 @@ msgstr "Agafa una rama o unes rutes a l'arbre de treball"
 
 #: common-cmds.h:12
 msgid "Clone a repository into a new directory"
-msgstr "Clona un repositori a un directori nou"
+msgstr "Clona un dipòsit a un directori nou"
 
 #: common-cmds.h:13
 msgid "Record changes to the repository"
-msgstr "Registre els canvis al repositori"
+msgstr "Registra els canvis al dipòsit"
 
 #: common-cmds.h:14
 msgid "Show changes between commits, commit and working tree, etc"
 msgstr ""
-"Mostra els canvis entre comissions, la comissió i l'arbre de treball, etc"
+"Mostra els canvis entre comissions, la comissió i l'arbre de treball, etc."
 
 #: common-cmds.h:15
 msgid "Download objects and refs from another repository"
-msgstr "Baixa objectes i referències d'altre repositori"
+msgstr "Baixa objectes i referències d'un altre dipòsit"
 
 #: common-cmds.h:16
 msgid "Print lines matching a pattern"
@@ -9941,7 +10136,7 @@ msgstr "Imprimeix les línies coincidents amb un patró"
 
 #: common-cmds.h:17
 msgid "Create an empty Git repository or reinitialize an existing one"
-msgstr "Crea un repositori de Git buit o reinicialitza un existent"
+msgstr "Crea un dipòsit de Git buit o reinicialitza un existent"
 
 #: common-cmds.h:18
 msgid "Show commit logs"
@@ -9953,11 +10148,11 @@ msgstr "Uneix dos o més històries de desenvolupament"
 
 #: common-cmds.h:20
 msgid "Move or rename a file, a directory, or a symlink"
-msgstr "Mou o canvia de nom un fitxer, directori, o enllaç simbòlic"
+msgstr "Mou o canvia de nom un fitxer, directori o enllaç simbòlic"
 
 #: common-cmds.h:21
 msgid "Fetch from and integrate with another repository or a local branch"
-msgstr "Obté de i integra con altre repositori o una rama local"
+msgstr "Obté de i integra con un altre dipòsit o una rama local"
 
 #: common-cmds.h:22
 msgid "Update remote refs along with associated objects"
@@ -9988,6 +10183,31 @@ msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 "Crea, llista, suprimeix o verifica un objecte d'etiqueta firmat amb GPG"
 
+#: parse-options.h:143
+msgid "expiry-date"
+msgstr "data-de-caducitat"
+
+#: parse-options.h:158
+msgid "no-op (backward compatibility)"
+msgstr "operació nul·la (per a compatibilitat amb versions anteriors)"
+
+#: parse-options.h:232
+msgid "be more verbose"
+msgstr "siguis més verbós"
+
+#: parse-options.h:234
+msgid "be more quiet"
+msgstr "siguis més callat"
+
+#: parse-options.h:240
+msgid "use <n> digits to display SHA-1s"
+msgstr "usa <n> xifres per presentar els SHA-1"
+
+#: rerere.h:27
+msgid "update the index with reused conflict resolution if possible"
+msgstr ""
+"actualitza l'índex amb la resolució de conflicte reusada si és possible"
+
 #: git-am.sh:52
 msgid "You need to set your committer info first"
 msgstr "Cal establir la vostra informació de comitent primer"
@@ -10007,7 +10227,7 @@ msgid ""
 "If you prefer to skip this patch, run \"$cmdline --skip\" instead.\n"
 "To restore the original branch and stop patching, run \"$cmdline --abort\"."
 msgstr ""
-"Quan heu resolt aquest problema, executeu \"$cmdline --continue\".\n"
+"Quan hàgiu resolt aquest problema, executeu \"$cmdline --continue\".\n"
 "Si preferiu saltar aquest pedaç, executeu \"$cmdline --skip\" en lloc.\n"
 "Per restaurar la rama original i deixar d'apedaçar, executeu \"$cmdline --"
 "abort\"."
@@ -10019,12 +10239,12 @@ msgstr "No es pot retrocedir a una fusió de 3 vies."
 #: git-am.sh:139
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
-"Al repositori li manquen els blobs necessaris per a retrocedir a una fusió "
-"de 3 vies."
+"Al dipòsit li manquen els blobs necessaris per a retrocedir a una fusió de 3 "
+"vies."
 
 #: git-am.sh:141
 msgid "Using index info to reconstruct a base tree..."
-msgstr "Utilitzant la informació d'índex per reconstruir un arbre base..."
+msgstr "Usant la informació d'índex per a reconstruir un arbre base..."
 
 #: git-am.sh:156
 msgid ""
@@ -10036,11 +10256,11 @@ msgstr ""
 
 #: git-am.sh:165
 msgid "Falling back to patching base and 3-way merge..."
-msgstr "Retrocedint a apedaçar el base i fusionar de 3 vies..."
+msgstr "Retrocedint a apedaçar la base i fusionar de 3 vies..."
 
 #: git-am.sh:181
 msgid "Failed to merge in the changes."
-msgstr "S'ha fallat al fusionar els canvis."
+msgstr "S'ha fallat en fusionar els canvis."
 
 #: git-am.sh:276
 msgid "Only one StGIT patch series can be applied at once"
@@ -10061,7 +10281,7 @@ msgid ""
 "it will be removed. Please do not use it anymore."
 msgstr ""
 "Fa molt que l'opció -b/--binary no ha fet res, i\n"
-"es traurà. Si us plau, no l'utilitzis més."
+"es traurà. Si us plau, no l'usis més."
 
 #: git-am.sh:486
 #, sh-format
@@ -10081,11 +10301,11 @@ msgid ""
 "Use \"git am --abort\" to remove it."
 msgstr ""
 "Directori $dotest extraviat trobat.\n"
-"Utilitzeu \"git am --abort\" per treure'l."
+"Useu \"git am --abort\" per a treure'l."
 
 #: git-am.sh:535
 msgid "Resolve operation not in progress, we are not resuming."
-msgstr "Operació de resolució no en curs, no reprenem."
+msgstr "Operació de resolució no en curs; no reprenem."
 
 #: git-am.sh:601
 #, sh-format
@@ -10100,9 +10320,9 @@ msgid ""
 "To restore the original branch and stop patching run \"$cmdline --abort\"."
 msgstr ""
 "El pedaç és buit. S'ha dividit mal?\n"
-"Si preferiríeu saltar aquest pedaç, en lloc executeu \"$cmdline --skip\".\n"
-"Per restaurar la rama original i deixar d'empaquetar, executeu \"$cmdline --"
-"abort\"."
+"Si preferiríeu saltar aquest pedaç, executeu en lloc \"$cmdline --skip\".\n"
+"Per a restaurar la rama original i deixar d'empaquetar, executeu \"$cmdline "
+"--abort\"."
 
 #: git-am.sh:732
 msgid "Patch does not have a valid e-mail address."
@@ -10122,7 +10342,7 @@ msgstr "El cos de la comissió és:"
 #. input at this point.
 #: git-am.sh:790
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all "
-msgstr "Aplica? sí [y]/[n]o/[e]dita/[v]isualitza pedaç/[a]ccepta tots"
+msgstr "Aplica? [y]es/[n]o/[e]dita/[v]isualitza pedaç/[a]ccepta tots"
 
 #: git-am.sh:826
 #, sh-format
@@ -10135,8 +10355,8 @@ msgid ""
 "If there is nothing left to stage, chances are that something else\n"
 "already introduced the same changes; you might want to skip this patch."
 msgstr ""
-"Cap canvi - heu oblidat utilitzar 'git add'?\n"
-"Si no hi ha res que allistar, probablement alguna altra cosa\n"
+"Cap canvi - heu oblidat usar 'git add'?\n"
+"Si no hi ha res a allistar, probablement alguna altra cosa\n"
 "ja ha introduït els mateixos canvis; potser voleu saltar aquest pedaç."
 
 #: git-am.sh:855
@@ -10145,11 +10365,11 @@ msgid ""
 "did you forget to use 'git add'?"
 msgstr ""
 "Encara teniu rutes sense fusionar en el vostre índex\n"
-"heu oblidat utilitzar 'git add'?"
+"heu oblidat d'usar 'git add'?"
 
 #: git-am.sh:871
 msgid "No changes -- Patch already applied."
-msgstr "Sense canvis -- Pedaç ja aplicat."
+msgstr "Sense canvis -- El pedaç ja s'ha aplicat."
 
 #: git-am.sh:881
 #, sh-format
@@ -10178,7 +10398,7 @@ msgstr "Cal començar per \"git bisect start\""
 #. at this point.
 #: git-bisect.sh:54
 msgid "Do you want me to do it for you [Y/n]? "
-msgstr "Voleu que jo el faci per vós [Y/n]? "
+msgstr "Voleu que es faci per vós [Y/n]? "
 
 #: git-bisect.sh:95
 #, sh-format
@@ -10199,8 +10419,8 @@ msgstr "HEAD dolent - Cal un HEAD"
 msgid ""
 "Checking out '$start_head' failed. Try 'git bisect reset <validbranch>'."
 msgstr ""
-"L'agafament de '$start_head' ha fallat. Proveu 'git bisect reset "
-"<validbranch>'."
+"L'agafament de '$start_head' ha fallat. Proveu 'git bisect reset <rama-"
+"vàlida>'."
 
 #: git-bisect.sh:140
 msgid "won't bisect on cg-seek'ed tree"
@@ -10246,21 +10466,21 @@ msgstr "Esteu segur [Y/n]? "
 
 #: git-bisect.sh:289
 msgid ""
-"You need to give me at least one good and one bad revisions.\n"
+"You need to give me at least one good and one bad revision.\n"
 "(You can use \"git bisect bad\" and \"git bisect good\" for that.)"
 msgstr ""
 "Cal donar-me almenys una revisió bona i una dolenta.\n"
-"(Podeu utilitzar \"git bisect bad\" i \"git bisect good\" per això.)"
+"(Podeu usar \"git bisect bad\" i \"git bisect good\" per això.)"
 
 #: git-bisect.sh:292
 msgid ""
 "You need to start by \"git bisect start\".\n"
-"You then need to give me at least one good and one bad revisions.\n"
+"You then need to give me at least one good and one bad revision.\n"
 "(You can use \"git bisect bad\" and \"git bisect good\" for that.)"
 msgstr ""
 "Cal començar amb \"git bisect start\".\n"
 "Després cal donar-me almenys una revisió bona i una dolenta.\n"
-"(Podeu utilitzar \"git bisect bad\" i \"git bisect good\" per això.)"
+"(Podeu usar \"git bisect bad\" i \"git bisect good\" per això.)"
 
 #: git-bisect.sh:363 git-bisect.sh:490
 msgid "We are not bisecting."
@@ -10287,7 +10507,7 @@ msgstr "Cap fitxer de registre donat"
 #: git-bisect.sh:407
 #, sh-format
 msgid "cannot read $file for replaying"
-msgstr "no es pot llegir $file per reproduir"
+msgstr "no es pot llegir $file per a reproducció"
 
 #: git-bisect.sh:424
 msgid "?? what are you talking about?"
@@ -10328,16 +10548,24 @@ msgstr "pas de bisecció reeixit"
 msgid ""
 "Pull is not possible because you have unmerged files.\n"
 "Please, fix them up in the work tree, and then use 'git add/rm <file>'\n"
-"as appropriate to mark resolution, or use 'git commit -a'."
+"as appropriate to mark resolution and make a commit."
 msgstr ""
 "Baixar no és possible perquè teniu fitxers sense fusionar.\n"
-"Si us plau, arregleu-los en l'arbre de treball, i després utilitzeu\n"
-"'git add/rm <file>' segons sigui apropiat per a marcar resolució, o\n"
-"utilitzeu 'git commit -a'."
+"Si us plau, arregleu-los en l'arbre de treball, i després useu\n"
+"'git add/rm <fitxer>' segons sigui apropiat per a marcar resolució i\n"
+"feu una comissió."
 
 #: git-pull.sh:25
 msgid "Pull is not possible because you have unmerged files."
 msgstr "Baixar no és possible perquè teniu fitxers sense fusionar."
+
+#: git-pull.sh:31
+msgid ""
+"You have not concluded your merge (MERGE_HEAD exists).\n"
+"Please, commit your changes before you can merge."
+msgstr ""
+"No heu terminat la vostra fusió (MERGE_HEAD existeix).\n"
+"Si us plau, cometeu els vostres canvis abans de fusionar."
 
 #: git-pull.sh:245
 msgid "updating an unborn branch with changes added to the index"
@@ -10350,14 +10578,13 @@ msgid ""
 "Warning: fast-forwarding your working tree from\n"
 "Warning: commit $orig_head."
 msgstr ""
-"Avís: l'obteniment ha actualitzat el cap de la\n"
-"Avís: rama actual. avançant ràpidament el\n"
-"Avís: vostre arbre de treball des de la\n"
-"Avís: comissió $orig_head."
+"Avís: l'obteniment ha actualitzat el cap de la rama actual.\n"
+"Avís: avançant ràpidament el vostre arbre de\n"
+"Avís: treball des de la comissió $orig_head."
 
 #: git-pull.sh:294
 msgid "Cannot merge multiple branches into empty head"
-msgstr "No es pot fusionar múltiples rama a un cap buit"
+msgstr "No es pot fusionar múltiples rames a un cap buit"
 
 #: git-pull.sh:298
 msgid "Cannot rebase onto multiple branches"
@@ -10370,14 +10597,14 @@ msgid ""
 "To check out the original branch and stop rebasing, run \"git rebase --abort"
 "\"."
 msgstr ""
-"Quan heu resolt aquest problema, executeu \"git rebase --continue\".\n"
+"Quan hàgiu resolt aquest problema, executeu \"git rebase --continue\".\n"
 "Si preferiu saltar aquest pedaç, executeu \"git rebase --skip\" en lloc.\n"
-"Per agafar la rama original i deixar de rebasar, executeu \"git rebase --"
+"Per a agafar la rama original i deixar de rebasar, executeu \"git rebase --"
 "abort\"."
 
 #: git-rebase.sh:165
 msgid "Applied autostash."
-msgstr "Magatzem automàtic aplicat."
+msgstr "S'ha aplicat el magatzem automàtic."
 
 #: git-rebase.sh:168
 #, sh-format
@@ -10391,7 +10618,7 @@ msgid ""
 "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
 msgstr ""
 "L'aplicació del magatzem automàtic ha resultat en conflictes.\n"
-"Els vostres canvis estan segurs el el magatzem.\n"
+"Els vostres canvis estan segurs en el magatzem.\n"
 "Podeu executar \"git stash pop\" o \"git stash drop\" en qualsevol moment.\n"
 
 #: git-rebase.sh:208
@@ -10404,16 +10631,15 @@ msgstr "Sembla que git-am està en curs. No es pot rebasar."
 
 #: git-rebase.sh:351
 msgid "The --exec option must be used with the --interactive option"
-msgstr "L'opció --exec s'ha d'utilitzar amb l'opció --interactive"
+msgstr "L'opció --exec s'ha d'usar amb l'opció --interactive"
 
 #: git-rebase.sh:356
 msgid "No rebase in progress?"
-msgstr "Cap rebase en curs?"
+msgstr "No hi ha rebase en curs?"
 
 #: git-rebase.sh:367
 msgid "The --edit-todo action can only be used during interactive rebase."
-msgstr ""
-"L'acció --edit-todo només es pot utilitzar durant un rebase interactiu."
+msgstr "L'acció --edit-todo només es pot usar durant una rebase interactiu."
 
 #: git-rebase.sh:374
 msgid "Cannot read HEAD"
@@ -10425,7 +10651,7 @@ msgid ""
 "mark them as resolved using git add"
 msgstr ""
 "Heu d'editar tots els conflictes de fusió i després\n"
-"marcar-los com resolts utilitzant git add"
+"marcar-los com a resolts per usar git add"
 
 #: git-rebase.sh:395
 #, sh-format
@@ -10444,8 +10670,8 @@ msgid ""
 "and run me again.  I am stopping in case you still have something\n"
 "valuable there."
 msgstr ""
-"Semla que ja hi ha altre directori $state_dir_base, i\n"
-"em pregonu si esteu en el medi d'altre rebase. Si això és el\n"
+"Sembla que ja hi ha un directori $state_dir_base, i\n"
+"em pregono si esteu en el medi d'una altra rebase. Si això és el\n"
 "cas, si us plau, proveu\n"
 "\t$cmd_live_rebase\n"
 "Si no és el cas, si us plau,\n"
@@ -10461,7 +10687,7 @@ msgstr "font invàlida $upstream_name"
 #: git-rebase.sh:489
 #, sh-format
 msgid "$onto_name: there are more than one merge bases"
-msgstr "$onto_name: ja hi ha més d'un base de fusió"
+msgstr "$onto_name: ja hi ha més d'una base de fusió"
 
 #: git-rebase.sh:492 git-rebase.sh:496
 #, sh-format
@@ -10476,7 +10702,7 @@ msgstr "No assenyala una comissió vàlida: $onto_name"
 #: git-rebase.sh:524
 #, sh-format
 msgid "fatal: no such branch: $branch_name"
-msgstr "fatal: cap rama així: $branch_name"
+msgstr "fatal: no hi ha tal rama: $branch_name"
 
 #: git-rebase.sh:557
 msgid "Cannot autostash"
@@ -10485,7 +10711,7 @@ msgstr "No es pot emmagatzemar automàticament"
 #: git-rebase.sh:562
 #, sh-format
 msgid "Created autostash: $stash_abbrev"
-msgstr "Magatzem automàtic creat: $stash_abbrev"
+msgstr "S'ha creat un magatzem automàtic: $stash_abbrev"
 
 #: git-rebase.sh:566
 msgid "Please commit or stash them."
@@ -10494,12 +10720,12 @@ msgstr "Si us plau, cometeu-los o emmagatzemeu-los."
 #: git-rebase.sh:586
 #, sh-format
 msgid "Current branch $branch_name is up to date."
-msgstr "La rama actual $branch_name està actualitzada."
+msgstr "La rama actual $branch_name està al dia."
 
 #: git-rebase.sh:590
 #, sh-format
 msgid "Current branch $branch_name is up to date, rebase forced."
-msgstr "La rama actual $branch_name està actualitzada, rebase forçat."
+msgstr "La rama actual $branch_name està al dia; rebase forçada."
 
 #: git-rebase.sh:601
 #, sh-format
@@ -10508,12 +10734,12 @@ msgstr "Canvis de $mb a $onto:"
 
 #: git-rebase.sh:610
 msgid "First, rewinding head to replay your work on top of it..."
-msgstr "Primer, rebobinant el cap per reproduir el vostre treball encima..."
+msgstr "Primer, rebobinant el cap per a reproduir el vostre treball encima..."
 
 #: git-rebase.sh:620
 #, sh-format
 msgid "Fast-forwarded $branch_name to $onto_name."
-msgstr "$branch_name avançada ràpidament a $onto_name"
+msgstr "S'ha avançat $branch_name ràpidament a $onto_name"
 
 #: git-stash.sh:51
 msgid "git stash clear with parameters is unimplemented"
@@ -10533,7 +10759,7 @@ msgstr "No es pot desar l'estat d'arbre de treball actual"
 
 #: git-stash.sh:141
 msgid "No changes selected"
-msgstr "Cap canvi seleccionat"
+msgstr "No hi ha canvis seleccionats"
 
 #: git-stash.sh:144
 msgid "Cannot remove temporary index (can't happen)"
@@ -10565,15 +10791,15 @@ msgid ""
 "       To provide a message, use git stash save -- '$option'"
 msgstr ""
 "error: opció desconeguda de 'stash save': $option\n"
-"       Per proveir un missatge, utilitzeu git stash save -- '$option'"
+"       Per a proveir un missatge, useu git stash save -- '$option'"
 
 #: git-stash.sh:259
 msgid "No local changes to save"
-msgstr "Cap canvi local que desar"
+msgstr "No hi ha canvis locals a desar"
 
 #: git-stash.sh:263
 msgid "Cannot initialize stash"
-msgstr "No es pot inicialitzar el magatzem."
+msgstr "No es pot inicialitzar el magatzem"
 
 #: git-stash.sh:267
 msgid "Cannot save the current status"
@@ -10594,13 +10820,13 @@ msgstr "Massa revisions especificades: $REV"
 
 #: git-stash.sh:397
 #, sh-format
-msgid "$reference is not valid reference"
+msgid "$reference is not a valid reference"
 msgstr "$reference no és referència vàlida"
 
 #: git-stash.sh:425
 #, sh-format
 msgid "'$args' is not a stash-like commit"
-msgstr "'$args' no és comissió com a un magatzem"
+msgstr "'$args' no és comissió com magatzem"
 
 #: git-stash.sh:436
 #, sh-format
@@ -10641,11 +10867,11 @@ msgstr "${REV} ($s) descartada"
 msgid "${REV}: Could not drop stash entry"
 msgstr "${REV}: No s'ha pogut descartar l'entrada de magatzem"
 
-#: git-stash.sh:538
+#: git-stash.sh:539
 msgid "No branch name specified"
 msgstr "Cap nom de rama especificat"
 
-#: git-stash.sh:610
+#: git-stash.sh:611
 msgid "(To restore them type \"git stash apply\")"
 msgstr "(Per restaurar-les teclegeu \"git stash apply\")"
 
@@ -10658,7 +10884,8 @@ msgstr "no es pot despullar un component de l'url '$remoteurl'"
 #, sh-format
 msgid "No submodule mapping found in .gitmodules for path '$sm_path'"
 msgstr ""
-"Cap mapatge de submòdul trobada en .gitmodules per a la ruta '$sm_path'"
+"No s'ha trobat una mapatge de submòdul en .gitmodules per a la ruta "
+"'$sm_path'"
 
 #: git-submodule.sh:287
 #, sh-format
@@ -10674,14 +10901,13 @@ msgstr ""
 #: git-submodule.sh:406
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
-"La ruta relativa només es pot utilitzar des del nivell superior de l'arbre "
-"de treball"
+"La ruta relativa només es pot usar des del nivell superior de l'arbre de "
+"treball"
 
 #: git-submodule.sh:416
 #, sh-format
 msgid "repo URL: '$repo' must be absolute or begin with ./|../"
-msgstr ""
-"URL de repositori: '$repo' ha de ser absolut o ha de començar amb ./|../"
+msgstr "URL de dipòsit: '$repo' ha de ser absolut o començar amb ./|../"
 
 #: git-submodule.sh:433
 #, sh-format
@@ -10697,17 +10923,17 @@ msgid ""
 msgstr ""
 "La ruta següent s'ignora per un dels vostres fitxers .gitignore:\n"
 "$sm_path\n"
-"Utilitzeu -f si realment voleu afegir-lo."
+"Useu -f si realment voleu afegir-lo."
 
 #: git-submodule.sh:455
 #, sh-format
 msgid "Adding existing repo at '$sm_path' to the index"
-msgstr "Afegint el repositori existent a '$sm_path' a l'índex"
+msgstr "Afegint el dipòsit existent a '$sm_path' a l'índex"
 
 #: git-submodule.sh:457
 #, sh-format
 msgid "'$sm_path' already exists and is not a valid git repo"
-msgstr "'$sm_path' ja existeix i no és un repositori de git vàlid"
+msgstr "'$sm_path' ja existeix i no és un dipòsit de git vàlid"
 
 #: git-submodule.sh:465
 #, sh-format
@@ -10720,16 +10946,16 @@ msgstr ""
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from"
 msgstr ""
-"Si voleu reutilitzar aquest directori de git local en lloc de clonar de nou "
-"de"
+"Si voleu tornar a usar aquest directori de git local en lloc de clonar de "
+"nou des de"
 
 #: git-submodule.sh:469
 #, sh-format
 msgid ""
 "use the '--force' option. If the local git directory is not the correct repo"
 msgstr ""
-"utilitzeu l'opció '--force'. Si el directori de git local no és el "
-"repositori correcte"
+"useu l'opció '--force'. Si el directori de git local no és el dipòsit "
+"correcte"
 
 #: git-submodule.sh:470
 #, sh-format
@@ -10737,7 +10963,7 @@ msgid ""
 "or you are unsure what this means choose another name with the '--name' "
 "option."
 msgstr ""
-"o esteu insegur de què vol dir això, trieu altre nom amb l'opció '--name'."
+"o esteu insegur de què vol dir això, trieu un altre nom amb l'opció '--name'."
 
 #: git-submodule.sh:472
 #, sh-format
@@ -10752,12 +10978,12 @@ msgstr "Incapaç d'agafar el submòdul '$sm_path'"
 #: git-submodule.sh:489
 #, sh-format
 msgid "Failed to add submodule '$sm_path'"
-msgstr "S'ha fallat al afegir el submòdul '$sm_path'"
+msgstr "S'ha fallat en afegir el submòdul '$sm_path'"
 
 #: git-submodule.sh:498
 #, sh-format
 msgid "Failed to register submodule '$sm_path'"
-msgstr "S'ha fallat al registrar el submòdul '$sm_path'"
+msgstr "S'ha fallat en registrar el submòdul '$sm_path'"
 
 #: git-submodule.sh:542
 #, sh-format
@@ -10773,30 +10999,31 @@ msgstr ""
 #: git-submodule.sh:608
 #, sh-format
 msgid "No url found for submodule path '$displaypath' in .gitmodules"
-msgstr "Cap url trobat per a la ruta de submòdul '$displaypath' en .gitmodules"
+msgstr ""
+"No s'ha trobat un url per a la ruta de submòdul '$displaypath' en .gitmodules"
 
 #: git-submodule.sh:617
 #, sh-format
 msgid "Failed to register url for submodule path '$displaypath'"
 msgstr ""
-"S'ha fallat al registrar l'url per a la ruta de submòdul '$displaypath'"
+"S'ha fallat en registrar l'url per a la ruta de submòdul '$displaypath'"
 
 #: git-submodule.sh:619
 #, sh-format
 msgid "Submodule '$name' ($url) registered for path '$displaypath'"
-msgstr "Submòdul '$name' ($url) registrat per a la ruta '$displaypath'"
+msgstr "S'ha registrat el submòdul '$name' ($url) per a la ruta '$displaypath'"
 
 #: git-submodule.sh:636
 #, sh-format
 msgid "Failed to register update mode for submodule path '$displaypath'"
 msgstr ""
-"S'ha fallat al registrar el mode d'actualització per a la ruta de submòdul "
+"S'ha fallat en registrar el mode d'actualització per a la ruta de submòdul "
 "'$displaypath'"
 
 #: git-submodule.sh:674
 #, sh-format
 msgid "Use '.' if you really want to deinitialize all submodules"
-msgstr "Utilitzeu '.' si realment voleu desinicialitzar tots els submòduls"
+msgstr "Useu '.' si realment voleu desinicialitzar tots els submòduls"
 
 #: git-submodule.sh:691
 #, sh-format
@@ -10808,7 +11035,7 @@ msgstr "L'arbre de treball de submòdul '$displaypath' conté un directori .git"
 msgid ""
 "(use 'rm -rf' if you really want to remove it including all of its history)"
 msgstr ""
-"(utilitzeu 'rm -rf' si realment voleu treure'l inclòs tota la seva història)"
+"(useu 'rm -rf' si realment voleu treure'l inclòs tota la seva història)"
 
 #: git-submodule.sh:698
 #, sh-format
@@ -10817,7 +11044,7 @@ msgid ""
 "discard them"
 msgstr ""
 "L'arbre de treball de submòdul '$displaypath' conté modificacions locals; "
-"utilitzeu '-f' per descartar-les"
+"useu '-f' per a descartar-les"
 
 #: git-submodule.sh:701
 #, sh-format
@@ -10846,7 +11073,7 @@ msgid ""
 "Maybe you want to use 'update --init'?"
 msgstr ""
 "Ruta de submòdul '$displaypath' no inicialitzat\n"
-"Potser voleu utilitzar 'update --init'?"
+"Potser voleu usar 'update --init'?"
 
 #: git-submodule.sh:843
 #, sh-format
@@ -10857,12 +11084,12 @@ msgstr ""
 #: git-submodule.sh:852
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
-msgstr "Incapaç d'agafar en la ruta de submòdul '$sm_path'"
+msgstr "Incapaç d'obtenir en la ruta de submòdul '$sm_path'"
 
 #: git-submodule.sh:876
 #, sh-format
 msgid "Unable to fetch in submodule path '$displaypath'"
-msgstr "Incapaç d'agafar en la ruta de submòdul '$displaypath'"
+msgstr "Incapaç d'obtenir en la ruta de submòdul '$displaypath'"
 
 #: git-submodule.sh:890
 #, sh-format
@@ -10872,7 +11099,7 @@ msgstr "Incapaç d'agafar '$sha1' en la ruta de submòdul '$displaypath'"
 #: git-submodule.sh:891
 #, sh-format
 msgid "Submodule path '$displaypath': checked out '$sha1'"
-msgstr "Ruta de submòdul '$displaypath': agafat '$sha1'"
+msgstr "Ruta de submòdul '$displaypath': s'ha agafat '$sha1'"
 
 #: git-submodule.sh:895
 #, sh-format
@@ -10882,7 +11109,7 @@ msgstr "Incapaç de rebasar '$sha1' en la ruta de submòdul '$displaypath'"
 #: git-submodule.sh:896
 #, sh-format
 msgid "Submodule path '$displaypath': rebased into '$sha1'"
-msgstr "Ruta de submòdul '$displaypath': rebasada en '$sha1'"
+msgstr "Ruta de submòdul '$displaypath': s'ha rebasat en '$sha1'"
 
 #: git-submodule.sh:901
 #, sh-format
@@ -10892,7 +11119,7 @@ msgstr "Incapaç de fusionar '$sha1' en la ruta de submòdul '$displaypath'"
 #: git-submodule.sh:902
 #, sh-format
 msgid "Submodule path '$displaypath': merged in '$sha1'"
-msgstr "Ruta de submòdul '$displaypath': fusionada en '$sha1'"
+msgstr "Ruta de submòdul '$displaypath': s'ha fusionat en '$sha1'"
 
 #: git-submodule.sh:907
 #, sh-format
@@ -10910,11 +11137,11 @@ msgstr "Ruta de submòdul '$prefix$sm_path': '$command $sha1'"
 #: git-submodule.sh:938
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
-msgstr "S'ha fallat al recursar a la ruta de submòdul '$displaypath'"
+msgstr "S'ha fallat en recursar a la ruta de submòdul '$displaypath'"
 
 #: git-submodule.sh:1046
 msgid "The --cached option cannot be used with the --files option"
-msgstr "L'opció --cached no es pot utilitzar amb l'opció --files"
+msgstr "L'opció --cached no es pot usar amb l'opció --files"
 
 #: git-submodule.sh:1098
 #, sh-format
@@ -10943,7 +11170,7 @@ msgstr "blob"
 #: git-submodule.sh:1267
 #, sh-format
 msgid "Failed to recurse into submodule path '$sm_path'"
-msgstr "S'ha fallat al recursar a la ruta de submòdul '$sm_path'"
+msgstr "S'ha fallat en recursar a la ruta de submòdul '$sm_path'"
 
 #: git-submodule.sh:1331
 #, sh-format


### PR DESCRIPTION
This commit brings the Catalan translation back up to 100%, corrects numerous anglicisms and typos, and incorporates suggestions from SoftCatalà's Guia d'Estil for translating software from English to Catalan.
