### PR TITLE
l10n: fr.po: Fix typo

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -1913,7 +1913,7 @@ msgid ""
 "Everything below will be removed."
 msgstr ""
 "Ne touchez pas à la ligne ci-dessus\n"
-"Tout se qui suit sera éliminé."
+"Tout ce qui suit sera éliminé."
 
 #: wt-status.c:948
 msgid "You have unmerged paths."


### PR DESCRIPTION
Fix simple typo in French translation.

Signed-off-by: Audric Schiltknecht <storm@chemicalstorm.org>