### PR TITLE
please pull German l10n updates for Git v2.2.0

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -6921,7 +6921,6 @@ msgid "show files on the filesystem that need to be removed"
 msgstr "Dateien im Dateisystem, die gelöscht werden müssen, anzeigen"
 
 #: builtin/ls-files.c:477
-#, fuzzy
 msgid "show 'other' directories' names only"
 msgstr "nur Namen von 'sonstigen' Verzeichnissen anzeigen"
 
@@ -8082,10 +8081,9 @@ msgstr ""
 "Objekte einschließen, die von Einträgen des Reflogs referenziert werden"
 
 #: builtin/pack-objects.c:2667
-#, fuzzy
 msgid "include objects referred to by the index"
 msgstr ""
-"Objekte einschließen, die von Einträgen des Reflogs referenziert werden"
+"Objekte einschließen, die von der Staging-Area referenziert werden"
 
 #: builtin/pack-objects.c:2670
 msgid "output pack to stdout"


### PR DESCRIPTION
Please pull German l10n updates vor Git v2.2.0.
One commit translates the two fuzzy messages appeared after your msgmerge update.
The other commit contains the translation of two new messages so the German translation
is now 100% complete.
Thanks
