### PR TITLE
Make the French translation gender neutral

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3907,7 +3907,7 @@ msgstr "  (utilisez \"git commit --amend\" pour corriger le commit actuel)"
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
-"  (utilisez \"git rebase --continue\" quand vous êtes satisfait de vos "
+"  (utilisez \"git rebase --continue\" quand vous avez effectué toutes vos "
 "modifications)"
 
 #: wt-status.c:1280
@@ -4927,7 +4927,7 @@ msgid ""
 "If you are sure you want to delete it, run 'git branch -D %s'."
 msgstr ""
 "La branche '%s' n'est pas totalement fusionnée.\n"
-"Si vous êtes sûr que vous voulez la supprimer, lancez 'git branch -D %s'."
+"Si vous souhaitez réellement la supprimer, lancez 'git branch -D %s'."
 
 #: builtin/branch.c:178
 msgid "Update of config-file failed"
@@ -10746,7 +10746,7 @@ msgid ""
 "to recover."
 msgstr ""
 "Avance rapide de votre arbre de travail impossible.\n"
-"Après vous être assuré que toute modification précieuse a été sauvegardée "
+"Après avoir vérifié que toute modification précieuse a été sauvegardée "
 "avec\n"
 "$ git diff %s\n"
 "lancez\n"
@@ -13667,7 +13667,7 @@ msgstr "Attention : bissection avec seulement une validation $TERM_BAD."
 #. at this point.
 #: git-bisect.sh:328
 msgid "Are you sure [Y/n]? "
-msgstr "Êtes-vous sûr [Y/n] ? "
+msgstr "Confirmez-vous [Y/n] ? "
 
 #: git-bisect.sh:340
 #, sh-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -4927,7 +4927,7 @@ msgid ""
 "If you are sure you want to delete it, run 'git branch -D %s'."
 msgstr ""
 "La branche '%s' n'est pas totalement fusionnée.\n"
-"Si vous êtes sur que vous voulez la supprimer, lancez 'git branch -D %s'."
+"Si vous êtes sûr que vous voulez la supprimer, lancez 'git branch -D %s'."
 
 #: builtin/branch.c:178
 msgid "Update of config-file failed"
@@ -5314,7 +5314,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Si vous vouliez que '%s' suive '%s', faîtes ceci :\n"
+"Si vous vouliez que '%s' suive '%s', faites ceci :\n"
 "\n"
 
 #: builtin/bundle.c:51
@@ -15113,8 +15113,8 @@ msgstr "Impossible de déterminer le chemin absolu du répertoire git"
 #~ "or you are unsure what this means choose another name with the '--name' "
 #~ "option."
 #~ msgstr ""
-#~ "ou vous ne savez pas ce que cela signifie de choisir un autre nom avec "
-#~ "l'option '--name'."
+#~ "ou si vous ne savez pas ce que cela signifie, choisissez un autre nom "
+#~ "avec l'option '--name'."
 
 #~ msgid "Submodule work tree '$displaypath' contains a .git directory"
 #~ msgstr ""


### PR DESCRIPTION
Based on #208 , just adds gender neutral adjectives (there's no need to assume a software developer needs to be a male).

We could also do it by changing the whole sentence
e.g.:
>  quand vous êtes satisfait de vos modifications

would become
> quand vos modification vous donnent satisfaction

> Si vous êtes sûr que vous voulez la supprimer

Could be phrased as
> Si vous souhaitez réellement la supprimer

> Après vous être assuré que toute modification précieuse a été sauvegardée

would be
> Après avoir vérifié que toute modification précieuse a été sauvegardée

> Êtes-vous sûr ?

would be
> Valider/Confirmer ce choix ?

(I can make it independent of #208, it's just that both are touching the same line, so I'm trying to avoid a conflict)