### PR TITLE
l10n: Update Swedish translation (4363t0f0u)

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -1,14 +1,14 @@
 # Swedish translations for Git.
-# Copyright (C) 2010-2018 Peter Krefting <peter@softwolves.pp.se>
+# Copyright (C) 2010-2019 Peter Krefting <peter@softwolves.pp.se>
 # This file is distributed under the same license as the Git package.
-# Peter Krefting <peter@softwolves.pp.se>, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018.
+# Peter Krefting <peter@softwolves.pp.se>, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git 2.20.0\n"
+"Project-Id-Version: git 2.21.0\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2018-12-02 10:55+0800\n"
-"PO-Revision-Date: 2018-12-02 15:41+0100\n"
+"POT-Creation-Date: 2019-02-15 10:09+0800\n"
+"PO-Revision-Date: 2019-02-15 09:03+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -18,47 +18,47 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
-#: advice.c:99
+#: advice.c:101
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%stips: %.*s%s\n"
 
-#: advice.c:152
+#: advice.c:154
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 "Du kan inte utföra en cherry-pick eftersom du har filer som inte slagits "
 "samman."
 
-#: advice.c:154
+#: advice.c:156
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 "Du kan inte utföra en incheckning eftersom du har filer som inte slagits "
 "samman."
 
-#: advice.c:156
+#: advice.c:158
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 "Du kan inte utföra en sammanslagning eftersom du har filer som inte slagits "
 "samman."
 
-#: advice.c:158
+#: advice.c:160
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 "Du kan inte utföra en \"pull\" eftersom du har filer som inte slagits samman."
 
-#: advice.c:160
+#: advice.c:162
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 "Du kan inte utföra en \"revert\" eftersom du har filer som inte slagits "
 "samman."
 
-#: advice.c:162
+#: advice.c:164
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr ""
 "Du kan inte utföra en \"%s\" eftersom du har filer som inte slagits samman."
 
-#: advice.c:170
+#: advice.c:172
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -66,23 +66,23 @@ msgstr ""
 "Rätta dem i din arbetskatalog och använd sedan \"git add/rm <fil>\"\n"
 "som lämpligt för att ange lösning och checka in."
 
-#: advice.c:178
+#: advice.c:180
 msgid "Exiting because of an unresolved conflict."
 msgstr "Avslutar på grund av olöst konflikgt."
 
-#: advice.c:183 builtin/merge.c:1289
+#: advice.c:185 builtin/merge.c:1290
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Du har inte avslutat sammanslagningen (MERGE_HEAD finns)."
 
-#: advice.c:185
+#: advice.c:187
 msgid "Please, commit your changes before merging."
 msgstr "Checka in dina ändringar innan du utför sammanslagningen."
 
-#: advice.c:186
+#: advice.c:188
 msgid "Exiting because of unfinished merge."
 msgstr "Avslutar på grund av ofullbordad sammanslagning."
 
-#: advice.c:192
+#: advice.c:194
 #, c-format
 msgid ""
 "Note: checking out '%s'.\n"
@@ -110,6 +110,14 @@ msgstr ""
 "\n"
 "  git checkout -b <namn-på-ny-gren>\n"
 "\n"
+
+#: alias.c:50
+msgid "cmdline ends with \\"
+msgstr "kommandorad avslutas med \\"
+
+#: alias.c:51
+msgid "unclosed quote"
+msgstr "citat ej stängt"
 
 #: apply.c:59
 #, c-format
@@ -141,62 +149,62 @@ msgstr "--index utanför arkiv"
 msgid "--cached outside a repository"
 msgstr "--cached utanför arkiv"
 
-#: apply.c:826
+#: apply.c:825
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
 msgstr "Kan inte förbereda reguljärt uttryck för tidsstämpeln %s"
 
-#: apply.c:835
+#: apply.c:834
 #, c-format
 msgid "regexec returned %d for input: %s"
 msgstr "regexec returnerade %d för indata: %s"
 
-#: apply.c:909
+#: apply.c:908
 #, c-format
 msgid "unable to find filename in patch at line %d"
 msgstr "kan inte hitta filnamn i patchen på rad %d"
 
-#: apply.c:947
+#: apply.c:946
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
 msgstr "git apply: dålig git-diff - förväntade /dev/null, fick %s på rad %d"
 
-#: apply.c:953
+#: apply.c:952
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr "git apply: dålig git-diff - motsägande nytt filnamn på rad %d"
 
-#: apply.c:954
+#: apply.c:953
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr "git apply: dålig git-diff - motsägande gammalt filnamn på rad %d"
 
-#: apply.c:959
+#: apply.c:958
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null on line %d"
 msgstr "git apply: dålig git-diff - förväntade /dev/null på rad %d"
 
-#: apply.c:988
+#: apply.c:987
 #, c-format
 msgid "invalid mode on line %d: %s"
 msgstr "ogiltigt läge på rad %d: %s"
 
-#: apply.c:1307
+#: apply.c:1306
 #, c-format
 msgid "inconsistent header lines %d and %d"
 msgstr "huvudet är inkonsekvent mellan rad %d och %d"
 
-#: apply.c:1479
+#: apply.c:1478
 #, c-format
 msgid "recount: unexpected line: %.*s"
 msgstr "recount: förväntade rad: %.*s"
 
-#: apply.c:1548
+#: apply.c:1547
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
 msgstr "patch-fragment utan huvud på rad %d: %.*s"
 
-#: apply.c:1568
+#: apply.c:1567
 #, c-format
 msgid ""
 "git diff header lacks filename information when removing %d leading pathname "
@@ -212,82 +220,82 @@ msgstr[1] ""
 "sökvägskomponenter\n"
 "tas bort (rad %d)"
 
-#: apply.c:1581
+#: apply.c:1580
 #, c-format
 msgid "git diff header lacks filename information (line %d)"
 msgstr "git-diff-huvudet saknar filnamnsinformation (rad %d)"
 
-#: apply.c:1769
+#: apply.c:1768
 msgid "new file depends on old contents"
 msgstr "ny fil beror på gammalt innehåll"
 
-#: apply.c:1771
+#: apply.c:1770
 msgid "deleted file still has contents"
 msgstr "borttagen fil har fortfarande innehåll"
 
-#: apply.c:1805
+#: apply.c:1804
 #, c-format
 msgid "corrupt patch at line %d"
 msgstr "trasig patch på rad %d"
 
-#: apply.c:1842
+#: apply.c:1841
 #, c-format
 msgid "new file %s depends on old contents"
 msgstr "nya filen %s beror på gammalt innehåll"
 
-#: apply.c:1844
+#: apply.c:1843
 #, c-format
 msgid "deleted file %s still has contents"
 msgstr "borttagna filen %s har fortfarande innehåll"
 
-#: apply.c:1847
+#: apply.c:1846
 #, c-format
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "** varning: filen %s blir tom men har inte tagits bort"
 
-#: apply.c:1994
+#: apply.c:1993
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "trasig binärpatch på rad %d: %.*s"
 
-#: apply.c:2031
+#: apply.c:2030
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "binärpatchen på rad %d känns inte igen"
 
-#: apply.c:2193
+#: apply.c:2192
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "patch med bara skräp på rad %d"
 
-#: apply.c:2279
+#: apply.c:2278
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "kunde inte läsa symboliska länken %s"
 
-#: apply.c:2283
+#: apply.c:2282
 #, c-format
 msgid "unable to open or read %s"
 msgstr "kunde inte öppna eller läsa %s"
 
-#: apply.c:2942
+#: apply.c:2941
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "felaktig inledning på rad: \"%c\""
 
-#: apply.c:3063
+#: apply.c:3062
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
 msgstr[0] "Stycke %d lyckades på %d (offset %d rad)."
 msgstr[1] "Stycke %d lyckades på %d (offset %d rader)."
 
-#: apply.c:3075
+#: apply.c:3074
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr "Sammanhang reducerat till (%ld/%ld) för att tillämpa fragment vid %d"
 
-#: apply.c:3081
+#: apply.c:3080
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -296,25 +304,25 @@ msgstr ""
 "vid sökning efter:\n"
 "%.*s"
 
-#: apply.c:3103
+#: apply.c:3102
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr "saknar binära patchdata för \"%s\""
 
-#: apply.c:3111
+#: apply.c:3110
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
 "kan inte applicera en binärpatch baklänges utan den omvända patchen för \"%s"
 "\""
 
-#: apply.c:3158
+#: apply.c:3157
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr ""
 "kan inte applicera binärpatch på \"%s\" utan den fullständiga indexraden"
 
-#: apply.c:3168
+#: apply.c:3167
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
@@ -322,27 +330,27 @@ msgstr ""
 "patchen appliceras på \"%s\" (%s), som inte motsvarar det nuvarande "
 "innehållet."
 
-#: apply.c:3176
+#: apply.c:3175
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "patchen appliceras på en tom \"%s\", men den är inte tom"
 
-#: apply.c:3194
+#: apply.c:3193
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr "nödvändig efterbild %s för \"%s\" kan inte läsas"
 
-#: apply.c:3207
+#: apply.c:3206
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "binärpatchen kan inte tillämpas på \"%s\""
 
-#: apply.c:3213
+#: apply.c:3212
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr "binärpatchen på \"%s\" ger felaktigt resultat (förväntade %s, fick %s)"
 
-#: apply.c:3234
+#: apply.c:3233
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "patch misslyckades: %s:%ld"
@@ -422,7 +430,8 @@ msgstr "%s: fel typ"
 msgid "%s has type %o, expected %o"
 msgstr "%s har typen %o, förväntade %o"
 
-#: apply.c:3881 apply.c:3883
+#: apply.c:3881 apply.c:3883 read-cache.c:820 read-cache.c:846
+#: read-cache.c:1299
 #, c-format
 msgid "invalid path '%s'"
 msgstr "ogiltig sökväg ”%s”"
@@ -477,7 +486,7 @@ msgstr "nytt läge för %s, som inte finns i nuvarande HEAD"
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "sha1-informationen saknas eller är oanvändbar (%s)."
 
-#: apply.c:4113 builtin/checkout.c:244 builtin/reset.c:142
+#: apply.c:4113 builtin/checkout.c:248 builtin/reset.c:143
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry misslyckades för sökvägen \"%s\""
@@ -553,7 +562,7 @@ msgstr[1] "Tillämpade patchen %%s med %d refuserade..."
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "trunkerar .rej-filnamnet till %.*s.rej"
 
-#: apply.c:4564 builtin/fetch.c:843 builtin/fetch.c:1122
+#: apply.c:4564 builtin/fetch.c:837 builtin/fetch.c:1118
 #, c-format
 msgid "cannot open %s"
 msgstr "kan inte öppna %s"
@@ -577,171 +586,171 @@ msgstr "Ignorerar patch \"%s\"."
 msgid "unrecognized input"
 msgstr "indata känns inte igen"
 
-#: apply.c:4719
+#: apply.c:4720
 msgid "unable to read index file"
 msgstr "kan inte läsa indexfilen"
 
-#: apply.c:4874
+#: apply.c:4875
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "kan inte öppna patchen \"%s\": %s"
 
-#: apply.c:4901
+#: apply.c:4902
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "undertryckte %d fel i blanksteg"
 msgstr[1] "undertryckte %d fel i blanksteg"
 
-#: apply.c:4907 apply.c:4922
+#: apply.c:4908 apply.c:4923
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d rad lägger till fel i blanksteg."
 msgstr[1] "%d rader lägger till fel i blanksteg."
 
-#: apply.c:4915
+#: apply.c:4916
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d rad applicerade efter att ha rättat fel i blanksteg."
 msgstr[1] "%d rader applicerade efter att ha rättat fel i blanksteg."
 
-#: apply.c:4931 builtin/add.c:538 builtin/mv.c:300 builtin/rm.c:389
+#: apply.c:4932 builtin/add.c:539 builtin/mv.c:301 builtin/rm.c:390
 msgid "Unable to write new index file"
 msgstr "Kunde inte skriva ny indexfil"
 
-#: apply.c:4958 apply.c:4961 builtin/am.c:2209 builtin/am.c:2212
-#: builtin/clone.c:121 builtin/fetch.c:118 builtin/merge.c:262
-#: builtin/pull.c:199 builtin/submodule--helper.c:406
-#: builtin/submodule--helper.c:1362 builtin/submodule--helper.c:1365
-#: builtin/submodule--helper.c:1846 builtin/submodule--helper.c:1849
-#: builtin/submodule--helper.c:2088 git-add--interactive.perl:197
+#: apply.c:4959 apply.c:4962 builtin/am.c:2203 builtin/am.c:2206
+#: builtin/clone.c:122 builtin/fetch.c:118 builtin/merge.c:263
+#: builtin/pull.c:200 builtin/submodule--helper.c:407
+#: builtin/submodule--helper.c:1366 builtin/submodule--helper.c:1369
+#: builtin/submodule--helper.c:1850 builtin/submodule--helper.c:1853
+#: builtin/submodule--helper.c:2092 git-add--interactive.perl:197
 msgid "path"
 msgstr "sökväg"
 
-#: apply.c:4959
+#: apply.c:4960
 msgid "don't apply changes matching the given path"
 msgstr "tillämpa inte ändringar som motsvarar given sökväg"
 
-#: apply.c:4962
+#: apply.c:4963
 msgid "apply changes matching the given path"
 msgstr "tillämpa ändringar som motsvarar given sökväg"
 
-#: apply.c:4964 builtin/am.c:2218
+#: apply.c:4965 builtin/am.c:2212
 msgid "num"
 msgstr "antal"
 
-#: apply.c:4965
+#: apply.c:4966
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "ta bort <antal> inledande snedstreck från traditionella diff-sökvägar"
 
-#: apply.c:4968
+#: apply.c:4969
 msgid "ignore additions made by the patch"
 msgstr "ignorera tillägg gjorda av patchen"
 
-#: apply.c:4970
+#: apply.c:4971
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr "istället för att tillämpa patchen, skriv ut diffstat för indata"
 
-#: apply.c:4974
+#: apply.c:4975
 msgid "show number of added and deleted lines in decimal notation"
 msgstr "visa antal tillagda och borttagna rader decimalt"
 
-#: apply.c:4976
+#: apply.c:4977
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "istället för att tillämpa patchen, skriv ut en summering av indata"
 
-#: apply.c:4978
+#: apply.c:4979
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "istället för att tillämpa patchen, se om patchen kan tillämpas"
 
-#: apply.c:4980
+#: apply.c:4981
 msgid "make sure the patch is applicable to the current index"
 msgstr "se till att patchen kan tillämpas på aktuellt index"
 
-#: apply.c:4982
+#: apply.c:4983
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "markera nya filer med \"git add --intent-to-add\""
 
-#: apply.c:4984
+#: apply.c:4985
 msgid "apply a patch without touching the working tree"
 msgstr "tillämpa en patch utan att röra arbetskatalogen"
 
-#: apply.c:4986
+#: apply.c:4987
 msgid "accept a patch that touches outside the working area"
 msgstr "godta en patch som rör filer utanför arbetskatalogen"
 
-#: apply.c:4989
+#: apply.c:4990
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "tillämpa också patchen (använd med --stat/--summary/--check)"
 
-#: apply.c:4991
+#: apply.c:4992
 msgid "attempt three-way merge if a patch does not apply"
 msgstr "försök en trevägssammanslagning om patchen inte kan tillämpas"
 
-#: apply.c:4993
+#: apply.c:4994
 msgid "build a temporary index based on embedded index information"
 msgstr "bygg ett temporärt index baserat på inbyggd indexinformation"
 
-#: apply.c:4996 builtin/checkout-index.c:170 builtin/ls-files.c:523
+#: apply.c:4997 builtin/checkout-index.c:173 builtin/ls-files.c:524
 msgid "paths are separated with NUL character"
 msgstr "sökvägar avdelas med NUL-tecken"
 
-#: apply.c:4998
+#: apply.c:4999
 msgid "ensure at least <n> lines of context match"
 msgstr "se till att åtminstone <n> rader sammanhang är lika"
 
-#: apply.c:4999 builtin/am.c:2197 builtin/interpret-trailers.c:97
+#: apply.c:5000 builtin/am.c:2191 builtin/interpret-trailers.c:97
 #: builtin/interpret-trailers.c:99 builtin/interpret-trailers.c:101
-#: builtin/pack-objects.c:3312 builtin/rebase.c:857
+#: builtin/pack-objects.c:3314 builtin/rebase.c:1065
 msgid "action"
 msgstr "åtgärd"
 
-#: apply.c:5000
+#: apply.c:5001
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "detektera nya eller ändrade rader som har fel i blanktecken"
 
-#: apply.c:5003 apply.c:5006
+#: apply.c:5004 apply.c:5007
 msgid "ignore changes in whitespace when finding context"
 msgstr "ignorera ändringar i blanktecken för sammanhang"
 
-#: apply.c:5009
+#: apply.c:5010
 msgid "apply the patch in reverse"
 msgstr "tillämpa patchen baklänges"
 
-#: apply.c:5011
+#: apply.c:5012
 msgid "don't expect at least one line of context"
 msgstr "förvänta inte minst en rad sammanhang"
 
-#: apply.c:5013
+#: apply.c:5014
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "lämna refuserade stycken i motsvarande *.rej-filer"
 
-#: apply.c:5015
+#: apply.c:5016
 msgid "allow overlapping hunks"
 msgstr "tillåt överlappande stycken"
 
-#: apply.c:5016 builtin/add.c:290 builtin/check-ignore.c:21
-#: builtin/commit.c:1309 builtin/count-objects.c:98 builtin/fsck.c:698
-#: builtin/log.c:2023 builtin/mv.c:122 builtin/read-tree.c:127
-#: builtin/rebase--interactive.c:157
+#: apply.c:5017 builtin/add.c:291 builtin/check-ignore.c:22
+#: builtin/commit.c:1312 builtin/count-objects.c:98 builtin/fsck.c:724
+#: builtin/log.c:2037 builtin/mv.c:123 builtin/read-tree.c:128
+#: builtin/rebase--interactive.c:159
 msgid "be verbose"
 msgstr "var pratsam"
 
-#: apply.c:5018
+#: apply.c:5019
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "tolerera felaktigt detekterade saknade nyradstecken vid filslut"
 
-#: apply.c:5021
+#: apply.c:5022
 msgid "do not trust the line counts in the hunk headers"
 msgstr "lite inte på antalet linjer i styckehuvuden"
 
-#: apply.c:5023 builtin/am.c:2206
+#: apply.c:5024 builtin/am.c:2200
 msgid "root"
 msgstr "rot"
 
-#: apply.c:5024
+#: apply.c:5025
 msgid "prepend <root> to all filenames"
 msgstr "lägg till <rot> i alla filnamn"
 
@@ -764,99 +773,118 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <arkiv> [--exec <kmd>] --list"
 
-#: archive.c:370 builtin/add.c:176 builtin/add.c:514 builtin/rm.c:298
+#: archive.c:372 builtin/add.c:177 builtin/add.c:515 builtin/rm.c:299
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "sökvägsangivelsen \"%s\" motsvarade inte några filer"
 
-#: archive.c:453
+#: archive.c:396
+#, c-format
+msgid "no such ref: %.*s"
+msgstr "ingen sådan referens: %.*s"
+
+#: archive.c:401
+#, c-format
+msgid "not a valid object name: %s"
+msgstr "objektnamnet är inte giltigt: %s"
+
+#: archive.c:414
+#, c-format
+msgid "not a tree object: %s"
+msgstr "inte ett trädobjekt: %s"
+
+#: archive.c:424
+msgid "current working directory is untracked"
+msgstr "aktuell arbetskatalog är inte spårad"
+
+#: archive.c:455
 msgid "fmt"
 msgstr "fmt"
 
-#: archive.c:453
+#: archive.c:455
 msgid "archive format"
 msgstr "arkivformat"
 
-#: archive.c:454 builtin/log.c:1536
+#: archive.c:456 builtin/log.c:1549
 msgid "prefix"
 msgstr "prefix"
 
-#: archive.c:455
+#: archive.c:457
 msgid "prepend prefix to each pathname in the archive"
 msgstr "lägg till prefix till varje sökväg i arkivet"
 
-#: archive.c:456 builtin/blame.c:820 builtin/blame.c:821 builtin/config.c:129
-#: builtin/fast-export.c:1013 builtin/fast-export.c:1015 builtin/grep.c:884
-#: builtin/hash-object.c:104 builtin/ls-files.c:559 builtin/ls-files.c:562
-#: builtin/notes.c:412 builtin/notes.c:575 builtin/read-tree.c:122
+#: archive.c:458 builtin/blame.c:820 builtin/blame.c:821 builtin/config.c:129
+#: builtin/fast-export.c:1091 builtin/fast-export.c:1093 builtin/grep.c:895
+#: builtin/hash-object.c:105 builtin/ls-files.c:560 builtin/ls-files.c:563
+#: builtin/notes.c:412 builtin/notes.c:578 builtin/read-tree.c:123
 #: parse-options.h:162
 msgid "file"
 msgstr "fil"
 
-#: archive.c:457 builtin/archive.c:89
+#: archive.c:459 builtin/archive.c:90
 msgid "write the archive to this file"
 msgstr "skriv arkivet till filen"
 
-#: archive.c:459
+#: archive.c:461
 msgid "read .gitattributes in working directory"
 msgstr "läs .gitattributes i arbetskatalogen"
 
-#: archive.c:460
+#: archive.c:462
 msgid "report archived files on stderr"
 msgstr "rapportera arkiverade filer på standard fel"
 
-#: archive.c:461
+#: archive.c:463
 msgid "store only"
 msgstr "endast spara"
 
-#: archive.c:462
+#: archive.c:464
 msgid "compress faster"
 msgstr "komprimera snabbare"
 
-#: archive.c:470
+#: archive.c:472
 msgid "compress better"
 msgstr "komprimera bättre"
 
-#: archive.c:473
+#: archive.c:475
 msgid "list supported archive formats"
 msgstr "visa understödda arkivformat"
 
-#: archive.c:475 builtin/archive.c:90 builtin/clone.c:111 builtin/clone.c:114
-#: builtin/submodule--helper.c:1374 builtin/submodule--helper.c:1855
+#: archive.c:477 builtin/archive.c:91 builtin/clone.c:112 builtin/clone.c:115
+#: builtin/submodule--helper.c:1378 builtin/submodule--helper.c:1859
 msgid "repo"
 msgstr "arkiv"
 
-#: archive.c:476 builtin/archive.c:91
+#: archive.c:478 builtin/archive.c:92
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "hämta arkivet från fjärrarkivet <arkiv>"
 
-#: archive.c:477 builtin/archive.c:92 builtin/difftool.c:714
-#: builtin/notes.c:496
+#: archive.c:479 builtin/archive.c:93 builtin/difftool.c:715
+#: builtin/notes.c:498
 msgid "command"
 msgstr "kommando"
 
-#: archive.c:478 builtin/archive.c:93
+#: archive.c:480 builtin/archive.c:94
 msgid "path to the remote git-upload-archive command"
 msgstr "sökväg till kommandot git-upload-archive på fjärren"
 
-#: archive.c:485
+#: archive.c:487
 msgid "Unexpected option --remote"
 msgstr "Oväntad flagga --remote"
 
-#: archive.c:487
+#: archive.c:489
 msgid "Option --exec can only be used together with --remote"
 msgstr "Flaggan --exec kan endast användas tillsammans med --remote"
 
-#: archive.c:489
+#: archive.c:491
 msgid "Unexpected option --output"
 msgstr "Oväntad flagga --output"
 
-#: archive.c:511
+#: archive.c:513
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Okänt arkivformat \"%s\""
 
-#: archive.c:518
+#: archive.c:520
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argumentet stöd inte för formatet \"%s\": -%d"
@@ -900,7 +928,7 @@ msgstr "sökvägen är inte giltig UTF-8: %s"
 msgid "path too long (%d chars, SHA1: %s): %s"
 msgstr "sökvägen för lång (%d tecken, SHA1: %s): %s"
 
-#: archive-zip.c:474 builtin/pack-objects.c:224 builtin/pack-objects.c:227
+#: archive-zip.c:474 builtin/pack-objects.c:225 builtin/pack-objects.c:228
 #, c-format
 msgid "deflate error (%d)"
 msgstr "fel i deflate (%d)"
@@ -910,12 +938,17 @@ msgstr "fel i deflate (%d)"
 msgid "timestamp too large for this system: %<PRIuMAX>"
 msgstr "tidsstämpeln för stor för detta system: %<PRIuMAX>"
 
-#: attr.c:212
+#: attr.c:211
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr "%-*s är inte ett giltigt namn på attribut"
 
-#: attr.c:409
+#: attr.c:368
+#, c-format
+msgid "%s not allowed: %s:%d"
+msgstr "%s inte tillåtet: %s:%d"
+
+#: attr.c:408
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -928,17 +961,17 @@ msgstr ""
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Felaktigt citerat innehåll i filen \"%s\": %s"
 
-#: bisect.c:676
+#: bisect.c:678
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Det finns inte mer att göra \"bisect\" på!\n"
 
-#: bisect.c:730
+#: bisect.c:733
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "Namnet på incheckningen är inte giltigt: %s"
 
-#: bisect.c:754
+#: bisect.c:758
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -947,7 +980,7 @@ msgstr ""
 "Sammanslagningsbasen %s är trasig.\n"
 "Det betyder att felet har rättats mellan %s och [%s].\n"
 
-#: bisect.c:759
+#: bisect.c:763
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -956,7 +989,7 @@ msgstr ""
 "Sammanslagningsbasen %s är ny.\n"
 "Egenskapen har ändrats mellan %s och [%s].\n"
 
-#: bisect.c:764
+#: bisect.c:768
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -965,7 +998,7 @@ msgstr ""
 "Sammanslagningsbasen %s är %s.\n"
 "Det betyder att den första \"%s\" incheckningen är mellan %s och [%s].\n"
 
-#: bisect.c:772
+#: bisect.c:776
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -976,7 +1009,7 @@ msgstr ""
 "git bisect kan inte fungera korrekt i detta fall.\n"
 "Kanske du skrev fel %s- och %s-revisioner?\n"
 
-#: bisect.c:785
+#: bisect.c:789
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -988,36 +1021,36 @@ msgstr ""
 "%s.\n"
 "Vi fortsätter ändå."
 
-#: bisect.c:818
+#: bisect.c:822
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Bisect: en sammanslagningsbas måste testas\n"
 
-#: bisect.c:858
+#: bisect.c:865
 #, c-format
 msgid "a %s revision is needed"
 msgstr "en %s-revision behövs"
 
-#: bisect.c:877 builtin/notes.c:177 builtin/tag.c:237
+#: bisect.c:884 builtin/notes.c:177 builtin/tag.c:237
 #, c-format
 msgid "could not create file '%s'"
 msgstr "kunde inte skapa filen \"%s\""
 
-#: bisect.c:928 builtin/merge.c:138
+#: bisect.c:937 builtin/merge.c:139
 #, c-format
 msgid "could not read file '%s'"
 msgstr "kunde inte läsa filen \"%s\""
 
-#: bisect.c:958
+#: bisect.c:967
 msgid "reading bisect refs failed"
 msgstr "misslyckades läsa bisect-referenser"
 
-#: bisect.c:977
+#: bisect.c:986
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s var både %s och %s\n"
 
-#: bisect.c:985
+#: bisect.c:994
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1026,7 +1059,7 @@ msgstr ""
 "Ingen testbar incheckning hittades.\n"
 "Kanske du startade med felaktiga sökvägsparametrar?\n"
 
-#: bisect.c:1004
+#: bisect.c:1013
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1036,48 +1069,48 @@ msgstr[1] "(ungefär %d steg)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1010
+#: bisect.c:1019
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
 msgstr[0] "Bisect: %d revision kvar att testa efter denna %s\n"
 msgstr[1] "Bisect: %d revisioner kvar att testa efter denna %s\n"
 
-#: blame.c:1787
+#: blame.c:1792
 msgid "--contents and --reverse do not blend well."
 msgstr "--contents och --reverse fungerar inte så bra tillsammans."
 
-#: blame.c:1801
+#: blame.c:1806
 msgid "cannot use --contents with final commit object name"
 msgstr "kan inte använda --contents med namn på slutgiltigt incheckningsobjekt"
 
-#: blame.c:1822
+#: blame.c:1827
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "--reverse och --first-parent tillsammans kräver att du anger senaste "
 "incheckningen"
 
-#: blame.c:1831 bundle.c:162 ref-filter.c:2046 sequencer.c:1963
-#: sequencer.c:4002 builtin/commit.c:1001 builtin/log.c:377 builtin/log.c:932
-#: builtin/log.c:1407 builtin/log.c:1783 builtin/log.c:2072 builtin/merge.c:406
+#: blame.c:1836 bundle.c:164 ref-filter.c:2071 remote.c:1948 sequencer.c:1993
+#: sequencer.c:4064 builtin/commit.c:1004 builtin/log.c:378 builtin/log.c:936
+#: builtin/log.c:1420 builtin/log.c:1796 builtin/log.c:2086 builtin/merge.c:407
 #: builtin/pack-objects.c:3137 builtin/pack-objects.c:3152
 #: builtin/shortlog.c:192
 msgid "revision walk setup failed"
 msgstr "misslyckades skapa revisionstraversering"
 
-#: blame.c:1849
+#: blame.c:1854
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
 "--reverse --first-parent tillsammans kräver ett intervall på första-förälder-"
 "kedjan"
 
-#: blame.c:1860
+#: blame.c:1865
 #, c-format
 msgid "no such path %s in %s"
 msgstr "sökvägen %s i %s finns inte"
 
-#: blame.c:1871
+#: blame.c:1876
 #, c-format
 msgid "cannot read blob %s for path %s"
 msgstr "kan inte läsa objektet %s för sökvägen %s"
@@ -1200,27 +1233,27 @@ msgstr ""
 "spåra dess fjärrmotsvarighet kan du använda \"git push -u\"\n"
 "för att ställa in uppströmskonfigurationen när du sänder in."
 
-#: branch.c:279
+#: branch.c:280
 #, c-format
 msgid "Not a valid object name: '%s'."
 msgstr "Objektnamnet är inte giltigt: \"%s\"."
 
-#: branch.c:299
+#: branch.c:300
 #, c-format
 msgid "Ambiguous object name: '%s'."
 msgstr "Objektnamnet är tvetydigt: \"%s\"."
 
-#: branch.c:304
+#: branch.c:305
 #, c-format
 msgid "Not a valid branch point: '%s'."
 msgstr "Avgreningspunkten är inte giltig: ”%s”."
 
-#: branch.c:358
+#: branch.c:359
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr "\"%s\" är redan utcheckad på \"%s\""
 
-#: branch.c:381
+#: branch.c:382
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD i arbetskatalogen %s har inte uppdaterats"
@@ -1235,70 +1268,70 @@ msgstr "'%s' ser inte ut som en v2-bundle-fil"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "okänt huvud: %s%s (%d)"
 
-#: bundle.c:90 rerere.c:480 rerere.c:690 sequencer.c:2182 sequencer.c:2722
-#: builtin/commit.c:774
+#: bundle.c:90 rerere.c:480 rerere.c:690 sequencer.c:2215 sequencer.c:2763
+#: builtin/commit.c:776
 #, c-format
 msgid "could not open '%s'"
 msgstr "kunde inte öppna \"%s\""
 
-#: bundle.c:141
+#: bundle.c:143
 msgid "Repository lacks these prerequisite commits:"
 msgstr "Arkivet saknar dessa nödvändiga incheckningar:"
 
-#: bundle.c:192
+#: bundle.c:194
 #, c-format
 msgid "The bundle contains this ref:"
 msgid_plural "The bundle contains these %d refs:"
 msgstr[0] "Paketet (bundlen) innehåller denna referens:"
 msgstr[1] "Paketet (bundlen) innehåller dessa %d referenser:"
 
-#: bundle.c:199
+#: bundle.c:201
 msgid "The bundle records a complete history."
 msgstr "Paketet (bundlen) beskriver en komplett historik."
 
-#: bundle.c:201
+#: bundle.c:203
 #, c-format
 msgid "The bundle requires this ref:"
 msgid_plural "The bundle requires these %d refs:"
 msgstr[0] "Paketet (bundlen) kräver denna referens:"
 msgstr[1] "Paketet (bundlen) kräver dessa %d referenser:"
 
-#: bundle.c:267
+#: bundle.c:269
 msgid "unable to dup bundle descriptor"
 msgstr "kan inte duplicera pakethandtag"
 
-#: bundle.c:274
+#: bundle.c:276
 msgid "Could not spawn pack-objects"
 msgstr "Kunde inte starta pack-objects"
 
-#: bundle.c:285
+#: bundle.c:287
 msgid "pack-objects died"
 msgstr "pack-objects misslyckades"
 
-#: bundle.c:327
+#: bundle.c:329
 msgid "rev-list died"
 msgstr "rev-list dog"
 
-#: bundle.c:376
+#: bundle.c:378
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
 msgstr "referensen \"%s\" exkluderas av argumenten till rev-list"
 
-#: bundle.c:456 builtin/log.c:192 builtin/log.c:1688 builtin/shortlog.c:304
+#: bundle.c:457 builtin/log.c:193 builtin/log.c:1701 builtin/shortlog.c:306
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "okänt argument: %s"
 
-#: bundle.c:464
+#: bundle.c:465
 msgid "Refusing to create empty bundle."
 msgstr "Vägrar skapa ett tomt paket (bundle)."
 
-#: bundle.c:474
+#: bundle.c:475
 #, c-format
 msgid "cannot create '%s'"
 msgstr "kan inte skapa \"%s\""
 
-#: bundle.c:498
+#: bundle.c:500
 msgid "index-pack died"
 msgstr "index-pack dog"
 
@@ -1307,8 +1340,8 @@ msgstr "index-pack dog"
 msgid "invalid color value: %.*s"
 msgstr "felaktigt färgvärde: %.*s"
 
-#: commit.c:50 sequencer.c:2528 builtin/am.c:370 builtin/am.c:414
-#: builtin/am.c:1390 builtin/am.c:2025 builtin/replace.c:376
+#: commit.c:50 sequencer.c:2567 builtin/am.c:355 builtin/am.c:399
+#: builtin/am.c:1375 builtin/am.c:2019 builtin/replace.c:376
 #: builtin/replace.c:448
 #, c-format
 msgid "could not parse %s"
@@ -1339,29 +1372,29 @@ msgstr ""
 "Slå av detta meddelande genom att skriva\n"
 "\"git config advice.graftFileDeprecated false\""
 
-#: commit.c:1115
+#: commit.c:1122
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Incheckningen %s har en obetrodd GPG-signatur som påstås vara gjord av %s."
 
-#: commit.c:1118
+#: commit.c:1125
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr ""
 "Incheckningen %s har en felaktig GPG-signatur som påstås vara gjord av %s."
 
-#: commit.c:1121
+#: commit.c:1128
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Incheckning %s har inte någon GPG-signatur."
 
-#: commit.c:1124
+#: commit.c:1131
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Incheckningen %s har en korrekt GPG-signatur av %s\n"
 
-#: commit.c:1378
+#: commit.c:1385
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -1371,92 +1404,134 @@ msgstr ""
 "Uppdatera det efter att ha rättat meddelandet, eller ändra variabeln\n"
 "i18n.commitencoding till den teckenkodning som används i ditt projekt.\n"
 
-#: commit-graph.c:108
+#: commit-graph.c:101
 #, c-format
 msgid "graph file %s is too small"
 msgstr "graffilen %s är för liten"
 
-#: commit-graph.c:115
+#: commit-graph.c:136
 #, c-format
 msgid "graph signature %X does not match signature %X"
 msgstr "grafsignaturen %X stämmer inte med signaturen %X"
 
-#: commit-graph.c:122
+#: commit-graph.c:143
 #, c-format
 msgid "graph version %X does not match version %X"
 msgstr "grafversionen %X stämmer inte med versionen %X"
 
-#: commit-graph.c:129
+#: commit-graph.c:150
 #, c-format
 msgid "hash version %X does not match version %X"
 msgstr "hash-versionen %X stämmer inte med versionen %X"
 
-#: commit-graph.c:153
+#: commit-graph.c:173
+msgid "chunk lookup table entry missing; graph file may be incomplete"
+msgstr ""
+"post saknas i styckeuppslagningstabell; graffilen kan vara ofullständig"
+
+#: commit-graph.c:184
 #, c-format
 msgid "improper chunk offset %08x%08x"
 msgstr "felaktigt offset för stycke %08x%08x"
 
-#: commit-graph.c:189
+#: commit-graph.c:221
 #, c-format
 msgid "chunk id %08x appears multiple times"
 msgstr "stycke-id %08x förekommer flera gånger"
 
-#: commit-graph.c:308
+#: commit-graph.c:334
 #, c-format
 msgid "could not find commit %s"
 msgstr "kunde inte hitta incheckningen %s"
 
-#: commit-graph.c:617 builtin/pack-objects.c:2652
+#: commit-graph.c:671 builtin/pack-objects.c:2646
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "kunde inte hämta typ för objektet %s"
 
-#: commit-graph.c:651
-msgid "Annotating commits in commit graph"
-msgstr "Dekorerar incheckningar i incheckningsgraf"
+#: commit-graph.c:704
+msgid "Loading known commits in commit graph"
+msgstr "Läser in kända incheckningar i incheckningsgraf"
 
-#: commit-graph.c:691
+#: commit-graph.c:720
+msgid "Expanding reachable commits in commit graph"
+msgstr "Expanderar nåbara incheckningar i incheckningsgraf"
+
+#: commit-graph.c:732
+msgid "Clearing commit marks in commit graph"
+msgstr "Rensar incheckningsmärken i incheckningsgraf"
+
+#: commit-graph.c:752
 msgid "Computing commit graph generation numbers"
 msgstr "Beräknar generationsvärden för incheckningsgraf"
 
-#: commit-graph.c:803 commit-graph.c:826 commit-graph.c:852
-msgid "Finding commits for commit graph"
-msgstr "Söker incheckningar för incheckingsgraf"
+#: commit-graph.c:869
+#, c-format
+msgid "Finding commits for commit graph in %d pack"
+msgid_plural "Finding commits for commit graph in %d packs"
+msgstr[0] "Söker incheckningar för incheckingsgraf i %d paket"
+msgstr[1] "Söker incheckningar för incheckingsgraf i %d paket"
 
-#: commit-graph.c:812
+#: commit-graph.c:882
 #, c-format
 msgid "error adding pack %s"
 msgstr "fel vid tillägg av paketet %s"
 
-#: commit-graph.c:814
+#: commit-graph.c:884
 #, c-format
 msgid "error opening index for %s"
 msgstr "fel vid öppning av indexet för %s"
 
-#: commit-graph.c:868
+#: commit-graph.c:898
+#, c-format
+msgid "Finding commits for commit graph from %d ref"
+msgid_plural "Finding commits for commit graph from %d refs"
+msgstr[0] "Söker incheckningar för incheckingsgraf från %d referens"
+msgstr[1] "Söker incheckningar för incheckingsgraf från %d referenser"
+
+#: commit-graph.c:930
+msgid "Finding commits for commit graph among packed objects"
+msgstr "Söker incheckningar för incheckingsgraf i packade objekt"
+
+#: commit-graph.c:943
+msgid "Counting distinct commits in commit graph"
+msgstr "Räknar olika incheckningar i incheckningsgraf"
+
+#: commit-graph.c:956
 #, c-format
 msgid "the commit graph format cannot write %d commits"
 msgstr "formatet på incheckningsgrafen kan inte visa %d incheckningar"
 
-#: commit-graph.c:895
+#: commit-graph.c:965
+msgid "Finding extra edges in commit graph"
+msgstr "Söker ytterligare kanter i incheckingsgraf"
+
+#: commit-graph.c:989
 msgid "too many commits to write graph"
 msgstr "för många incheckningar för att skriva graf"
 
-#: commit-graph.c:902 midx.c:769
+#: commit-graph.c:996 midx.c:769
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "kunde inte skapa inledande kataloger för %s"
 
-#: commit-graph.c:1002
+#: commit-graph.c:1036
+#, c-format
+msgid "Writing out commit graph in %d pass"
+msgid_plural "Writing out commit graph in %d passes"
+msgstr[0] "Skriver ut incheckningsgraf i %d pass"
+msgstr[1] "Skriver ut incheckningsgraf i %d pass"
+
+#: commit-graph.c:1109
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "filen med incheckningsgraf har felaktig checksumma och är troligtvis trasig"
 
-#: commit-graph.c:1046
+#: commit-graph.c:1153
 msgid "Verifying commits in commit graph"
 msgstr "Bekräftar incheckningar i incheckningsgraf"
 
-#: compat/obstack.c:405 compat/obstack.c:407
+#: compat/obstack.c:406 compat/obstack.c:408
 msgid "memory exhausted"
 msgstr "minnet slut"
 
@@ -1498,7 +1573,7 @@ msgstr "nyckeln innehåller inte ett stycke: %s"
 msgid "key does not contain variable name: %s"
 msgstr "nyckeln innehåller inte variabelnamn: %s"
 
-#: config.c:378 sequencer.c:2296
+#: config.c:378 sequencer.c:2330
 #, c-format
 msgid "invalid key: %s"
 msgstr "felaktig nyckel: %s"
@@ -1641,7 +1716,7 @@ msgstr "felformat värde för %s: %s"
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "måste vara en av nothing, matching, simple, upstream eller current"
 
-#: config.c:1481 builtin/pack-objects.c:3391
+#: config.c:1481 builtin/pack-objects.c:3394
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "felaktig paketkomprimeringsgrad %d"
@@ -1715,62 +1790,62 @@ msgstr "%s har flera värden"
 msgid "failed to write new configuration file %s"
 msgstr "kan inte skriva nya konfigurationsfilen \"%s\""
 
-#: config.c:2717 config.c:3041
+#: config.c:2716 config.c:3040
 #, c-format
 msgid "could not lock config file %s"
 msgstr "kunde inte låsa konfigurationsfilen %s"
 
-#: config.c:2728
+#: config.c:2727
 #, c-format
 msgid "opening %s"
 msgstr "öppnar %s"
 
-#: config.c:2763 builtin/config.c:327
+#: config.c:2762 builtin/config.c:328
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "ogiltigt mönster: %s"
 
-#: config.c:2788
+#: config.c:2787
 #, c-format
 msgid "invalid config file %s"
 msgstr "ogiltig konfigurationsfil: \"%s\""
 
-#: config.c:2801 config.c:3054
+#: config.c:2800 config.c:3053
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat misslyckades på %s"
 
-#: config.c:2812
+#: config.c:2811
 #, c-format
 msgid "unable to mmap '%s'"
 msgstr "kunde inte utföra mmap på \"%s\""
 
-#: config.c:2821 config.c:3059
+#: config.c:2820 config.c:3058
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod misslyckades på %s"
 
-#: config.c:2906 config.c:3156
+#: config.c:2905 config.c:3155
 #, c-format
 msgid "could not write config file %s"
 msgstr "kunde inte skriva konfigurationsfilen %s"
 
-#: config.c:2940
+#: config.c:2939
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "kunde inte ställa in \"%s\" till \"%s\""
 
-#: config.c:2942 builtin/remote.c:782
+#: config.c:2941 builtin/remote.c:782
 #, c-format
 msgid "could not unset '%s'"
 msgstr "kunde inte ta bort inställning för \"%s\""
 
-#: config.c:3032
+#: config.c:3031
 #, c-format
 msgid "invalid section name: %s"
 msgstr "felaktigt namn på stycke: %s"
 
-#: config.c:3199
+#: config.c:3198
 #, c-format
 msgid "missing value for '%s'"
 msgstr "värde saknas för \"%s\""
@@ -1823,50 +1898,45 @@ msgstr "protokollfel: förväntade \"shallow sha-1\" fick \"%s\""
 msgid "repository on the other end cannot be shallow"
 msgstr "arkivet på andra sidan kan inte vara grunt"
 
-#: connect.c:310 fetch-pack.c:182 builtin/archive.c:63
-#, c-format
-msgid "remote error: %s"
-msgstr "fjärrfel: %s"
-
-#: connect.c:316
+#: connect.c:313
 msgid "invalid packet"
 msgstr "ogiltigt paket"
 
-#: connect.c:336
+#: connect.c:333
 #, c-format
 msgid "protocol error: unexpected '%s'"
 msgstr "protokollfel: förväntade inte \"%s\""
 
-#: connect.c:444
+#: connect.c:441
 #, c-format
 msgid "invalid ls-refs response: %s"
 msgstr "ogiltigt svar på ls-refs: %s"
 
-#: connect.c:448
+#: connect.c:445
 msgid "expected flush after ref listing"
 msgstr "oväntad \"flush\" efter ref-listan"
 
-#: connect.c:547
+#: connect.c:544
 #, c-format
 msgid "protocol '%s' is not supported"
 msgstr "protokollet \"%s\" stöds inte"
 
-#: connect.c:598
+#: connect.c:595
 msgid "unable to set SO_KEEPALIVE on socket"
 msgstr "kunde inte sätta SO_KEEPALIVE på uttaget"
 
-#: connect.c:638 connect.c:701
+#: connect.c:635 connect.c:698
 #, c-format
 msgid "Looking up %s ... "
 msgstr "Slår upp %s..."
 
-#: connect.c:642
+#: connect.c:639
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
 msgstr "kan inte slå upp %s (port %s) (%s)"
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
-#: connect.c:646 connect.c:717
+#: connect.c:643 connect.c:714
 #, c-format
 msgid ""
 "done.\n"
@@ -1875,7 +1945,7 @@ msgstr ""
 "klart.\n"
 "Ansluter till %s (port %s)..."
 
-#: connect.c:668 connect.c:745
+#: connect.c:665 connect.c:742
 #, c-format
 msgid ""
 "unable to connect to %s:\n"
@@ -1885,63 +1955,63 @@ msgstr ""
 "%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#: connect.c:674 connect.c:751
+#: connect.c:671 connect.c:748
 msgid "done."
 msgstr "klart."
 
-#: connect.c:705
+#: connect.c:702
 #, c-format
 msgid "unable to look up %s (%s)"
 msgstr "kunde inte slå upp %s (%s)"
 
-#: connect.c:711
+#: connect.c:708
 #, c-format
 msgid "unknown port %s"
 msgstr "okänd port %s"
 
-#: connect.c:848 connect.c:1174
+#: connect.c:845 connect.c:1171
 #, c-format
 msgid "strange hostname '%s' blocked"
 msgstr "konstigt värdnamn \"%s\" blockerat"
 
-#: connect.c:850
+#: connect.c:847
 #, c-format
 msgid "strange port '%s' blocked"
 msgstr "konstig port \"%s\" blockerad"
 
-#: connect.c:860
+#: connect.c:857
 #, c-format
 msgid "cannot start proxy %s"
 msgstr "kan inte starta mellanserver (proxy) %s"
 
-#: connect.c:927
+#: connect.c:924
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr "ingen sökväg angavs; se \"git help pull\" för giltig URL-syntax"
 
-#: connect.c:1122
+#: connect.c:1119
 msgid "ssh variant 'simple' does not support -4"
 msgstr "ssh-varianten \"simple\" stöder inte -4"
 
-#: connect.c:1134
+#: connect.c:1131
 msgid "ssh variant 'simple' does not support -6"
 msgstr "ssh-varianten \"simple\" stöder inte -6"
 
-#: connect.c:1151
+#: connect.c:1148
 msgid "ssh variant 'simple' does not support setting port"
 msgstr "ssh-varianten \"simple\" stöder inte val av port"
 
-#: connect.c:1262
+#: connect.c:1259
 #, c-format
 msgid "strange pathname '%s' blocked"
 msgstr "konstigt sökvägsnamn \"%s\" blockerat"
 
-#: connect.c:1307
+#: connect.c:1304
 msgid "unable to fork"
 msgstr "kunde inte grena (fork)"
 
 # Vague original, not networking-related, but rather related to the actual
 # objects in the database.
-#: connected.c:68 builtin/fsck.c:202 builtin/prune.c:147
+#: connected.c:68 builtin/fsck.c:221 builtin/prune.c:146
 msgid "Checking connectivity"
 msgstr "Kontrollerar konnektivitet"
 
@@ -1957,17 +2027,17 @@ msgstr "kunde inte skriva till rev-list"
 msgid "failed to close rev-list's stdin"
 msgstr "kunde inte stänga rev-list:s standard in"
 
-#: convert.c:194
+#: convert.c:193
 #, c-format
 msgid "illegal crlf_action %d"
 msgstr "felaktig crlf_action %d"
 
-#: convert.c:207
+#: convert.c:206
 #, c-format
 msgid "CRLF would be replaced by LF in %s"
 msgstr "CRLF skulle ersättas av LF i %s"
 
-#: convert.c:209
+#: convert.c:208
 #, c-format
 msgid ""
 "CRLF will be replaced by LF in %s.\n"
@@ -1976,12 +2046,12 @@ msgstr ""
 "CRLF kommer att ersättas av LF i %s.\n"
 "Filen kommer att ha sina ursprungliga radbrytningar i din arbetskatalog"
 
-#: convert.c:217
+#: convert.c:216
 #, c-format
 msgid "LF would be replaced by CRLF in %s"
 msgstr "LF skulle ersättas av CRLF i %s"
 
-#: convert.c:219
+#: convert.c:218
 #, c-format
 msgid ""
 "LF will be replaced by CRLF in %s.\n"
@@ -1990,12 +2060,12 @@ msgstr ""
 "LF kommer att ersättas av CRLF i %s.\n"
 "Filen kommer att ha sina ursprungliga radbrytningar i din arbetskatalog"
 
-#: convert.c:280
+#: convert.c:279
 #, c-format
 msgid "BOM is prohibited in '%s' if encoded as %s"
 msgstr "BOM är förbjudet i \"%s\" om kodat som %s"
 
-#: convert.c:287
+#: convert.c:286
 #, c-format
 msgid ""
 "The file '%s' contains a byte order mark (BOM). Please use UTF-%s as working-"
@@ -2004,12 +2074,12 @@ msgstr ""
 "Filen \"%s\" innehåller byte order mark (BOM). Använd UTF-%s som "
 "teckenkodning i arbetskatalogen."
 
-#: convert.c:305
+#: convert.c:304
 #, c-format
 msgid "BOM is required in '%s' if encoded as %s"
 msgstr "BOM krävs om \"%s\" kodas som %s"
 
-#: convert.c:307
+#: convert.c:306
 #, c-format
 msgid ""
 "The file '%s' is missing a byte order mark (BOM). Please use UTF-%sBE or UTF-"
@@ -2018,38 +2088,38 @@ msgstr ""
 "Filen \"%s\" saknar byte order mark (BOM). Använd UTF-%sBE eller UTF-%sLE "
 "(beroende på byteordning) som teckenkodning i arbetskatalogen."
 
-#: convert.c:425 convert.c:496
+#: convert.c:424 convert.c:495
 #, c-format
 msgid "failed to encode '%s' from %s to %s"
 msgstr "misslyckades omkoda \"%s\" från %s till %s"
 
-#: convert.c:468
+#: convert.c:467
 #, c-format
 msgid "encoding '%s' from %s to %s and back is not the same"
 msgstr ""
 "omkodning av \"%s\" från %s till %s och tillbaka ger inte samma resultat"
 
-#: convert.c:674
+#: convert.c:673
 #, c-format
 msgid "cannot fork to run external filter '%s'"
 msgstr "kan inte grena (fork) för att köra externt filter \"%s\""
 
-#: convert.c:694
+#: convert.c:693
 #, c-format
 msgid "cannot feed the input to external filter '%s'"
 msgstr "kunde inte skicka indata till externt filter \"%s\""
 
-#: convert.c:701
+#: convert.c:700
 #, c-format
 msgid "external filter '%s' failed %d"
 msgstr "externt filter \"%s\" misslyckades %d"
 
-#: convert.c:736 convert.c:739
+#: convert.c:735 convert.c:738
 #, c-format
 msgid "read from external filter '%s' failed"
 msgstr "läsning från externt filter \"%s\" misslyckades"
 
-#: convert.c:742 convert.c:796
+#: convert.c:741 convert.c:796
 #, c-format
 msgid "external filter '%s' failed"
 msgstr "externt filter \"%s\" misslyckades"
@@ -2085,53 +2155,53 @@ msgstr "%s: \"clean\"-filtret \"%s\" misslyckades"
 msgid "%s: smudge filter %s failed"
 msgstr "%s: \"smudge\"-filtret \"%s\" misslyckades"
 
-#: date.c:116
+#: date.c:137
 msgid "in the future"
 msgstr "i framtiden"
 
-#: date.c:122
+#: date.c:143
 #, c-format
 msgid "%<PRIuMAX> second ago"
 msgid_plural "%<PRIuMAX> seconds ago"
 msgstr[0] "%<PRIuMAX> sekund sedan"
 msgstr[1] "%<PRIuMAX> sekunder sedan"
 
-#: date.c:129
+#: date.c:150
 #, c-format
 msgid "%<PRIuMAX> minute ago"
 msgid_plural "%<PRIuMAX> minutes ago"
 msgstr[0] "%<PRIuMAX> minut sedan"
 msgstr[1] "%<PRIuMAX> minuter sedan"
 
-#: date.c:136
+#: date.c:157
 #, c-format
 msgid "%<PRIuMAX> hour ago"
 msgid_plural "%<PRIuMAX> hours ago"
 msgstr[0] "%<PRIuMAX> timme sedan"
 msgstr[1] "%<PRIuMAX> timmar sedan"
 
-#: date.c:143
+#: date.c:164
 #, c-format
 msgid "%<PRIuMAX> day ago"
 msgid_plural "%<PRIuMAX> days ago"
 msgstr[0] "%<PRIuMAX> dag sedan"
 msgstr[1] "%<PRIuMAX> dagar sedan"
 
-#: date.c:149
+#: date.c:170
 #, c-format
 msgid "%<PRIuMAX> week ago"
 msgid_plural "%<PRIuMAX> weeks ago"
 msgstr[0] "%<PRIuMAX> vecka sedan"
 msgstr[1] "%<PRIuMAX> veckor sedan"
 
-#: date.c:156
+#: date.c:177
 #, c-format
 msgid "%<PRIuMAX> month ago"
 msgid_plural "%<PRIuMAX> months ago"
 msgstr[0] "%<PRIuMAX> månad sedan"
 msgstr[1] "%<PRIuMAX> månader sedan"
 
-#: date.c:167
+#: date.c:188
 #, c-format
 msgid "%<PRIuMAX> year"
 msgid_plural "%<PRIuMAX> years"
@@ -2139,40 +2209,40 @@ msgstr[0] "%<PRIuMAX> år"
 msgstr[1] "%<PRIuMAX> år"
 
 #. TRANSLATORS: "%s" is "<n> years"
-#: date.c:170
+#: date.c:191
 #, c-format
 msgid "%s, %<PRIuMAX> month ago"
 msgid_plural "%s, %<PRIuMAX> months ago"
 msgstr[0] "%s, %<PRIuMAX> månad sedan"
 msgstr[1] "%s, %<PRIuMAX> månader sedan"
 
-#: date.c:175 date.c:180
+#: date.c:196 date.c:201
 #, c-format
 msgid "%<PRIuMAX> year ago"
 msgid_plural "%<PRIuMAX> years ago"
 msgstr[0] "%<PRIuMAX> år sedan"
 msgstr[1] "%<PRIuMAX> år sedan"
 
-#: delta-islands.c:268
+#: delta-islands.c:272
 msgid "Propagating island marks"
 msgstr "Sprider ö-markeringar"
 
-#: delta-islands.c:286
+#: delta-islands.c:290
 #, c-format
 msgid "bad tree object %s"
 msgstr "felaktigt trädobjektet %s"
 
-#: delta-islands.c:330
+#: delta-islands.c:334
 #, c-format
 msgid "failed to load island regex for '%s': %s"
 msgstr "kunde inte hämta ö-regex för \"%s\": %s"
 
-#: delta-islands.c:386
+#: delta-islands.c:390
 #, c-format
 msgid "island regex from config has too many capture groups (max=%d)"
 msgstr "ö-regex från konfiguration har för många fångstgrupper (max=%d)"
 
-#: delta-islands.c:462
+#: delta-islands.c:466
 #, c-format
 msgid "Marked %d islands, done.\n"
 msgstr "Markerade %d öar, klar.\n"
@@ -2209,25 +2279,30 @@ msgstr ""
 "färginställningen för flyttade block måste vara en av \"no\", \"default\", "
 "\"blocks\", \"zebra\", \"dimmed_zebra\", \"plain\""
 
-#: diff.c:316
+#: diff.c:319
 #, c-format
-msgid "ignoring unknown color-moved-ws mode '%s'"
-msgstr "ignorerar okänt läge för color-mode-ws \"%s\""
-
-#: diff.c:323
 msgid ""
-"color-moved-ws: allow-indentation-change cannot be combined with other white "
-"space modes"
+"unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
+"'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-change'"
+msgstr ""
+"okänt läge \"%s\" för color-moved-ws, möjliga värden är \"ignore-space-change"
+"\", \"ignore-space-at-eol\", \"ignore-all-space\", \"allow-indentation-change"
+"\""
+
+#: diff.c:327
+msgid ""
+"color-moved-ws: allow-indentation-change cannot be combined with other "
+"whitespace modes"
 msgstr ""
 "color-moved-ws: allow-indentation-change kan inte kombineras med andra "
 "blankstegslägen"
 
-#: diff.c:394
+#: diff.c:400
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Okänt värde för konfigurationsvariabeln \"diff.submodule\": \"%s\""
 
-#: diff.c:454
+#: diff.c:460
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -2236,24 +2311,24 @@ msgstr ""
 "Hittade fel i konfigurationsvariabeln \"diff.dirstat\":\n"
 "%s"
 
-#: diff.c:4140
+#: diff.c:4211
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "extern diff dog, stannar vid %s"
 
-#: diff.c:4482
+#: diff.c:4553
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr "--name-only, --name-status, -check och -s är ömsesidigt uteslutande"
 
-#: diff.c:4485
+#: diff.c:4556
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S och --find-object är ömsesidigt uteslutande"
 
-#: diff.c:4563
+#: diff.c:4634
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow kräver exakt en sökvägsangivelse"
 
-#: diff.c:4729
+#: diff.c:4800
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -2262,61 +2337,61 @@ msgstr ""
 "Misslyckades tolka argument till flaggan --dirstat/-X;\n"
 "%s"
 
-#: diff.c:4743
+#: diff.c:4814
 #, c-format
 msgid "Failed to parse --submodule option parameter: '%s'"
 msgstr "Misslyckades tolka argument till flaggan --submodule: \"%s\""
 
-#: diff.c:5823
+#: diff.c:5900
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
 "onöjaktig namnbytesdetektering utfördes inte på grund av för många filer."
 
-#: diff.c:5826
+#: diff.c:5903
 msgid "only found copies from modified paths due to too many files."
 msgstr "hittade bara kopior från ändrade sökvägar på grund av för många filer."
 
-#: diff.c:5829
+#: diff.c:5906
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
 msgstr ""
 "du kan sätta variabeln %s till åtminstone %d och försöka kommandot på nytt."
 
-#: dir.c:576
+#: dir.c:538
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
 msgstr "sökvägsangivelsen \"%s\" motsvarade inte några av git kända filer"
 
-#: dir.c:965
+#: dir.c:927
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "kan inte använda %s som exkluderingsfil"
 
-#: dir.c:1880
+#: dir.c:1842
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "kunde inte öppna katalogen \"%s\""
 
-#: dir.c:2122
+#: dir.c:2084
 msgid "failed to get kernel name and information"
 msgstr "misslyckades hämta kärnans namn och information"
 
-#: dir.c:2246
+#: dir.c:2208
 msgid "untracked cache is disabled on this system or location"
 msgstr "ospårad cache är inaktiverad på systemet eller platsen"
 
-#: dir.c:3047
+#: dir.c:3009
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "indexfilen trasig i arkivet %s"
 
-#: dir.c:3092 dir.c:3097
+#: dir.c:3054 dir.c:3059
 #, c-format
 msgid "could not create directories for %s"
 msgstr "kunde inte skapa kataloger för %s"
 
-#: dir.c:3126
+#: dir.c:3088
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "kunde inte migrera git-katalog från \"%s\" till \"%s\""
@@ -2358,236 +2433,240 @@ msgstr "Fjärr utan URL"
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: förväntade grund lista"
 
-#: fetch-pack.c:163
+#: fetch-pack.c:154
+msgid "git fetch-pack: expected a flush packet after shallow list"
+msgstr "git fetch-pack: förväntade ett flush-paket efter grund lista"
+
+#: fetch-pack.c:165
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: förväntade ACK/NAK, fick flush-paket"
 
-#: fetch-pack.c:183
+#: fetch-pack.c:185
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: förväntade ACK/NAK, fick \"%s\""
 
-#: fetch-pack.c:253
+#: fetch-pack.c:256
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc kräver ”multi_ack_detailed”"
 
-#: fetch-pack.c:347 fetch-pack.c:1277
+#: fetch-pack.c:358 fetch-pack.c:1264
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ogiltig \"shallow\"-rad: %s"
 
-#: fetch-pack.c:353 fetch-pack.c:1283
+#: fetch-pack.c:364 fetch-pack.c:1271
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ogiltig \"unshallow\"-rad: %s"
 
-#: fetch-pack.c:355 fetch-pack.c:1285
+#: fetch-pack.c:366 fetch-pack.c:1273
 #, c-format
 msgid "object not found: %s"
 msgstr "objektet hittades inte: %s"
 
-#: fetch-pack.c:358 fetch-pack.c:1288
+#: fetch-pack.c:369 fetch-pack.c:1276
 #, c-format
 msgid "error in object: %s"
 msgstr "fel i objekt: %s"
 
-#: fetch-pack.c:360 fetch-pack.c:1290
+#: fetch-pack.c:371 fetch-pack.c:1278
 #, c-format
 msgid "no shallow found: %s"
 msgstr "ingen \"shallow\" hittades: %s"
 
-#: fetch-pack.c:363 fetch-pack.c:1293
+#: fetch-pack.c:374 fetch-pack.c:1282
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "förväntade shallow/unshallow, fick %s"
 
-#: fetch-pack.c:404
+#: fetch-pack.c:415
 #, c-format
 msgid "got %s %d %s"
 msgstr "fick %s %d %s"
 
-#: fetch-pack.c:421
+#: fetch-pack.c:432
 #, c-format
 msgid "invalid commit %s"
 msgstr "ogiltig incheckning %s"
 
-#: fetch-pack.c:452
+#: fetch-pack.c:463
 msgid "giving up"
 msgstr "ger upp"
 
-#: fetch-pack.c:464 progress.c:229
+#: fetch-pack.c:475 progress.c:229
 msgid "done"
 msgstr "klart"
 
-#: fetch-pack.c:476
+#: fetch-pack.c:487
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "fick %s (%d) %s"
 
-#: fetch-pack.c:522
+#: fetch-pack.c:533
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Markerar %s som komplett"
 
-#: fetch-pack.c:764
+#: fetch-pack.c:740
 #, c-format
 msgid "already have %s (%s)"
 msgstr "har redan %s (%s)"
 
-#: fetch-pack.c:803
+#: fetch-pack.c:779
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-patch: kunde inte grena av sidbandsmultiplexare"
 
-#: fetch-pack.c:811
+#: fetch-pack.c:787
 msgid "protocol error: bad pack header"
 msgstr "protokollfel: felaktigt packhuvud"
 
-#: fetch-pack.c:879
+#: fetch-pack.c:855
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-patch: kunde inte grena av %s"
 
-#: fetch-pack.c:895
+#: fetch-pack.c:871
 #, c-format
 msgid "%s failed"
 msgstr "%s misslyckades"
 
-#: fetch-pack.c:897
+#: fetch-pack.c:873
 msgid "error in sideband demultiplexer"
 msgstr "fel i sidbands-avmultiplexare"
 
-#: fetch-pack.c:926
+#: fetch-pack.c:902
 msgid "Server does not support shallow clients"
 msgstr "Servern stöder inte klienter med grunda arkiv"
 
-#: fetch-pack.c:930
+#: fetch-pack.c:906
 msgid "Server supports multi_ack_detailed"
 msgstr "Servern stöder \"multi_ack_detailed\""
 
-#: fetch-pack.c:933
+#: fetch-pack.c:909
 msgid "Server supports no-done"
 msgstr "Servern stöder \"no-done\""
 
-#: fetch-pack.c:939
+#: fetch-pack.c:915
 msgid "Server supports multi_ack"
 msgstr "Servern stöder \"multi_ack\""
 
-#: fetch-pack.c:943
+#: fetch-pack.c:919
 msgid "Server supports side-band-64k"
 msgstr "Servern stöder \"side-band-64k\""
 
-#: fetch-pack.c:947
+#: fetch-pack.c:923
 msgid "Server supports side-band"
 msgstr "Servern stöder \"side-band\""
 
-#: fetch-pack.c:951
+#: fetch-pack.c:927
 msgid "Server supports allow-tip-sha1-in-want"
 msgstr "Servern stöder \"allow-tip-sha1-in-want\""
 
-#: fetch-pack.c:955
+#: fetch-pack.c:931
 msgid "Server supports allow-reachable-sha1-in-want"
 msgstr "Servern stöder \"allow-reachable-sha1-in-want\""
 
-#: fetch-pack.c:965
+#: fetch-pack.c:941
 msgid "Server supports ofs-delta"
 msgstr "Servern stöder \"ofs-delta\""
 
-#: fetch-pack.c:971 fetch-pack.c:1158
+#: fetch-pack.c:947 fetch-pack.c:1140
 msgid "Server supports filter"
 msgstr "Servern stöder filter"
 
-#: fetch-pack.c:979
+#: fetch-pack.c:955
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Serverversionen är %.*s"
 
-#: fetch-pack.c:985
+#: fetch-pack.c:961
 msgid "Server does not support --shallow-since"
 msgstr "Servern stöder inte --shallow-since"
 
-#: fetch-pack.c:989
+#: fetch-pack.c:965
 msgid "Server does not support --shallow-exclude"
 msgstr "Servern stöder inte --shallow-exclude"
 
-#: fetch-pack.c:991
+#: fetch-pack.c:967
 msgid "Server does not support --deepen"
 msgstr "Servern stöder inte --deepen"
 
-#: fetch-pack.c:1008
+#: fetch-pack.c:984
 msgid "no common commits"
 msgstr "inga gemensamma incheckningar"
 
-#: fetch-pack.c:1020 fetch-pack.c:1418
+#: fetch-pack.c:996 fetch-pack.c:1419
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-patch: hämtning misslyckades."
 
-#: fetch-pack.c:1153
+#: fetch-pack.c:1134
 msgid "Server does not support shallow requests"
 msgstr "Servern stöder inte grunda förfrågningar"
 
-#: fetch-pack.c:1199
+#: fetch-pack.c:1184
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "fel vid läsning av styckehuvudet \"%s\""
 
-#: fetch-pack.c:1205
+#: fetch-pack.c:1190
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "förväntade \"%s\", tog emot \"%s\""
 
-#: fetch-pack.c:1244
+#: fetch-pack.c:1229
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "förväntade bekräftelserad: \"%s\""
 
-#: fetch-pack.c:1249
+#: fetch-pack.c:1234
 #, c-format
 msgid "error processing acks: %d"
 msgstr "fel vid hantering av bekräftelser: %d"
 
-#: fetch-pack.c:1259
+#: fetch-pack.c:1244
 msgid "expected packfile to be sent after 'ready'"
 msgstr "väntade att paketfil skulle sändas efter \"ready\""
 
-#: fetch-pack.c:1261
+#: fetch-pack.c:1246
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 "väntade inte att några ytterligare sektioner skulle sändas efter \"ready\""
 
-#: fetch-pack.c:1298
+#: fetch-pack.c:1287
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "fel vid hantering av grund (\"shallow\") info: %d"
 
-#: fetch-pack.c:1314
+#: fetch-pack.c:1308
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "förväntade wanted-ref, fick %s"
 
-#: fetch-pack.c:1324
+#: fetch-pack.c:1318
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "oväntad wanted-ref: \"%s\""
 
-#: fetch-pack.c:1328
+#: fetch-pack.c:1322
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "fel vid hantering av önskade referenser: %d"
 
-#: fetch-pack.c:1642
+#: fetch-pack.c:1646
 msgid "no matching remote head"
 msgstr "inget motsvarande fjärrhuvud"
 
-#: fetch-pack.c:1660 builtin/clone.c:664
+#: fetch-pack.c:1664 builtin/clone.c:671
 msgid "remote did not send all necessary objects"
 msgstr "fjärren sände inte alla nödvändiga objekt"
 
-#: fetch-pack.c:1686
+#: fetch-pack.c:1690
 #, c-format
 msgid "no such remote ref %s"
 msgstr "ingen sådan fjärreferens: %s"
 
-#: fetch-pack.c:1689
+#: fetch-pack.c:1693
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Servern tillåter inte förfrågan om ej tillkännagivet objekt %s"
@@ -2615,8 +2694,8 @@ msgstr "ignorera felaktig färg \"%.*s\" i log.graphColors"
 msgid "'%s': unable to read %s"
 msgstr "\"%s\" kunde inte läsa %s"
 
-#: grep.c:2130 setup.c:164 builtin/clone.c:410 builtin/diff.c:81
-#: builtin/rm.c:134
+#: grep.c:2130 setup.c:164 builtin/clone.c:411 builtin/diff.c:82
+#: builtin/rm.c:135
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "misslyckades ta status på \"%s\""
@@ -2678,41 +2757,41 @@ msgstr "Lågnivåkommandon / synka arkiv"
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Lågnivåkommandon / interna hjälpare"
 
-#: help.c:296
+#: help.c:298
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "git-kommandon tillgängliga i \"%s\""
 
-#: help.c:303
+#: help.c:305
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "git-kommandon från andra platser i din $PATH"
 
-#: help.c:312
+#: help.c:314
 msgid "These are common Git commands used in various situations:"
 msgstr "Dessa vanliga Git-kommandon används i olika situationer:"
 
-#: help.c:361 git.c:90
+#: help.c:363 git.c:90
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "okänd kommandolisttyp \"%s\""
 
-#: help.c:408
+#: help.c:410
 msgid "The common Git guides are:"
 msgstr "De vanliga Git-vägledningarna är:"
 
-#: help.c:517
+#: help.c:519
 msgid "See 'git help <command>' to read about a specific subcommand"
 msgstr "Se \"git help <kommando>\" för att läsa om ett specifikt underkommando"
 
-#: help.c:522
+#: help.c:524
 msgid "External commands"
 msgstr "Externa kommandon"
 
-#: help.c:530
+#: help.c:539
 msgid "Command aliases"
 msgstr "Kommadoalias"
 
-#: help.c:594
+#: help.c:603
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -2721,32 +2800,32 @@ msgstr ""
 "\"%s\" verkar vara ett git-kommando, men vi kan inte\n"
 "köra det. Kanske git-%s är trasigt?"
 
-#: help.c:653
+#: help.c:662
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Oj då. Ditt system rapporterar inga Git-kommandon alls."
 
-#: help.c:675
+#: help.c:684
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr "VARNING: Du anropade ett Git-kommando vid namn \"%s\", som inte finns."
 
-#: help.c:680
+#: help.c:689
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Fortsätter under förutsättningen att du menade ”%s”."
 
-#: help.c:685
+#: help.c:694
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr ""
 "Fortsätter om %0.1f sekunder, under förutsättningen att du menade ”%s”."
 
-#: help.c:693
+#: help.c:702
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: \"%s\" är inte ett git-kommando. Se \"git --help\"."
 
-#: help.c:697
+#: help.c:706
 msgid ""
 "\n"
 "The most similar command is"
@@ -2760,16 +2839,16 @@ msgstr[1] ""
 "\n"
 "Mest lika kommandon är"
 
-#: help.c:712
+#: help.c:721
 msgid "git version [<options>]"
 msgstr "git version [<flaggor>]"
 
-#: help.c:780
+#: help.c:789
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:784
+#: help.c:793
 msgid ""
 "\n"
 "Did you mean this?"
@@ -2837,20 +2916,20 @@ msgstr "tomt ident-namn (för <%s>) ej tillåtet"
 msgid "name consists only of disallowed characters: %s"
 msgstr "namnet består enbart av ej tillåtna tecken: %s"
 
-#: ident.c:419 builtin/commit.c:606
+#: ident.c:419 builtin/commit.c:608
 #, c-format
 msgid "invalid date format: %s"
 msgstr "felaktigt datumformat: %s"
 
-#: list-objects-filter-options.c:35
+#: list-objects-filter-options.c:36
 msgid "multiple filter-specs cannot be combined"
 msgstr "flera filterspecifikationer kan inte kombineras"
 
 #: list-objects-filter-options.c:58
-msgid "only 'tree:0' is supported"
-msgstr "endast \"tree:0\" stöds"
+msgid "expected 'tree:<depth>'"
+msgstr "förväntade \"tree:<djup>\""
 
-#: list-objects-filter-options.c:137
+#: list-objects-filter-options.c:152
 msgid "cannot change partial clone promisor remote"
 msgstr "kan inte ändra kontraktsfjärr för delvis kloning"
 
@@ -2883,99 +2962,99 @@ msgstr "Kunde inte skapa \"%s.lock\": %s"
 msgid "failed to read the cache"
 msgstr "misslyckades läsa cachen"
 
-#: merge.c:107 rerere.c:720 builtin/am.c:1899 builtin/am.c:1933
-#: builtin/checkout.c:387 builtin/checkout.c:708 builtin/clone.c:764
+#: merge.c:107 rerere.c:720 builtin/am.c:1884 builtin/am.c:1918
+#: builtin/checkout.c:416 builtin/checkout.c:745 builtin/clone.c:771
 msgid "unable to write new index file"
 msgstr "kunde inte skriva ny indexfil"
 
-#: merge-recursive.c:323
+#: merge-recursive.c:332
 msgid "(bad commit)\n"
 msgstr "(felaktig incheckning)\n"
 
-#: merge-recursive.c:345
+#: merge-recursive.c:355
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr ""
 "add_cahceinfo misslyckades för sökvägen \"%s\"; avslutar sammanslagningen."
 
-#: merge-recursive.c:353
+#: merge-recursive.c:364
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
 "add_cacheinfo misslyckades uppdatera för sökvägen \"%s\"; avslutar "
 "sammanslagningen."
 
-#: merge-recursive.c:435
+#: merge-recursive.c:447
 msgid "error building trees"
 msgstr "fel vid byggande av träd"
 
-#: merge-recursive.c:906
+#: merge-recursive.c:902
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr "misslyckades skapa sökvägen \"%s\"%s"
 
-#: merge-recursive.c:917
+#: merge-recursive.c:913
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr "Tar bort %s för att göra plats för underkatalog\n"
 
-#: merge-recursive.c:931 merge-recursive.c:950
+#: merge-recursive.c:927 merge-recursive.c:946
 msgid ": perhaps a D/F conflict?"
 msgstr ": kanske en K/F-konflikt?"
 
-#: merge-recursive.c:940
+#: merge-recursive.c:936
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr "vägrar förlora ospårad fil vid \"%s\""
 
-#: merge-recursive.c:982 builtin/cat-file.c:39
+#: merge-recursive.c:978 builtin/cat-file.c:40
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "kan inte läsa objektet %s: \"%s\""
 
-#: merge-recursive.c:984
+#: merge-recursive.c:980
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "blob förväntades för %s \"%s\""
 
-#: merge-recursive.c:1008
+#: merge-recursive.c:1004
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr "misslyckades öppna \"%s\": %s"
 
-#: merge-recursive.c:1019
+#: merge-recursive.c:1015
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr "misslyckades skapa symboliska länken \"%s\": %s"
 
-#: merge-recursive.c:1024
+#: merge-recursive.c:1020
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "vet inte hur %06o %s \"%s\" skall hanteras"
 
-#: merge-recursive.c:1212
+#: merge-recursive.c:1211
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Misslyckades slå ihop undermodulen %s (ej utcheckad)"
 
-#: merge-recursive.c:1219
+#: merge-recursive.c:1218
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Misslyckades slå ihop undermodulen %s (incheckningar saknas)"
 
-#: merge-recursive.c:1226
+#: merge-recursive.c:1225
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 "Misslyckades slå ihop undermodulen %s (incheckningar följer inte "
 "sammanslagningsbasen)"
 
-#: merge-recursive.c:1234 merge-recursive.c:1246
+#: merge-recursive.c:1233 merge-recursive.c:1245
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr "Snabbspolar undermodulen %s till följande incheckning:"
 
-#: merge-recursive.c:1237 merge-recursive.c:1249
+#: merge-recursive.c:1236 merge-recursive.c:1248
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr "Snabbspolar undermodulen %s"
@@ -3019,26 +3098,26 @@ msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr ""
 "Misslyckades slå ihop undermodulen %s (flera sammanslagningar hittades)"
 
-#: merge-recursive.c:1358
+#: merge-recursive.c:1361
 msgid "Failed to execute internal merge"
 msgstr "Misslyckades exekvera intern sammanslagning"
 
-#: merge-recursive.c:1363
+#: merge-recursive.c:1366
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Kunde inte lägga till %s till databasen"
 
-#: merge-recursive.c:1395
+#: merge-recursive.c:1398
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Slår ihop %s automatiskt"
 
-#: merge-recursive.c:1416
+#: merge-recursive.c:1419
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr "Fel: Vägrar förlora ospårad fil vid %s; skriver till %s istället."
 
-#: merge-recursive.c:1483
+#: merge-recursive.c:1486
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -3047,7 +3126,7 @@ msgstr ""
 "KONFLIKT (%s/radera): %s raderad i %s och %s i %s. Versionen %s av %s lämnad "
 "i trädet."
 
-#: merge-recursive.c:1488
+#: merge-recursive.c:1491
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -3056,7 +3135,7 @@ msgstr ""
 "KONFLIKT (%s/radera): %s raderad i %s och %s till %s i %s. Versionen %s av "
 "%s lämnad i trädet."
 
-#: merge-recursive.c:1495
+#: merge-recursive.c:1498
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -3065,7 +3144,7 @@ msgstr ""
 "KONFLIKT (%s/radera): %s raderad i %s och %s i %s. Versionen %s av %s lämnad "
 "i trädet vid %s."
 
-#: merge-recursive.c:1500
+#: merge-recursive.c:1503
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -3074,31 +3153,40 @@ msgstr ""
 "KONFLIKT (%s/radera): %s raderad i %s och %s till %s i %s. Versionen %s av "
 "%s lämnad i trädet vid %s."
 
-#: merge-recursive.c:1534
+#: merge-recursive.c:1537
 msgid "rename"
 msgstr "namnbyte"
 
-#: merge-recursive.c:1534
+#: merge-recursive.c:1537
 msgid "renamed"
 msgstr "namnbytt"
 
-#: merge-recursive.c:1588 merge-recursive.c:1737 merge-recursive.c:2369
-#: merge-recursive.c:3124
+#: merge-recursive.c:1633 merge-recursive.c:2481 merge-recursive.c:3213
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Vägrar förlora lortig fil vid \"%s\""
 
-#: merge-recursive.c:1602
+#: merge-recursive.c:1643
+#, c-format
+msgid "Refusing to lose untracked file at %s, even though it's in the way."
+msgstr "Vägrar förlora ospårad fil vid %s, trots att den är i vägen."
+
+#: merge-recursive.c:1706
+#, c-format
+msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
+msgstr "KONFLIKT (namnbyte/tillägg): Namnbyte %s->%s i %s. Lade till %s i %s"
+
+#: merge-recursive.c:1734
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "%s är en katalog i %s lägger till som %s istället"
 
-#: merge-recursive.c:1607
+#: merge-recursive.c:1739
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr "Vägrar förlora ospårad fil vid %s; lägger till som %s istället"
 
-#: merge-recursive.c:1633
+#: merge-recursive.c:1759
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -3107,27 +3195,17 @@ msgstr ""
 "KONFLIKT (namnbyte/namnbyte): Namnbyte \"%s\"->\"%s\" på grenen \"%s\" "
 "namnbyte \"%s\"->\"%s\" i \"%s\"%s"
 
-#: merge-recursive.c:1638
+#: merge-recursive.c:1764
 msgid " (left unresolved)"
 msgstr " (lämnad olöst)"
 
-#: merge-recursive.c:1699
+#: merge-recursive.c:1868
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "KONFLIKT (namnbyte/namnbyte): Namnbyte %s->%s i %s. Namnbyte %s->%s i %s"
 
-#: merge-recursive.c:1734
-#, c-format
-msgid "Renaming %s to %s and %s to %s instead"
-msgstr "Byter namn på %s till %s och %s till %s istället"
-
-#: merge-recursive.c:1746
-#, c-format
-msgid "Refusing to lose untracked file at %s, even though it's in the way."
-msgstr "Vägrar förlora ospårad fil vid %s, trots att den är i vägen."
-
-#: merge-recursive.c:1952
+#: merge-recursive.c:2064
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -3138,7 +3216,7 @@ msgstr ""
 "katalogen %s bytte namn till flera andra kataloger, utan att någon "
 "destination fick en majoritet av filerna."
 
-#: merge-recursive.c:1984
+#: merge-recursive.c:2096
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -3147,7 +3225,7 @@ msgstr ""
 "KONFLIKT (implicit nämnändrad kat): Befintlig fil/kat vid %s är i vägen för "
 "implicit namnändrad(e) katalog(er) som lägger dit följande sökväg(ar): %s."
 
-#: merge-recursive.c:1994
+#: merge-recursive.c:2106
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -3156,7 +3234,7 @@ msgstr ""
 "KONFLIKT (implicit namnändrad kat): Kan inte koppla mer än en sökväg till "
 "%s; implicita katalognamnändringar försökte lägga följande sökvägar där: %s"
 
-#: merge-recursive.c:2086
+#: merge-recursive.c:2198
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
@@ -3165,7 +3243,7 @@ msgstr ""
 "KONFLIKT (namnbyte/namnbyte): Namnbytt katalog %s->%s i %s. Namnbytt katalog "
 "%s->%s i %s"
 
-#: merge-recursive.c:2331
+#: merge-recursive.c:2443
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -3174,86 +3252,81 @@ msgstr ""
 "VARNING: Undviker att applicera namnändring %s -> %s på %s, då %s själv har "
 "bytt namn."
 
-#: merge-recursive.c:2737
-#, c-format
-msgid "CONFLICT (rename/add): Rename %s->%s in %s. %s added in %s"
-msgstr "KONFLIKT (namnbyte/tillägg): Namnbyte %s->%s i %s. %s tillagd i %s"
-
-#: merge-recursive.c:2763
-#, c-format
-msgid "Adding merged %s"
-msgstr "Lägger till sammanslagen %s"
-
-#: merge-recursive.c:2770 merge-recursive.c:3127
-#, c-format
-msgid "Adding as %s instead"
-msgstr "Lägger till som %s istället"
-
-#: merge-recursive.c:2934
+#: merge-recursive.c:3022
 #, c-format
 msgid "cannot read object %s"
 msgstr "kan inte läsa objektet %s"
 
-#: merge-recursive.c:2937
+#: merge-recursive.c:3025
 #, c-format
 msgid "object %s is not a blob"
 msgstr "objektet %s är inte en blob"
 
-#: merge-recursive.c:3006
+#: merge-recursive.c:3094
 msgid "modify"
 msgstr "ändra"
 
-#: merge-recursive.c:3006
+#: merge-recursive.c:3094
 msgid "modified"
 msgstr "ändrad"
 
-#: merge-recursive.c:3017
+#: merge-recursive.c:3105
 msgid "content"
 msgstr "innehåll"
 
-#: merge-recursive.c:3024
+#: merge-recursive.c:3112
 msgid "add/add"
 msgstr "tillägg/tillägg"
 
-#: merge-recursive.c:3071
+#: merge-recursive.c:3160
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "Hoppade över %s (sammanslagen samma som befintlig)"
 
-#: merge-recursive.c:3093 git-submodule.sh:858
+#: merge-recursive.c:3182 git-submodule.sh:861
 msgid "submodule"
 msgstr "undermodul"
 
-#: merge-recursive.c:3094
+#: merge-recursive.c:3183
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "KONFLIKT (%s): Sammanslagningskonflikt i %s"
 
 #: merge-recursive.c:3216
 #, c-format
+msgid "Adding as %s instead"
+msgstr "Lägger till som %s istället"
+
+#: merge-recursive.c:3319
+#, c-format
 msgid "Removing %s"
 msgstr "Tar bort %s"
 
-#: merge-recursive.c:3242
+#: merge-recursive.c:3345
 msgid "file/directory"
 msgstr "fil/katalog"
 
-#: merge-recursive.c:3248
+#: merge-recursive.c:3351
 msgid "directory/file"
 msgstr "katalog/fil"
 
-#: merge-recursive.c:3255
+#: merge-recursive.c:3358
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 "KONFLIKT (%s): Det finns en katalog med namnet %s i %s. Lägger till %s som %s"
 
-#: merge-recursive.c:3264
+#: merge-recursive.c:3367
 #, c-format
 msgid "Adding %s"
 msgstr "Lägger till %s"
 
-#: merge-recursive.c:3300
+#: merge-recursive.c:3376
+#, c-format
+msgid "CONFLICT (add/add): Merge conflict in %s"
+msgstr "KONFLIKT (tillägg/tillägg): Sammanslagningskonflikt i %s"
+
+#: merge-recursive.c:3417
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -3263,36 +3336,36 @@ msgstr ""
 "sammanslagning:\n"
 "  %s"
 
-#: merge-recursive.c:3311
+#: merge-recursive.c:3428
 msgid "Already up to date!"
 msgstr "Redan à jour!"
 
-#: merge-recursive.c:3320
+#: merge-recursive.c:3437
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "sammanslagning av träden %s och %s misslyckades"
 
-#: merge-recursive.c:3419
+#: merge-recursive.c:3536
 msgid "Merging:"
 msgstr "Slår ihop:"
 
-#: merge-recursive.c:3432
+#: merge-recursive.c:3549
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "hittade %u gemensam förfader:"
 msgstr[1] "hittade %u gemensamma förfäder:"
 
-#: merge-recursive.c:3471
+#: merge-recursive.c:3588
 msgid "merge returned no commit"
 msgstr "sammanslagningen returnerade ingen incheckning"
 
-#: merge-recursive.c:3537
+#: merge-recursive.c:3654
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Kunde inte tolka objektet \"%s\""
 
-#: merge-recursive.c:3553 builtin/merge.c:691 builtin/merge.c:849
+#: merge-recursive.c:3670 builtin/merge.c:692 builtin/merge.c:850
 msgid "Unable to write index."
 msgstr "Kunde inte skriva indexet."
 
@@ -3409,22 +3482,22 @@ msgstr "misslyckades läsa paketindex för paketfil %s"
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "felaktigt objekt-offset för oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: name-hash.c:532
+#: name-hash.c:531
 #, c-format
 msgid "unable to create lazy_dir thread: %s"
 msgstr "misslyckades skapa lazy_dir-tråd: %s"
 
-#: name-hash.c:554
+#: name-hash.c:553
 #, c-format
 msgid "unable to create lazy_name thread: %s"
 msgstr "misslyckades skapa lazy_name-tråd: %s"
 
-#: name-hash.c:560
+#: name-hash.c:559
 #, c-format
 msgid "unable to join lazy_name thread: %s"
 msgstr "misslyckades utföra join på lazy_name-tråd: %s"
 
-#: notes-merge.c:275
+#: notes-merge.c:277
 #, c-format
 msgid ""
 "You have not concluded your previous notes merge (%s exists).\n"
@@ -3436,21 +3509,21 @@ msgstr ""
 "att checka in eller avbryta föregående sammanslagning innan du påbörjar en "
 "ny antecknings-sammanslagning."
 
-#: notes-merge.c:282
+#: notes-merge.c:284
 #, c-format
 msgid "You have not concluded your notes merge (%s exists)."
 msgstr "Du har inte avslutat antecknings-sammanslagningen (%s finns)."
 
-#: notes-utils.c:45
+#: notes-utils.c:46
 msgid "Cannot commit uninitialized/unreferenced notes tree"
 msgstr "Kan inte checka in oinitierat/orefererat anteckningsträd"
 
-#: notes-utils.c:104
+#: notes-utils.c:105
 #, c-format
 msgid "Bad notes.rewriteMode value: '%s'"
 msgstr "Felaktigt värde för notes.rewriteMode: '%s'"
 
-#: notes-utils.c:114
+#: notes-utils.c:115
 #, c-format
 msgid "Refusing to rewrite notes in %s (outside of refs/notes/)"
 msgstr "Vägrar skriva över anteckningar i %s (utanför refs/notes/)"
@@ -3459,7 +3532,7 @@ msgstr "Vägrar skriva över anteckningar i %s (utanför refs/notes/)"
 #. the environment variable, the second %s is
 #. its value.
 #.
-#: notes-utils.c:144
+#: notes-utils.c:145
 #, c-format
 msgid "Bad %s value: '%s'"
 msgstr "Felaktigt värde på %s: \"%s\""
@@ -3469,45 +3542,105 @@ msgstr "Felaktigt värde på %s: \"%s\""
 msgid "invalid object type \"%s\""
 msgstr "ogiltig objekttyp \"%s\""
 
-#: object.c:173
+#: object.c:174
 #, c-format
 msgid "object %s is a %s, not a %s"
 msgstr "objektet %s är en %s, inte en %s"
 
-#: object.c:233
+#: object.c:234
 #, c-format
 msgid "object %s has unknown type id %d"
 msgstr "objektet %s har okänd typ-id %d"
 
-#: object.c:246
+#: object.c:247
 #, c-format
 msgid "unable to parse object: %s"
 msgstr "kunde inte tolka objektet: %s"
 
-#: object.c:266 object.c:277
+#: object.c:267 object.c:278
 #, c-format
-msgid "sha1 mismatch %s"
-msgstr "sha1 stämmer inte överens %s"
+msgid "hash mismatch %s"
+msgstr "hashvärde stämmer inte överens %s"
 
 #: packfile.c:607
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "offset före slutet av packfilen (trasig .idx?)"
 
-#: packfile.c:1864
+#: packfile.c:1870
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "offset före slutet av packindex för %s (trasigt index?)"
 
-#: packfile.c:1868
+#: packfile.c:1874
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr "offset borton slutet av packindex för %s (trunkerat index?)"
 
-#: parse-options.c:672
+#: parse-options.c:35
+#, c-format
+msgid "%s requires a value"
+msgstr "%s behöver ett värde"
+
+#: parse-options.c:69
+#, c-format
+msgid "%s is incompatible with %s"
+msgstr "%s är inkompatibel med %s"
+
+#: parse-options.c:74
+#, c-format
+msgid "%s : incompatible with something else"
+msgstr "%s: inkompatibelt med något annat"
+
+#: parse-options.c:88 parse-options.c:92 parse-options.c:260
+#, c-format
+msgid "%s takes no value"
+msgstr "%s tar inget värde"
+
+#: parse-options.c:90
+#, c-format
+msgid "%s isn't available"
+msgstr "%s är inte tillgängligt"
+
+#: parse-options.c:178
+#, c-format
+msgid "%s expects a numerical value"
+msgstr "%s förväntar ett numeriskt värde"
+
+#: parse-options.c:194
+#, c-format
+msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
+msgstr "%s förväntar ett icke-negativt heltalsvärde, med valfritt k/m/g-suffix"
+
+#: parse-options.c:322
+#, c-format
+msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
+msgstr "tvetydig flagga: %s (kan vara --%s%s eller --%s%s)"
+
+#: parse-options.c:356 parse-options.c:364
+#, c-format
+msgid "did you mean `--%s` (with two dashes ?)"
+msgstr "menade du \"--%s\" (med två bindestreck?)"
+
+#: parse-options.c:649
+#, c-format
+msgid "unknown option `%s'"
+msgstr "okänd flagga \"%s\""
+
+#: parse-options.c:651
+#, c-format
+msgid "unknown switch `%c'"
+msgstr "okänd flagga \"%c\""
+
+#: parse-options.c:653
+#, c-format
+msgid "unknown non-ascii option in string: `%s'"
+msgstr "okänd icke-ascii-flagga i strängen: \"%s\""
+
+#: parse-options.c:675
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:691
+#: parse-options.c:694
 #, c-format
 msgid "usage: %s"
 msgstr "användning: %s"
@@ -3515,26 +3648,37 @@ msgstr "användning: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:697
+#: parse-options.c:700
 #, c-format
 msgid "   or: %s"
 msgstr "     eller: %s"
 
-#: parse-options.c:700
+#: parse-options.c:703
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:739
+#: parse-options.c:742
 msgid "-NUM"
 msgstr "-TAL"
 
-#: parse-options-cb.c:37
+#: parse-options-cb.c:21
+#, c-format
+msgid "option `%s' expects a numerical value"
+msgstr "flaggan \"%s\" antar ett numeriskt värde"
+
+#: parse-options-cb.c:38
 #, c-format
 msgid "malformed expiration date '%s'"
 msgstr "trasigt utlöpsdatum: ”%s”"
 
-#: parse-options-cb.c:109
+#: parse-options-cb.c:51
+#, c-format
+msgid "option `%s' expects \"always\", \"auto\", or \"never\""
+msgstr ""
+"flaggan \"%s\" antar \"always\" (alltid), \"auto\" eller \"never\" (aldrig)"
+
+#: parse-options-cb.c:110
 #, c-format
 msgid "malformed object name '%s'"
 msgstr "felformat objektnamn \"%s\""
@@ -3544,29 +3688,29 @@ msgstr "felformat objektnamn \"%s\""
 msgid "Could not make %s writable by group"
 msgstr "Kunde inte göra %s skrivbar för gruppen"
 
-#: pathspec.c:129
+#: pathspec.c:128
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr "Specialtecknet \"\\\" tillåts inte som sista tecken i attributvärde"
 
-#: pathspec.c:147
+#: pathspec.c:146
 msgid "Only one 'attr:' specification is allowed."
 msgstr "Endast en \"attr:\"-angivelse tillåten."
 
-#: pathspec.c:150
+#: pathspec.c:149
 msgid "attr spec must not be empty"
 msgstr "attr-angivelse kan inte vara tom"
 
-#: pathspec.c:193
+#: pathspec.c:192
 #, c-format
 msgid "invalid attribute name %s"
 msgstr "ogiltigt attributnamn %s"
 
-#: pathspec.c:258
+#: pathspec.c:257
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr ""
 "de globala sökvägsinställningarna \"glob\" och \"noglob\" är inkompatibla"
 
-#: pathspec.c:265
+#: pathspec.c:264
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
@@ -3574,46 +3718,46 @@ msgstr ""
 "den globala sökvägsinställningen \"literal\" är inkompatibel med alla andra "
 "globala sökvägsinställningar"
 
-#: pathspec.c:305
+#: pathspec.c:304
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr "ogiltig parameter för sökvägsuttrycket för \"prefix\""
 
-#: pathspec.c:326
+#: pathspec.c:325
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr "Felaktigt sökvägsuttryck \"%.*s\" i \"%s\""
 
-#: pathspec.c:331
+#: pathspec.c:330
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr "\")\" saknas i slutet av sökvägsuttrycket för \"%s\""
 
-#: pathspec.c:369
+#: pathspec.c:368
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr "Ej implementerat sökvägsuttryckmagi ”%c” i ”%s”"
 
-#: pathspec.c:428
+#: pathspec.c:427
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr "%s: \"literal\" och \"glob\" är inkompatibla"
 
-#: pathspec.c:441
+#: pathspec.c:440
 #, c-format
 msgid "%s: '%s' is outside repository"
 msgstr "%s: \"%s\" är utanför arkivet"
 
-#: pathspec.c:515
+#: pathspec.c:514
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr "\"%s\" (minnesstöd: \"%c\")"
 
-#: pathspec.c:525
+#: pathspec.c:524
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr "%s: sökvägsuttrycket hanteras inte av det här kommandot: %s"
 
-#: pathspec.c:592
+#: pathspec.c:591
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr "sökvägsangivelsen \"%s\" är på andra sidan av en symbolisk länk"
@@ -3622,50 +3766,55 @@ msgstr "sökvägsangivelsen \"%s\" är på andra sidan av en symbolisk länk"
 msgid "flush packet write failed"
 msgstr "fel vid skrivning av \"flush\"-paket"
 
-#: pkt-line.c:142 pkt-line.c:228
+#: pkt-line.c:144 pkt-line.c:230
 msgid "protocol error: impossibly long line"
 msgstr "protokollfel: omöjligt lång rad"
 
-#: pkt-line.c:158 pkt-line.c:160
+#: pkt-line.c:160 pkt-line.c:162
 msgid "packet write with format failed"
 msgstr "paketskrivning med format misslyckades"
 
-#: pkt-line.c:192
+#: pkt-line.c:194
 msgid "packet write failed - data exceeds max packet size"
 msgstr "paketskrivning misslyckades - data överskrider maximal paketstorlek"
 
-#: pkt-line.c:199 pkt-line.c:206
+#: pkt-line.c:201 pkt-line.c:208
 msgid "packet write failed"
 msgstr "paketskrivning misslyckades"
 
-#: pkt-line.c:291
+#: pkt-line.c:293
 msgid "read error"
 msgstr "läsfel"
 
-#: pkt-line.c:299
+#: pkt-line.c:301
 msgid "the remote end hung up unexpectedly"
 msgstr "fjärren lade på oväntat"
 
-#: pkt-line.c:327
+#: pkt-line.c:329
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "protokollfel: felaktig radlängdstecken: %.4s"
 
-#: pkt-line.c:337 pkt-line.c:342
+#: pkt-line.c:339 pkt-line.c:344
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "protokollfel: felaktig radlängd: %d"
 
-#: preload-index.c:118
+#: pkt-line.c:353
+#, c-format
+msgid "remote error: %s"
+msgstr "fjärrfel: %s"
+
+#: preload-index.c:119
 msgid "Refreshing index"
 msgstr "Uppdaterar indexet"
 
-#: preload-index.c:137
+#: preload-index.c:138
 #, c-format
 msgid "unable to create threaded lstat: %s"
 msgstr "kunde inte skapa trådad lstat: %s"
 
-#: pretty.c:962
+#: pretty.c:963
 msgid "unable to parse --pretty format"
 msgstr "kunde inte tolka format för --pretty"
 
@@ -3677,7 +3826,7 @@ msgstr "kunde inte starta \"log\""
 msgid "could not read `log` output"
 msgstr "kunde inte läsa utdata från \"log\""
 
-#: range-diff.c:74 sequencer.c:4764
+#: range-diff.c:74 sequencer.c:4828
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "kunde inte tolka incheckningen \"%s\""
@@ -3691,11 +3840,46 @@ msgstr "misslyckades skapa diff"
 msgid "could not parse log for '%s'"
 msgstr "kunde inte tolka loggen för \"%s\""
 
-#: read-cache.c:1490
+#: read-cache.c:673
+#, c-format
+msgid "will not add file alias '%s' ('%s' already exists in index)"
+msgstr "lägger inte till filalias \"%s\" (\"%s\" finns redan i indexet)"
+
+#: read-cache.c:689
+msgid "cannot create an empty blob in the object database"
+msgstr "kan inte skapa tom blob i objektdatabasen"
+
+#: read-cache.c:710
+#, c-format
+msgid "%s: can only add regular files, symbolic links or git-directories"
+msgstr ""
+"%s: kan bara lägga till vanliga filer, symboliska länkar och git-kataloger"
+
+#: read-cache.c:765
+#, c-format
+msgid "unable to index file '%s'"
+msgstr "kan inte indexera filen \"%s\""
+
+#: read-cache.c:784
+#, c-format
+msgid "unable to add '%s' to index"
+msgstr "kan inte lägga till \"%s\" till indexet"
+
+#: read-cache.c:795
+#, c-format
+msgid "unable to stat '%s'"
+msgstr "kan inte ta status på \"%s\""
+
+#: read-cache.c:1304
+#, c-format
+msgid "'%s' appears as both a file and as a directory"
+msgstr "\"%s\" finns både som en fil och en katalog"
+
+#: read-cache.c:1489
 msgid "Refresh index"
 msgstr "Uppdatera indexet"
 
-#: read-cache.c:1604
+#: read-cache.c:1603
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -3704,7 +3888,7 @@ msgstr ""
 "index.version satt, men värdet är ogiltigt.\n"
 "Använder version %i"
 
-#: read-cache.c:1614
+#: read-cache.c:1613
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -3713,58 +3897,142 @@ msgstr ""
 "GIT_INDEX_VERSION satt, men värdet är ogiltigt.\n"
 "Använder version %i"
 
-#: read-cache.c:1792
+#: read-cache.c:1684
+#, c-format
+msgid "bad signature 0x%08x"
+msgstr "felaktig signatur 0x%08x"
+
+#: read-cache.c:1687
+#, c-format
+msgid "bad index version %d"
+msgstr "felaktig indexversion %d"
+
+#: read-cache.c:1696
+msgid "bad index file sha1 signature"
+msgstr "felaktig sha1-signatur för indexfil"
+
+#: read-cache.c:1726
+#, c-format
+msgid "index uses %.4s extension, which we do not understand"
+msgstr "index använder filtillägget %.4s, vilket vi inte förstår"
+
+#: read-cache.c:1728
+#, c-format
+msgid "ignoring %.4s extension"
+msgstr "ignorerar filtillägget %.4s"
+
+#: read-cache.c:1765
+#, c-format
+msgid "unknown index entry format 0x%08x"
+msgstr "okänt format 0x%08x på indexpost"
+
+#: read-cache.c:1781
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "felformat namnfält i indexet, nära sökvägen \"%s\""
 
-#: read-cache.c:1960 rerere.c:565 rerere.c:599 rerere.c:1111 builtin/add.c:458
-#: builtin/check-ignore.c:177 builtin/checkout.c:289 builtin/checkout.c:585
-#: builtin/checkout.c:953 builtin/clean.c:954 builtin/commit.c:343
-#: builtin/diff-tree.c:115 builtin/grep.c:489 builtin/mv.c:144
-#: builtin/reset.c:244 builtin/rm.c:270 builtin/submodule--helper.c:329
+#: read-cache.c:1836
+msgid "unordered stage entries in index"
+msgstr "osorterade köposter i index"
+
+#: read-cache.c:1839
+#, c-format
+msgid "multiple stage entries for merged file '%s'"
+msgstr "flera köposter för den sammanslagna filen \"%s\""
+
+#: read-cache.c:1842
+#, c-format
+msgid "unordered stage entries for '%s'"
+msgstr "osorterade köposter för \"%s\""
+
+#: read-cache.c:1949 read-cache.c:2227 rerere.c:565 rerere.c:599 rerere.c:1111
+#: builtin/add.c:459 builtin/check-ignore.c:178 builtin/checkout.c:294
+#: builtin/checkout.c:622 builtin/checkout.c:991 builtin/clean.c:955
+#: builtin/commit.c:344 builtin/diff-tree.c:116 builtin/grep.c:498
+#: builtin/mv.c:145 builtin/reset.c:245 builtin/rm.c:271
+#: builtin/submodule--helper.c:330
 msgid "index file corrupt"
 msgstr "indexfilen trasig"
 
-#: read-cache.c:2101
+#: read-cache.c:2090
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "kunde inte läsa in cache_entries-tråden: %s"
 
-#: read-cache.c:2114
+#: read-cache.c:2103
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "kunde inte utföra join på cache_entries-tråden: %s"
 
-#: read-cache.c:2201
+#: read-cache.c:2136
+#, c-format
+msgid "%s: index file open failed"
+msgstr "%s: öppning av indexfilen misslyckades"
+
+#: read-cache.c:2140
+#, c-format
+msgid "%s: cannot stat the open index"
+msgstr "%s: kan inte ta startus på det öppna indexet"
+
+#: read-cache.c:2144
+#, c-format
+msgid "%s: index file smaller than expected"
+msgstr "%s: indexfilen mindre än förväntat"
+
+#: read-cache.c:2148
+#, c-format
+msgid "%s: unable to map index file"
+msgstr "%s: kan inte koppla indexfilen"
+
+#: read-cache.c:2190
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "kunde inte skapa load_index_extensions-tråden: %s"
 
-#: read-cache.c:2228
+#: read-cache.c:2217
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "kunde inte utföra join på load_index_extensions-tråden: %s"
 
-#: read-cache.c:2982 sequencer.c:4727 wrapper.c:658 builtin/merge.c:1086
+#: read-cache.c:2239
+#, c-format
+msgid "could not freshen shared index '%s'"
+msgstr "kunde inte uppdatera delat index \"%s\""
+
+#: read-cache.c:2274
+#, c-format
+msgid "broken index, expect %s in %s, got %s"
+msgstr "trasigt index, förväntade %s i %s, fick %s"
+
+#: read-cache.c:2971 sequencer.c:4791 wrapper.c:658 builtin/merge.c:1087
 #, c-format
 msgid "could not close '%s'"
 msgstr "kunde inte stänga \"%s\""
 
-#: read-cache.c:3055 sequencer.c:2203 sequencer.c:3592
+#: read-cache.c:3044 sequencer.c:2237 sequencer.c:3647
 #, c-format
 msgid "could not stat '%s'"
 msgstr "kunde inte ta status på \"%s\""
 
-#: read-cache.c:3068
+#: read-cache.c:3057
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "kunde inte öppna git-katalog: %s"
 
-#: read-cache.c:3080
+#: read-cache.c:3069
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "misslyckades ta bort länken: %s"
+
+#: read-cache.c:3088
+#, c-format
+msgid "cannot fix permission bits on '%s'"
+msgstr "kan inte rätta behörighetsbitar på \"%s\""
+
+#: read-cache.c:3237
+#, c-format
+msgid "%s: cannot drop to stage #0"
+msgstr "%s: kan inte återgå till kö 0"
 
 #: rebase-interactive.c:10
 msgid ""
@@ -3855,8 +4123,8 @@ msgstr ""
 msgid "Note that empty commits are commented out"
 msgstr "Observera att tomma incheckningar är utkommenterade"
 
-#: rebase-interactive.c:62 rebase-interactive.c:75 sequencer.c:2186
-#: sequencer.c:4505 sequencer.c:4561 sequencer.c:4836
+#: rebase-interactive.c:62 rebase-interactive.c:75 sequencer.c:2219
+#: sequencer.c:4569 sequencer.c:4625 sequencer.c:4900
 #, c-format
 msgid "could not read '%s'."
 msgstr "kunde inte läsa \"%s\"."
@@ -3871,7 +4139,7 @@ msgstr "\"%s\" pekar inte på ett giltigt objekt!"
 msgid "ignoring dangling symref %s"
 msgstr "ignorerar dinglande symbolisk referens %s"
 
-#: refs.c:585 ref-filter.c:1951
+#: refs.c:585 ref-filter.c:1976
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "ignorerar trasig referens %s"
@@ -3896,15 +4164,15 @@ msgstr "referensen \"%s\" finns redan"
 msgid "unexpected object ID when writing '%s'"
 msgstr "oväntat objekt-id vid skrivning \"%s\""
 
-#: refs.c:740 sequencer.c:394 sequencer.c:2510 sequencer.c:2636
-#: sequencer.c:2650 sequencer.c:2877 sequencer.c:4725 sequencer.c:4788
+#: refs.c:740 sequencer.c:396 sequencer.c:2549 sequencer.c:2675
+#: sequencer.c:2689 sequencer.c:2923 sequencer.c:4789 sequencer.c:4852
 #: wrapper.c:656
 #, c-format
 msgid "could not write to '%s'"
 msgstr "kunde inte skriva till \"%s\""
 
-#: refs.c:767 sequencer.c:4723 sequencer.c:4782 wrapper.c:225 wrapper.c:395
-#: builtin/am.c:728
+#: refs.c:767 sequencer.c:4787 sequencer.c:4846 wrapper.c:225 wrapper.c:395
+#: builtin/am.c:713 builtin/rebase.c:575
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "kunde inte öppna \"%s\" för skrivning"
@@ -3979,7 +4247,7 @@ msgstr "kunde inte ta bort referenser: %s"
 msgid "invalid refspec '%s'"
 msgstr "felaktig referensspecifikation: \"%s\""
 
-#: ref-filter.c:39 wt-status.c:1855
+#: ref-filter.c:39 wt-status.c:1861
 msgid "gone"
 msgstr "försvunnen"
 
@@ -4028,149 +4296,154 @@ msgstr "okänt %%(%s)-argument: %s"
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) tar inte argument"
 
-#: ref-filter.c:235
+#: ref-filter.c:245
 #, c-format
-msgid "%%(objectsize) does not take arguments"
-msgstr "%%(objectsize) tar inte argument"
+msgid "unrecognized %%(objectsize) argument: %s"
+msgstr "okänt %%(objectsize)-argument: %s"
 
-#: ref-filter.c:247
+#: ref-filter.c:253
+#, c-format
+msgid "%%(deltabase) does not take arguments"
+msgstr "%%(deltabase) tar inte argument"
+
+#: ref-filter.c:265
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) tar inte argument"
 
-#: ref-filter.c:256
+#: ref-filter.c:274
 #, c-format
 msgid "%%(subject) does not take arguments"
 msgstr "%%(subject) tar inte argument"
 
-#: ref-filter.c:278
+#: ref-filter.c:296
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "okänt %%(trailers)-argument: %s"
 
-#: ref-filter.c:307
+#: ref-filter.c:325
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "positivt värde förväntat contents:lines=%s"
 
-#: ref-filter.c:309
+#: ref-filter.c:327
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "okänt %%(contents)-argument: %s"
 
-#: ref-filter.c:324
+#: ref-filter.c:342
 #, c-format
 msgid "positive value expected objectname:short=%s"
 msgstr "positivt värde förväntat objectname:short=%s"
 
-#: ref-filter.c:328
+#: ref-filter.c:346
 #, c-format
 msgid "unrecognized %%(objectname) argument: %s"
 msgstr "okänt %%(objectname)-argument: %s"
 
-#: ref-filter.c:358
+#: ref-filter.c:376
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "förväntat format: %%(align:<bredd>,<position>)"
 
-#: ref-filter.c:370
+#: ref-filter.c:388
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "okänd position:%s"
 
-#: ref-filter.c:377
+#: ref-filter.c:395
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "okänd bredd:%s"
 
-#: ref-filter.c:386
+#: ref-filter.c:404
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "okänt %%(align)-argument: %s"
 
-#: ref-filter.c:394
+#: ref-filter.c:412
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "positiv bredd förväntad med atomen %%(align)"
 
-#: ref-filter.c:412
+#: ref-filter.c:430
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "okänt %%(if)-argument: %s"
 
-#: ref-filter.c:508
+#: ref-filter.c:527
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "felformat fältnamn: %.*s"
 
-#: ref-filter.c:535
+#: ref-filter.c:554
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "okänt fältnamn: %.*s"
 
-#: ref-filter.c:539
+#: ref-filter.c:558
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 "inte ett git-arkiv, men fältet \"%.*s\" kräver tillgång till objektdata"
 
-#: ref-filter.c:663
+#: ref-filter.c:682
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "format: atomen %%(if) använd utan en %%(then)-atom"
 
-#: ref-filter.c:726
+#: ref-filter.c:745
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "format: atomen %%(then) använd utan en %%(if)-atom"
 
-#: ref-filter.c:728
+#: ref-filter.c:747
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "format: atomen %%(then) använd mer än en gång"
 
-#: ref-filter.c:730
+#: ref-filter.c:749
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: atomen %%(then) använd efter %%(else)"
 
-#: ref-filter.c:758
+#: ref-filter.c:777
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "format: atomen %%(else) använd utan en %%(if)-atom"
 
-#: ref-filter.c:760
+#: ref-filter.c:779
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "format: atomen %%(else) använd utan en %%(then)-atom"
 
-#: ref-filter.c:762
+#: ref-filter.c:781
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "format: atomen %%(else) använd mer än en gång"
 
-#: ref-filter.c:777
+#: ref-filter.c:796
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "format: atomen %%(end) använd utan motsvarande atom"
 
-#: ref-filter.c:834
+#: ref-filter.c:853
 #, c-format
 msgid "malformed format string %s"
 msgstr "felformad formatsträng %s"
 
-#: ref-filter.c:1424
+#: ref-filter.c:1447
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(ingen gren, ombaserar %s)"
 
-#: ref-filter.c:1427
+#: ref-filter.c:1450
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(ingen gren, ombaserar frånkopplat HEAD %s)"
 
-#: ref-filter.c:1430
+#: ref-filter.c:1453
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(ingen gren, \"bisect\" startad på %s)"
@@ -4178,7 +4451,7 @@ msgstr "(ingen gren, \"bisect\" startad på %s)"
 #. TRANSLATORS: make sure this matches "HEAD
 #. detached at " in wt-status.c
 #.
-#: ref-filter.c:1438
+#: ref-filter.c:1461
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD frånkopplat vid %s)"
@@ -4186,142 +4459,287 @@ msgstr "(HEAD frånkopplat vid %s)"
 #. TRANSLATORS: make sure this matches "HEAD
 #. detached from " in wt-status.c
 #.
-#: ref-filter.c:1445
+#: ref-filter.c:1468
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD frånkopplat från %s)"
 
-#: ref-filter.c:1449
+#: ref-filter.c:1472
 msgid "(no branch)"
 msgstr "(ingen gren)"
 
-#: ref-filter.c:1483 ref-filter.c:1638
+#: ref-filter.c:1506 ref-filter.c:1663
 #, c-format
 msgid "missing object %s for %s"
 msgstr "objektet %s saknas för %s"
 
-#: ref-filter.c:1491
+#: ref-filter.c:1516
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer misslyckades på %s för %s"
 
-#: ref-filter.c:1857
+#: ref-filter.c:1882
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "felformat objekt vid \"%s\""
 
-#: ref-filter.c:1946
+#: ref-filter.c:1971
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "ignorerar referens med trasigt namn %s"
 
-#: ref-filter.c:2232
+#: ref-filter.c:2257
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "format: atomen %%(end) saknas"
 
-#: ref-filter.c:2338
+#: ref-filter.c:2352
+#, c-format
+msgid "option `%s' is incompatible with --merged"
+msgstr "flaggan \"%s\" är inkompatibel med --merged"
+
+#: ref-filter.c:2355
+#, c-format
+msgid "option `%s' is incompatible with --no-merged"
+msgstr "flaggan \"%s\" är inkompatibel med --no-merged"
+
+#: ref-filter.c:2365
 #, c-format
 msgid "malformed object name %s"
 msgstr "felformat objektnamn %s"
 
-#: remote.c:607
+#: ref-filter.c:2370
+#, c-format
+msgid "option `%s' must point to a commit"
+msgstr "flaggan \"%s\" måste peka på en incheckning"
+
+#: remote.c:363
+#, c-format
+msgid "config remote shorthand cannot begin with '/': %s"
+msgstr "konfigurerad kortform för fjärr kan inte börja med \"/\": %s"
+
+#: remote.c:410
+msgid "more than one receivepack given, using the first"
+msgstr "mer än en receivepack angavs, använder den första"
+
+#: remote.c:418
+msgid "more than one uploadpack given, using the first"
+msgstr "mer än en uploadpack angavs, använder den första"
+
+#: remote.c:608
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Kan inte hämta både %s och %s till %s"
 
-#: remote.c:611
+#: remote.c:612
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s spårar vanligtvis %s, inte %s"
 
-#: remote.c:615
+#: remote.c:616
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s spårar både %s och %s"
 
-#: remote.c:623
-msgid "Internal error"
-msgstr "Internt fel"
+#: remote.c:684
+#, c-format
+msgid "key '%s' of pattern had no '*'"
+msgstr "nyckeln \"%s\" i mönstret innehåller ingen \"*\""
 
-#: remote.c:1569 remote.c:1670
+#: remote.c:694
+#, c-format
+msgid "value '%s' of pattern has no '*'"
+msgstr "värdet \"%s\" i mönstret innehåller ingen \"*\""
+
+#: remote.c:1000
+#, c-format
+msgid "src refspec %s does not match any"
+msgstr "käll-referensspecifikationen %s motsvarar ingen"
+
+#: remote.c:1005
+#, c-format
+msgid "src refspec %s matches more than one"
+msgstr "käll-referensspecifikationen %s motsvarar mer än en"
+
+#. TRANSLATORS: "matches '%s'%" is the <dst> part of "git push
+#. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
+#. the <src>.
+#.
+#: remote.c:1020
+#, c-format
+msgid ""
+"The destination you provided is not a full refname (i.e.,\n"
+"starting with \"refs/\"). We tried to guess what you meant by:\n"
+"\n"
+"- Looking for a ref that matches '%s' on the remote side.\n"
+"- Checking if the <src> being pushed ('%s')\n"
+"  is a ref in \"refs/{heads,tags}/\". If so we add a corresponding\n"
+"  refs/{heads,tags}/ prefix on the remote side.\n"
+"\n"
+"Neither worked, so we gave up. You must fully qualify the ref."
+msgstr ""
+"Målet du angav är inte ett komplett referensamn (dvs.,\n"
+"startar med \"refs/\"). Vi försökte gissa vad du menade genom att:\n"
+"\n"
+"- Se efter en referens som motsvarar \"%s\" på fjärrsidan.\n"
+"- Se om <källan> som sänds (\"%s\")\n"
+"  är en referens i \"refs/{heads,tags}/\". Om så lägger vi till\n"
+"  motsvarande refs/{heads,tags}/-prefix på fjärrsidan.\n"
+"\n"
+"Inget av dem fungerade, så vi gav upp. Ange fullständig referens."
+
+#: remote.c:1040
+#, c-format
+msgid ""
+"The <src> part of the refspec is a commit object.\n"
+"Did you mean to create a new branch by pushing to\n"
+"'%s:refs/heads/%s'?"
+msgstr ""
+"<Källa>-delen av ref.spec-en är ett incheckningsobjekt.\n"
+"Var det meningen att skapa en ny gren genom att sända\n"
+"till \"%s:refs/heads/%s\"?"
+
+#: remote.c:1045
+#, c-format
+msgid ""
+"The <src> part of the refspec is a tag object.\n"
+"Did you mean to create a new tag by pushing to\n"
+"'%s:refs/tags/%s'?"
+msgstr ""
+"<Källa>-delen av ref.spec-en är ett taggobjekt.\n"
+"Var det meningen att skapa en ny tagg genom att sända\n"
+"till \"%s:refs/tags/%s\"?"
+
+#: remote.c:1050
+#, c-format
+msgid ""
+"The <src> part of the refspec is a tree object.\n"
+"Did you mean to tag a new tree by pushing to\n"
+"'%s:refs/tags/%s'?"
+msgstr ""
+"<Källa>-delen av ref.spec-en är ett trädobjekt.\n"
+"Var det meningen att tagga ett nytt träd genom att sända\n"
+"till \"%s:refs/tags/%s\"?"
+
+#: remote.c:1055
+#, c-format
+msgid ""
+"The <src> part of the refspec is a blob object.\n"
+"Did you mean to tag a new blob by pushing to\n"
+"'%s:refs/tags/%s'?"
+msgstr ""
+"<Källa>-delen av ref.spec-en är ett blobobjekt.\n"
+"Var det meningen att tagga en ny blob genom att sända\n"
+"till \"%s:refs/tags/%s\"?"
+
+#: remote.c:1091
+#, c-format
+msgid "%s cannot be resolved to branch"
+msgstr "%s kan inte slås upp till en gren"
+
+#: remote.c:1102
+#, c-format
+msgid "unable to delete '%s': remote ref does not exist"
+msgstr "kan inte ta bort \"%s\": fjärreferensen finns inte"
+
+#: remote.c:1114
+#, c-format
+msgid "dst refspec %s matches more than one"
+msgstr "fjärr-referensspecifikationen \"%s\" motsvarar mer än en"
+
+#: remote.c:1121
+#, c-format
+msgid "dst ref %s receives from more than one src"
+msgstr "fjärr-referensen \"%s\" hämtar från mer än en källa"
+
+#: remote.c:1624 remote.c:1725
 msgid "HEAD does not point to a branch"
 msgstr "HEAD pekar inte på en gren"
 
-#: remote.c:1578
+#: remote.c:1633
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "okänd gren: \"%s\""
 
-#: remote.c:1581
+#: remote.c:1636
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "ingen standarduppström angiven för grenen \"%s\""
 
-#: remote.c:1587
+#: remote.c:1642
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "uppströmsgrenen \"%s\" är inte lagrad som en fjärrspårande gren"
 
-#: remote.c:1602
+#: remote.c:1657
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr "push-målet \"%s\" på fjärren \"%s\" har ingen lokalt spårande gren"
 
-#: remote.c:1614
+#: remote.c:1669
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "grenen \"%s\" har ingen fjärr för \"push\""
 
-#: remote.c:1624
+#: remote.c:1679
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "\"push\"-referensspecifikation för \"%s\" innehåller inte \"%s\""
 
-#: remote.c:1637
+#: remote.c:1692
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "\"push\" har inget mål (push.default är \"ingenting\")"
 
-#: remote.c:1659
+#: remote.c:1714
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "\"enkel push\" motsvarar flera olika mål"
 
-#: remote.c:1935
+#: remote.c:1840
+#, c-format
+msgid "couldn't find remote ref %s"
+msgstr "Kunde inte hitta fjärr-referensen %s"
+
+#: remote.c:1853
+#, c-format
+msgid "* Ignoring funny ref '%s' locally"
+msgstr "* Ignorerar märklig referens \"%s\" lokalt"
+
+#: remote.c:1990
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Din gren är baserad på \"%s\", men den har försvunnit uppströms.\n"
 
-#: remote.c:1939
+#: remote.c:1994
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (använd \"git branch --unset-upstream\" för att rätta)\n"
 
-#: remote.c:1942
+#: remote.c:1997
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Din gren är à jour med \"%s\".\n"
 
-#: remote.c:1946
+#: remote.c:2001
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Din gren och \"%s\" pekar på olika incheckningar.\n"
 
-#: remote.c:1949
+#: remote.c:2004
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (använd \"%s\" för detaljer)\n"
 
-#: remote.c:1953
+#: remote.c:2008
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Din gren ligger före \"%s\" med %d incheckning.\n"
 msgstr[1] "Din gren ligger före \"%s\" med %d incheckningar.\n"
 
-#: remote.c:1959
+#: remote.c:2014
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (använd \"git push\" för att publicera dina lokala incheckningar)\n"
 
-#: remote.c:1962
+#: remote.c:2017
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -4331,11 +4749,11 @@ msgstr[0] ""
 msgstr[1] ""
 "Din gren ligger efter \"%s\" med %d incheckningar, och kan snabbspolas.\n"
 
-#: remote.c:1970
+#: remote.c:2025
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (använd \"git pull\" för att uppdatera din lokala gren)\n"
 
-#: remote.c:1973
+#: remote.c:2028
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -4350,9 +4768,14 @@ msgstr[1] ""
 "Din gren och \"%s\" har divergerat,\n"
 "och har %d respektive %d olika incheckningar.\n"
 
-#: remote.c:1983
+#: remote.c:2038
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr "  (använd \"git pull\" för att slå ihop fjärrgrenen med din egen)\n"
+
+#: remote.c:2221
+#, c-format
+msgid "cannot parse expected object name '%s'"
+msgstr "kan inte tolka förväntat objektnamn \"%s\""
 
 #: replace-object.c:21
 #, c-format
@@ -4377,7 +4800,8 @@ msgstr "trasig MERGE_RR"
 msgid "unable to write rerere record"
 msgstr "kunde inte skriva rerere-post"
 
-#: rerere.c:485 rerere.c:692 sequencer.c:3136 sequencer.c:3162
+#: rerere.c:485 rerere.c:692 sequencer.c:3186 sequencer.c:3212
+#: builtin/fsck.c:314
 #, c-format
 msgid "could not write '%s'"
 msgstr "kunde inte skriva \"%s\""
@@ -4432,8 +4856,8 @@ msgstr "kan inte ta bort lös länk \"%s\""
 msgid "Recorded preimage for '%s'"
 msgstr "Sparade förhandsbild för \"%s\""
 
-#: rerere.c:881 submodule.c:1763 builtin/submodule--helper.c:1413
-#: builtin/submodule--helper.c:1423
+#: rerere.c:881 submodule.c:2012 builtin/submodule--helper.c:1417
+#: builtin/submodule--helper.c:1427
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "kunde inte skapa katalogen \"%s\""
@@ -4467,29 +4891,29 @@ msgstr "Glömde lösning för \"%s\"\n"
 msgid "unable to open rr-cache directory"
 msgstr "kan inte uppdatera katalogen rr-cache"
 
-#: revision.c:2324
+#: revision.c:2484
 msgid "your current branch appears to be broken"
 msgstr "din nuvarande gren verkar vara trasig"
 
-#: revision.c:2327
+#: revision.c:2487
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "din nuvarande gren \"%s\" innehåller ännu inte några incheckningar"
 
-#: revision.c:2523
+#: revision.c:2684
 msgid "--first-parent is incompatible with --bisect"
 msgstr "--first-parent är inkompatibelt med --bisect"
 
-#: run-command.c:740
+#: run-command.c:742
 msgid "open /dev/null failed"
 msgstr "misslyckades öppna /dev/null"
 
-#: run-command.c:1229
+#: run-command.c:1231
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "kan inte skapa asynkron tråd: %s"
 
-#: run-command.c:1293
+#: run-command.c:1295
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
@@ -4498,29 +4922,29 @@ msgstr ""
 "Kroken \"%s\" ignorerades eftersom den inte är markerad som körbar.\n"
 "Du kan inaktivera varningen med \"git config advice.ignoredHook false\"."
 
-#: send-pack.c:142
+#: send-pack.c:141
 msgid "unexpected flush packet while reading remote unpack status"
 msgstr "oväntat flush-paket vid läsning av fjärruppackningsstatus"
 
-#: send-pack.c:144
+#: send-pack.c:143
 #, c-format
 msgid "unable to parse remote unpack status: %s"
 msgstr "kunde inte tolka fjärruppackningsstatus: %s"
 
-#: send-pack.c:146
+#: send-pack.c:145
 #, c-format
 msgid "remote unpack failed: %s"
 msgstr "fjärruppackning misslyckades: %s"
 
-#: send-pack.c:308
+#: send-pack.c:306
 msgid "failed to sign the push certificate"
 msgstr "misslyckades underteckna push-certifikatet"
 
-#: send-pack.c:421
+#: send-pack.c:420
 msgid "the receiving end does not support --signed push"
 msgstr "mottagarsidan stöder inte push med --signed"
 
-#: send-pack.c:423
+#: send-pack.c:422
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -4528,42 +4952,42 @@ msgstr ""
 "sänder inte push-certifikat eftersom mottagarsidan inte stlder push med --"
 "signed"
 
-#: send-pack.c:435
+#: send-pack.c:434
 msgid "the receiving end does not support --atomic push"
 msgstr "mottagarsidan stöder inte push med --atomic"
 
-#: send-pack.c:440
+#: send-pack.c:439
 msgid "the receiving end does not support push options"
 msgstr "mottagarsidan stöder inte push-flaggor"
 
-#: sequencer.c:183
+#: sequencer.c:184
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "felaktigt incheckningsmeddelandestädningsläge \"%s\""
 
-#: sequencer.c:287
+#: sequencer.c:288
 #, c-format
 msgid "could not delete '%s'"
 msgstr "kunde inte ta bort \"%s\""
 
-#: sequencer.c:313
+#: sequencer.c:314
 msgid "revert"
 msgstr "revert"
 
-#: sequencer.c:315
+#: sequencer.c:316
 msgid "cherry-pick"
 msgstr "cherry-pick"
 
-#: sequencer.c:317
+#: sequencer.c:318
 msgid "rebase -i"
 msgstr "rebase -i"
 
-#: sequencer.c:319
+#: sequencer.c:320
 #, c-format
 msgid "unknown action: %d"
 msgstr "okänd funktion: %d"
 
-#: sequencer.c:376
+#: sequencer.c:378
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -4571,7 +4995,7 @@ msgstr ""
 "efter att ha löst konflikterna, markera de rättade sökvägarna\n"
 "med \"git add <sökvägar>\" eller \"git rm <sökvägar>\""
 
-#: sequencer.c:379
+#: sequencer.c:381
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
@@ -4581,39 +5005,39 @@ msgstr ""
 "med \"git add <sökvägar>\" eller \"git rm <sökvägar>\"\n"
 "och checka in resultatet med \"git commit\""
 
-#: sequencer.c:392 sequencer.c:2632
+#: sequencer.c:394 sequencer.c:2671
 #, c-format
 msgid "could not lock '%s'"
 msgstr "kunde inte låsa \"%s\""
 
-#: sequencer.c:399
+#: sequencer.c:401
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "kunde inte skriva radslut till \"%s\""
 
-#: sequencer.c:404 sequencer.c:2515 sequencer.c:2638 sequencer.c:2652
-#: sequencer.c:2885
+#: sequencer.c:406 sequencer.c:2554 sequencer.c:2677 sequencer.c:2691
+#: sequencer.c:2931
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "misslyckades färdigställa \"%s\""
 
-#: sequencer.c:427 sequencer.c:921 sequencer.c:1594 sequencer.c:2535
-#: sequencer.c:2867 sequencer.c:2974 builtin/am.c:260 builtin/commit.c:746
-#: builtin/merge.c:1084 builtin/rebase.c:152
+#: sequencer.c:429 sequencer.c:931 sequencer.c:1615 sequencer.c:2574
+#: sequencer.c:2913 sequencer.c:3022 builtin/am.c:245 builtin/commit.c:748
+#: builtin/merge.c:1085 builtin/rebase.c:154
 #, c-format
 msgid "could not read '%s'"
 msgstr "kunde inte läsa \"%s\""
 
-#: sequencer.c:453
+#: sequencer.c:455
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "dina lokala ändringar skulle skrivas över av %s."
 
-#: sequencer.c:457
+#: sequencer.c:459
 msgid "commit your changes or stash them to proceed."
 msgstr "checka in dina ändringar eller använd \"stash\" för att fortsätta."
 
-#: sequencer.c:486
+#: sequencer.c:491
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: snabbspola"
@@ -4621,70 +5045,70 @@ msgstr "%s: snabbspola"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase -i".
 #.
-#: sequencer.c:575
+#: sequencer.c:582
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: Kunde inte skriva ny indexfil"
 
-#: sequencer.c:591
+#: sequencer.c:598
 msgid "unable to update cache tree"
 msgstr "kan inte uppdatera cacheträd"
 
-#: sequencer.c:604
+#: sequencer.c:612
 msgid "could not resolve HEAD commit"
 msgstr "kunde inte bestämma HEAD:s incheckning"
 
-#: sequencer.c:684
+#: sequencer.c:692
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "ingen nyckel i  \"%.*s\""
 
-#: sequencer.c:695
+#: sequencer.c:703
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "kan inte ta bort citering av värdet \"%s\""
 
-#: sequencer.c:732 wrapper.c:227 wrapper.c:397 builtin/am.c:719
-#: builtin/am.c:811 builtin/merge.c:1081
+#: sequencer.c:740 wrapper.c:227 wrapper.c:397 builtin/am.c:704
+#: builtin/am.c:796 builtin/merge.c:1082 builtin/rebase.c:617
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "kunde inte öppna \"%s\" för läsning"
 
-#: sequencer.c:742
+#: sequencer.c:750
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "\"GIT_AUTHOR_NAME\" har redan angivits"
 
-#: sequencer.c:747
+#: sequencer.c:755
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "\"GIT_AUTHOR_EMAIL\" har redan angivits"
 
-#: sequencer.c:752
+#: sequencer.c:760
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "\"GIT_AUTHOR_DATE\" har redan angivits"
 
-#: sequencer.c:756
+#: sequencer.c:764
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "okänd variabel \"%s\""
 
-#: sequencer.c:761
+#: sequencer.c:769
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "\"GIT_AUTHOR_NAME\" saknas"
 
-#: sequencer.c:763
+#: sequencer.c:771
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "\"GIT_AUTHOR_EMAIL\" saknas"
 
-#: sequencer.c:765
+#: sequencer.c:773
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "\"GIT_AUTHOR_DATE\" saknas"
 
-#: sequencer.c:825
+#: sequencer.c:833
 #, c-format
 msgid "invalid date format '%s' in '%s'"
 msgstr "ogiltigt datumformat \"%s\" i \"%s\""
 
-#: sequencer.c:842
+#: sequencer.c:850
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -4713,15 +5137,15 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:935
+#: sequencer.c:945
 msgid "writing root commit"
 msgstr "skriver rotincheckning"
 
-#: sequencer.c:1142
+#: sequencer.c:1155
 msgid "'prepare-commit-msg' hook failed"
 msgstr "kroken \"prepare-commit-msg\" misslyckades"
 
-#: sequencer.c:1149
+#: sequencer.c:1162
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -4748,7 +5172,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1162
+#: sequencer.c:1175
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -4773,301 +5197,296 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1202
+#: sequencer.c:1217
 msgid "couldn't look up newly created commit"
 msgstr "kunde inte slå upp en precis skapad incheckning"
 
-#: sequencer.c:1204
+#: sequencer.c:1219
 msgid "could not parse newly created commit"
 msgstr "kunde inte tolka en precis skapad incheckning"
 
-#: sequencer.c:1250
+#: sequencer.c:1265
 msgid "unable to resolve HEAD after creating commit"
 msgstr "kunde inte bestämma HEAD efter att ha skapat incheckning"
 
-#: sequencer.c:1252
+#: sequencer.c:1267
 msgid "detached HEAD"
 msgstr "frånkopplad HEAD"
 
-#: sequencer.c:1256
+#: sequencer.c:1271
 msgid " (root-commit)"
 msgstr " (rotincheckning)"
 
-#: sequencer.c:1277
+#: sequencer.c:1292
 msgid "could not parse HEAD"
 msgstr "kunde inte tolka HEAD"
 
-#: sequencer.c:1279
+#: sequencer.c:1294
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s är inte en incheckning!"
 
-#: sequencer.c:1283 builtin/commit.c:1543
+#: sequencer.c:1298 builtin/commit.c:1546
 msgid "could not parse HEAD commit"
 msgstr "kunde inte tolka HEAD:s incheckning"
 
-#: sequencer.c:1334 sequencer.c:1934
+#: sequencer.c:1350 sequencer.c:1964
 msgid "unable to parse commit author"
 msgstr "kunde inte tolka incheckningens författare"
 
-#: sequencer.c:1344 builtin/am.c:1585 builtin/merge.c:677
+#: sequencer.c:1360 builtin/am.c:1570 builtin/merge.c:678
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree misslyckades skriva ett träd"
 
-#: sequencer.c:1361 sequencer.c:1416
+#: sequencer.c:1377 sequencer.c:1433
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "kunde inte läsa incheckningsmeddelande från \"%s\""
 
-#: sequencer.c:1383 builtin/am.c:1606 builtin/commit.c:1646 builtin/merge.c:858
-#: builtin/merge.c:883
+#: sequencer.c:1399 builtin/am.c:1591 builtin/commit.c:1649 builtin/merge.c:859
+#: builtin/merge.c:884
 msgid "failed to write commit object"
 msgstr "kunde inte skriva incheckningsobjekt"
 
-#: sequencer.c:1443
+#: sequencer.c:1460
 #, c-format
 msgid "could not parse commit %s"
 msgstr "kunde inte tolka incheckningen %s"
 
-#: sequencer.c:1448
+#: sequencer.c:1465
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "kunde inte tolka föräldraincheckningen %s"
 
-#: sequencer.c:1546 sequencer.c:1654
+#: sequencer.c:1565 sequencer.c:1675
 #, c-format
 msgid "unknown command: %d"
 msgstr "okänt kommando: %d"
 
-#: sequencer.c:1601 sequencer.c:1626
+#: sequencer.c:1622 sequencer.c:1647
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Det här är en kombination av %d incheckningar."
 
-#: sequencer.c:1611 sequencer.c:4744
+#: sequencer.c:1632 sequencer.c:4808
 msgid "need a HEAD to fixup"
 msgstr "behöver en HEAD-incheckning att rätta"
 
-#: sequencer.c:1613 sequencer.c:2912
+#: sequencer.c:1634 sequencer.c:2958
 msgid "could not read HEAD"
 msgstr "kunde inte läsa HEAD"
 
-#: sequencer.c:1615
+#: sequencer.c:1636
 msgid "could not read HEAD's commit message"
 msgstr "kunde inte läsa HEAD:s incheckningsmeddelande"
 
-#: sequencer.c:1621
+#: sequencer.c:1642
 #, c-format
 msgid "cannot write '%s'"
 msgstr "kan inte skriva \"%s\""
 
-#: sequencer.c:1628 git-rebase--preserve-merges.sh:441
+#: sequencer.c:1649 git-rebase--preserve-merges.sh:441
 msgid "This is the 1st commit message:"
 msgstr "Det här är 1:a incheckningsmeddelandet:"
 
-#: sequencer.c:1636
+#: sequencer.c:1657
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "kunde inte läsa incheckningsmeddelande för %s"
 
-#: sequencer.c:1643
+#: sequencer.c:1664
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Det här är incheckningsmeddelande %d:"
 
-#: sequencer.c:1649
+#: sequencer.c:1670
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Incheckningsmeddelande %d kommer hoppas över:"
 
-#: sequencer.c:1732
+#: sequencer.c:1758
 msgid "your index file is unmerged."
 msgstr "din indexfil har inte slagits ihop."
 
-#: sequencer.c:1739
+#: sequencer.c:1765
 msgid "cannot fixup root commit"
 msgstr "kan inte göra \"fixup\" på rotincheckning"
 
-#: sequencer.c:1758
+#: sequencer.c:1784
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "incheckning %s är en sammanslagning, men flaggan -m angavs inte."
 
-#: sequencer.c:1766
+#: sequencer.c:1792 sequencer.c:1800
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "incheckning %s har inte förälder %d"
 
-#: sequencer.c:1770
-#, c-format
-msgid "mainline was specified but commit %s is not a merge."
-msgstr "huvudlinje angavs, men incheckningen %s är inte en sammanslagning."
-
-#: sequencer.c:1776
+#: sequencer.c:1806
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "kan inte hämta incheckningsmeddelande för %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1795
+#: sequencer.c:1825
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: kan inte tolka föräldraincheckningen %s"
 
-#: sequencer.c:1860
+#: sequencer.c:1890
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "kunde inte byta namn på \"%s\" till \"%s\""
 
-#: sequencer.c:1915
+#: sequencer.c:1945
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "kunde inte ångra %s... %s"
 
-#: sequencer.c:1916
+#: sequencer.c:1946
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "kunde inte tillämpa %s... %s"
 
-#: sequencer.c:1974
+#: sequencer.c:2005
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: misslyckades läsa indexet"
 
-#: sequencer.c:1981
+#: sequencer.c:2012
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: misslyckades uppdatera indexet"
 
-#: sequencer.c:2062
+#: sequencer.c:2094
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s tar inte argument: \"%s\""
 
-#: sequencer.c:2071
+#: sequencer.c:2103
 #, c-format
 msgid "missing arguments for %s"
 msgstr "argument saknas för %s"
 
-#: sequencer.c:2130
+#: sequencer.c:2163
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "ogiltig rad %d: %.*s"
 
-#: sequencer.c:2138
+#: sequencer.c:2171
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "kan inte utföra \"%s\" utan en föregående incheckning"
 
-#: sequencer.c:2209
+#: sequencer.c:2243
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "rätta det med \"git rebase --edit-todo\"."
 
-#: sequencer.c:2211
+#: sequencer.c:2245
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "oanvändbart manus: ”%s”"
 
-#: sequencer.c:2216
+#: sequencer.c:2250
 msgid "no commits parsed."
 msgstr "inga incheckningar lästes."
 
-#: sequencer.c:2227
+#: sequencer.c:2261
 msgid "cannot cherry-pick during a revert."
 msgstr "kan inte utföra \"cherry-pick\" under en \"revert\"."
 
-#: sequencer.c:2229
+#: sequencer.c:2263
 msgid "cannot revert during a cherry-pick."
 msgstr "kan inte utföra \"revert\" under en \"cherry-pick\"."
 
-#: sequencer.c:2299
+#: sequencer.c:2333
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "felaktigt värde för %s: %s"
 
-#: sequencer.c:2380
+#: sequencer.c:2420
 msgid "unusable squash-onto"
 msgstr "oanvändbar squash-onto"
 
-#: sequencer.c:2396
+#: sequencer.c:2436
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "trasigt manus: ”%s”"
 
-#: sequencer.c:2479 sequencer.c:4005
+#: sequencer.c:2518 sequencer.c:4067
 msgid "empty commit set passed"
 msgstr "den angivna uppsättningen incheckningar är tom"
 
-#: sequencer.c:2487
+#: sequencer.c:2526
 msgid "a cherry-pick or revert is already in progress"
 msgstr "en \"cherry-pick\" eller \"revert\" pågår redan"
 
-#: sequencer.c:2488
+#: sequencer.c:2527
 msgid "try \"git cherry-pick (--continue | --quit | --abort)\""
 msgstr "testa \"git cherry-pick (--continue | --quit | --abort)\""
 
-#: sequencer.c:2491
+#: sequencer.c:2530
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "kunde inte skapa \"sequencer\"-katalogen \"%s\""
 
-#: sequencer.c:2505
+#: sequencer.c:2544
 msgid "could not lock HEAD"
 msgstr "kunde inte låsa HEAD"
 
-#: sequencer.c:2560 sequencer.c:3761
+#: sequencer.c:2599 sequencer.c:3819
 msgid "no cherry-pick or revert in progress"
 msgstr "ingen \"cherry-pick\" eller \"revert\" pågår"
 
-#: sequencer.c:2562
+#: sequencer.c:2601
 msgid "cannot resolve HEAD"
 msgstr "kan inte bestämma HEAD"
 
-#: sequencer.c:2564 sequencer.c:2599
+#: sequencer.c:2603 sequencer.c:2638
 msgid "cannot abort from a branch yet to be born"
 msgstr "kan inte avbryta från en gren som ännu inte är född"
 
-#: sequencer.c:2585 builtin/grep.c:721
+#: sequencer.c:2624 builtin/grep.c:732
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kan inte öppna \"%s\""
 
-#: sequencer.c:2587
+#: sequencer.c:2626
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "kan inte läsa \"%s\": %s"
 
-#: sequencer.c:2588
+#: sequencer.c:2627
 msgid "unexpected end of file"
 msgstr "oväntat filslut"
 
-#: sequencer.c:2594
+#: sequencer.c:2633
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "sparad HEAD-fil från före \"cherry-pick\", \"%s\", är trasig"
 
-#: sequencer.c:2605
+#: sequencer.c:2644
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Du verkar ha flyttat HEAD.\n"
 "Spolar inte tillbaka, kontrollera HEAD!"
 
-#: sequencer.c:2709 sequencer.c:3679
+#: sequencer.c:2750 sequencer.c:3735
 #, c-format
 msgid "could not update %s"
 msgstr "kunde inte uppdatera %s"
 
-#: sequencer.c:2747 sequencer.c:3659
+#: sequencer.c:2788 sequencer.c:3715
 msgid "cannot read HEAD"
 msgstr "kan inte läsa HEAD"
 
-#: sequencer.c:2762
+#: sequencer.c:2805
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "kan inte kopiera in \"%s\" till \"%s\""
 
-#: sequencer.c:2770
+#: sequencer.c:2813
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -5086,27 +5505,27 @@ msgstr ""
 "\n"
 "\tgit rebase --continue\n"
 
-#: sequencer.c:2780
+#: sequencer.c:2823
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Kunde inte tillämpa %s... %.*s"
 
-#: sequencer.c:2787
+#: sequencer.c:2830
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Kunde inte slå ihop %.*s"
 
-#: sequencer.c:2798 sequencer.c:2802 builtin/difftool.c:640
+#: sequencer.c:2844 sequencer.c:2848 builtin/difftool.c:641
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "kunde inte kopiera in \"%s\" till \"%s\""
 
-#: sequencer.c:2824 sequencer.c:3242 builtin/rebase.c:580 builtin/rebase.c:1019
-#: builtin/rebase.c:1372 builtin/rebase.c:1426
+#: sequencer.c:2870 sequencer.c:3293 builtin/rebase.c:424 builtin/rebase.c:1230
+#: builtin/rebase.c:1591 builtin/rebase.c:1646
 msgid "could not read index"
 msgstr "kunde inte läsa indexet"
 
-#: sequencer.c:2829
+#: sequencer.c:2875
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -5121,11 +5540,11 @@ msgstr ""
 "\tgit rebase --continue\n"
 "\n"
 
-#: sequencer.c:2835
+#: sequencer.c:2881
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "och gjorde ändringar till indexet och/eller arbetskatalogen\n"
 
-#: sequencer.c:2841
+#: sequencer.c:2887
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -5142,76 +5561,76 @@ msgstr ""
 "\tgit rebase --continue\n"
 "\n"
 
-#: sequencer.c:2902
+#: sequencer.c:2948
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "ogiltigt etikettnamn: \"%.*s\""
 
-#: sequencer.c:2954
+#: sequencer.c:3002
 msgid "writing fake root commit"
 msgstr "skriver fejkad rotincheckning"
 
-#: sequencer.c:2959
+#: sequencer.c:3007
 msgid "writing squash-onto"
 msgstr "skriver squash-onto"
 
-#: sequencer.c:2997 builtin/rebase.c:585 builtin/rebase.c:591
+#: sequencer.c:3045 builtin/rebase.c:429 builtin/rebase.c:435
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "kunde inte hitta trädet för %s."
 
-#: sequencer.c:3015 builtin/rebase.c:604
+#: sequencer.c:3063 builtin/rebase.c:448
 msgid "could not write index"
 msgstr "kunde inte skriva indexet"
 
-#: sequencer.c:3042
+#: sequencer.c:3090
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "kunde inte upplösa \"%s\""
 
-#: sequencer.c:3068
+#: sequencer.c:3118
 msgid "cannot merge without a current revision"
 msgstr "kan inte slå ihop utan en aktuell incheckning"
 
-#: sequencer.c:3090
+#: sequencer.c:3140
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "kan inte tolka \"%.*s\""
 
-#: sequencer.c:3099
+#: sequencer.c:3149
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "inget att slå samman: \"%.*s\""
 
-#: sequencer.c:3111
+#: sequencer.c:3161
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "\"octopus\"-sammanslagning kan inte köras ovanpå en [ny rot]"
 
-#: sequencer.c:3126
+#: sequencer.c:3176
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "kunde inte läsa incheckningsmeddelande för \"%s\""
 
-#: sequencer.c:3274
+#: sequencer.c:3325
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "kunde inte ens försöka slå ihop \"%.*s\""
 
-#: sequencer.c:3290
+#: sequencer.c:3341
 msgid "merge: Unable to write new index file"
 msgstr "sammanslagning: Kunde inte skriva ny indexfil"
 
-#: sequencer.c:3358 builtin/rebase.c:268
+#: sequencer.c:3409 builtin/rebase.c:298
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Tillämpade autostash.\n"
 
-#: sequencer.c:3370
+#: sequencer.c:3421
 #, c-format
 msgid "cannot store %s"
 msgstr "kan inte spara %s"
 
-#: sequencer.c:3373 builtin/rebase.c:284
+#: sequencer.c:3424 builtin/rebase.c:314
 #, c-format
 msgid ""
 "Applying autostash resulted in conflicts.\n"
@@ -5222,31 +5641,31 @@ msgstr ""
 "Dina ändringar är säkra i stashen.\n"
 "Du kan när som helst använda \"git stash pop\" eller \"git stash drop\".\n"
 
-#: sequencer.c:3427
+#: sequencer.c:3478
 #, c-format
 msgid "could not checkout %s"
 msgstr "kunde inte checka ut %s"
 
-#: sequencer.c:3441
+#: sequencer.c:3492
 #, c-format
 msgid "%s: not a valid OID"
 msgstr "%s: inte ett giltigt OID"
 
-#: sequencer.c:3446 git-rebase--preserve-merges.sh:724
+#: sequencer.c:3497 git-rebase--preserve-merges.sh:724
 msgid "could not detach HEAD"
 msgstr "kunde inte koppla från HEAD"
 
-#: sequencer.c:3461
+#: sequencer.c:3512
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Stoppade på HEAD\n"
 
-#: sequencer.c:3463
+#: sequencer.c:3514
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Stoppade på %s\n"
 
-#: sequencer.c:3471
+#: sequencer.c:3522
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -5267,48 +5686,48 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:3543
+#: sequencer.c:3597
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Stoppade på %s... %.*s\n"
 
-#: sequencer.c:3622
+#: sequencer.c:3677
 #, c-format
 msgid "unknown command %d"
 msgstr "okänt kommando %d"
 
-#: sequencer.c:3667
+#: sequencer.c:3723
 msgid "could not read orig-head"
 msgstr "kunde inte läsa orig-head"
 
-#: sequencer.c:3672 sequencer.c:4741
+#: sequencer.c:3728 sequencer.c:4805
 msgid "could not read 'onto'"
 msgstr "kunde inte läsa \"onto\""
 
-#: sequencer.c:3686
+#: sequencer.c:3742
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "kunde inte uppdatera HEAD till %s"
 
-#: sequencer.c:3772
+#: sequencer.c:3831
 msgid "cannot rebase: You have unstaged changes."
 msgstr "kan inte ombasera: Du har oköade ändringar."
 
-#: sequencer.c:3781
+#: sequencer.c:3840
 msgid "cannot amend non-existing commit"
 msgstr "kan inte lägga till incheckning som inte finns"
 
-#: sequencer.c:3783
+#: sequencer.c:3842
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "ogiltig fil: \"%s\""
 
-#: sequencer.c:3785
+#: sequencer.c:3844
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "ogiltigt innehåll: \"%s\""
 
-#: sequencer.c:3788
+#: sequencer.c:3847
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -5318,54 +5737,54 @@ msgstr ""
 "Du har ändringar i arbetskatalogen som inte checkats in. Checka in dem\n"
 "först och kör sedan \"git rebase --continute\" igen."
 
-#: sequencer.c:3824 sequencer.c:3862
+#: sequencer.c:3883 sequencer.c:3921
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "kunde inte skriva fil: \"%s\""
 
-#: sequencer.c:3877
+#: sequencer.c:3936
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "kunde inte ta bort CHERRY_PICK_HEAD"
 
-#: sequencer.c:3884
+#: sequencer.c:3943
 msgid "could not commit staged changes."
 msgstr "kunde inte checka in köade ändringar."
 
-#: sequencer.c:3982
+#: sequencer.c:4044
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: kan inte göra \"cherry-pick\" på typen ”%s”"
 
-#: sequencer.c:3986
+#: sequencer.c:4048
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: felaktig revision"
 
-#: sequencer.c:4021
+#: sequencer.c:4083
 msgid "can't revert as initial commit"
 msgstr "kan inte ångra som första incheckning"
 
-#: sequencer.c:4466
+#: sequencer.c:4529
 msgid "make_script: unhandled options"
 msgstr "make_script: flaggor som inte stöds"
 
-#: sequencer.c:4469
+#: sequencer.c:4532
 msgid "make_script: error preparing revisions"
 msgstr "make_script: fel när revisioner skulle förberedas"
 
-#: sequencer.c:4509 sequencer.c:4565 sequencer.c:4840
+#: sequencer.c:4573 sequencer.c:4629 sequencer.c:4904
 #, c-format
 msgid "unusable todo list: '%s'"
 msgstr "oanvändbar todo-lista: %s"
 
-#: sequencer.c:4620
+#: sequencer.c:4684
 #, c-format
 msgid ""
 "unrecognized setting %s for option rebase.missingCommitsCheck. Ignoring."
 msgstr ""
 "okänd inställning %s för flaggan rebase.missingCommitsCheck. Ignorerar."
 
-#: sequencer.c:4690
+#: sequencer.c:4754
 #, c-format
 msgid ""
 "Warning: some commits may have been dropped accidentally.\n"
@@ -5374,7 +5793,7 @@ msgstr ""
 "Varning: vissa incheckningar kan av misstag ha tappats.\n"
 "Tappade incheckningar (nyaste först):\n"
 
-#: sequencer.c:4697
+#: sequencer.c:4761
 #, c-format
 msgid ""
 "To avoid this message, use \"drop\" to explicitly remove a commit.\n"
@@ -5394,7 +5813,7 @@ msgstr ""
 "\" (fel).\n"
 "\n"
 
-#: sequencer.c:4710
+#: sequencer.c:4774
 #, c-format
 msgid ""
 "You can fix this with 'git rebase --edit-todo' and then run 'git rebase --"
@@ -5405,31 +5824,31 @@ msgstr ""
 "continue\".\n"
 "Avbryt ombaseringen med \"git rebase --abort\".\n"
 
-#: sequencer.c:4848 sequencer.c:4886
+#: sequencer.c:4912 sequencer.c:4950
 msgid "nothing to do"
 msgstr "inget att göra"
 
-#: sequencer.c:4852
+#: sequencer.c:4916
 #, c-format
 msgid "Rebase %s onto %s (%d command)"
 msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Ombasera %s på %s (%d kommando)"
 msgstr[1] "Ombasera %s på %s (%d kommandon)"
 
-#: sequencer.c:4864
+#: sequencer.c:4928
 #, c-format
 msgid "could not copy '%s' to '%s'."
 msgstr "kunde inte kopiera \"%s\" till \"%s\"."
 
-#: sequencer.c:4868 sequencer.c:4897
+#: sequencer.c:4932 sequencer.c:4961
 msgid "could not transform the todo list"
 msgstr "kunde inte transformera att göra-listan"
 
-#: sequencer.c:4900
+#: sequencer.c:4964
 msgid "could not skip unnecessary pick commands"
 msgstr "kunde inte hoppa över onödiga \"pick\"-kommandon"
 
-#: sequencer.c:4983
+#: sequencer.c:5047
 msgid "the script was already rearranged."
 msgstr "skriptet har redan omordnats."
 
@@ -5538,30 +5957,30 @@ msgstr "inte ett git-arkiv: \"%s\""
 msgid "cannot chdir to '%s'"
 msgstr "kan inte byta katalog (chdir) till \"%s\""
 
-#: setup.c:711 setup.c:767 setup.c:777 setup.c:816 setup.c:824 setup.c:839
+#: setup.c:711 setup.c:767 setup.c:777 setup.c:816 setup.c:824
 msgid "cannot come back to cwd"
 msgstr "kan inte gå tillbaka till arbetskatalogen (cwd)"
 
-#: setup.c:837
-#, c-format
-msgid "not a git repository (or any of the parent directories): %s"
-msgstr "inte ett git-arkiv (eller någon av föräldrakatalogerna): %s"
-
-#: setup.c:848
+#: setup.c:838
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "misslyckades ta status på \"%*ss%s%s\""
 
-#: setup.c:1078
+#: setup.c:1068
 msgid "Unable to read current working directory"
 msgstr "Kan inte läsa aktuell arbetskatalog"
 
-#: setup.c:1090 setup.c:1096
+#: setup.c:1077 setup.c:1083
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "kan inte byta till \"%s\""
 
-#: setup.c:1109
+#: setup.c:1088
+#, c-format
+msgid "not a git repository (or any of the parent directories): %s"
+msgstr "inte ett git-arkiv (eller någon av föräldrakatalogerna): %s"
+
+#: setup.c:1094
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -5571,7 +5990,7 @@ msgstr ""
 "monteringspunkten %s)\n"
 "Stoppar vid filsystemsgräns (GIT_DISCOVERY_ACROSS_FILESYSTEM är inte satt)."
 
-#: setup.c:1192
+#: setup.c:1204
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -5580,278 +5999,278 @@ msgstr ""
 "problem med filläges-värdet i core.sharedRepository (0%.3o).\n"
 "Ägaren av filerna måste alltid ha läs- och skrivbehörighet."
 
-#: setup.c:1235
+#: setup.c:1247
 msgid "open /dev/null or dup failed"
 msgstr "misslyckades öppna /dev/null eller \"dup\""
 
-#: setup.c:1250
+#: setup.c:1262
 msgid "fork failed"
 msgstr "\"fork\" misslyckades"
 
-#: setup.c:1255
+#: setup.c:1267
 msgid "setsid failed"
 msgstr "\"setsid\" misslyckades"
 
-#: sha1-file.c:381
+#: sha1-file.c:445
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr "objektkatalogen %s finns inte; se .git/objects/info/alternates"
 
-#: sha1-file.c:432
+#: sha1-file.c:496
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "kunde inte normalisera alternativ objektsökväg: %s"
 
-#: sha1-file.c:503
+#: sha1-file.c:568
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: ignorerar alternativa objektlagringar, för djup nästling"
 
-#: sha1-file.c:510
+#: sha1-file.c:575
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "kan inte normalisera objektkatalogen: %s"
 
-#: sha1-file.c:565
+#: sha1-file.c:618
 msgid "unable to fdopen alternates lockfile"
 msgstr "kan inte utföra \"fdopen\" på låsfil för \"alternates\""
 
-#: sha1-file.c:583
+#: sha1-file.c:636
 msgid "unable to read alternates file"
 msgstr "kan inte läsa \"alternates\"-filen"
 
-#: sha1-file.c:590
+#: sha1-file.c:643
 msgid "unable to move new alternates file into place"
 msgstr "kan inte flytta ny \"alternates\"-fil på plats"
 
-#: sha1-file.c:625
+#: sha1-file.c:678
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "sökvägen \"%s\" finns inte"
 
-#: sha1-file.c:651
+#: sha1-file.c:704
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr "referensarkivet \"%s\" som en länkad utcheckning stöds inte ännu."
 
-#: sha1-file.c:657
+#: sha1-file.c:710
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "referensarkivet \"%s\" är inte ett lokalt arkiv."
 
-#: sha1-file.c:663
+#: sha1-file.c:716
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "referensarkivet \"%s\" är grunt"
 
-#: sha1-file.c:671
+#: sha1-file.c:724
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "referensarkivet \"%s\" är ympat"
 
-#: sha1-file.c:781
+#: sha1-file.c:838
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "försök att utföra \"mmap\" på %<PRIuMAX> över gränsen %<PRIuMAX>"
 
-#: sha1-file.c:806
+#: sha1-file.c:863
 msgid "mmap failed"
 msgstr "mmap misslyckades"
 
-#: sha1-file.c:973
+#: sha1-file.c:1027
 #, c-format
 msgid "object file %s is empty"
 msgstr "objektfilen %s är tom"
 
-#: sha1-file.c:1093 sha1-file.c:2215
+#: sha1-file.c:1151 sha1-file.c:2288
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "trasigt löst objekt \"%s\""
 
-#: sha1-file.c:1095 sha1-file.c:2219
+#: sha1-file.c:1153 sha1-file.c:2292
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "skräp i slutet av löst objekt \"%s\""
 
-#: sha1-file.c:1137
+#: sha1-file.c:1195
 msgid "invalid object type"
 msgstr "felaktig objekttyp"
 
-#: sha1-file.c:1219
+#: sha1-file.c:1279
 #, c-format
 msgid "unable to unpack %s header with --allow-unknown-type"
 msgstr "kan inte packa upp %s-huvud med --allow-unknown-type"
 
-#: sha1-file.c:1222
+#: sha1-file.c:1282
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "kan inte packa upp %s-huvudet"
 
-#: sha1-file.c:1228
+#: sha1-file.c:1288
 #, c-format
 msgid "unable to parse %s header with --allow-unknown-type"
 msgstr "kan inte tolka %s-huvud med --allow-unknown-type"
 
-#: sha1-file.c:1231
+#: sha1-file.c:1291
 #, c-format
 msgid "unable to parse %s header"
 msgstr "kan inte tolka %s-huvud"
 
-#: sha1-file.c:1422
+#: sha1-file.c:1481
 #, c-format
 msgid "failed to read object %s"
 msgstr "misslyckades läsa objektet %s"
 
-#: sha1-file.c:1426
+#: sha1-file.c:1485
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "ersättningen %s hittades inte för %s"
 
-#: sha1-file.c:1430
+#: sha1-file.c:1489
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "löst objekt %s (lagrat i %s) är trasigt"
 
-#: sha1-file.c:1434
+#: sha1-file.c:1493
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "packat objekt %s (lagrat i %s) är trasigt"
 
-#: sha1-file.c:1536
+#: sha1-file.c:1595
 #, c-format
-msgid "unable to write sha1 filename %s"
-msgstr "kan inte skriva sha1-filnamn %s"
+msgid "unable to write file %s"
+msgstr "kunde inte skriva filen %s"
 
-#: sha1-file.c:1543
+#: sha1-file.c:1602
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "kan inte sätta behörigheten till \"%s\""
 
-#: sha1-file.c:1550
+#: sha1-file.c:1609
 msgid "file write error"
 msgstr "fel vid skrivning av fil"
 
-#: sha1-file.c:1569
-msgid "error when closing sha1 file"
-msgstr "fel vid stängning av sha1-fil"
+#: sha1-file.c:1628
+msgid "error when closing loose object file"
+msgstr "fel vid stängning av fil för löst objekt"
 
-#: sha1-file.c:1635
+#: sha1-file.c:1693
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "otillräcklig behörighet för att lägga till objekt till arkivdatabasen %s"
 
-#: sha1-file.c:1637
+#: sha1-file.c:1695
 msgid "unable to create temporary file"
 msgstr "kan inte skapa temporär fil"
 
-#: sha1-file.c:1661
-msgid "unable to write sha1 file"
-msgstr "kan inte skriva sha1-filen"
+#: sha1-file.c:1719
+msgid "unable to write loose object file"
+msgstr "kunde inte skriva fil för löst objekt"
 
-#: sha1-file.c:1667
+#: sha1-file.c:1725
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "kan inte utföra \"deflate\" på nytt objekt %s (%d)"
 
-#: sha1-file.c:1671
+#: sha1-file.c:1729
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "\"deflateend\" på objektet %s misslyckades (%d)"
 
-#: sha1-file.c:1675
+#: sha1-file.c:1733
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "förvirrad av instabil objektkälldata för %s"
 
-#: sha1-file.c:1685 builtin/pack-objects.c:918
+#: sha1-file.c:1743 builtin/pack-objects.c:919
 #, c-format
 msgid "failed utime() on %s"
 msgstr "\"utime()\" misslyckades på %s"
 
-#: sha1-file.c:1760
+#: sha1-file.c:1818
 #, c-format
-msgid "cannot read sha1_file for %s"
-msgstr "kan inte läsa sha1_file för %s"
+msgid "cannot read object for %s"
+msgstr "kan inte läsa objekt för %s"
 
-#: sha1-file.c:1805
+#: sha1-file.c:1858
 msgid "corrupt commit"
 msgstr "trasik incheckning"
 
-#: sha1-file.c:1813
+#: sha1-file.c:1866
 msgid "corrupt tag"
 msgstr "trasig tagg"
 
-#: sha1-file.c:1912
+#: sha1-file.c:1965
 #, c-format
 msgid "read error while indexing %s"
 msgstr "läsfel vid indexering av %s"
 
-#: sha1-file.c:1915
+#: sha1-file.c:1968
 #, c-format
 msgid "short read while indexing %s"
 msgstr "för lite lästes vid indexering av %s"
 
-#: sha1-file.c:1988 sha1-file.c:1997
+#: sha1-file.c:2041 sha1-file.c:2050
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: misslyckades lägga in i databasen"
 
-#: sha1-file.c:2003
+#: sha1-file.c:2056
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: filtypen stöds ej"
 
-#: sha1-file.c:2027
+#: sha1-file.c:2080
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s är inte ett giltigt objekt"
 
-#: sha1-file.c:2029
+#: sha1-file.c:2082
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s är inte ett giltigt \"%s\"-objekt"
 
-#: sha1-file.c:2056 builtin/index-pack.c:154
+#: sha1-file.c:2109 builtin/index-pack.c:154
 #, c-format
 msgid "unable to open %s"
 msgstr "kan inte öppna %s"
 
-#: sha1-file.c:2226 sha1-file.c:2278
+#: sha1-file.c:2299 sha1-file.c:2351
 #, c-format
-msgid "sha1 mismatch for %s (expected %s)"
-msgstr "sha1 stämmer inte för %s (förväntade %s)"
+msgid "hash mismatch for %s (expected %s)"
+msgstr "hash stämmer inte för %s (förväntade %s)"
 
-#: sha1-file.c:2250
+#: sha1-file.c:2323
 #, c-format
 msgid "unable to mmap %s"
 msgstr "kan inte utföra \"mmap\" för %s"
 
-#: sha1-file.c:2255
+#: sha1-file.c:2328
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "kan inte packa upp huvud för %s"
 
-#: sha1-file.c:2261
+#: sha1-file.c:2334
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "kan inte tolka huvud för %s"
 
-#: sha1-file.c:2272
+#: sha1-file.c:2345
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "kan inte tolka innehåll i %s"
 
-#: sha1-name.c:476
+#: sha1-name.c:448
 #, c-format
 msgid "short SHA1 %s is ambiguous"
 msgstr "kort SHA1 %s är tvetydig"
 
-#: sha1-name.c:487
+#: sha1-name.c:459
 msgid "The candidates are:"
 msgstr "Kandidaterna är:"
 
-#: sha1-name.c:770
+#: sha1-name.c:742
 msgid ""
 "Git normally never creates a ref that ends with 40 hex characters\n"
 "because it will be ignored when you just specify 40-hex. These refs\n"
@@ -5873,71 +6292,81 @@ msgstr ""
 "Undersök referenserna och ta kanske bort dem. Stäng av meddelandet\n"
 "genom att köra \"git config advice.objectNameWarning false\""
 
-#: submodule.c:116 submodule.c:145
+#: submodule.c:114 submodule.c:143
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
 msgstr ""
 "Kan inte ändra .gitmodules-fil som inte slagits ihop, lös "
 "sammanslagningskonflikter först"
 
-#: submodule.c:120 submodule.c:149
+#: submodule.c:118 submodule.c:147
 #, c-format
 msgid "Could not find section in .gitmodules where path=%s"
 msgstr "Hittade inte någon sektion i .gitmodules där sökväg=%s"
 
-#: submodule.c:156
+#: submodule.c:154
 #, c-format
 msgid "Could not remove .gitmodules entry for %s"
 msgstr "Kunde inte ta bort .gitmodules-posten för %s"
 
-#: submodule.c:167
+#: submodule.c:165
 msgid "staging updated .gitmodules failed"
 msgstr "misslyckades köa uppdaterad .gitmodules"
 
-#: submodule.c:329
+#: submodule.c:327
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "i ej utcheckad undermodul \"%s\""
 
-#: submodule.c:360
+#: submodule.c:358
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Sökvägsangivelsen \"%s\" är i undermodulen \"%.*s\""
 
-#: submodule.c:857
+#: submodule.c:906
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "undermodulposten \"%s\" (%s) är en %s, inte en incheckning"
 
-#: submodule.c:1097 builtin/branch.c:656 builtin/submodule--helper.c:1985
+#: submodule.c:1143 builtin/branch.c:656 builtin/submodule--helper.c:1989
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Misslyckades slå upp HEAD som giltig referens."
 
-#: submodule.c:1404
+#: submodule.c:1477
+#, c-format
+msgid "Could not access submodule '%s'"
+msgstr "kunde inte komma åt undermodulen \"%s\""
+
+#: submodule.c:1639
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "\"%s\" känns inte igen som ett git-arkiv"
 
-#: submodule.c:1542
+#: submodule.c:1777
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "kunde inte starta \"git status\" i undermodulen \"%s\""
 
-#: submodule.c:1555
+#: submodule.c:1790
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "kunde inte köra \"git status\" i undermodulen \"%s\""
 
-#: submodule.c:1648
+#: submodule.c:1805
+#, c-format
+msgid "Could not unset core.worktree setting in submodule '%s'"
+msgstr "Kunde inte ta bort inställningen core.worktree i undermodulen \"%s\""
+
+#: submodule.c:1895
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "undermodulen \"%s\" har ett smutsigt index"
 
-#: submodule.c:1700
+#: submodule.c:1947
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Undermoduler \"%s\" kunde inte uppdateras."
 
-#: submodule.c:1747
+#: submodule.c:1996
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -5945,12 +6374,12 @@ msgstr ""
 "relocate_gitdir för undermodulen \"%s\", som har mer än en arbetskatalog, "
 "stöds ej"
 
-#: submodule.c:1759 submodule.c:1815
+#: submodule.c:2008 submodule.c:2064
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "kunde inte slå upp namnet för undermodulen \"%s\""
 
-#: submodule.c:1766
+#: submodule.c:2015
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -5961,16 +6390,16 @@ msgstr ""
 "\"%s\" till\n"
 "\"%s\"\n"
 
-#: submodule.c:1850
+#: submodule.c:2099
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "kunde inte rekursera in i undermodulen \"%s\""
 
-#: submodule.c:1894
+#: submodule.c:2143
 msgid "could not start ls-files in .."
 msgstr "kunde inte starta ls-files i .."
 
-#: submodule.c:1933
+#: submodule.c:2182
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree returnerade en oväntad returkod %d"
@@ -6029,7 +6458,7 @@ msgstr "kunde inte läsa indatafilen \"%s\""
 msgid "could not read from stdin"
 msgstr "kunde inte läsa från standard in"
 
-#: trailer.c:1011 builtin/am.c:47
+#: trailer.c:1011 wrapper.c:701
 #, c-format
 msgid "could not stat %s"
 msgstr "kunde inte ta status på %s"
@@ -6068,29 +6497,29 @@ msgstr "kunde inte läsa paketet (bundlen) \"%s\""
 msgid "transport: invalid depth option '%s'"
 msgstr "transport: ogiltig flagga för depth: ”%s”"
 
-#: transport.c:616
+#: transport.c:617
 msgid "could not parse transport.color.* config"
 msgstr "kunde inte tolka inställningen för transport.color.*"
 
-#: transport.c:689
+#: transport.c:690
 msgid "support for protocol v2 not implemented yet"
 msgstr "stöd för protokoll v2 ännu ej implementerat"
 
-#: transport.c:816
+#: transport.c:817
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "okänt värde för inställningen \"%s\": %s"
 
-#: transport.c:882
+#: transport.c:883
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "transporten \"%s\" tillåts inte"
 
-#: transport.c:936
+#: transport.c:937
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync stöds inte längre"
 
-#: transport.c:1031
+#: transport.c:1032
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -6099,7 +6528,7 @@ msgstr ""
 "Följande undermodulsökvägar innehåller ändringar som\n"
 "inte kan hittas av fjärrarna:\n"
 
-#: transport.c:1035
+#: transport.c:1036
 #, c-format
 msgid ""
 "\n"
@@ -6126,19 +6555,19 @@ msgstr ""
 "för att sända dem till fjärren.\n"
 "\n"
 
-#: transport.c:1043
+#: transport.c:1044
 msgid "Aborting."
 msgstr "Avbryter."
 
-#: transport.c:1182
+#: transport.c:1184
 msgid "failed to push all needed submodules"
 msgstr "kunde inte sända alla nödvändiga undermoduler"
 
-#: transport.c:1315 transport-helper.c:643
+#: transport.c:1317 transport-helper.c:643
 msgid "operation not supported by protocol"
 msgstr "funktionen stöds inte av protokollet"
 
-#: transport.c:1419
+#: transport.c:1421
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "felaktig rad vid tolkning av alternativa referenser: %s"
@@ -6189,7 +6618,7 @@ msgstr "kunde inte köra fast-import"
 msgid "error while running fast-import"
 msgstr "fel när fast-import kördes"
 
-#: transport-helper.c:531 transport-helper.c:1091
+#: transport-helper.c:531 transport-helper.c:1097
 #, c-format
 msgid "could not read ref %s"
 msgstr "kunde inte läsa referensen %s"
@@ -6212,54 +6641,54 @@ msgstr "felaktig sökväg till fjärrtjänst"
 msgid "can't connect to subservice %s"
 msgstr "kan inte ansluta till undertjänsten %s"
 
-#: transport-helper.c:713
+#: transport-helper.c:718
 #, c-format
 msgid "expected ok/error, helper said '%s'"
 msgstr "förväntade ok/error, hjälpprogrammet svarade \"%s\""
 
-#: transport-helper.c:766
+#: transport-helper.c:771
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "hjälparen returnerade oväntad status %s"
 
-#: transport-helper.c:827
+#: transport-helper.c:832
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "hjälparen %s stöder inte dry-run"
 
-#: transport-helper.c:830
+#: transport-helper.c:835
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "hjälparen %s stöder inte --signed"
 
-#: transport-helper.c:833
+#: transport-helper.c:838
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "hjälparen %s stöder inte --signed=if-asked"
 
-#: transport-helper.c:840
+#: transport-helper.c:845
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "hjälparen %s stöder inte \"push-option\""
 
-#: transport-helper.c:932
+#: transport-helper.c:937
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr "fjärrhjälparen stöder inte push; referensspecifikation krävs"
 
-#: transport-helper.c:937
+#: transport-helper.c:942
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "hjälparen %s stöder inte \"force\""
 
-#: transport-helper.c:984
+#: transport-helper.c:989
 msgid "couldn't run fast-export"
 msgstr "kunde inte köra fast-export"
 
-#: transport-helper.c:989
+#: transport-helper.c:994
 msgid "error while running fast-export"
 msgstr "fel vid körning av fast-export"
 
-#: transport-helper.c:1014
+#: transport-helper.c:1019
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -6268,47 +6697,47 @@ msgstr ""
 "Inga gemensamma referenser och inga angavs; gör inget.\n"
 "Du kanske borde ange en gren såsom \"master\".\n"
 
-#: transport-helper.c:1077
+#: transport-helper.c:1083
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "felformat svar i referenslistan: %s"
 
-#: transport-helper.c:1231
+#: transport-helper.c:1236
 #, c-format
 msgid "read(%s) failed"
 msgstr "läs(%s) misslyckades"
 
-#: transport-helper.c:1258
+#: transport-helper.c:1263
 #, c-format
 msgid "write(%s) failed"
 msgstr "skriv(%s) misslyckades"
 
-#: transport-helper.c:1307
+#: transport-helper.c:1312
 #, c-format
 msgid "%s thread failed"
 msgstr "%s-tråden misslyckades"
 
-#: transport-helper.c:1311
+#: transport-helper.c:1316
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "%s-tråden misslyckades ansluta: %s"
 
-#: transport-helper.c:1330 transport-helper.c:1334
+#: transport-helper.c:1335 transport-helper.c:1339
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "kan inte starta tråd för kopiering av data: %s"
 
-#: transport-helper.c:1371
+#: transport-helper.c:1376
 #, c-format
 msgid "%s process failed to wait"
 msgstr "processen %s misslyckades vänta"
 
-#: transport-helper.c:1375
+#: transport-helper.c:1380
 #, c-format
 msgid "%s process failed"
 msgstr "processen %s misslyckades"
 
-#: transport-helper.c:1393 transport-helper.c:1402
+#: transport-helper.c:1398 transport-helper.c:1407
 msgid "can't start thread for copying data"
 msgstr "kan inte skapa tråd för kopiering av data"
 
@@ -6324,11 +6753,11 @@ msgstr "felformat läge i trädpost"
 msgid "empty filename in tree entry"
 msgstr "tomt filnamn i trädpost"
 
-#: tree-walk.c:115
+#: tree-walk.c:116
 msgid "too-short tree file"
 msgstr "trädfil för kort"
 
-#: unpack-trees.c:112
+#: unpack-trees.c:111
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -6337,7 +6766,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av utcheckning:\n"
 "%%sChecka in dina ändringar eller använd \"stash\" innan du byter gren."
 
-#: unpack-trees.c:114
+#: unpack-trees.c:113
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -6346,7 +6775,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av utcheckning:\n"
 "%%s"
 
-#: unpack-trees.c:117
+#: unpack-trees.c:116
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -6356,7 +6785,7 @@ msgstr ""
 "sammanslagning:\n"
 "%%sChecka in dina ändringar eller använd \"stash\" innan du byter gren."
 
-#: unpack-trees.c:119
+#: unpack-trees.c:118
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -6366,7 +6795,7 @@ msgstr ""
 "sammanslagning:\n"
 "%%s"
 
-#: unpack-trees.c:122
+#: unpack-trees.c:121
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -6375,7 +6804,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av \"%s\":\n"
 "%%sChecka in dina ändringar eller använd \"stash\" innan du \"%s\"."
 
-#: unpack-trees.c:124
+#: unpack-trees.c:123
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -6384,7 +6813,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av \"%s\":\n"
 "%%s"
 
-#: unpack-trees.c:129
+#: unpack-trees.c:128
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
@@ -6394,7 +6823,7 @@ msgstr ""
 "dem:\n"
 "%s"
 
-#: unpack-trees.c:133
+#: unpack-trees.c:132
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -6403,7 +6832,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av utcheckningen:\n"
 "%%sFlytta eller ta bort dem innan du byter gren."
 
-#: unpack-trees.c:135
+#: unpack-trees.c:134
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -6412,7 +6841,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av utcheckningen:\n"
 "%%s"
 
-#: unpack-trees.c:138
+#: unpack-trees.c:137
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -6422,7 +6851,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%sFlytta eller ta bort dem innan du slår samman."
 
-#: unpack-trees.c:140
+#: unpack-trees.c:139
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -6432,7 +6861,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%s"
 
-#: unpack-trees.c:143
+#: unpack-trees.c:142
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -6441,7 +6870,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av \"%s\":\n"
 "%%sFlytta eller ta bort dem innan du \"%s\"."
 
-#: unpack-trees.c:145
+#: unpack-trees.c:144
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -6450,7 +6879,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av \"%s\":\n"
 "%%s"
 
-#: unpack-trees.c:151
+#: unpack-trees.c:150
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -6461,7 +6890,7 @@ msgstr ""
 "utcheckningen:\n"
 "%%sFlytta eller ta bort dem innan du byter gren."
 
-#: unpack-trees.c:153
+#: unpack-trees.c:152
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -6472,7 +6901,7 @@ msgstr ""
 "utcheckningen:\n"
 "%%s"
 
-#: unpack-trees.c:156
+#: unpack-trees.c:155
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -6482,7 +6911,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%sFlytta eller ta bort dem innan du byter gren."
 
-#: unpack-trees.c:158
+#: unpack-trees.c:157
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -6492,7 +6921,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%s"
 
-#: unpack-trees.c:161
+#: unpack-trees.c:160
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -6501,7 +6930,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle skrivas över av \"%s\":\n"
 "%%sFlytta eller ta bort dem innan du \"%s\"."
 
-#: unpack-trees.c:163
+#: unpack-trees.c:162
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -6510,12 +6939,12 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle skrivas över av \"%s\":\n"
 "%%s"
 
-#: unpack-trees.c:171
+#: unpack-trees.c:170
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
 msgstr "Posten \"%s\" överlappar \"%s\". Kan inte binda."
 
-#: unpack-trees.c:174
+#: unpack-trees.c:173
 #, c-format
 msgid ""
 "Cannot update sparse checkout: the following entries are not up to date:\n"
@@ -6524,7 +6953,7 @@ msgstr ""
 "Kan inte uppdatera gles utcheckning: följande poster är inte à jour:\n"
 "%s"
 
-#: unpack-trees.c:176
+#: unpack-trees.c:175
 #, c-format
 msgid ""
 "The following working tree files would be overwritten by sparse checkout "
@@ -6535,7 +6964,7 @@ msgstr ""
 "utcheckning:\n"
 "%s"
 
-#: unpack-trees.c:178
+#: unpack-trees.c:177
 #, c-format
 msgid ""
 "The following working tree files would be removed by sparse checkout "
@@ -6546,7 +6975,7 @@ msgstr ""
 "utcheckning:\n"
 "%s"
 
-#: unpack-trees.c:180
+#: unpack-trees.c:179
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
@@ -6555,16 +6984,16 @@ msgstr ""
 "Kan inte uppdatera undermodul:\n"
 "%s"
 
-#: unpack-trees.c:254
+#: unpack-trees.c:253
 #, c-format
 msgid "Aborting\n"
 msgstr "Avbryter\n"
 
-#: unpack-trees.c:336
+#: unpack-trees.c:335
 msgid "Checking out files"
 msgstr "Checkar ut filer"
 
-#: unpack-trees.c:368
+#: unpack-trees.c:367
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
@@ -6603,7 +7032,7 @@ msgstr "felaktigt portnummer"
 msgid "invalid '..' path segment"
 msgstr "felaktigt \"..\"-sökvägssegment"
 
-#: worktree.c:249 builtin/am.c:2100
+#: worktree.c:249 builtin/am.c:2094
 #, c-format
 msgid "failed to read '%s'"
 msgstr "misslyckades läsa \"%s\""
@@ -6647,155 +7076,155 @@ msgstr "kan inte komma åt \"%s\""
 msgid "unable to get current working directory"
 msgstr "kan inte hämta aktuell arbetskatalog"
 
-#: wt-status.c:154
+#: wt-status.c:155
 msgid "Unmerged paths:"
 msgstr "Ej sammanslagna sökvägar:"
 
-#: wt-status.c:181 wt-status.c:208
+#: wt-status.c:182 wt-status.c:209
 #, c-format
 msgid "  (use \"git reset %s <file>...\" to unstage)"
 msgstr "  (använd \"git reset %s <fil>...\" för att ta bort från kö)"
 
-#: wt-status.c:183 wt-status.c:210
+#: wt-status.c:184 wt-status.c:211
 msgid "  (use \"git rm --cached <file>...\" to unstage)"
 msgstr "  (använd \"git rm --cached <fil>...\" för att ta bort från kö)"
 
-#: wt-status.c:187
+#: wt-status.c:188
 msgid "  (use \"git add <file>...\" to mark resolution)"
 msgstr "  (använd \"git add <fil>...\" för att ange lösning)"
 
-#: wt-status.c:189 wt-status.c:193
+#: wt-status.c:190 wt-status.c:194
 msgid "  (use \"git add/rm <file>...\" as appropriate to mark resolution)"
 msgstr "  (använd \"git add/rm <fil>...\" som lämpligt för att ange lösning)"
 
-#: wt-status.c:191
+#: wt-status.c:192
 msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr "  (använd \"git rm <fil>...\" för att ange lösning)"
 
-#: wt-status.c:202 wt-status.c:1042
+#: wt-status.c:203 wt-status.c:1046
 msgid "Changes to be committed:"
 msgstr "Ändringar att checka in:"
 
-#: wt-status.c:220 wt-status.c:1051
+#: wt-status.c:221 wt-status.c:1055
 msgid "Changes not staged for commit:"
 msgstr "Ändringar ej i incheckningskön:"
 
-#: wt-status.c:224
+#: wt-status.c:225
 msgid "  (use \"git add <file>...\" to update what will be committed)"
 msgstr ""
 "  (använd \"git add <fil>...\" för att uppdatera vad som skall checkas in)"
 
-#: wt-status.c:226
+#: wt-status.c:227
 msgid "  (use \"git add/rm <file>...\" to update what will be committed)"
 msgstr ""
 "  (använd \"git add/rm <fil>...\" för att uppdatera vad som skall checkas in)"
 
-#: wt-status.c:227
+#: wt-status.c:228
 msgid ""
 "  (use \"git checkout -- <file>...\" to discard changes in working directory)"
 msgstr ""
 "  (använd \"git checkout -- <fil>...\" för att förkasta ändringar i "
 "arbetskatalogen)"
 
-#: wt-status.c:229
+#: wt-status.c:230
 msgid "  (commit or discard the untracked or modified content in submodules)"
 msgstr ""
 "  (checka in eller förkasta ospårat eller ändrat innehåll i undermoduler)"
 
-#: wt-status.c:241
+#: wt-status.c:242
 #, c-format
 msgid "  (use \"git %s <file>...\" to include in what will be committed)"
 msgstr ""
 "  (använd \"git %s <fil>...\" för att ta med i det som skall checkas in)"
 
-#: wt-status.c:256
+#: wt-status.c:257
 msgid "both deleted:"
 msgstr "borttaget av bägge:"
 
-#: wt-status.c:258
+#: wt-status.c:259
 msgid "added by us:"
 msgstr "tillagt av oss:"
 
-#: wt-status.c:260
+#: wt-status.c:261
 msgid "deleted by them:"
 msgstr "borttaget av dem:"
 
-#: wt-status.c:262
+#: wt-status.c:263
 msgid "added by them:"
 msgstr "tillagt av dem:"
 
-#: wt-status.c:264
+#: wt-status.c:265
 msgid "deleted by us:"
 msgstr "borttaget av oss:"
 
-#: wt-status.c:266
+#: wt-status.c:267
 msgid "both added:"
 msgstr "tillagt av bägge:"
 
-#: wt-status.c:268
+#: wt-status.c:269
 msgid "both modified:"
 msgstr "ändrat av bägge:"
 
-#: wt-status.c:278
+#: wt-status.c:279
 msgid "new file:"
 msgstr "ny fil:"
 
-#: wt-status.c:280
+#: wt-status.c:281
 msgid "copied:"
 msgstr "kopierad:"
 
-#: wt-status.c:282
+#: wt-status.c:283
 msgid "deleted:"
 msgstr "borttagen:"
 
-#: wt-status.c:284
+#: wt-status.c:285
 msgid "modified:"
 msgstr "ändrad:"
 
-#: wt-status.c:286
+#: wt-status.c:287
 msgid "renamed:"
 msgstr "namnbytt:"
 
-#: wt-status.c:288
+#: wt-status.c:289
 msgid "typechange:"
 msgstr "typbyte:"
 
-#: wt-status.c:290
+#: wt-status.c:291
 msgid "unknown:"
 msgstr "okänd:"
 
-#: wt-status.c:292
+#: wt-status.c:293
 msgid "unmerged:"
 msgstr "osammanslagen:"
 
-#: wt-status.c:372
+#: wt-status.c:373
 msgid "new commits, "
 msgstr "nya incheckningar, "
 
-#: wt-status.c:374
+#: wt-status.c:375
 msgid "modified content, "
 msgstr "ändrat innehåll, "
 
-#: wt-status.c:376
+#: wt-status.c:377
 msgid "untracked content, "
 msgstr "ospårat innehåll, "
 
-#: wt-status.c:880
+#: wt-status.c:884
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Stashen innehåller just nu %d post"
 msgstr[1] "Stashen innehåller just nu %d poster"
 
-#: wt-status.c:912
+#: wt-status.c:916
 msgid "Submodules changed but not updated:"
 msgstr "Undermoduler ändrade men inte uppdaterade:"
 
-#: wt-status.c:914
+#: wt-status.c:918
 msgid "Submodule changes to be committed:"
 msgstr "Undermodulers ändringar att checka in:"
 
-#: wt-status.c:996
+#: wt-status.c:1000
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -6803,107 +7232,107 @@ msgstr ""
 "Raden ovan får inte ändras eller tas bort.\n"
 "Allt under den kommer tas bort."
 
-#: wt-status.c:1097
+#: wt-status.c:1101
 msgid "You have unmerged paths."
 msgstr "Du har ej sammanslagna sökvägar."
 
-#: wt-status.c:1100
+#: wt-status.c:1104
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (rätta konflikter och kör \"git commit\")"
 
-#: wt-status.c:1102
+#: wt-status.c:1106
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (använd \"git merge --abort\" för att avbryta sammanslagningen)"
 
-#: wt-status.c:1106
+#: wt-status.c:1110
 msgid "All conflicts fixed but you are still merging."
 msgstr "Alla konflikter har rättats men du är fortfarande i en sammanslagning."
 
-#: wt-status.c:1109
+#: wt-status.c:1113
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (använd \"git commit\" för att slutföra sammanslagningen)"
 
-#: wt-status.c:1118
+#: wt-status.c:1122
 msgid "You are in the middle of an am session."
 msgstr "Du är i mitten av en körning av \"git am\"."
 
-#: wt-status.c:1121
+#: wt-status.c:1125
 msgid "The current patch is empty."
 msgstr "Aktuell patch är tom."
 
-#: wt-status.c:1125
+#: wt-status.c:1129
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git am --continue\")"
 
-#: wt-status.c:1127
+#: wt-status.c:1131
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (använd \"git am --skip\" för att hoppa över patchen)"
 
-#: wt-status.c:1129
+#: wt-status.c:1133
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr "  (använd \"git am --abort\" för att återställa ursprungsgrenen)"
 
-#: wt-status.c:1260
+#: wt-status.c:1264
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo saknas."
 
-#: wt-status.c:1262
+#: wt-status.c:1266
 msgid "No commands done."
 msgstr "Inga kommandon utförda."
 
-#: wt-status.c:1265
+#: wt-status.c:1269
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Sista kommandot utfört (%d kommando utfört):"
 msgstr[1] "Sista kommandot utfört (%d kommandon utfört):"
 
-#: wt-status.c:1276
+#: wt-status.c:1280
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (se fler i filen %s)"
 
-#: wt-status.c:1281
+#: wt-status.c:1285
 msgid "No commands remaining."
 msgstr "Inga kommandon återstår."
 
-#: wt-status.c:1284
+#: wt-status.c:1288
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Nästa kommando att utföra (%d kommando återstår):"
 msgstr[1] "Följande kommandon att utföra (%d kommandon återstår):"
 
-#: wt-status.c:1292
+#: wt-status.c:1296
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (använd \"git rebase --edit-todo\" för att visa och redigera)"
 
-#: wt-status.c:1304
+#: wt-status.c:1308
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Du håller på att ombasera grenen \"%s\" ovanpå \"%s\"."
 
-#: wt-status.c:1309
+#: wt-status.c:1313
 msgid "You are currently rebasing."
 msgstr "Du håller på med en ombasering."
 
-#: wt-status.c:1322
+#: wt-status.c:1326
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git rebase --continue\")"
 
-#: wt-status.c:1324
+#: wt-status.c:1328
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (använd \"git rebase --skip\" för att hoppa över patchen)"
 
-#: wt-status.c:1326
+#: wt-status.c:1330
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr "  (använd \"git rebase --abort\" för att checka ut ursprungsgrenen)"
 
-#: wt-status.c:1333
+#: wt-status.c:1337
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (alla konflikter rättade: kör \"git rebase --continue\")"
 
-#: wt-status.c:1337
+#: wt-status.c:1341
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -6911,126 +7340,126 @@ msgstr ""
 "Du håller på att dela upp en incheckning medan du ombaserar grenen \"%s\" "
 "ovanpå \"%s\"."
 
-#: wt-status.c:1342
+#: wt-status.c:1346
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Du håller på att dela upp en incheckning i en ombasering."
 
-#: wt-status.c:1345
+#: wt-status.c:1349
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr "  (Så fort din arbetskatalog är ren, kör \"git rebase --continue\")"
 
-#: wt-status.c:1349
+#: wt-status.c:1353
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Du håller på att redigera en incheckning medan du ombaserar grenen \"%s\" "
 "ovanpå \"%s\"."
 
-#: wt-status.c:1354
+#: wt-status.c:1358
 msgid "You are currently editing a commit during a rebase."
 msgstr "Du håller på att redigera en incheckning under en ombasering."
 
-#: wt-status.c:1357
+#: wt-status.c:1361
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr ""
 "  (använd \"git commit --amend\" för att lägga till på aktuell incheckning)"
 
-#: wt-status.c:1359
+#: wt-status.c:1363
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr "  (använd \"git rebase --continue\" när du är nöjd med dina ändringar)"
 
-#: wt-status.c:1368
+#: wt-status.c:1372
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Du håller på med en \"cherry-pick\" av incheckningen %s."
 
-#: wt-status.c:1373
+#: wt-status.c:1377
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git cherry-pick --continue\")"
 
-#: wt-status.c:1376
+#: wt-status.c:1380
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr "  (alla konflikter rättade: kör \"git cherry-pick --continue\")"
 
-#: wt-status.c:1378
+#: wt-status.c:1382
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (använd \"git cherry-pick --abort\" för att avbryta \"cherry-pick\"-"
 "operationen)"
 
-#: wt-status.c:1386
+#: wt-status.c:1390
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Du håller på med att ångra incheckningen %s."
 
-#: wt-status.c:1391
+#: wt-status.c:1395
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git revert --continue\")"
 
-#: wt-status.c:1394
+#: wt-status.c:1398
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (alla konflikter rättade: kör \"git revert --continue\")"
 
-#: wt-status.c:1396
+#: wt-status.c:1400
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr "  (använd \"git revert --abort\" för att avbryta ångrandet)"
 
-#: wt-status.c:1406
+#: wt-status.c:1410
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Du håller på med en \"bisect\", startad från grenen \"%s\"."
 
-#: wt-status.c:1410
+#: wt-status.c:1414
 msgid "You are currently bisecting."
 msgstr "Du håller på med en \"bisect\"."
 
-#: wt-status.c:1413
+#: wt-status.c:1417
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr ""
 "  (använd \"git bisect reset\" för att komma tillbaka till ursprungsgrenen)"
 
-#: wt-status.c:1611
+#: wt-status.c:1617
 msgid "On branch "
 msgstr "På grenen "
 
-#: wt-status.c:1618
+#: wt-status.c:1624
 msgid "interactive rebase in progress; onto "
 msgstr "interaktiv ombasering pågår; ovanpå "
 
-#: wt-status.c:1620
+#: wt-status.c:1626
 msgid "rebase in progress; onto "
 msgstr "ombasering pågår; ovanpå "
 
-#: wt-status.c:1625
+#: wt-status.c:1631
 msgid "HEAD detached at "
 msgstr "HEAD frånkopplad vid "
 
-#: wt-status.c:1627
+#: wt-status.c:1633
 msgid "HEAD detached from "
 msgstr "HEAD frånkopplad från "
 
-#: wt-status.c:1630
+#: wt-status.c:1636
 msgid "Not currently on any branch."
 msgstr "Inte på någon gren för närvarande."
 
-#: wt-status.c:1647
+#: wt-status.c:1653
 msgid "Initial commit"
 msgstr "Första incheckning"
 
-#: wt-status.c:1648
+#: wt-status.c:1654
 msgid "No commits yet"
 msgstr "Inga incheckningar ännu"
 
-#: wt-status.c:1662
+#: wt-status.c:1668
 msgid "Untracked files"
 msgstr "Ospårade filer"
 
-#: wt-status.c:1664
+#: wt-status.c:1670
 msgid "Ignored files"
 msgstr "Ignorerade filer"
 
-#: wt-status.c:1668
+#: wt-status.c:1674
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -7042,32 +7471,32 @@ msgstr ""
 "lägga till nya filer själv (se \"git help status\")."
 
 # %s är nästa sträng eller tom.
-#: wt-status.c:1674
+#: wt-status.c:1680
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Ospårade filer visas ej%s"
 
-#: wt-status.c:1676
+#: wt-status.c:1682
 msgid " (use -u option to show untracked files)"
 msgstr " (använd flaggan -u för att visa ospårade filer)"
 
-#: wt-status.c:1682
+#: wt-status.c:1688
 msgid "No changes"
 msgstr "Inga ändringar"
 
-#: wt-status.c:1687
+#: wt-status.c:1693
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "inga ändringar att checka in (använd \"git add\" och/eller \"git commit -a"
 "\")\n"
 
-#: wt-status.c:1690
+#: wt-status.c:1696
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "inga ändringar att checka in\n"
 
-#: wt-status.c:1693
+#: wt-status.c:1699
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -7076,186 +7505,186 @@ msgstr ""
 "inget köat för incheckning, men ospårade filer finns (spåra med \"git add"
 "\")\n"
 
-#: wt-status.c:1696
+#: wt-status.c:1702
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "inget köat för incheckning, men ospårade filer finns\n"
 
-#: wt-status.c:1699
+#: wt-status.c:1705
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr "inget att checka in (skapa/kopiera filer och spåra med \"git add\")\n"
 
-#: wt-status.c:1702 wt-status.c:1707
+#: wt-status.c:1708 wt-status.c:1713
 #, c-format
 msgid "nothing to commit\n"
 msgstr "inget att checka in\n"
 
-#: wt-status.c:1705
+#: wt-status.c:1711
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr "inget att checka in (använd -u för att visa ospårade filer)\n"
 
-#: wt-status.c:1709
+#: wt-status.c:1715
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "inget att checka in, arbetskatalogen ren\n"
 
-#: wt-status.c:1822
+#: wt-status.c:1828
 msgid "No commits yet on "
 msgstr "Inga incheckningar ännu på "
 
-#: wt-status.c:1826
+#: wt-status.c:1832
 msgid "HEAD (no branch)"
 msgstr "HEAD (ingen gren)"
 
-#: wt-status.c:1857
+#: wt-status.c:1863
 msgid "different"
 msgstr "olika"
 
-#: wt-status.c:1859 wt-status.c:1867
+#: wt-status.c:1865 wt-status.c:1873
 msgid "behind "
 msgstr "efter "
 
-#: wt-status.c:1862 wt-status.c:1865
+#: wt-status.c:1868 wt-status.c:1871
 msgid "ahead "
 msgstr "före "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2374
+#: wt-status.c:2386
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "kan inte %s: Du har oköade ändringar."
 
-#: wt-status.c:2380
+#: wt-status.c:2392
 msgid "additionally, your index contains uncommitted changes."
 msgstr "dessutom innehåller dit index ändringar som inte har checkats in."
 
-#: wt-status.c:2382
+#: wt-status.c:2394
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "kan inte %s: Ditt index innehåller ändringar som inte checkats in."
 
-#: builtin/add.c:24
+#: builtin/add.c:25
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<flaggor>] [--] <sökväg>..."
 
-#: builtin/add.c:83
+#: builtin/add.c:84
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "diff-status %c förväntades inte"
 
-#: builtin/add.c:88 builtin/commit.c:284
+#: builtin/add.c:89 builtin/commit.c:285
 msgid "updating files failed"
 msgstr "misslyckades uppdatera filer"
 
-#: builtin/add.c:98
+#: builtin/add.c:99
 #, c-format
 msgid "remove '%s'\n"
 msgstr "ta bort \"%s\"\n"
 
-#: builtin/add.c:173
+#: builtin/add.c:174
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Oköade ändringar efter att ha uppdaterat indexet:"
 
-#: builtin/add.c:233 builtin/rev-parse.c:895
+#: builtin/add.c:234 builtin/rev-parse.c:896
 msgid "Could not read the index"
 msgstr "Kunde inte läsa indexet"
 
-#: builtin/add.c:244
+#: builtin/add.c:245
 #, c-format
 msgid "Could not open '%s' for writing."
 msgstr "Kunde inte öppna \"%s\" för skrivning."
 
-#: builtin/add.c:248
+#: builtin/add.c:249
 msgid "Could not write patch"
 msgstr "Kunde inte skriva patch"
 
-#: builtin/add.c:251
+#: builtin/add.c:252
 msgid "editing patch failed"
 msgstr "redigering av patch misslyckades"
 
-#: builtin/add.c:254
+#: builtin/add.c:255
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Kunde inte ta status på \"%s\""
 
-#: builtin/add.c:256
+#: builtin/add.c:257
 msgid "Empty patch. Aborted."
 msgstr "Tom patch. Avbryter."
 
-#: builtin/add.c:261
+#: builtin/add.c:262
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Kunde inte tillämpa \"%s\""
 
-#: builtin/add.c:269
+#: builtin/add.c:270
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "Följande sökvägar ignoreras av en av dina .gitignore-filer:\n"
 
-#: builtin/add.c:289 builtin/clean.c:907 builtin/fetch.c:137 builtin/mv.c:123
-#: builtin/prune-packed.c:56 builtin/pull.c:213 builtin/push.c:557
-#: builtin/remote.c:1345 builtin/rm.c:240 builtin/send-pack.c:165
+#: builtin/add.c:290 builtin/clean.c:908 builtin/fetch.c:137 builtin/mv.c:124
+#: builtin/prune-packed.c:56 builtin/pull.c:214 builtin/push.c:560
+#: builtin/remote.c:1345 builtin/rm.c:241 builtin/send-pack.c:165
 msgid "dry run"
 msgstr "testkörning"
 
-#: builtin/add.c:292
+#: builtin/add.c:293
 msgid "interactive picking"
 msgstr "plocka interaktivt"
 
-#: builtin/add.c:293 builtin/checkout.c:1258 builtin/reset.c:305
+#: builtin/add.c:294 builtin/checkout.c:1304 builtin/reset.c:306
 msgid "select hunks interactively"
 msgstr "välj stycken interaktivt"
 
-#: builtin/add.c:294
+#: builtin/add.c:295
 msgid "edit current diff and apply"
 msgstr "redigera aktuell diff och applicera"
 
-#: builtin/add.c:295
+#: builtin/add.c:296
 msgid "allow adding otherwise ignored files"
 msgstr "tillåt lägga till annars ignorerade filer"
 
-#: builtin/add.c:296
+#: builtin/add.c:297
 msgid "update tracked files"
 msgstr "uppdatera spårade filer"
 
-#: builtin/add.c:297
+#: builtin/add.c:298
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "åternormalisera radslut i spårade filer (implicerar -u)"
 
-#: builtin/add.c:298
+#: builtin/add.c:299
 msgid "record only the fact that the path will be added later"
 msgstr "registrera endast att sökvägen kommer läggas till senare"
 
-#: builtin/add.c:299
+#: builtin/add.c:300
 msgid "add changes from all tracked and untracked files"
 msgstr "lägg till ändringar från alla spårade och ospårade filer"
 
-#: builtin/add.c:302
+#: builtin/add.c:303
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "ignorera sökvägar borttagna i arbetskatalogen (samma som --no-all)"
 
-#: builtin/add.c:304
+#: builtin/add.c:305
 msgid "don't add, only refresh the index"
 msgstr "lägg inte till, uppdatera endast indexet"
 
-#: builtin/add.c:305
+#: builtin/add.c:306
 msgid "just skip files which cannot be added because of errors"
 msgstr "hoppa bara över filer som inte kan läggas till på grund av fel"
 
-#: builtin/add.c:306
+#: builtin/add.c:307
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "se om - även saknade - filer ignoreras i testkörning"
 
-#: builtin/add.c:308 builtin/update-index.c:990
+#: builtin/add.c:309 builtin/update-index.c:991
 msgid "override the executable bit of the listed files"
 msgstr "överstyr exekveringsbiten för angivna filer"
 
-#: builtin/add.c:310
+#: builtin/add.c:311
 msgid "warn when adding an embedded repository"
 msgstr "varna när ett inbyggt arkiv läggs till"
 
-#: builtin/add.c:325
+#: builtin/add.c:326
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -7286,150 +7715,150 @@ msgstr ""
 "\n"
 "Se ”git help submodule” för ytterligare information."
 
-#: builtin/add.c:353
+#: builtin/add.c:354
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "lägger till inbäddat git-arkiv: %s"
 
-#: builtin/add.c:371
+#: builtin/add.c:372
 #, c-format
 msgid "Use -f if you really want to add them.\n"
 msgstr "Använd -f om du verkligen vill lägga till dem.\n"
 
-#: builtin/add.c:379
+#: builtin/add.c:380
 msgid "adding files failed"
 msgstr "misslyckades lägga till filer"
 
-#: builtin/add.c:417
+#: builtin/add.c:418
 msgid "-A and -u are mutually incompatible"
 msgstr "-A och -u är ömsesidigt inkompatibla"
 
-#: builtin/add.c:424
+#: builtin/add.c:425
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr "Flaggan --ignore-missing kan endast användas tillsammans med --dry-run"
 
-#: builtin/add.c:428
+#: builtin/add.c:429
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod-parametern \"%s\" måste antingen vara -x eller +x"
 
-#: builtin/add.c:443
+#: builtin/add.c:444
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Inget angivet, inget tillagt.\n"
 
-#: builtin/add.c:444
+#: builtin/add.c:445
 #, c-format
 msgid "Maybe you wanted to say 'git add .'?\n"
 msgstr "Kanske menade du att skriva \"git add .\"?\n"
 
-#: builtin/am.c:363
+#: builtin/am.c:348
 msgid "could not parse author script"
 msgstr "kunde inte tolka författarskript"
 
-#: builtin/am.c:447
+#: builtin/am.c:432
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "\"%s\" togs bort av kroken applypatch-msg"
 
-#: builtin/am.c:488
+#: builtin/am.c:473
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Felaktig indatarad: \"%s\"."
 
-#: builtin/am.c:525
+#: builtin/am.c:510
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Misslyckades kopiera anteckningar från \"%s\" till \"%s\""
 
-#: builtin/am.c:551
+#: builtin/am.c:536
 msgid "fseek failed"
 msgstr "\"fseek\" misslyckades"
 
-#: builtin/am.c:739
+#: builtin/am.c:724
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "kunde inte tolka patchen \"%s\""
 
-#: builtin/am.c:804
+#: builtin/am.c:789
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Endast en StGIT-patchserie kan tillämpas åt gången"
 
-#: builtin/am.c:852
+#: builtin/am.c:837
 msgid "invalid timestamp"
 msgstr "ogiltig tidsstämpel"
 
-#: builtin/am.c:857 builtin/am.c:869
+#: builtin/am.c:842 builtin/am.c:854
 msgid "invalid Date line"
 msgstr "ogiltig \"Date\"-rad"
 
-#: builtin/am.c:864
+#: builtin/am.c:849
 msgid "invalid timezone offset"
 msgstr "ogiltig tidszons-offset"
 
-#: builtin/am.c:957
+#: builtin/am.c:942
 msgid "Patch format detection failed."
 msgstr "Misslyckades detektera patchformat."
 
-#: builtin/am.c:962 builtin/clone.c:408
+#: builtin/am.c:947 builtin/clone.c:409
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "misslyckades skapa katalogen \"%s\""
 
-#: builtin/am.c:967
+#: builtin/am.c:952
 msgid "Failed to split patches."
 msgstr "Misslyckades dela patchar."
 
-#: builtin/am.c:1097 builtin/commit.c:369
+#: builtin/am.c:1082 builtin/commit.c:371
 msgid "unable to write index file"
 msgstr "kan inte skriva indexfil"
 
-#: builtin/am.c:1111
+#: builtin/am.c:1096
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "När du har löst problemet, kör \"%s --continue\"."
 
-#: builtin/am.c:1112
+#: builtin/am.c:1097
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr "Om du hellre vill hoppa över patchen, kör \"%s --skip\" i stället."
 
-#: builtin/am.c:1113
+#: builtin/am.c:1098
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "För att återgå till ursprunglig gren och sluta patcha, kör \"%s --abort\"."
 
-#: builtin/am.c:1196
+#: builtin/am.c:1181
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch sänd med format=flowed; blanksteg på slut av rader kan ha tappats."
 
-#: builtin/am.c:1224
+#: builtin/am.c:1209
 msgid "Patch is empty."
 msgstr "Patchen är tom."
 
-#: builtin/am.c:1290
+#: builtin/am.c:1275
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "ogiltig ident-rad: %.*s"
 
-#: builtin/am.c:1312
+#: builtin/am.c:1297
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "kunde inte tolka incheckningen %s"
 
-#: builtin/am.c:1508
+#: builtin/am.c:1493
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Arkivet saknar objekt som behövs för att falla tillbaka på 3-"
 "vägssammanslagning."
 
-#: builtin/am.c:1510
+#: builtin/am.c:1495
 msgid "Using index info to reconstruct a base tree..."
 msgstr "Använder indexinfo för att återskapa ett basträd..."
 
-#: builtin/am.c:1529
+#: builtin/am.c:1514
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -7437,30 +7866,30 @@ msgstr ""
 "Har du handredigerat din patch?\n"
 "Den kan inte tillämpas på blobbar som antecknats i dess index."
 
-#: builtin/am.c:1535
+#: builtin/am.c:1520
 msgid "Falling back to patching base and 3-way merge..."
 msgstr ""
 "Faller tillbaka på att patcha grundversionen och trevägssammanslagning..."
 
-#: builtin/am.c:1561
+#: builtin/am.c:1546
 msgid "Failed to merge in the changes."
 msgstr "Misslyckades slå ihop ändringarna."
 
-#: builtin/am.c:1593
+#: builtin/am.c:1578
 msgid "applying to an empty history"
 msgstr "tillämpar på en tom historik"
 
-#: builtin/am.c:1639 builtin/am.c:1643
+#: builtin/am.c:1624 builtin/am.c:1628
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "kan inte återuppta: %s finns inte."
 
-#: builtin/am.c:1659
+#: builtin/am.c:1644
 msgid "cannot be interactive without stdin connected to a terminal."
 msgstr ""
 "kan inte vara interaktiv om standard in inte är ansluten till en terminal."
 
-#: builtin/am.c:1664
+#: builtin/am.c:1649
 msgid "Commit Body is:"
 msgstr "Incheckningskroppen är:"
 
@@ -7468,35 +7897,35 @@ msgstr "Incheckningskroppen är:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1674
+#: builtin/am.c:1659
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr "Tillämpa? Y=ja/N=nej/E=redigera/V=visa patch/A=godta alla: "
 
-#: builtin/am.c:1724
+#: builtin/am.c:1709
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Smutsigt index: kan inte tillämpa patchar (smutsiga: %s)"
 
-#: builtin/am.c:1764 builtin/am.c:1832
+#: builtin/am.c:1749 builtin/am.c:1817
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Tillämpar: %.*s"
 
-#: builtin/am.c:1781
+#: builtin/am.c:1766
 msgid "No changes -- Patch already applied."
 msgstr "Inga ändringar -- Patchen har redan tillämpats."
 
-#: builtin/am.c:1787
+#: builtin/am.c:1772
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Patch misslyckades på %s %.*s"
 
-#: builtin/am.c:1791
+#: builtin/am.c:1776
 msgid "Use 'git am --show-current-patch' to see the failed patch"
 msgstr ""
 "Använd \"git am --show-current-patch\" för att se patchen som misslyckades"
 
-#: builtin/am.c:1835
+#: builtin/am.c:1820
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -7506,7 +7935,7 @@ msgstr ""
 "Om det inte är något kvar att köa kan det hända att något annat redan\n"
 "introducerat samma ändringar; kanske du bör hoppa över patchen."
 
-#: builtin/am.c:1842
+#: builtin/am.c:1827
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -7518,17 +7947,17 @@ msgstr ""
 "lösta.\n"
 "Du kan köra ”git rm” för att godta ”borttagen av dem” för den."
 
-#: builtin/am.c:1949 builtin/am.c:1953 builtin/am.c:1965 builtin/reset.c:328
-#: builtin/reset.c:336
+#: builtin/am.c:1934 builtin/am.c:1938 builtin/am.c:1950 builtin/reset.c:329
+#: builtin/reset.c:337
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Kan inte tolka objektet ”%s”."
 
-#: builtin/am.c:2001
+#: builtin/am.c:1986
 msgid "failed to clean index"
 msgstr "misslyckades städa upp indexet"
 
-#: builtin/am.c:2036
+#: builtin/am.c:2030
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -7536,143 +7965,143 @@ msgstr ""
 "Du verkar ha flyttat HEAD sedan \"am\" sist misslyckades.\n"
 "Återställer inte till ORIG_HEAD"
 
-#: builtin/am.c:2129
+#: builtin/am.c:2123
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Felaktigt värde för --patch-format: %s"
 
-#: builtin/am.c:2165
+#: builtin/am.c:2159
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<flaggor>] [(<mbox> | <Maildir>)...]"
 
-#: builtin/am.c:2166
+#: builtin/am.c:2160
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<flaggor>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2172
+#: builtin/am.c:2166
 msgid "run interactively"
 msgstr "kör interaktivt"
 
-#: builtin/am.c:2174
+#: builtin/am.c:2168
 msgid "historical option -- no-op"
 msgstr "historisk flagga -- no-op"
 
-#: builtin/am.c:2176
+#: builtin/am.c:2170
 msgid "allow fall back on 3way merging if needed"
 msgstr "tillåt falla tillbaka på trevägssammanslagning om nödvändigt"
 
-#: builtin/am.c:2177 builtin/init-db.c:486 builtin/prune-packed.c:58
+#: builtin/am.c:2171 builtin/init-db.c:486 builtin/prune-packed.c:58
 #: builtin/repack.c:306
 msgid "be quiet"
 msgstr "var tyst"
 
-#: builtin/am.c:2179
+#: builtin/am.c:2173
 msgid "add a Signed-off-by line to the commit message"
 msgstr "lägg till \"Signed-off-by\"-rad i incheckningsmeddelandet"
 
-#: builtin/am.c:2182
+#: builtin/am.c:2176
 msgid "recode into utf8 (default)"
 msgstr "koda om till utf8 (standard)"
 
-#: builtin/am.c:2184
+#: builtin/am.c:2178
 msgid "pass -k flag to git-mailinfo"
 msgstr "sänd flaggan -k till git-mailinfo"
 
-#: builtin/am.c:2186
+#: builtin/am.c:2180
 msgid "pass -b flag to git-mailinfo"
 msgstr "sänd flaggan -b till git-mailinfo"
 
-#: builtin/am.c:2188
+#: builtin/am.c:2182
 msgid "pass -m flag to git-mailinfo"
 msgstr "sänd flaggan -m till git-mailinfo"
 
-#: builtin/am.c:2190
+#: builtin/am.c:2184
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "sänd flaggan --keep-cr till git-mailsplit för mbox-formatet"
 
-#: builtin/am.c:2193
+#: builtin/am.c:2187
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr "sänd inte flaggan --keep-cr till git-mailsplit oberoende av am.keepcr"
 
-#: builtin/am.c:2196
+#: builtin/am.c:2190
 msgid "strip everything before a scissors line"
 msgstr "ta bort allting före en saxlinje"
 
-#: builtin/am.c:2198 builtin/am.c:2201 builtin/am.c:2204 builtin/am.c:2207
-#: builtin/am.c:2210 builtin/am.c:2213 builtin/am.c:2216 builtin/am.c:2219
-#: builtin/am.c:2225
+#: builtin/am.c:2192 builtin/am.c:2195 builtin/am.c:2198 builtin/am.c:2201
+#: builtin/am.c:2204 builtin/am.c:2207 builtin/am.c:2210 builtin/am.c:2213
+#: builtin/am.c:2219
 msgid "pass it through git-apply"
 msgstr "sänd det genom git-apply"
 
-#: builtin/am.c:2215 builtin/commit.c:1340 builtin/fmt-merge-msg.c:671
-#: builtin/fmt-merge-msg.c:674 builtin/grep.c:868 builtin/merge.c:239
-#: builtin/pull.c:151 builtin/pull.c:209 builtin/rebase.c:854
+#: builtin/am.c:2209 builtin/commit.c:1343 builtin/fmt-merge-msg.c:671
+#: builtin/fmt-merge-msg.c:674 builtin/grep.c:879 builtin/merge.c:240
+#: builtin/pull.c:152 builtin/pull.c:210 builtin/rebase.c:1062
 #: builtin/repack.c:317 builtin/repack.c:321 builtin/repack.c:323
 #: builtin/show-branch.c:651 builtin/show-ref.c:171 builtin/tag.c:386
-#: parse-options.h:144 parse-options.h:146 parse-options.h:268
+#: parse-options.h:144 parse-options.h:146 parse-options.h:266
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2221 builtin/branch.c:637 builtin/for-each-ref.c:38
+#: builtin/am.c:2215 builtin/branch.c:637 builtin/for-each-ref.c:38
 #: builtin/replace.c:544 builtin/tag.c:422 builtin/verify-tag.c:39
 msgid "format"
 msgstr "format"
 
-#: builtin/am.c:2222
+#: builtin/am.c:2216
 msgid "format the patch(es) are in"
 msgstr "format för patch(ar)"
 
-#: builtin/am.c:2228
+#: builtin/am.c:2222
 msgid "override error message when patch failure occurs"
 msgstr "överstyr felmeddelanden när patchfel uppstår"
 
-#: builtin/am.c:2230
+#: builtin/am.c:2224
 msgid "continue applying patches after resolving a conflict"
 msgstr "fortsätt applicera patchar efter att ha löst en konflikt"
 
-#: builtin/am.c:2233
+#: builtin/am.c:2227
 msgid "synonyms for --continue"
 msgstr "synonymer till --continue"
 
-#: builtin/am.c:2236
+#: builtin/am.c:2230
 msgid "skip the current patch"
 msgstr "hoppa över den aktuella grenen"
 
-#: builtin/am.c:2239
+#: builtin/am.c:2233
 msgid "restore the original branch and abort the patching operation."
 msgstr "återställ originalgrenen och avbryt patchningen."
 
-#: builtin/am.c:2242
+#: builtin/am.c:2236
 msgid "abort the patching operation but keep HEAD where it is."
 msgstr "avbryt patchningen men behåll HEAD där det är."
 
-#: builtin/am.c:2245
+#: builtin/am.c:2239
 msgid "show the patch being applied."
 msgstr "visa patchen som tillämpas."
 
-#: builtin/am.c:2249
+#: builtin/am.c:2243
 msgid "lie about committer date"
 msgstr "ljug om incheckningsdatum"
 
-#: builtin/am.c:2251
+#: builtin/am.c:2245
 msgid "use current timestamp for author date"
 msgstr "använd nuvarande tidsstämpel för författardatum"
 
-#: builtin/am.c:2253 builtin/commit.c:1483 builtin/merge.c:273
-#: builtin/pull.c:184 builtin/rebase.c:898 builtin/rebase--interactive.c:183
-#: builtin/revert.c:113 builtin/tag.c:402
+#: builtin/am.c:2247 builtin/commit.c:1486 builtin/merge.c:274
+#: builtin/pull.c:185 builtin/rebase.c:1106 builtin/rebase--interactive.c:185
+#: builtin/revert.c:114 builtin/tag.c:402
 msgid "key-id"
 msgstr "nyckel-id"
 
-#: builtin/am.c:2254 builtin/rebase.c:899 builtin/rebase--interactive.c:184
+#: builtin/am.c:2248 builtin/rebase.c:1107 builtin/rebase--interactive.c:186
 msgid "GPG-sign commits"
 msgstr "GPG-signera incheckningar"
 
-#: builtin/am.c:2257
+#: builtin/am.c:2251
 msgid "(internal use for git-rebase)"
 msgstr "(används internt av git-rebase)"
 
-#: builtin/am.c:2275
+#: builtin/am.c:2269
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -7680,16 +8109,16 @@ msgstr ""
 "Flaggan -b/--binary har varit utan funktion länge, och\n"
 "kommer tas bort. Vi ber dig att inte använda den längre."
 
-#: builtin/am.c:2282
+#: builtin/am.c:2276
 msgid "failed to read the index"
 msgstr "misslyckades läsa indexet"
 
-#: builtin/am.c:2297
+#: builtin/am.c:2291
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "tidigare rebase-katalog %s finns fortfarande, men mbox angavs."
 
-#: builtin/am.c:2321
+#: builtin/am.c:2315
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -7698,7 +8127,7 @@ msgstr ""
 "Kvarbliven katalog %s hittades.\n"
 "Använd \"git am --abort\" för att ta bort den."
 
-#: builtin/am.c:2327
+#: builtin/am.c:2321
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Lösningsoperation pågår inte, vi återupptar inte."
 
@@ -7719,85 +8148,296 @@ msgstr "kunde inte omdirigera utdata"
 msgid "git archive: Remote with no URL"
 msgstr "git archive: Fjärr utan URL"
 
-#: builtin/archive.c:58
+#: builtin/archive.c:61
 msgid "git archive: expected ACK/NAK, got a flush packet"
 msgstr "git archive: förväntade ACK/NAK, fick flush-paket"
 
-#: builtin/archive.c:61
+#: builtin/archive.c:64
 #, c-format
 msgid "git archive: NACK %s"
 msgstr "git archive: NACK %s"
 
-#: builtin/archive.c:64
+#: builtin/archive.c:65
 msgid "git archive: protocol error"
 msgstr "git archive: protokollfel"
 
-#: builtin/archive.c:68
+#: builtin/archive.c:69
 msgid "git archive: expected a flush"
 msgstr "git archive: förväntade en tömning (flush)"
 
-#: builtin/bisect--helper.c:12
+#: builtin/bisect--helper.c:22
 msgid "git bisect--helper --next-all [--no-checkout]"
 msgstr "git bisect--helper --next-all [--no-checkout]"
 
-#: builtin/bisect--helper.c:13
+#: builtin/bisect--helper.c:23
 msgid "git bisect--helper --write-terms <bad_term> <good_term>"
 msgstr "git bisect--helper --write-terms <term-för-fel> <term-för-rätt>"
 
-#: builtin/bisect--helper.c:14
+#: builtin/bisect--helper.c:24
 msgid "git bisect--helper --bisect-clean-state"
 msgstr "git bisect--helper --bisect-clean-state"
 
-#: builtin/bisect--helper.c:46
+#: builtin/bisect--helper.c:25
+msgid "git bisect--helper --bisect-reset [<commit>]"
+msgstr "git bisect--helper --bisect-reset [<incheckning>]"
+
+#: builtin/bisect--helper.c:26
+msgid ""
+"git bisect--helper --bisect-write [--no-log] <state> <revision> <good_term> "
+"<bad_term>"
+msgstr ""
+"git bisect--helper --bisect-write [--no-log] <tillstånd> <revision> <term-"
+"för-rätt> <term-för-fel>"
+
+#: builtin/bisect--helper.c:27
+msgid ""
+"git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
+"<bad_term>"
+msgstr ""
+"git bisect--helper --bisect-check-and-set-terms <kommadno> <term-för-rätt> "
+"<term-för-fel>"
+
+#: builtin/bisect--helper.c:28
+msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
+msgstr ""
+"git bisect--helper --bisect-next-check <term-för-rätt> <term-för-fel> <eterm>"
+
+#: builtin/bisect--helper.c:29
+msgid ""
+"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
+"term-new]"
+msgstr ""
+"git-bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
+"term-new]"
+
+#: builtin/bisect--helper.c:30
+msgid ""
+"git bisect--helper --bisect-start [--term-{old,good}=<term> --term-{new,bad}"
+"=<term>][--no-checkout] [<bad> [<good>...]] [--] [<paths>...]"
+msgstr ""
+"git bisect--helper --bisect-start [--term-{old,good}=<term> --term-{new,bad}"
+"=<term>][--no-checkout] [<fel> [<rätt>...]] [--] [<sökvägar>...]"
+
+#: builtin/bisect--helper.c:86
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "\"%s\" är inte en giltig term"
 
-#: builtin/bisect--helper.c:50
+#: builtin/bisect--helper.c:90
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "kan inte använda det inbyggda kommandot \"%s\" som term"
 
-#: builtin/bisect--helper.c:60
+#: builtin/bisect--helper.c:100
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "kan inte ändra betydelsen av termen \"%s\""
 
-#: builtin/bisect--helper.c:71
+#: builtin/bisect--helper.c:111
 msgid "please use two different terms"
 msgstr "termerna måste vara olika"
 
-#: builtin/bisect--helper.c:78
+#: builtin/bisect--helper.c:118
 msgid "could not open the file BISECT_TERMS"
 msgstr "kunde inte öppna filen BISECT_TERMS"
 
-#: builtin/bisect--helper.c:120
+#: builtin/bisect--helper.c:155
+#, c-format
+msgid "We are not bisecting.\n"
+msgstr "Vi utför ingen bisect för tillfället.\n"
+
+#: builtin/bisect--helper.c:163
+#, c-format
+msgid "'%s' is not a valid commit"
+msgstr "\"%s\" är inte en giltig incheckning"
+
+#: builtin/bisect--helper.c:174
+#, c-format
+msgid ""
+"could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
+msgstr ""
+"Kunde inte checka ut original-HEAD \"%s\". Försök \"git bisect reset "
+"<incheckning>\"."
+
+#: builtin/bisect--helper.c:215
+#, c-format
+msgid "Bad bisect_write argument: %s"
+msgstr "Felaktigt argument till bisect_write: %s"
+
+#: builtin/bisect--helper.c:220
+#, c-format
+msgid "couldn't get the oid of the rev '%s'"
+msgstr "kan inte läsa oid för referensen \"%s\""
+
+#: builtin/bisect--helper.c:232
+#, c-format
+msgid "couldn't open the file '%s'"
+msgstr "kunde inte öppna filen \"%s\""
+
+#: builtin/bisect--helper.c:258
+#, c-format
+msgid "Invalid command: you're currently in a %s/%s bisect"
+msgstr "Ogiltigt kommando: du utför just nu en \"bisect\" med %s/%s."
+
+#: builtin/bisect--helper.c:285
+#, c-format
+msgid ""
+"You need to give me at least one %s and %s revision.\n"
+"You can use \"git bisect %s\" and \"git bisect %s\" for that."
+msgstr ""
+"Du måste ange åtminstone en %s och en %s version.\n"
+"(Du kan använda \"git bisect %s\" och \"git bisect %s\" för detta.)"
+
+#: builtin/bisect--helper.c:289
+#, c-format
+msgid ""
+"You need to start by \"git bisect start\".\n"
+"You then need to give me at least one %s and %s revision.\n"
+"You can use \"git bisect %s\" and \"git bisect %s\" for that."
+msgstr ""
+"Du måste starta med \"git bisect start\".\n"
+"Du måste sedan ange åtminstone en %s och en %s version.\n"
+"(Du kan använda \"git bisect %s\" och \"git bisect %s\" för detta.)"
+
+#: builtin/bisect--helper.c:321
+#, c-format
+msgid "bisecting only with a %s commit"
+msgstr "utför bisect med endast en %s incheckning"
+
+#. TRANSLATORS: Make sure to include [Y] and [n] in your
+#. translation. The program will only accept English input
+#. at this point.
+#.
+#: builtin/bisect--helper.c:329
+msgid "Are you sure [Y/n]? "
+msgstr "Är du säker [Y=ja/N=nej]? "
+
+#: builtin/bisect--helper.c:376
+msgid "no terms defined"
+msgstr "inga termer angivna"
+
+#: builtin/bisect--helper.c:379
+#, c-format
+msgid ""
+"Your current terms are %s for the old state\n"
+"and %s for the new state.\n"
+msgstr ""
+"Aktuella termer är %s för det gamla tillståndet\n"
+"och %s för det nya tillståndet.\n"
+
+#: builtin/bisect--helper.c:389
+#, c-format
+msgid ""
+"invalid argument %s for 'git bisect terms'.\n"
+"Supported options are: --term-good|--term-old and --term-bad|--term-new."
+msgstr ""
+"ogiltigt argument %s för \"git bisect terms\".\n"
+"Flaggor som stöds är: --term-good|--term-old och --term-bad|--term-new."
+
+#: builtin/bisect--helper.c:475
+#, c-format
+msgid "unrecognized option: '%s'"
+msgstr "okänd flagga: %s"
+
+#: builtin/bisect--helper.c:479
+#, c-format
+msgid "'%s' does not appear to be a valid revision"
+msgstr "\"%s\" verkar inte vara en giltig revision"
+
+#: builtin/bisect--helper.c:511
+msgid "bad HEAD - I need a HEAD"
+msgstr "felaktigt HEAD - Jag behöver ett HEAD"
+
+#: builtin/bisect--helper.c:526
+#, c-format
+msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
+msgstr ""
+"misslyckades checka ut \"%s\". Försök \"git bisect reset <giltig_gren>”."
+
+# cogito-relaterat
+#: builtin/bisect--helper.c:547
+msgid "won't bisect on cg-seek'ed tree"
+msgstr "kör inte \"bisect\" på träd där \"cg-seek\" använts"
+
+#: builtin/bisect--helper.c:550
+msgid "bad HEAD - strange symbolic ref"
+msgstr "felaktigt HEAD - konstig symbolisk referens"
+
+#: builtin/bisect--helper.c:627
 msgid "perform 'git bisect next'"
 msgstr "utför 'git bisect next'"
 
-#: builtin/bisect--helper.c:122
+#: builtin/bisect--helper.c:629
 msgid "write the terms to .git/BISECT_TERMS"
 msgstr "skriv termerna i .git/BISECT_TERMS"
 
-#: builtin/bisect--helper.c:124
+#: builtin/bisect--helper.c:631
 msgid "cleanup the bisection state"
 msgstr "städar upp bisect-tillstånd"
 
-#: builtin/bisect--helper.c:126
+#: builtin/bisect--helper.c:633
 msgid "check for expected revs"
 msgstr "kontrollera för förväntade versioner"
 
-#: builtin/bisect--helper.c:128
+#: builtin/bisect--helper.c:635
+msgid "reset the bisection state"
+msgstr "återställ bisect-tillstånd"
+
+#: builtin/bisect--helper.c:637
+msgid "write out the bisection state in BISECT_LOG"
+msgstr "skriver bisect-tillståndet i BISECT_LOG"
+
+#: builtin/bisect--helper.c:639
+msgid "check and set terms in a bisection state"
+msgstr "visa och ange termer för bisect-tillstånd"
+
+#: builtin/bisect--helper.c:641
+msgid "check whether bad or good terms exist"
+msgstr "se efter om termer för rätt och fel finns"
+
+#: builtin/bisect--helper.c:643
+msgid "print out the bisect terms"
+msgstr "skriv ut termer för bisect"
+
+#: builtin/bisect--helper.c:645
+msgid "start the bisect session"
+msgstr "påbörja bisect-körningen"
+
+#: builtin/bisect--helper.c:647
 msgid "update BISECT_HEAD instead of checking out the current commit"
 msgstr "uppdatera BISECT_HEAD istället för att checka ut aktuell incheckning"
 
-#: builtin/bisect--helper.c:143
+#: builtin/bisect--helper.c:649
+msgid "no log for BISECT_WRITE"
+msgstr "ingen logg för BISECT_WRITE"
+
+#: builtin/bisect--helper.c:666
 msgid "--write-terms requires two arguments"
 msgstr "--write-terms kräver två argument"
 
-#: builtin/bisect--helper.c:147
+#: builtin/bisect--helper.c:670
 msgid "--bisect-clean-state requires no arguments"
 msgstr "--bisect-clean-state tar inga argument"
+
+#: builtin/bisect--helper.c:677
+msgid "--bisect-reset requires either no argument or a commit"
+msgstr "--bisect-reset kräver antingen inget argument eller en incheckning"
+
+#: builtin/bisect--helper.c:681
+msgid "--bisect-write requires either 4 or 5 arguments"
+msgstr "--bisect-write kräver antingen 4 eller 5 argument"
+
+#: builtin/bisect--helper.c:687
+msgid "--check-and-set-terms requires 3 arguments"
+msgstr "--check-and-set-terms kräver tre argument"
+
+#: builtin/bisect--helper.c:693
+msgid "--bisect-next-check requires 2 or 3 arguments"
+msgstr "--bisect-next-check kräver 2 eller 3 argument"
+
+#: builtin/bisect--helper.c:699
+msgid "--bisect-terms requires 0 or 1 argument"
+msgstr "--bisect-terms kräver noll eller ett argument"
 
 #: builtin/blame.c:31
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
@@ -7933,7 +8573,7 @@ msgstr "n,m"
 msgid "Process only line range n,m, counting from 1"
 msgstr "Behandla endast radintervallet n,m, med början på 1"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:875
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr "--progress kan inte användas med --incremental eller porslinsformat"
 
@@ -7945,18 +8585,18 @@ msgstr "--progress kan inte användas med --incremental eller porslinsformat"
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:924
+#: builtin/blame.c:926
 msgid "4 years, 11 months ago"
 msgstr "4 år, 11 månader sedan"
 
-#: builtin/blame.c:1011
+#: builtin/blame.c:1018
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "filen %s har bara %lu rad"
 msgstr[1] "filen %s har bara %lu rader"
 
-#: builtin/blame.c:1057
+#: builtin/blame.c:1064
 msgid "Blaming lines"
 msgstr "Klandra rader"
 
@@ -8157,7 +8797,7 @@ msgstr "ställ in spårningsläge (se git-pull(1))"
 msgid "do not use"
 msgstr "använd ej"
 
-#: builtin/branch.c:602 builtin/rebase--interactive.c:180
+#: builtin/branch.c:602 builtin/rebase--interactive.c:182
 msgid "upstream"
 msgstr "uppströms"
 
@@ -8256,7 +8896,7 @@ msgid "field name to sort on"
 msgstr "fältnamn att sortera på"
 
 #: builtin/branch.c:633 builtin/for-each-ref.c:43 builtin/notes.c:415
-#: builtin/notes.c:418 builtin/notes.c:578 builtin/notes.c:581
+#: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
 #: builtin/tag.c:418
 msgid "object"
 msgstr "objekt"
@@ -8274,7 +8914,7 @@ msgstr "sortering och filtrering skiljer gemener och VERSALER"
 msgid "format to use for the output"
 msgstr "format att använda för utdata"
 
-#: builtin/branch.c:660 builtin/clone.c:739
+#: builtin/branch.c:660 builtin/clone.c:746
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD hittades inte under refs/heads!"
 
@@ -8323,7 +8963,7 @@ msgid ""
 msgstr ""
 "kunde inte sätta uppström för HEAD till %s när det inte pekar mot någon gren."
 
-#: builtin/branch.c:776 builtin/branch.c:798
+#: builtin/branch.c:776 builtin/branch.c:799
 #, c-format
 msgid "no such branch '%s'"
 msgstr "okänd gren \"%s\""
@@ -8333,27 +8973,27 @@ msgstr "okänd gren \"%s\""
 msgid "branch '%s' does not exist"
 msgstr "grenen \"%s\" finns inte"
 
-#: builtin/branch.c:792
+#: builtin/branch.c:793
 msgid "too many arguments to unset upstream"
 msgstr "för många flaggor för att ta bort uppström"
 
-#: builtin/branch.c:796
+#: builtin/branch.c:797
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "kunde inte ta bort uppström för HEAD när det inte pekar mot någon gren."
 
-#: builtin/branch.c:802
+#: builtin/branch.c:803
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Grenen \"%s\" har ingen uppströmsinformation"
 
-#: builtin/branch.c:812
+#: builtin/branch.c:813
 msgid "-a and -r options to 'git branch' do not make sense with a branch name"
 msgstr ""
 "flaggorna -a och -r på \"git branch\" kan inte anges tillsammans med ett "
 "grennamn"
 
-#: builtin/branch.c:815
+#: builtin/branch.c:816
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -8374,7 +9014,7 @@ msgstr "Behöver ett arkiv för att skapa ett paket (bundle)."
 msgid "Need a repository to unbundle."
 msgstr "Behöver ett arkiv för att packa upp ett paket (bundle)."
 
-#: builtin/cat-file.c:587
+#: builtin/cat-file.c:593
 msgid ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <type> | --textconv | --filters) [--path=<path>] <object>"
@@ -8382,7 +9022,7 @@ msgstr ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <typ> | --textconv | --filters) [--path=<sökväg>] <objekt>"
 
-#: builtin/cat-file.c:588
+#: builtin/cat-file.c:594
 msgid ""
 "git cat-file (--batch | --batch-check) [--follow-symlinks] [--textconv | --"
 "filters]"
@@ -8390,133 +9030,133 @@ msgstr ""
 "git cat-file (--batch | --batch-check) [--follow-symlinks] [--textconv | --"
 "filters]"
 
-#: builtin/cat-file.c:609
+#: builtin/cat-file.c:615
 msgid "only one batch option may be specified"
 msgstr "endast en buntflagga kan anges"
 
-#: builtin/cat-file.c:627
+#: builtin/cat-file.c:633
 msgid "<type> can be one of: blob, tree, commit, tag"
 msgstr "<typ> kan vara en av: blob, tree, commit, tag"
 
-#: builtin/cat-file.c:628
+#: builtin/cat-file.c:634
 msgid "show object type"
 msgstr "visa objekttyp"
 
-#: builtin/cat-file.c:629
+#: builtin/cat-file.c:635
 msgid "show object size"
 msgstr "visa objektstorlek"
 
-#: builtin/cat-file.c:631
+#: builtin/cat-file.c:637
 msgid "exit with zero when there's no error"
 msgstr "avsluta med noll när det inte uppstått något fel"
 
-#: builtin/cat-file.c:632
+#: builtin/cat-file.c:638
 msgid "pretty-print object's content"
 msgstr "visa objektets innehåll snyggt"
 
-#: builtin/cat-file.c:634
+#: builtin/cat-file.c:640
 msgid "for blob objects, run textconv on object's content"
 msgstr "för blob-objekt, kör filter på objektets innehåll"
 
-#: builtin/cat-file.c:636
+#: builtin/cat-file.c:642
 msgid "for blob objects, run filters on object's content"
 msgstr "för blob-objekt, kör filger på objektets innehåll"
 
-#: builtin/cat-file.c:637 git-submodule.sh:857
+#: builtin/cat-file.c:643 git-submodule.sh:860
 msgid "blob"
 msgstr "blob"
 
-#: builtin/cat-file.c:638
+#: builtin/cat-file.c:644
 msgid "use a specific path for --textconv/--filters"
 msgstr "använd specifik sökväg för --textconv/--filters"
 
-#: builtin/cat-file.c:640
+#: builtin/cat-file.c:646
 msgid "allow -s and -t to work with broken/corrupt objects"
 msgstr "låter -s och -t att fungera med trasiga/sönderskrivna objekt"
 
-#: builtin/cat-file.c:641
+#: builtin/cat-file.c:647
 msgid "buffer --batch output"
 msgstr "buffra utdata från --batch"
 
-#: builtin/cat-file.c:643
+#: builtin/cat-file.c:649
 msgid "show info and content of objects fed from the standard input"
 msgstr "visa information och innehåll för objekt som listas på standard in"
 
-#: builtin/cat-file.c:647
+#: builtin/cat-file.c:653
 msgid "show info about objects fed from the standard input"
 msgstr "visa information för objekt som listas på standard in"
 
-#: builtin/cat-file.c:651
+#: builtin/cat-file.c:657
 msgid "follow in-tree symlinks (used with --batch or --batch-check)"
 msgstr ""
 "följ symboliska länkar i trädet (använd med --batch eller --batch-check)"
 
-#: builtin/cat-file.c:653
+#: builtin/cat-file.c:659
 msgid "show all objects with --batch or --batch-check"
 msgstr "visa alla objekt med --batch eller --batch-check"
 
-#: builtin/cat-file.c:655
+#: builtin/cat-file.c:661
 msgid "do not order --batch-all-objects output"
 msgstr "ordna inte --batch-all-objects output"
 
-#: builtin/check-attr.c:12
+#: builtin/check-attr.c:13
 msgid "git check-attr [-a | --all | <attr>...] [--] <pathname>..."
 msgstr "git check-attr [-a | --all | <attr>...] [--] <sökväg>..."
 
-#: builtin/check-attr.c:13
+#: builtin/check-attr.c:14
 msgid "git check-attr --stdin [-z] [-a | --all | <attr>...]"
 msgstr "git check-attr --stdin [-z] [-a | --all | <attr>...]"
 
-#: builtin/check-attr.c:20
+#: builtin/check-attr.c:21
 msgid "report all attributes set on file"
 msgstr "visa alla attribut som satts på filen"
 
-#: builtin/check-attr.c:21
+#: builtin/check-attr.c:22
 msgid "use .gitattributes only from the index"
 msgstr "använd .gitattributes endast från indexet"
 
-#: builtin/check-attr.c:22 builtin/check-ignore.c:24 builtin/hash-object.c:101
+#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:102
 msgid "read file names from stdin"
 msgstr "läs filnamn från standard in"
 
-#: builtin/check-attr.c:24 builtin/check-ignore.c:26
+#: builtin/check-attr.c:25 builtin/check-ignore.c:27
 msgid "terminate input and output records by a NUL character"
 msgstr "avsluta in- och utdataposter med NUL-tecken"
 
-#: builtin/check-ignore.c:20 builtin/checkout.c:1234 builtin/gc.c:517
-#: builtin/worktree.c:495
+#: builtin/check-ignore.c:21 builtin/checkout.c:1280 builtin/gc.c:517
+#: builtin/worktree.c:496
 msgid "suppress progress reporting"
 msgstr "undertryck förloppsrapportering"
 
-#: builtin/check-ignore.c:28
+#: builtin/check-ignore.c:29
 msgid "show non-matching input paths"
 msgstr "visa indatasökvägar som inte träffas"
 
-#: builtin/check-ignore.c:30
+#: builtin/check-ignore.c:31
 msgid "ignore index when checking"
 msgstr "ignorera index vid kontroll"
 
-#: builtin/check-ignore.c:159
+#: builtin/check-ignore.c:160
 msgid "cannot specify pathnames with --stdin"
 msgstr "kan inte ange sökvägsnamn med --stdin"
 
-#: builtin/check-ignore.c:162
+#: builtin/check-ignore.c:163
 msgid "-z only makes sense with --stdin"
 msgstr "-z kan endast användas tillsammans med --stdin"
 
-#: builtin/check-ignore.c:164
+#: builtin/check-ignore.c:165
 msgid "no path specified"
 msgstr "ingen sökväg angavs"
 
-#: builtin/check-ignore.c:168
+#: builtin/check-ignore.c:169
 msgid "--quiet is only valid with a single pathname"
 msgstr "--quiet kan endast användas med ett enkelt sökvägsnamn"
 
-#: builtin/check-ignore.c:170
+#: builtin/check-ignore.c:171
 msgid "cannot have both --quiet and --verbose"
 msgstr "kan inte använda både --quiet och --verbose"
 
-#: builtin/check-ignore.c:173
+#: builtin/check-ignore.c:174
 msgid "--non-matching is only valid with --verbose"
 msgstr "--non-matching är endast giltig med --verbose"
 
@@ -8537,164 +9177,185 @@ msgstr "kunde inte tolka kontakt: %s"
 msgid "no contacts specified"
 msgstr "inga kontakter angavs"
 
-#: builtin/checkout-index.c:128
+#: builtin/checkout-index.c:131
 msgid "git checkout-index [<options>] [--] [<file>...]"
 msgstr "git checkout-index [<flaggor>] [--] [<fil>...]"
 
-#: builtin/checkout-index.c:145
+#: builtin/checkout-index.c:148
 msgid "stage should be between 1 and 3 or all"
 msgstr "etapp måste vara mellan 1 och 3 eller \"all\""
 
-#: builtin/checkout-index.c:161
+#: builtin/checkout-index.c:164
 msgid "check out all files in the index"
 msgstr "checka ut alla filer i indexet"
 
-#: builtin/checkout-index.c:162
+#: builtin/checkout-index.c:165
 msgid "force overwrite of existing files"
 msgstr "tvinga överskrivning av befintliga filer"
 
-#: builtin/checkout-index.c:164
+#: builtin/checkout-index.c:167
 msgid "no warning for existing files and files not in index"
 msgstr "ingen varning för existerande filer och filer ej i indexet"
 
-#: builtin/checkout-index.c:166
+#: builtin/checkout-index.c:169
 msgid "don't checkout new files"
 msgstr "checka inte ut nya filer"
 
-#: builtin/checkout-index.c:168
+#: builtin/checkout-index.c:171
 msgid "update stat information in the index file"
 msgstr "uppdatera stat-information i indexfilen"
 
-#: builtin/checkout-index.c:172
+#: builtin/checkout-index.c:175
 msgid "read list of paths from the standard input"
 msgstr "läs listan över sökvägar från standard in"
 
-#: builtin/checkout-index.c:174
+#: builtin/checkout-index.c:177
 msgid "write the content to temporary files"
 msgstr "skriv innehåll till temporära filer"
 
-#: builtin/checkout-index.c:175 builtin/column.c:31
-#: builtin/submodule--helper.c:1368 builtin/submodule--helper.c:1371
-#: builtin/submodule--helper.c:1379 builtin/submodule--helper.c:1853
-#: builtin/worktree.c:668
+#: builtin/checkout-index.c:178 builtin/column.c:31
+#: builtin/submodule--helper.c:1372 builtin/submodule--helper.c:1375
+#: builtin/submodule--helper.c:1383 builtin/submodule--helper.c:1857
+#: builtin/worktree.c:669
 msgid "string"
 msgstr "sträng"
 
-#: builtin/checkout-index.c:176
+#: builtin/checkout-index.c:179
 msgid "when creating files, prepend <string>"
 msgstr "när filer skapas, lägg till <sträng> först"
 
-#: builtin/checkout-index.c:178
+#: builtin/checkout-index.c:181
 msgid "copy out the files from named stage"
 msgstr "kopiera ut filer från namngiven etapp"
 
-#: builtin/checkout.c:31
+#: builtin/checkout.c:32
 msgid "git checkout [<options>] <branch>"
 msgstr "git checkout [<flaggor>] <gren>"
 
-#: builtin/checkout.c:32
+#: builtin/checkout.c:33
 msgid "git checkout [<options>] [<branch>] -- <file>..."
 msgstr "git checkout [<flaggor>] [<gren>] -- <fil>..."
 
-#: builtin/checkout.c:144 builtin/checkout.c:177
+#: builtin/checkout.c:147 builtin/checkout.c:181
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "sökvägen \"%s\" har inte vår version"
 
-#: builtin/checkout.c:146 builtin/checkout.c:179
+#: builtin/checkout.c:149 builtin/checkout.c:183
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "sökvägen \"%s\" har inte deras version"
 
-#: builtin/checkout.c:162
+#: builtin/checkout.c:165
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "sökvägen \"%s\" innehåller inte alla nödvändiga versioner"
 
-#: builtin/checkout.c:206
+#: builtin/checkout.c:210
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "sökvägen \"%s\" innehåller inte nödvändiga versioner"
 
-#: builtin/checkout.c:224
+#: builtin/checkout.c:228
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "sökväg \"%s\": kan inte slå ihop"
 
-#: builtin/checkout.c:240
+#: builtin/checkout.c:244
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Kunde inte lägga till sammanslagningsresultat för \"%s\""
 
-#: builtin/checkout.c:262 builtin/checkout.c:265 builtin/checkout.c:268
-#: builtin/checkout.c:271
+#: builtin/checkout.c:267 builtin/checkout.c:270 builtin/checkout.c:273
+#: builtin/checkout.c:276
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "\"%s\" kan inte användas vid uppdatering av sökvägar"
 
-#: builtin/checkout.c:274 builtin/checkout.c:277
+#: builtin/checkout.c:279 builtin/checkout.c:282
 #, c-format
 msgid "'%s' cannot be used with %s"
 msgstr "\"%s\" kan inte användas med %s"
 
-#: builtin/checkout.c:280
+#: builtin/checkout.c:285
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr "Kan inte uppdatera sökvägar och växla till grenen \"%s\" samtidigt."
 
-#: builtin/checkout.c:349 builtin/checkout.c:356
+#: builtin/checkout.c:354 builtin/checkout.c:361
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "sökvägen \"%s\" har inte slagits ihop"
 
-#: builtin/checkout.c:608
+#: builtin/checkout.c:397
+#, c-format
+msgid "Recreated %d merge conflict"
+msgid_plural "Recreated %d merge conflicts"
+msgstr[0] "Återskapade %d sammanslagningskonflikt"
+msgstr[1] "Återskapade %d sammanslagningskonflikter"
+
+#: builtin/checkout.c:402
+#, c-format
+msgid "Updated %d path from %s"
+msgid_plural "Updated %d paths from %s"
+msgstr[0] "Uppdaterade %d sökväg från %s"
+msgstr[1] "Uppdaterade %d sökvägar från %s"
+
+#: builtin/checkout.c:409
+#, c-format
+msgid "Updated %d path from the index"
+msgid_plural "Updated %d paths from the index"
+msgstr[0] "Uppdaterade %d sökväg från indexet"
+msgstr[1] "Uppdaterade %d sökvägar från indexet"
+
+#: builtin/checkout.c:645
 msgid "you need to resolve your current index first"
 msgstr "du måste lösa ditt befintliga index först"
 
-#: builtin/checkout.c:745
+#: builtin/checkout.c:782
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Kan inte skapa referenslogg för \"%s\": %s\n"
 
-#: builtin/checkout.c:786
+#: builtin/checkout.c:824
 msgid "HEAD is now at"
 msgstr "HEAD är nu på"
 
-#: builtin/checkout.c:790 builtin/clone.c:692
+#: builtin/checkout.c:828 builtin/clone.c:699
 msgid "unable to update HEAD"
 msgstr "kan inte uppdatera HEAD"
 
-#: builtin/checkout.c:794
+#: builtin/checkout.c:832
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Återställ gren \"%s\"\n"
 
-#: builtin/checkout.c:797
+#: builtin/checkout.c:835
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Redan på \"%s\"\n"
 
-#: builtin/checkout.c:801
+#: builtin/checkout.c:839
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Växlade till och nollställde grenen \"%s\"\n"
 
-#: builtin/checkout.c:803 builtin/checkout.c:1166
+#: builtin/checkout.c:841 builtin/checkout.c:1212
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Växlade till en ny gren \"%s\"\n"
 
-#: builtin/checkout.c:805
+#: builtin/checkout.c:843
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Växlade till grenen \"%s\"\n"
 
-#: builtin/checkout.c:856
+#: builtin/checkout.c:894
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... och %d till.\n"
 
-#: builtin/checkout.c:862
+#: builtin/checkout.c:900
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -8717,7 +9378,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:881
+#: builtin/checkout.c:919
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -8744,161 +9405,170 @@ msgstr[1] ""
 " git branch <nytt_grennamn> %s\n"
 "\n"
 
-#: builtin/checkout.c:913
+#: builtin/checkout.c:951
 msgid "internal error in revision walk"
 msgstr "internt fel vid genomgång av revisioner (revision walk)"
 
-#: builtin/checkout.c:917
+#: builtin/checkout.c:955
 msgid "Previous HEAD position was"
 msgstr "Tidigare position för HEAD var"
 
-#: builtin/checkout.c:945 builtin/checkout.c:1161
+#: builtin/checkout.c:983 builtin/checkout.c:1207
 msgid "You are on a branch yet to be born"
 msgstr "Du är på en gren som ännu inte är född"
 
-#: builtin/checkout.c:1066
+#: builtin/checkout.c:1104
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "endast en referens förväntades, %d gavs."
 
-#: builtin/checkout.c:1107 builtin/worktree.c:289 builtin/worktree.c:444
+#: builtin/checkout.c:1140
+#, c-format
+msgid ""
+"'%s' could be both a local file and a tracking branch.\n"
+"Please use -- (and optionally --no-guess) to disambiguate"
+msgstr ""
+"\"%s\" kan vara både en lokal fil och en spårande gren.\n"
+"Använd -- (och möjligen --no-guess) för att göra otvetydig"
+
+#: builtin/checkout.c:1153 builtin/worktree.c:290 builtin/worktree.c:445
 #, c-format
 msgid "invalid reference: %s"
 msgstr "felaktig referens: %s"
 
-#: builtin/checkout.c:1136
+#: builtin/checkout.c:1182
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "referensen är inte ett träd: %s"
 
-#: builtin/checkout.c:1175
+#: builtin/checkout.c:1221
 msgid "paths cannot be used with switching branches"
 msgstr "sökvägar kan inte användas vid byte av gren"
 
-#: builtin/checkout.c:1178 builtin/checkout.c:1182
+#: builtin/checkout.c:1224 builtin/checkout.c:1228
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "\"%s\" kan inte användas vid byte av gren"
 
-#: builtin/checkout.c:1186 builtin/checkout.c:1189 builtin/checkout.c:1194
-#: builtin/checkout.c:1197
+#: builtin/checkout.c:1232 builtin/checkout.c:1235 builtin/checkout.c:1240
+#: builtin/checkout.c:1243
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "\"%s\" kan inte användas med \"%s\""
 
-#: builtin/checkout.c:1202
+#: builtin/checkout.c:1248
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Kan inte växla gren till icke-incheckningen \"%s\""
 
-#: builtin/checkout.c:1235 builtin/checkout.c:1237 builtin/clone.c:119
-#: builtin/remote.c:169 builtin/remote.c:171 builtin/worktree.c:488
-#: builtin/worktree.c:490
+#: builtin/checkout.c:1281 builtin/checkout.c:1283 builtin/clone.c:120
+#: builtin/remote.c:169 builtin/remote.c:171 builtin/worktree.c:489
+#: builtin/worktree.c:491
 msgid "branch"
 msgstr "gren"
 
-#: builtin/checkout.c:1236
+#: builtin/checkout.c:1282
 msgid "create and checkout a new branch"
 msgstr "skapa och checka ut en ny gren"
 
-#: builtin/checkout.c:1238
+#: builtin/checkout.c:1284
 msgid "create/reset and checkout a branch"
 msgstr "skapa/nollställ och checka ut en gren"
 
-#: builtin/checkout.c:1239
+#: builtin/checkout.c:1285
 msgid "create reflog for new branch"
 msgstr "skapa reflogg för ny gren"
 
-#: builtin/checkout.c:1240 builtin/worktree.c:492
+#: builtin/checkout.c:1286 builtin/worktree.c:493
 msgid "detach HEAD at named commit"
 msgstr "koppla från HEAD vid namngiven incheckning"
 
-#: builtin/checkout.c:1241
+#: builtin/checkout.c:1287
 msgid "set upstream info for new branch"
 msgstr "sätt uppströmsinformation för ny gren"
 
-#: builtin/checkout.c:1243
+#: builtin/checkout.c:1289
 msgid "new-branch"
 msgstr "ny-gren"
 
-#: builtin/checkout.c:1243
+#: builtin/checkout.c:1289
 msgid "new unparented branch"
 msgstr "ny gren utan förälder"
 
-#: builtin/checkout.c:1245
+#: builtin/checkout.c:1291
 msgid "checkout our version for unmerged files"
 msgstr "checka ut vår version för ej sammanslagna filer"
 
-#: builtin/checkout.c:1248
+#: builtin/checkout.c:1294
 msgid "checkout their version for unmerged files"
 msgstr "checka ut deras version för ej sammanslagna filer"
 
-#: builtin/checkout.c:1250
+#: builtin/checkout.c:1296
 msgid "force checkout (throw away local modifications)"
 msgstr "tvinga utcheckning (kasta bort lokala ändringar)"
 
-#: builtin/checkout.c:1252
+#: builtin/checkout.c:1298
 msgid "perform a 3-way merge with the new branch"
 msgstr "utför en 3-vägssammanslagning för den nya grenen"
 
-#: builtin/checkout.c:1254 builtin/merge.c:275
+#: builtin/checkout.c:1300 builtin/merge.c:276
 msgid "update ignored files (default)"
 msgstr "uppdatera ignorerade filer (standard)"
 
-#: builtin/checkout.c:1256 builtin/log.c:1573 parse-options.h:274
+#: builtin/checkout.c:1302 builtin/log.c:1586 parse-options.h:272
 msgid "style"
 msgstr "stil"
 
-#: builtin/checkout.c:1257
+#: builtin/checkout.c:1303
 msgid "conflict style (merge or diff3)"
 msgstr "konfliktstil (merge eller diff3)"
 
-#: builtin/checkout.c:1260
+#: builtin/checkout.c:1306
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "begränsa inte sökvägar till endast glesa poster"
 
-#: builtin/checkout.c:1262
-msgid "second guess 'git checkout <no-such-branch>'"
-msgstr "förutspå \"git checkout <gren-saknas>\""
+#: builtin/checkout.c:1308
+msgid "do not second guess 'git checkout <no-such-branch>'"
+msgstr "försök inte vara förutspå \"git checkout <gren-saknas>\""
 
-#: builtin/checkout.c:1264
+#: builtin/checkout.c:1310
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "kontrollera inte om en annan arbetskatalog håller den angivna referensen"
 
-#: builtin/checkout.c:1268 builtin/clone.c:86 builtin/fetch.c:141
-#: builtin/merge.c:272 builtin/pull.c:129 builtin/push.c:572
+#: builtin/checkout.c:1314 builtin/clone.c:87 builtin/fetch.c:141
+#: builtin/merge.c:273 builtin/pull.c:130 builtin/push.c:575
 #: builtin/send-pack.c:174
 msgid "force progress reporting"
 msgstr "tvinga förloppsrapportering"
 
-#: builtin/checkout.c:1298
+#: builtin/checkout.c:1345
 msgid "-b, -B and --orphan are mutually exclusive"
 msgstr "-b, -B och --orphan är ömsesidigt uteslutande"
 
-#: builtin/checkout.c:1315
+#: builtin/checkout.c:1362
 msgid "--track needs a branch name"
 msgstr "--track behöver ett namn på en gren"
 
-#: builtin/checkout.c:1320
+#: builtin/checkout.c:1367
 msgid "missing branch name; try -b"
 msgstr "grennamn saknas; försök med -b"
 
-#: builtin/checkout.c:1357
+#: builtin/checkout.c:1404
 msgid "invalid path specification"
 msgstr "felaktig sökvägsangivelse"
 
-#: builtin/checkout.c:1364
+#: builtin/checkout.c:1411
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "”%s” är inte en incheckning och grenen ”%s” kan inte skapas från den"
 
-#: builtin/checkout.c:1368
+#: builtin/checkout.c:1415
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach tar inte en sökväg som argument \"%s\""
 
-#: builtin/checkout.c:1372
+#: builtin/checkout.c:1419
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -8906,7 +9576,7 @@ msgstr ""
 "git checkout: --ours/--theirs, --force och --merge är inkompatibla när\n"
 "du checkar ut från indexet."
 
-#: builtin/checkout.c:1392
+#: builtin/checkout.c:1439
 #, c-format
 msgid ""
 "'%s' matched more than one remote tracking branch.\n"
@@ -8935,39 +9605,39 @@ msgstr ""
 "föredra en fjärr, t.ex fjärren \"origin\" kan du ställa in\n"
 "checkout.defaultRemote=origin i din konfiguration."
 
-#: builtin/clean.c:27
+#: builtin/clean.c:28
 msgid ""
 "git clean [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <paths>..."
 msgstr ""
 "git clean [-d] [-f] [-i] [-n] [-q] [-e <mönster>] [-x | -X] [--] "
 "<sökvägar>..."
 
-#: builtin/clean.c:31
+#: builtin/clean.c:32
 #, c-format
 msgid "Removing %s\n"
 msgstr "Tar bort %s\n"
 
-#: builtin/clean.c:32
+#: builtin/clean.c:33
 #, c-format
 msgid "Would remove %s\n"
 msgstr "Skulle ta bort %s\n"
 
-#: builtin/clean.c:33
+#: builtin/clean.c:34
 #, c-format
 msgid "Skipping repository %s\n"
 msgstr "Hoppar över arkivet %s\n"
 
-#: builtin/clean.c:34
+#: builtin/clean.c:35
 #, c-format
 msgid "Would skip repository %s\n"
 msgstr "Skulle hoppa över arkivet %s\n"
 
-#: builtin/clean.c:35
+#: builtin/clean.c:36
 #, c-format
 msgid "failed to remove %s"
 msgstr "misslyckades ta bort %s"
 
-#: builtin/clean.c:298 git-add--interactive.perl:579
+#: builtin/clean.c:299 git-add--interactive.perl:579
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -8980,7 +9650,7 @@ msgstr ""
 "foo        - markera post baserad på unikt prefix\n"
 "           - (tomt) markera ingenting\n"
 
-#: builtin/clean.c:302 git-add--interactive.perl:588
+#: builtin/clean.c:303 git-add--interactive.perl:588
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -9001,38 +9671,38 @@ msgstr ""
 "*          - välj alla poster\n"
 "           - (tomt) avsluta markering\n"
 
-#: builtin/clean.c:518 git-add--interactive.perl:554
+#: builtin/clean.c:519 git-add--interactive.perl:554
 #: git-add--interactive.perl:559
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
 msgstr "Vadå (%s)?\n"
 
-#: builtin/clean.c:660
+#: builtin/clean.c:661
 #, c-format
 msgid "Input ignore patterns>> "
 msgstr "Ange ignoreringsmönster>>"
 
-#: builtin/clean.c:697
+#: builtin/clean.c:698
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
 msgstr "VARNING: Hittar inte poster som motsvarar: %s"
 
-#: builtin/clean.c:718
+#: builtin/clean.c:719
 msgid "Select items to delete"
 msgstr "Välj poster att ta bort"
 
 #. TRANSLATORS: Make sure to keep [y/N] as is
-#: builtin/clean.c:759
+#: builtin/clean.c:760
 #, c-format
 msgid "Remove %s [y/N]? "
 msgstr "Ta bort %s [Y=ja / N=nej]? "
 
-#: builtin/clean.c:784 git-add--interactive.perl:1717
+#: builtin/clean.c:785 git-add--interactive.perl:1717
 #, c-format
 msgid "Bye.\n"
 msgstr "Hej då.\n"
 
-#: builtin/clean.c:792
+#: builtin/clean.c:793
 msgid ""
 "clean               - start cleaning\n"
 "filter by pattern   - exclude items from deletion\n"
@@ -9050,64 +9720,64 @@ msgstr ""
 "help                - denna skärm\n"
 "?                   - hjälp för kommandoval"
 
-#: builtin/clean.c:819 git-add--interactive.perl:1793
+#: builtin/clean.c:820 git-add--interactive.perl:1793
 msgid "*** Commands ***"
 msgstr "*** Kommandon ***"
 
-#: builtin/clean.c:820 git-add--interactive.perl:1790
+#: builtin/clean.c:821 git-add--interactive.perl:1790
 msgid "What now"
 msgstr "Vad nu"
 
-#: builtin/clean.c:828
+#: builtin/clean.c:829
 msgid "Would remove the following item:"
 msgid_plural "Would remove the following items:"
 msgstr[0] "Skulle ta bort följande post:"
 msgstr[1] "Skulle ta bort följande poster:"
 
-#: builtin/clean.c:844
+#: builtin/clean.c:845
 msgid "No more files to clean, exiting."
 msgstr "Inga fler filer att städa, avslutar."
 
-#: builtin/clean.c:906
+#: builtin/clean.c:907
 msgid "do not print names of files removed"
 msgstr "skriv inte ut namn på borttagna filer"
 
-#: builtin/clean.c:908
+#: builtin/clean.c:909
 msgid "force"
 msgstr "tvinga"
 
-#: builtin/clean.c:909
+#: builtin/clean.c:910
 msgid "interactive cleaning"
 msgstr "städa interaktivt"
 
-#: builtin/clean.c:911
+#: builtin/clean.c:912
 msgid "remove whole directories"
 msgstr "ta bort hela kataloger"
 
-#: builtin/clean.c:912 builtin/describe.c:545 builtin/describe.c:547
-#: builtin/grep.c:886 builtin/log.c:166 builtin/log.c:168
-#: builtin/ls-files.c:556 builtin/name-rev.c:415 builtin/name-rev.c:417
+#: builtin/clean.c:913 builtin/describe.c:546 builtin/describe.c:548
+#: builtin/grep.c:897 builtin/log.c:167 builtin/log.c:169
+#: builtin/ls-files.c:557 builtin/name-rev.c:415 builtin/name-rev.c:417
 #: builtin/show-ref.c:178
 msgid "pattern"
 msgstr "mönster"
 
-#: builtin/clean.c:913
+#: builtin/clean.c:914
 msgid "add <pattern> to ignore rules"
 msgstr "lägg till <mönster> till ignoreringsregler"
 
-#: builtin/clean.c:914
+#: builtin/clean.c:915
 msgid "remove ignored files, too"
 msgstr "ta även bort ignorerade filer"
 
-#: builtin/clean.c:916
+#: builtin/clean.c:917
 msgid "remove only ignored files"
 msgstr "ta endast bort ignorerade filer"
 
-#: builtin/clean.c:934
+#: builtin/clean.c:935
 msgid "-x and -X cannot be used together"
 msgstr "-x och -X kan inte användas samtidigt"
 
-#: builtin/clean.c:938
+#: builtin/clean.c:939
 msgid ""
 "clean.requireForce set to true and neither -i, -n, nor -f given; refusing to "
 "clean"
@@ -9115,7 +9785,7 @@ msgstr ""
 "clean.requireForce satt till true, men varken -i, -n eller -f angavs; vägrar "
 "städa"
 
-#: builtin/clean.c:941
+#: builtin/clean.c:942
 msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
@@ -9123,146 +9793,146 @@ msgstr ""
 "clean.requireForce har standardvärdet true och varken -i, -n eller -f "
 "angavs; vägrar städa"
 
-#: builtin/clone.c:43
+#: builtin/clone.c:44
 msgid "git clone [<options>] [--] <repo> [<dir>]"
 msgstr "git clone [<flaggor>] [--] <arkiv> [<kat>]"
 
-#: builtin/clone.c:88
+#: builtin/clone.c:89
 msgid "don't create a checkout"
 msgstr "skapa inte någon utcheckning"
 
-#: builtin/clone.c:89 builtin/clone.c:91 builtin/init-db.c:481
+#: builtin/clone.c:90 builtin/clone.c:92 builtin/init-db.c:481
 msgid "create a bare repository"
 msgstr "skapa ett naket (\"bare\") arkiv"
 
-#: builtin/clone.c:93
+#: builtin/clone.c:94
 msgid "create a mirror repository (implies bare)"
 msgstr "skapa ett spegelarkiv (implicerar \"bare\")"
 
-#: builtin/clone.c:95
+#: builtin/clone.c:96
 msgid "to clone from a local repository"
 msgstr "för att klona från ett lokalt arkiv"
 
-#: builtin/clone.c:97
+#: builtin/clone.c:98
 msgid "don't use local hardlinks, always copy"
 msgstr "skapa inte lokala hårda länkar, kopiera alltid"
 
-#: builtin/clone.c:99
+#: builtin/clone.c:100
 msgid "setup as shared repository"
 msgstr "skapa som ett delat arkiv"
 
-#: builtin/clone.c:101 builtin/clone.c:105
+#: builtin/clone.c:102 builtin/clone.c:106
 msgid "pathspec"
 msgstr "sökvägsangivelse"
 
-#: builtin/clone.c:101 builtin/clone.c:105
+#: builtin/clone.c:102 builtin/clone.c:106
 msgid "initialize submodules in the clone"
 msgstr "initiera undermoduler i klonen"
 
-#: builtin/clone.c:108
+#: builtin/clone.c:109
 msgid "number of submodules cloned in parallel"
 msgstr "antal undermoduler som klonas parallellt"
 
-#: builtin/clone.c:109 builtin/init-db.c:478
+#: builtin/clone.c:110 builtin/init-db.c:478
 msgid "template-directory"
 msgstr "mallkatalog"
 
-#: builtin/clone.c:110 builtin/init-db.c:479
+#: builtin/clone.c:111 builtin/init-db.c:479
 msgid "directory from which templates will be used"
 msgstr "katalog att använda mallar från"
 
-#: builtin/clone.c:112 builtin/clone.c:114 builtin/submodule--helper.c:1375
-#: builtin/submodule--helper.c:1856
+#: builtin/clone.c:113 builtin/clone.c:115 builtin/submodule--helper.c:1379
+#: builtin/submodule--helper.c:1860
 msgid "reference repository"
 msgstr "referensarkiv"
 
-#: builtin/clone.c:116 builtin/submodule--helper.c:1377
-#: builtin/submodule--helper.c:1858
+#: builtin/clone.c:117 builtin/submodule--helper.c:1381
+#: builtin/submodule--helper.c:1862
 msgid "use --reference only while cloning"
 msgstr "använd --reference endast under kloningen"
 
-#: builtin/clone.c:117 builtin/column.c:27 builtin/merge-file.c:46
-#: builtin/pack-objects.c:3301 builtin/repack.c:329
+#: builtin/clone.c:118 builtin/column.c:27 builtin/merge-file.c:46
+#: builtin/pack-objects.c:3303 builtin/repack.c:329
 msgid "name"
 msgstr "namn"
 
-#: builtin/clone.c:118
+#: builtin/clone.c:119
 msgid "use <name> instead of 'origin' to track upstream"
 msgstr "använd <namn> istället för \"origin\" för att spåra uppströms"
 
-#: builtin/clone.c:120
+#: builtin/clone.c:121
 msgid "checkout <branch> instead of the remote's HEAD"
 msgstr "checka ut <gren> istället för fjärrens HEAD"
 
-#: builtin/clone.c:122
+#: builtin/clone.c:123
 msgid "path to git-upload-pack on the remote"
 msgstr "sökväg till git-upload-pack på fjärren"
 
-#: builtin/clone.c:123 builtin/fetch.c:142 builtin/grep.c:825
-#: builtin/pull.c:217
+#: builtin/clone.c:124 builtin/fetch.c:142 builtin/grep.c:836
+#: builtin/pull.c:218
 msgid "depth"
 msgstr "djup"
 
-#: builtin/clone.c:124
+#: builtin/clone.c:125
 msgid "create a shallow clone of that depth"
 msgstr "skapa en grund klon på detta djup"
 
-#: builtin/clone.c:125 builtin/fetch.c:144 builtin/pack-objects.c:3292
+#: builtin/clone.c:126 builtin/fetch.c:144 builtin/pack-objects.c:3292
 msgid "time"
 msgstr "tid"
 
-#: builtin/clone.c:126
+#: builtin/clone.c:127
 msgid "create a shallow clone since a specific time"
 msgstr "skapa en grund klon från en angiven tidpunkt"
 
-#: builtin/clone.c:127 builtin/fetch.c:146 builtin/fetch.c:169
-#: builtin/rebase.c:831
+#: builtin/clone.c:128 builtin/fetch.c:146 builtin/fetch.c:169
+#: builtin/rebase.c:1039
 msgid "revision"
 msgstr "revision"
 
-#: builtin/clone.c:128 builtin/fetch.c:147
+#: builtin/clone.c:129 builtin/fetch.c:147
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "fördjupa historik för grund klon, exkludera revisionen"
 
-#: builtin/clone.c:130
+#: builtin/clone.c:131
 msgid "clone only one branch, HEAD or --branch"
 msgstr "klona endast en gren, HEAD eller --branch"
 
-#: builtin/clone.c:132
+#: builtin/clone.c:133
 msgid "don't clone any tags, and make later fetches not to follow them"
 msgstr "klona inga taggar och gör att senare hämtningar inte följer dem"
 
-#: builtin/clone.c:134
+#: builtin/clone.c:135
 msgid "any cloned submodules will be shallow"
 msgstr "klonade undermoduler kommer vara grunda"
 
-#: builtin/clone.c:135 builtin/init-db.c:487
+#: builtin/clone.c:136 builtin/init-db.c:487
 msgid "gitdir"
 msgstr "gitkat"
 
-#: builtin/clone.c:136 builtin/init-db.c:488
+#: builtin/clone.c:137 builtin/init-db.c:488
 msgid "separate git dir from working tree"
 msgstr "separera gitkatalogen från arbetskatalogen"
 
-#: builtin/clone.c:137
+#: builtin/clone.c:138
 msgid "key=value"
 msgstr "nyckel=värde"
 
-#: builtin/clone.c:138
+#: builtin/clone.c:139
 msgid "set config inside the new repository"
 msgstr "ställ in konfiguration i det nya arkivet"
 
-#: builtin/clone.c:139 builtin/fetch.c:165 builtin/pull.c:230
-#: builtin/push.c:583
+#: builtin/clone.c:140 builtin/fetch.c:165 builtin/pull.c:231
+#: builtin/push.c:586
 msgid "use IPv4 addresses only"
 msgstr "använd endast IPv4-adresser"
 
-#: builtin/clone.c:141 builtin/fetch.c:167 builtin/pull.c:233
-#: builtin/push.c:585
+#: builtin/clone.c:142 builtin/fetch.c:167 builtin/pull.c:234
+#: builtin/push.c:588
 msgid "use IPv6 addresses only"
 msgstr "använd endast IPv6-adresser"
 
-#: builtin/clone.c:279
+#: builtin/clone.c:280
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -9270,47 +9940,47 @@ msgstr ""
 "Kunde inte gissa katalognamn.\n"
 "Ange en katalog på kommandoraden"
 
-#: builtin/clone.c:332
+#: builtin/clone.c:333
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: Kan inte skapa alternativ för \"%s\": %s\n"
 
-#: builtin/clone.c:404
+#: builtin/clone.c:405
 #, c-format
 msgid "failed to open '%s'"
 msgstr "misslyckades öppna \"%s\""
 
-#: builtin/clone.c:412
+#: builtin/clone.c:413
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s finns och är ingen katalog"
 
-#: builtin/clone.c:426
+#: builtin/clone.c:427
 #, c-format
 msgid "failed to stat %s\n"
 msgstr "misslyckades ta status på %s\n"
 
-#: builtin/clone.c:443
+#: builtin/clone.c:444
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "misslyckades ta bort länken \"%s\""
 
-#: builtin/clone.c:448
+#: builtin/clone.c:449
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "misslyckades skapa länken \"%s\""
 
-#: builtin/clone.c:452
+#: builtin/clone.c:453
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "misslyckades kopiera filen till \"%s\""
 
-#: builtin/clone.c:478
+#: builtin/clone.c:479
 #, c-format
 msgid "done.\n"
 msgstr "klart.\n"
 
-#: builtin/clone.c:492
+#: builtin/clone.c:493
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -9320,133 +9990,133 @@ msgstr ""
 "Du kan inspektera det som checkades ut med \"git status\"\n"
 "och försöka checka ut igen med \"git checkout -f HEAD\"\n"
 
-#: builtin/clone.c:569
+#: builtin/clone.c:570
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Kunde inte hitta fjärrgrenen %s för att klona."
 
-#: builtin/clone.c:680
+#: builtin/clone.c:687
 #, c-format
 msgid "unable to update %s"
 msgstr "kan inte uppdatera %s"
 
-#: builtin/clone.c:730
+#: builtin/clone.c:737
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "HEAD hos fjärren pekar på en obefintlig referens, kan inte checka ut.\n"
 
-#: builtin/clone.c:761
+#: builtin/clone.c:768
 msgid "unable to checkout working tree"
 msgstr "kunde inte checka ut arbetskatalogen"
 
-#: builtin/clone.c:806
+#: builtin/clone.c:813
 msgid "unable to write parameters to config file"
 msgstr "kunde inte skriva parametrar till konfigurationsfilen"
 
-#: builtin/clone.c:869
+#: builtin/clone.c:876
 msgid "cannot repack to clean up"
 msgstr "kan inte packa om för att städa upp"
 
-#: builtin/clone.c:871
+#: builtin/clone.c:878
 msgid "cannot unlink temporary alternates file"
 msgstr "kunde inte ta bort temporär \"alternates\"-fil"
 
-#: builtin/clone.c:911 builtin/receive-pack.c:1941
+#: builtin/clone.c:918 builtin/receive-pack.c:1941
 msgid "Too many arguments."
 msgstr "För många argument."
 
-#: builtin/clone.c:915
+#: builtin/clone.c:922
 msgid "You must specify a repository to clone."
 msgstr "Du måste ange ett arkiv att klona."
 
-#: builtin/clone.c:928
+#: builtin/clone.c:935
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "flaggorna --bare och --origin %s är inkompatibla."
 
-#: builtin/clone.c:931
+#: builtin/clone.c:938
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "flaggorna --bare och --separate-git-dir är inkompatibla."
 
-#: builtin/clone.c:944
+#: builtin/clone.c:951
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "arkivet \"%s\" finns inte"
 
-#: builtin/clone.c:950 builtin/fetch.c:1606
+#: builtin/clone.c:957 builtin/fetch.c:1608
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "djupet %s är inte ett positivt tal"
 
-#: builtin/clone.c:960
+#: builtin/clone.c:967
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "destinationssökvägen \"%s\" finns redan och är inte en tom katalog."
 
-#: builtin/clone.c:970
+#: builtin/clone.c:977
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "arbetsträdet \"%s\" finns redan."
 
-#: builtin/clone.c:985 builtin/clone.c:1006 builtin/difftool.c:271
-#: builtin/worktree.c:295 builtin/worktree.c:325
+#: builtin/clone.c:992 builtin/clone.c:1013 builtin/difftool.c:272
+#: builtin/worktree.c:296 builtin/worktree.c:326
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "kunde inte skapa inledande kataloger för \"%s\""
 
-#: builtin/clone.c:990
+#: builtin/clone.c:997
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "kunde inte skapa arbetskatalogen \"%s\""
 
-#: builtin/clone.c:1010
+#: builtin/clone.c:1017
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Klonar till ett naket arkiv \"%s\"...\n"
 
-#: builtin/clone.c:1012
+#: builtin/clone.c:1019
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Klonar till \"%s\"...\n"
 
-#: builtin/clone.c:1036
+#: builtin/clone.c:1043
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
 msgstr ""
 "clone --recursive är inte kompatibel med --reference och --reference-if-able"
 
-#: builtin/clone.c:1097
+#: builtin/clone.c:1104
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "--depth ignoreras i lokala kloningar; använd file:// istället."
 
-#: builtin/clone.c:1099
+#: builtin/clone.c:1106
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr "--shallow-since ignoreras i lokala kloningar; använd file:// istället."
 
-#: builtin/clone.c:1101
+#: builtin/clone.c:1108
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude ignoreras i lokala kloningar; använd file:// istället."
 
-#: builtin/clone.c:1103
+#: builtin/clone.c:1110
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr "--filter ignoreras i lokala kloningar; använd file:// istället."
 
-#: builtin/clone.c:1106
+#: builtin/clone.c:1113
 msgid "source repository is shallow, ignoring --local"
 msgstr "källarkivet är grunt, ignorerar --local"
 
-#: builtin/clone.c:1111
+#: builtin/clone.c:1118
 msgid "--local is ignored"
 msgstr "--local ignoreras"
 
-#: builtin/clone.c:1181 builtin/clone.c:1189
+#: builtin/clone.c:1192 builtin/clone.c:1200
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Fjärrgrenen %s hittades inte i uppströmsarkivet %s"
 
-#: builtin/clone.c:1192
+#: builtin/clone.c:1203
 msgid "You appear to have cloned an empty repository."
 msgstr "Du verkar ha klonat ett tomt arkiv."
 
@@ -9482,15 +10152,15 @@ msgstr "Spaltfyllnad mellan spalter"
 msgid "--command must be the first argument"
 msgstr "--command måste vara första argument"
 
-#: builtin/commit.c:40
+#: builtin/commit.c:41
 msgid "git commit [<options>] [--] <pathspec>..."
 msgstr "git commit [<flaggor>] [--] <sökväg>..."
 
-#: builtin/commit.c:45
+#: builtin/commit.c:46
 msgid "git status [<options>] [--] <pathspec>..."
 msgstr "git status [<flaggor>] [--] <sökväg>..."
 
-#: builtin/commit.c:50
+#: builtin/commit.c:51
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -9500,7 +10170,7 @@ msgstr ""
 "blir den tom. Du kan köra kommandot på nytt med --allow-empty, eller\n"
 "så kan du ta bort incheckningen helt med \"git reset HEAD^\".\n"
 
-#: builtin/commit.c:55
+#: builtin/commit.c:56
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -9514,11 +10184,11 @@ msgstr ""
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:62
+#: builtin/commit.c:63
 msgid "Otherwise, please use 'git reset'\n"
 msgstr "Använd annars \"git reset\"\n"
 
-#: builtin/commit.c:65
+#: builtin/commit.c:66
 msgid ""
 "If you wish to skip this commit, use:\n"
 "\n"
@@ -9534,61 +10204,61 @@ msgstr ""
 "\"git cherry-pick --continue\" kommer därefter att återuppta\n"
 "cherry-pick för återstående incheckningar.\n"
 
-#: builtin/commit.c:311
+#: builtin/commit.c:312
 msgid "failed to unpack HEAD tree object"
 msgstr "misslyckades packa upp HEAD:s trädobjekt"
 
-#: builtin/commit.c:352
+#: builtin/commit.c:353
 msgid "unable to create temporary index"
 msgstr "kunde inte skapa temporär indexfil"
 
-#: builtin/commit.c:358
+#: builtin/commit.c:359
 msgid "interactive add failed"
 msgstr "interaktiv tilläggning misslyckades"
 
-#: builtin/commit.c:371
+#: builtin/commit.c:373
 msgid "unable to update temporary index"
 msgstr "kan inte uppdatera temporärt index"
 
-#: builtin/commit.c:373
+#: builtin/commit.c:375
 msgid "Failed to update main cache tree"
 msgstr "Misslyckades uppdatera huvud-cacheträdet"
 
-#: builtin/commit.c:398 builtin/commit.c:421 builtin/commit.c:467
+#: builtin/commit.c:400 builtin/commit.c:423 builtin/commit.c:469
 msgid "unable to write new_index file"
 msgstr "kunde inte skriva filen new_index"
 
-#: builtin/commit.c:450
+#: builtin/commit.c:452
 msgid "cannot do a partial commit during a merge."
 msgstr "kan inte utföra en delvis incheckning under en sammanslagning."
 
-#: builtin/commit.c:452
+#: builtin/commit.c:454
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr "kan inte utföra en delvis incheckning under en cherry-pick."
 
-#: builtin/commit.c:460
+#: builtin/commit.c:462
 msgid "cannot read the index"
 msgstr "kan inte läsa indexet"
 
-#: builtin/commit.c:479
+#: builtin/commit.c:481
 msgid "unable to write temporary index file"
 msgstr "kunde inte skriva temporär indexfil"
 
-#: builtin/commit.c:577
+#: builtin/commit.c:579
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "incheckningen \"%s\" saknar författarhuvud"
 
-#: builtin/commit.c:579
+#: builtin/commit.c:581
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "incheckningen \"%s\" har felformaterat författarhuvud"
 
-#: builtin/commit.c:598
+#: builtin/commit.c:600
 msgid "malformed --author parameter"
 msgstr "felformad \"--author\"-flagga"
 
-#: builtin/commit.c:650
+#: builtin/commit.c:652
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -9596,38 +10266,38 @@ msgstr ""
 "kunde inte välja ett kommentarstecken som inte använts\n"
 "i det befintliga incheckningsmeddelandet"
 
-#: builtin/commit.c:687 builtin/commit.c:720 builtin/commit.c:1049
+#: builtin/commit.c:689 builtin/commit.c:722 builtin/commit.c:1052
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "kunde inte slå upp incheckningen %s"
 
-#: builtin/commit.c:699 builtin/shortlog.c:317
+#: builtin/commit.c:701 builtin/shortlog.c:319
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(läser loggmeddelande från standard in)\n"
 
-#: builtin/commit.c:701
+#: builtin/commit.c:703
 msgid "could not read log from standard input"
 msgstr "kunde inte läsa logg från standard in"
 
-#: builtin/commit.c:705
+#: builtin/commit.c:707
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "kunde inte läsa loggfilen \"%s\""
 
-#: builtin/commit.c:734 builtin/commit.c:742
+#: builtin/commit.c:736 builtin/commit.c:744
 msgid "could not read SQUASH_MSG"
 msgstr "kunde inte läsa SQUASH_MSG"
 
-#: builtin/commit.c:739
+#: builtin/commit.c:741
 msgid "could not read MERGE_MSG"
 msgstr "kunde inte läsa MERGE_MSG"
 
-#: builtin/commit.c:793
+#: builtin/commit.c:795
 msgid "could not write commit template"
 msgstr "kunde inte skriva incheckningsmall"
 
-#: builtin/commit.c:811
+#: builtin/commit.c:813
 #, c-format
 msgid ""
 "\n"
@@ -9642,7 +10312,7 @@ msgstr ""
 "\t%s\n"
 "och försöker igen.\n"
 
-#: builtin/commit.c:816
+#: builtin/commit.c:818
 #, c-format
 msgid ""
 "\n"
@@ -9657,7 +10327,7 @@ msgstr ""
 "\t%s\n"
 "och försöker igen.\n"
 
-#: builtin/commit.c:829
+#: builtin/commit.c:831
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -9667,7 +10337,7 @@ msgstr ""
 "med \"%c\" kommer ignoreras, och ett tomt meddelande avbryter "
 "incheckningen.\n"
 
-#: builtin/commit.c:837
+#: builtin/commit.c:839
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -9678,148 +10348,148 @@ msgstr ""
 "med \"%c\" kommer behållas; du kan själv ta bort dem om du vill.\n"
 "Ett tomt meddelande avbryter incheckningen.\n"
 
-#: builtin/commit.c:854
+#: builtin/commit.c:856
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sFörfattare: %.*s <%.*s>"
 
-#: builtin/commit.c:862
+#: builtin/commit.c:864
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sDatum:      %s"
 
-#: builtin/commit.c:869
+#: builtin/commit.c:871
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sIncheckare: %.*s <%.*s>"
 
-#: builtin/commit.c:887
+#: builtin/commit.c:889
 msgid "Cannot read index"
 msgstr "Kan inte läsa indexet"
 
-#: builtin/commit.c:953
+#: builtin/commit.c:956
 msgid "Error building trees"
 msgstr "Fel vid byggande av träd"
 
-#: builtin/commit.c:967 builtin/tag.c:258
+#: builtin/commit.c:970 builtin/tag.c:258
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Ange meddelandet en av flaggorna -m eller -F.\n"
 
-#: builtin/commit.c:1011
+#: builtin/commit.c:1014
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' är inte 'Namn <epost>' och matchar ingen befintlig författare"
 
-#: builtin/commit.c:1025
+#: builtin/commit.c:1028
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Ogiltigt ignorerat läge \"%s\""
 
-#: builtin/commit.c:1039 builtin/commit.c:1276
+#: builtin/commit.c:1042 builtin/commit.c:1279
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Ogiltigt läge för ospårade filer: \"%s\""
 
-#: builtin/commit.c:1077
+#: builtin/commit.c:1080
 msgid "--long and -z are incompatible"
 msgstr "--long och -z är inkompatibla"
 
-#: builtin/commit.c:1110
+#: builtin/commit.c:1113
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "Kan inte använda både --reset-author och --author"
 
-#: builtin/commit.c:1119
+#: builtin/commit.c:1122
 msgid "You have nothing to amend."
 msgstr "Du har inget att utöka."
 
-#: builtin/commit.c:1122
+#: builtin/commit.c:1125
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Du är i mitten av en sammanslagning -- kan inte utöka."
 
-#: builtin/commit.c:1124
+#: builtin/commit.c:1127
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "Du är i mitten av en cherry-pick -- kan inte utöka."
 
-#: builtin/commit.c:1127
+#: builtin/commit.c:1130
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Flaggorna --squash och --fixup kan inte användas samtidigt"
 
-#: builtin/commit.c:1137
+#: builtin/commit.c:1140
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Endast en av -c/-C/-F/--fixup kan användas."
 
-#: builtin/commit.c:1139
+#: builtin/commit.c:1142
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Flaggan -m kan inte kombineras med -c/-C/-F."
 
-#: builtin/commit.c:1147
+#: builtin/commit.c:1150
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset-author kan endast användas med -C, -c eller --amend."
 
-#: builtin/commit.c:1164
+#: builtin/commit.c:1167
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Endast en av --include/--only/--all/--interactive/--patch kan användas."
 
-#: builtin/commit.c:1166
+#: builtin/commit.c:1169
 msgid "No paths with --include/--only does not make sense."
 msgstr "Du måste ange sökvägar tillsammans med --include/--only."
 
-#: builtin/commit.c:1180 builtin/tag.c:546
+#: builtin/commit.c:1183 builtin/tag.c:546
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Felaktigt städningsläge %s"
 
-#: builtin/commit.c:1185
+#: builtin/commit.c:1188
 msgid "Paths with -a does not make sense."
 msgstr "Kan inte ange sökvägar med -a."
 
-#: builtin/commit.c:1311 builtin/commit.c:1495
+#: builtin/commit.c:1314 builtin/commit.c:1498
 msgid "show status concisely"
 msgstr "visa koncis status"
 
-#: builtin/commit.c:1313 builtin/commit.c:1497
+#: builtin/commit.c:1316 builtin/commit.c:1500
 msgid "show branch information"
 msgstr "visa information om gren"
 
-#: builtin/commit.c:1315
+#: builtin/commit.c:1318
 msgid "show stash information"
 msgstr "visa information om stash"
 
-#: builtin/commit.c:1317 builtin/commit.c:1499
+#: builtin/commit.c:1320 builtin/commit.c:1502
 msgid "compute full ahead/behind values"
 msgstr "beräkna fullständiga före-/efter-värden"
 
-#: builtin/commit.c:1319
+#: builtin/commit.c:1322
 msgid "version"
 msgstr "version"
 
-#: builtin/commit.c:1319 builtin/commit.c:1501 builtin/push.c:558
-#: builtin/worktree.c:639
+#: builtin/commit.c:1322 builtin/commit.c:1504 builtin/push.c:561
+#: builtin/worktree.c:640
 msgid "machine-readable output"
 msgstr "maskinläsbar utdata"
 
-#: builtin/commit.c:1322 builtin/commit.c:1503
+#: builtin/commit.c:1325 builtin/commit.c:1506
 msgid "show status in long format (default)"
 msgstr "visa status i långt format (standard)"
 
-#: builtin/commit.c:1325 builtin/commit.c:1506
+#: builtin/commit.c:1328 builtin/commit.c:1509
 msgid "terminate entries with NUL"
 msgstr "terminera poster med NUL"
 
-#: builtin/commit.c:1327 builtin/commit.c:1331 builtin/commit.c:1509
-#: builtin/fast-export.c:1007 builtin/fast-export.c:1010 builtin/rebase.c:910
+#: builtin/commit.c:1330 builtin/commit.c:1334 builtin/commit.c:1512
+#: builtin/fast-export.c:1085 builtin/fast-export.c:1088 builtin/rebase.c:1118
 #: builtin/tag.c:400
 msgid "mode"
 msgstr "läge"
 
-#: builtin/commit.c:1328 builtin/commit.c:1509
+#: builtin/commit.c:1331 builtin/commit.c:1512
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr "visa ospårade filer, valfria lägen: all, normal, no. (Standard: all)"
 
-#: builtin/commit.c:1332
+#: builtin/commit.c:1335
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -9827,11 +10497,11 @@ msgstr ""
 "visa ignorerade filer, valfria lägen: traditional, matching, no (Standard: "
 "traditional)"
 
-#: builtin/commit.c:1334 parse-options.h:164
+#: builtin/commit.c:1337 parse-options.h:164
 msgid "when"
 msgstr "när"
 
-#: builtin/commit.c:1335
+#: builtin/commit.c:1338
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -9839,194 +10509,194 @@ msgstr ""
 "ignorera ändringar i undermoduler, valfritt när: all, dirty, untracked. "
 "(Default: all)"
 
-#: builtin/commit.c:1337
+#: builtin/commit.c:1340
 msgid "list untracked files in columns"
 msgstr "visa ospårade filer i spalter"
 
-#: builtin/commit.c:1338
+#: builtin/commit.c:1341
 msgid "do not detect renames"
 msgstr "detektera inte namnändringar"
 
-#: builtin/commit.c:1340
+#: builtin/commit.c:1343
 msgid "detect renames, optionally set similarity index"
 msgstr "detektera namnändringar, möjligen sätt likhetsindex"
 
-#: builtin/commit.c:1360
+#: builtin/commit.c:1363
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr "Kombinationen av argument för ignorerade och ospårade filer stöds ej"
 
-#: builtin/commit.c:1465
+#: builtin/commit.c:1468
 msgid "suppress summary after successful commit"
 msgstr "undertryck sammanfattning efter framgångsrik incheckning"
 
-#: builtin/commit.c:1466
+#: builtin/commit.c:1469
 msgid "show diff in commit message template"
 msgstr "visa diff i mallen för incheckningsmeddelandet"
 
-#: builtin/commit.c:1468
+#: builtin/commit.c:1471
 msgid "Commit message options"
 msgstr "Alternativ för incheckningsmeddelande"
 
-#: builtin/commit.c:1469 builtin/merge.c:263 builtin/tag.c:397
+#: builtin/commit.c:1472 builtin/merge.c:264 builtin/tag.c:397
 msgid "read message from file"
 msgstr "läs meddelande från fil"
 
-#: builtin/commit.c:1470
+#: builtin/commit.c:1473
 msgid "author"
 msgstr "författare"
 
-#: builtin/commit.c:1470
+#: builtin/commit.c:1473
 msgid "override author for commit"
 msgstr "överstyr författare för incheckningen"
 
-#: builtin/commit.c:1471 builtin/gc.c:518
+#: builtin/commit.c:1474 builtin/gc.c:518
 msgid "date"
 msgstr "datum"
 
-#: builtin/commit.c:1471
+#: builtin/commit.c:1474
 msgid "override date for commit"
 msgstr "överstyr datum för incheckningen"
 
-#: builtin/commit.c:1472 builtin/merge.c:259 builtin/notes.c:409
-#: builtin/notes.c:572 builtin/tag.c:395
+#: builtin/commit.c:1475 builtin/merge.c:260 builtin/notes.c:409
+#: builtin/notes.c:575 builtin/tag.c:395
 msgid "message"
 msgstr "meddelande"
 
-#: builtin/commit.c:1472
+#: builtin/commit.c:1475
 msgid "commit message"
 msgstr "incheckningsmeddelande"
 
-#: builtin/commit.c:1473 builtin/commit.c:1474 builtin/commit.c:1475
-#: builtin/commit.c:1476 ref-filter.h:92 parse-options.h:280
+#: builtin/commit.c:1476 builtin/commit.c:1477 builtin/commit.c:1478
+#: builtin/commit.c:1479 parse-options.h:278 ref-filter.h:92
 msgid "commit"
 msgstr "incheckning"
 
-#: builtin/commit.c:1473
+#: builtin/commit.c:1476
 msgid "reuse and edit message from specified commit"
 msgstr "återanvänd och redigera meddelande från angiven incheckning"
 
-#: builtin/commit.c:1474
+#: builtin/commit.c:1477
 msgid "reuse message from specified commit"
 msgstr "återanvänd meddelande från angiven incheckning"
 
-#: builtin/commit.c:1475
+#: builtin/commit.c:1478
 msgid "use autosquash formatted message to fixup specified commit"
 msgstr ""
 "använd autosquash-formaterat meddelande för att fixa angiven incheckning"
 
-#: builtin/commit.c:1476
+#: builtin/commit.c:1479
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "använd autosquash-formaterat meddelande för att slå ihop med angiven "
 "incheckning"
 
-#: builtin/commit.c:1477
+#: builtin/commit.c:1480
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "jag är nu författare av incheckningen (används med -C/-c/--amend)"
 
-#: builtin/commit.c:1478 builtin/log.c:1520 builtin/merge.c:276
-#: builtin/pull.c:155 builtin/revert.c:106
+#: builtin/commit.c:1481 builtin/log.c:1533 builtin/merge.c:277
+#: builtin/pull.c:156 builtin/revert.c:107
 msgid "add Signed-off-by:"
 msgstr "lägg till Signed-off-by:"
 
-#: builtin/commit.c:1479
+#: builtin/commit.c:1482
 msgid "use specified template file"
 msgstr "använd angiven mallfil"
 
-#: builtin/commit.c:1480
+#: builtin/commit.c:1483
 msgid "force edit of commit"
 msgstr "tvinga redigering av incheckning"
 
-#: builtin/commit.c:1481
+#: builtin/commit.c:1484
 msgid "default"
 msgstr "standard"
 
-#: builtin/commit.c:1481 builtin/tag.c:401
+#: builtin/commit.c:1484 builtin/tag.c:401
 msgid "how to strip spaces and #comments from message"
 msgstr "hur blanksteg och #kommentarer skall tas bort från meddelande"
 
-#: builtin/commit.c:1482
+#: builtin/commit.c:1485
 msgid "include status in commit message template"
 msgstr "inkludera status i mallen för incheckningsmeddelandet"
 
-#: builtin/commit.c:1484 builtin/merge.c:274 builtin/pull.c:185
-#: builtin/revert.c:114
+#: builtin/commit.c:1487 builtin/merge.c:275 builtin/pull.c:186
+#: builtin/revert.c:115
 msgid "GPG sign commit"
 msgstr "GPG-signera incheckning"
 
-#: builtin/commit.c:1487
+#: builtin/commit.c:1490
 msgid "Commit contents options"
 msgstr "Alternativ för incheckningens innehåll"
 
-#: builtin/commit.c:1488
+#: builtin/commit.c:1491
 msgid "commit all changed files"
 msgstr "checka in alla ändrade filer"
 
-#: builtin/commit.c:1489
+#: builtin/commit.c:1492
 msgid "add specified files to index for commit"
 msgstr "lägg till angivna filer till indexet för incheckning"
 
-#: builtin/commit.c:1490
+#: builtin/commit.c:1493
 msgid "interactively add files"
 msgstr "lägg till filer interaktivt"
 
-#: builtin/commit.c:1491
+#: builtin/commit.c:1494
 msgid "interactively add changes"
 msgstr "lägg till ändringar interaktivt"
 
-#: builtin/commit.c:1492
+#: builtin/commit.c:1495
 msgid "commit only specified files"
 msgstr "checka endast in angivna filer"
 
-#: builtin/commit.c:1493
+#: builtin/commit.c:1496
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "förbigå pre-commit- och commit-msg-krokar"
 
-#: builtin/commit.c:1494
+#: builtin/commit.c:1497
 msgid "show what would be committed"
 msgstr "visa vad som skulle checkas in"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1510
 msgid "amend previous commit"
 msgstr "lägg till föregående incheckning"
 
-#: builtin/commit.c:1508
+#: builtin/commit.c:1511
 msgid "bypass post-rewrite hook"
 msgstr "förbigå post-rewrite-krok"
 
-#: builtin/commit.c:1513
+#: builtin/commit.c:1516
 msgid "ok to record an empty change"
 msgstr "ok att registrera en tom ändring"
 
-#: builtin/commit.c:1515
+#: builtin/commit.c:1518
 msgid "ok to record a change with an empty message"
 msgstr "ok att registrera en ändring med tomt meddelande"
 
-#: builtin/commit.c:1588
+#: builtin/commit.c:1591
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Trasig MERGE_HEAD-fil (%s)"
 
-#: builtin/commit.c:1595
+#: builtin/commit.c:1598
 msgid "could not read MERGE_MODE"
 msgstr "kunde inte läsa MERGE_MODE"
 
-#: builtin/commit.c:1614
+#: builtin/commit.c:1617
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "kunde inte läsa incheckningsmeddelande: %s"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1628
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Avbryter på grund av tomt incheckningsmeddelande.\n"
 
-#: builtin/commit.c:1630
+#: builtin/commit.c:1633
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Avbryter incheckning; meddelandet inte redigerat.\n"
 
-#: builtin/commit.c:1665
+#: builtin/commit.c:1668
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -10059,7 +10729,7 @@ msgstr ""
 
 #: builtin/commit-graph.c:48 builtin/commit-graph.c:78
 #: builtin/commit-graph.c:132 builtin/commit-graph.c:190 builtin/fetch.c:153
-#: builtin/log.c:1540
+#: builtin/log.c:1553
 msgid "dir"
 msgstr "kat"
 
@@ -10249,48 +10919,48 @@ msgstr "värde"
 msgid "with --get, use default value when missing entry"
 msgstr "med --get, använd standardvärde vid saknad post"
 
-#: builtin/config.c:171
+#: builtin/config.c:172
 #, c-format
 msgid "wrong number of arguments, should be %d"
 msgstr "fel antal argument, skulle vara %d"
 
-#: builtin/config.c:173
+#: builtin/config.c:174
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
 msgstr "fel antal argument, skulle vara från %d till %d"
 
-#: builtin/config.c:307
+#: builtin/config.c:308
 #, c-format
 msgid "invalid key pattern: %s"
 msgstr "felaktigt nyckelmönster: %s"
 
-#: builtin/config.c:343
+#: builtin/config.c:344
 #, c-format
 msgid "failed to format default config value: %s"
 msgstr "misslyckades formatera standardkonfigurationsvärde: %s"
 
-#: builtin/config.c:400
+#: builtin/config.c:401
 #, c-format
 msgid "cannot parse color '%s'"
 msgstr "kan inte tolka färgen \"%s\""
 
-#: builtin/config.c:442
+#: builtin/config.c:443
 msgid "unable to parse default color value"
 msgstr "kan inte tolka standardfärgvärde"
 
-#: builtin/config.c:495 builtin/config.c:741
+#: builtin/config.c:496 builtin/config.c:742
 msgid "not in a git directory"
 msgstr "inte i en git-katalog"
 
-#: builtin/config.c:498
+#: builtin/config.c:499
 msgid "writing to stdin is not supported"
 msgstr "skriva till standard in stöds inte"
 
-#: builtin/config.c:501
+#: builtin/config.c:502
 msgid "writing config blobs is not supported"
-msgstr "skriva konfigurations-blobar stöds inte"
+msgstr "skriva konfigurations-blobbar stöds inte"
 
-#: builtin/config.c:586
+#: builtin/config.c:587
 #, c-format
 msgid ""
 "# This is Git's per-user configuration file.\n"
@@ -10305,23 +10975,23 @@ msgstr ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 
-#: builtin/config.c:610
+#: builtin/config.c:611
 msgid "only one config file at a time"
 msgstr "endast en konfigurationsfil åt gången"
 
-#: builtin/config.c:615
+#: builtin/config.c:616
 msgid "--local can only be used inside a git repository"
 msgstr "--local kan bara användas inuti ett git-arkiv"
 
-#: builtin/config.c:618
+#: builtin/config.c:619
 msgid "--blob can only be used inside a git repository"
 msgstr "--blob kan bara användas inuti ett git-arkiv"
 
-#: builtin/config.c:637
+#: builtin/config.c:638
 msgid "$HOME not set"
 msgstr "$HOME inte satt"
 
-#: builtin/config.c:657
+#: builtin/config.c:658
 msgid ""
 "--worktree cannot be used with multiple working trees unless the config\n"
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
@@ -10331,52 +11001,52 @@ msgstr ""
 "konfigurationsutöknignen worktreeConfig har aktiverats. Läsa stycket\n"
 "\"KONFIGURATIONSFIL\" i \"git help worktree\" för detaljer"
 
-#: builtin/config.c:687
+#: builtin/config.c:688
 msgid "--get-color and variable type are incoherent"
 msgstr "--get-color och variabeltyp stämmer inte överens"
 
-#: builtin/config.c:692
+#: builtin/config.c:693
 msgid "only one action at a time"
 msgstr "endast en åtgärd åt gången"
 
-#: builtin/config.c:705
+#: builtin/config.c:706
 msgid "--name-only is only applicable to --list or --get-regexp"
 msgstr "--name-only gäller bara för --list eller --get-regexp"
 
-#: builtin/config.c:711
+#: builtin/config.c:712
 msgid ""
 "--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
 "list"
 msgstr ""
 "--show-origin gäller bara för --get, --get-all, --get-regexp och --list"
 
-#: builtin/config.c:717
+#: builtin/config.c:718
 msgid "--default is only applicable to --get"
 msgstr "--default gäller bara för --get"
 
-#: builtin/config.c:730
+#: builtin/config.c:731
 #, c-format
 msgid "unable to read config file '%s'"
 msgstr "kan inte konfigurationsfil \"%s\""
 
-#: builtin/config.c:733
+#: builtin/config.c:734
 msgid "error processing config file(s)"
 msgstr "fel vid hantering av konfigurationsfil(er)"
 
-#: builtin/config.c:743
+#: builtin/config.c:744
 msgid "editing stdin is not supported"
 msgstr "redigering av standard in stöds ej"
 
-#: builtin/config.c:745
+#: builtin/config.c:746
 msgid "editing blobs is not supported"
-msgstr "redigering av blobar stöds ej"
+msgstr "redigering av blobbar stöds ej"
 
-#: builtin/config.c:759
+#: builtin/config.c:760
 #, c-format
 msgid "cannot create configuration file %s"
 msgstr "kan inte skapa konfigurationsfilen \"%s\""
 
-#: builtin/config.c:772
+#: builtin/config.c:773
 #, c-format
 msgid ""
 "cannot overwrite multiple values with a single value\n"
@@ -10385,7 +11055,7 @@ msgstr ""
 "kan inte skriva över flera värden med ett ensamt värde\n"
 "       Använd en regexp, --add eller --replace-all för att ändra %s."
 
-#: builtin/config.c:846 builtin/config.c:857
+#: builtin/config.c:847 builtin/config.c:858
 #, c-format
 msgid "no such section: %s"
 msgstr "ingen sådan sektion: %s"
@@ -10398,58 +11068,58 @@ msgstr "git count-objects [-v] [-H | --human-readable]"
 msgid "print sizes in human readable format"
 msgstr "skriv storlekar i människoläsbart format"
 
-#: builtin/describe.c:26
+#: builtin/describe.c:27
 msgid "git describe [<options>] [<commit-ish>...]"
 msgstr "git describe [<flaggor>] [<incheckning-igt>...]"
 
-#: builtin/describe.c:27
+#: builtin/describe.c:28
 msgid "git describe [<options>] --dirty"
 msgstr "git describe [<flaggor>] --dirty"
 
-#: builtin/describe.c:62
+#: builtin/describe.c:63
 msgid "head"
 msgstr "huvud"
 
-#: builtin/describe.c:62
+#: builtin/describe.c:63
 msgid "lightweight"
 msgstr "lättviktig"
 
-#: builtin/describe.c:62
+#: builtin/describe.c:63
 msgid "annotated"
 msgstr "annoterad"
 
-#: builtin/describe.c:272
+#: builtin/describe.c:273
 #, c-format
 msgid "annotated tag %s not available"
 msgstr "den annoterade taggen %s inte tillgänglig"
 
-#: builtin/describe.c:276
+#: builtin/describe.c:277
 #, c-format
 msgid "annotated tag %s has no embedded name"
 msgstr "den annoterade taggen %s har inget inbäddat namn"
 
-#: builtin/describe.c:278
+#: builtin/describe.c:279
 #, c-format
 msgid "tag '%s' is really '%s' here"
 msgstr "taggen \"%s\" är i verkligheten \"%s\" här"
 
-#: builtin/describe.c:322
+#: builtin/describe.c:323
 #, c-format
 msgid "no tag exactly matches '%s'"
 msgstr "ingen tagg motsvarar \"%s\" exakt"
 
-#: builtin/describe.c:324
+#: builtin/describe.c:325
 #, c-format
 msgid "No exact match on refs or tags, searching to describe\n"
 msgstr ""
 "Ingen exakt träff mot referenser eller taggar, söker för att beskriva\n"
 
-#: builtin/describe.c:378
+#: builtin/describe.c:379
 #, c-format
 msgid "finished search at %s\n"
 msgstr "avslutade sökning på %s\n"
 
-#: builtin/describe.c:404
+#: builtin/describe.c:405
 #, c-format
 msgid ""
 "No annotated tags can describe '%s'.\n"
@@ -10458,7 +11128,7 @@ msgstr ""
 "Inga annoterade taggar kan beskriva \"%s\".\n"
 "Det finns dock oannoterade taggar: testa --tags."
 
-#: builtin/describe.c:408
+#: builtin/describe.c:409
 #, c-format
 msgid ""
 "No tags can describe '%s'.\n"
@@ -10467,12 +11137,12 @@ msgstr ""
 "Inga taggar kan beskriva \"%s\".\n"
 "Testa --always, eller skapa några taggar."
 
-#: builtin/describe.c:438
+#: builtin/describe.c:439
 #, c-format
 msgid "traversed %lu commits\n"
 msgstr "traverserade %lu incheckningar\n"
 
-#: builtin/describe.c:441
+#: builtin/describe.c:442
 #, c-format
 msgid ""
 "more than %i tags found; listed %i most recent\n"
@@ -10481,148 +11151,148 @@ msgstr ""
 "mer än %i taggar hittades; listar de %i senaste\n"
 "gav upp sökningen vid %s\n"
 
-#: builtin/describe.c:509
+#: builtin/describe.c:510
 #, c-format
 msgid "describe %s\n"
 msgstr "beskriva %s\n"
 
-#: builtin/describe.c:512 builtin/log.c:513
+#: builtin/describe.c:513 builtin/log.c:516
 #, c-format
 msgid "Not a valid object name %s"
 msgstr "Objektnamnet är inte giltigt: %s"
 
-#: builtin/describe.c:520
+#: builtin/describe.c:521
 #, c-format
 msgid "%s is neither a commit nor blob"
 msgstr "%s är varken incheckning eller blob"
 
-#: builtin/describe.c:534
+#: builtin/describe.c:535
 msgid "find the tag that comes after the commit"
 msgstr "hitta taggen som kommer efter incheckningen"
 
-#: builtin/describe.c:535
+#: builtin/describe.c:536
 msgid "debug search strategy on stderr"
 msgstr "felsök sökstrategin på standard fel"
 
-#: builtin/describe.c:536
+#: builtin/describe.c:537
 msgid "use any ref"
 msgstr "använd alla referenser"
 
-#: builtin/describe.c:537
+#: builtin/describe.c:538
 msgid "use any tag, even unannotated"
 msgstr "använd alla taggar, även oannoterade"
 
-#: builtin/describe.c:538
+#: builtin/describe.c:539
 msgid "always use long format"
 msgstr "använd alltid långt format"
 
-#: builtin/describe.c:539
+#: builtin/describe.c:540
 msgid "only follow first parent"
 msgstr "följ endast första föräldern"
 
-#: builtin/describe.c:542
+#: builtin/describe.c:543
 msgid "only output exact matches"
 msgstr "skriv endast ut exakta träffar"
 
-#: builtin/describe.c:544
+#: builtin/describe.c:545
 msgid "consider <n> most recent tags (default: 10)"
 msgstr "överväg de <n> nyaste taggarna (standard: 10)"
 
-#: builtin/describe.c:546
+#: builtin/describe.c:547
 msgid "only consider tags matching <pattern>"
 msgstr "överväg endast taggar som motsvarar <mönster>"
 
-#: builtin/describe.c:548
+#: builtin/describe.c:549
 msgid "do not consider tags matching <pattern>"
 msgstr "överväg inte taggar som motsvarar <mönster>"
 
-#: builtin/describe.c:550 builtin/name-rev.c:424
+#: builtin/describe.c:551 builtin/name-rev.c:424
 msgid "show abbreviated commit object as fallback"
 msgstr "visa förkortade incheckningsobjekt som standard"
 
-#: builtin/describe.c:551 builtin/describe.c:554
+#: builtin/describe.c:552 builtin/describe.c:555
 msgid "mark"
 msgstr "märke"
 
-#: builtin/describe.c:552
+#: builtin/describe.c:553
 msgid "append <mark> on dirty working tree (default: \"-dirty\")"
 msgstr "lägg till <märke> på lortigt arbetsträd (standard: \"-dirty\")"
 
-#: builtin/describe.c:555
+#: builtin/describe.c:556
 msgid "append <mark> on broken working tree (default: \"-broken\")"
 msgstr "lägg till <märke> på trasigt arbetsträd (standard: \"-broken\")"
 
-#: builtin/describe.c:573
+#: builtin/describe.c:574
 msgid "--long is incompatible with --abbrev=0"
 msgstr "--long är inkompatibel med --abbrev=0"
 
-#: builtin/describe.c:602
+#: builtin/describe.c:603
 msgid "No names found, cannot describe anything."
 msgstr "Inga namn hittades, kan inte beskriva något."
 
-#: builtin/describe.c:652
+#: builtin/describe.c:654
 msgid "--dirty is incompatible with commit-ishes"
 msgstr "--dirty är inkompatibelt med \"commit-ish\"-värden"
 
-#: builtin/describe.c:654
+#: builtin/describe.c:656
 msgid "--broken is incompatible with commit-ishes"
 msgstr "--broken är inkompatibelt med \"commit-ish\"-värden"
 
-#: builtin/diff.c:83
+#: builtin/diff.c:84
 #, c-format
 msgid "'%s': not a regular file or symlink"
 msgstr "\"%s\": inte en normal fil eller symbolisk länk"
 
-#: builtin/diff.c:234
+#: builtin/diff.c:235
 #, c-format
 msgid "invalid option: %s"
 msgstr "ogiltig flagga: %s"
 
-#: builtin/diff.c:363
+#: builtin/diff.c:364
 msgid "Not a git repository"
 msgstr "Inte ett git-arkiv"
 
-#: builtin/diff.c:407
+#: builtin/diff.c:408
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "objektet \"%s\" som angavs är felaktigt."
 
-#: builtin/diff.c:416
+#: builtin/diff.c:417
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "mer än två blobbar angavs: \"%s\""
 
-#: builtin/diff.c:421
+#: builtin/diff.c:422
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "ej hanterat objekt \"%s\" angavs."
 
-#: builtin/difftool.c:30
+#: builtin/difftool.c:31
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr ""
 "git difftool [<flaggor>] [<incheckning> [<incheckning>]] [--] [<sökväg>...]"
 
-#: builtin/difftool.c:260
+#: builtin/difftool.c:261
 #, c-format
 msgid "failed: %d"
 msgstr "misslyckades: %d"
 
-#: builtin/difftool.c:302
+#: builtin/difftool.c:303
 #, c-format
 msgid "could not read symlink %s"
 msgstr "kunde inte läsa symboliska länken %s"
 
-#: builtin/difftool.c:304
+#: builtin/difftool.c:305
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "kunde inte läsa symbolisk länk-fil %s"
 
-#: builtin/difftool.c:312
+#: builtin/difftool.c:313
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "kunde inte läsa objektet %s för symboliska länken %s"
 
-#: builtin/difftool.c:413
+#: builtin/difftool.c:414
 msgid ""
 "combined diff formats('-c' and '--cc') are not supported in\n"
 "directory diff mode('-d' and '--dir-diff')."
@@ -10630,53 +11300,53 @@ msgstr ""
 "kombinerade diff-format (\"-c\" och \"--cc\") stöds inte i\n"
 "katalogdiffläge (\"-d\" och \"--dir-diff\")."
 
-#: builtin/difftool.c:633
+#: builtin/difftool.c:634
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "bägge filerna ändrade: \"%s\" och \"%s\"."
 
-#: builtin/difftool.c:635
+#: builtin/difftool.c:636
 msgid "working tree file has been left."
 msgstr "filen i arbetskatalogen lämnades kvar."
 
-#: builtin/difftool.c:646
+#: builtin/difftool.c:647
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "temporära filer finns i \"%s\"."
 
-#: builtin/difftool.c:647
+#: builtin/difftool.c:648
 msgid "you may want to cleanup or recover these."
 msgstr "du kanske vill städa eller rädda dem."
 
-#: builtin/difftool.c:696
+#: builtin/difftool.c:697
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "använd \"diff.guitool\" istället för \"diff.tool\""
 
-#: builtin/difftool.c:698
+#: builtin/difftool.c:699
 msgid "perform a full-directory diff"
 msgstr "utför diff för hela katalogen"
 
-#: builtin/difftool.c:700
+#: builtin/difftool.c:701
 msgid "do not prompt before launching a diff tool"
 msgstr "fråga inte vid start av diff-verktyg"
 
-#: builtin/difftool.c:705
+#: builtin/difftool.c:706
 msgid "use symlinks in dir-diff mode"
 msgstr "använd symboliska länkar i katalogdiffläge"
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:707
 msgid "tool"
 msgstr "verktyg"
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:708
 msgid "use the specified diff tool"
 msgstr "använd angivet diff-verktyg"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:710
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr "visa en lista över diff-verktyg som kan användas med ”--tool”"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:713
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
 "code"
@@ -10684,15 +11354,15 @@ msgstr ""
 "låt \"git-difftool\" avbryta när ett anropat diff-verktyg ger returvärde "
 "skilt från noll"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:716
 msgid "specify a custom command for viewing diffs"
 msgstr "ange eget kommando för att visa diffar"
 
-#: builtin/difftool.c:739
+#: builtin/difftool.c:740
 msgid "no <tool> given for --tool=<tool>"
 msgstr "inget <verktyg> angavs för --tool=<verktyg>"
 
-#: builtin/difftool.c:746
+#: builtin/difftool.c:747
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "inget <kommando> angavs för --extcmd=<kommando>"
 
@@ -10700,53 +11370,61 @@ msgstr "inget <kommando> angavs för --extcmd=<kommando>"
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [rev-list-flaggor]"
 
-#: builtin/fast-export.c:1006
+#: builtin/fast-export.c:1084
 msgid "show progress after <n> objects"
 msgstr "visa förlopp efter <n> objekt"
 
-#: builtin/fast-export.c:1008
+#: builtin/fast-export.c:1086
 msgid "select handling of signed tags"
 msgstr "välj hantering av signerade taggar"
 
-#: builtin/fast-export.c:1011
+#: builtin/fast-export.c:1089
 msgid "select handling of tags that tag filtered objects"
 msgstr "välj hantering av taggar som har taggfiltrerade objekt"
 
-#: builtin/fast-export.c:1014
+#: builtin/fast-export.c:1092
 msgid "Dump marks to this file"
 msgstr "Dump märken till filen"
 
-#: builtin/fast-export.c:1016
+#: builtin/fast-export.c:1094
 msgid "Import marks from this file"
 msgstr "Importera märken från filen"
 
-#: builtin/fast-export.c:1018
+#: builtin/fast-export.c:1096
 msgid "Fake a tagger when tags lack one"
 msgstr "Fejka taggare när taggen saknar en"
 
-#: builtin/fast-export.c:1020
+#: builtin/fast-export.c:1098
 msgid "Output full tree for each commit"
 msgstr "Skriv ut hela trädet för varje incheckning"
 
-#: builtin/fast-export.c:1022
+#: builtin/fast-export.c:1100
 msgid "Use the done feature to terminate the stream"
 msgstr "Använd done-funktionen för att avsluta strömmen"
 
-#: builtin/fast-export.c:1023
+#: builtin/fast-export.c:1101
 msgid "Skip output of blob data"
 msgstr "Hoppa över skrivning av blob-data"
 
-#: builtin/fast-export.c:1024 builtin/log.c:1588
+#: builtin/fast-export.c:1102 builtin/log.c:1601
 msgid "refspec"
 msgstr "referensspecifikation"
 
-#: builtin/fast-export.c:1025
+#: builtin/fast-export.c:1103
 msgid "Apply refspec to exported refs"
 msgstr "Applicera referensspecifikation på exporterade referenser"
 
-#: builtin/fast-export.c:1026
+#: builtin/fast-export.c:1104
 msgid "anonymize output"
 msgstr "anonymisera utdata"
+
+#: builtin/fast-export.c:1106
+msgid "Reference parents which are not in fast-export stream by object id"
+msgstr "Referera föräldrar som inte finns i fast-export-ström med objekt-id"
+
+#: builtin/fast-export.c:1108
+msgid "Show original object ids of blobs/commits"
+msgstr "Visa ursprungliga objekt-ID för blobbar/incheckningar"
 
 #: builtin/fetch.c:28
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
@@ -10764,15 +11442,15 @@ msgstr "git fetch --multiple [<flaggor>] [(<arkiv> | <grupp>)...]"
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<flaggor>]"
 
-#: builtin/fetch.c:115 builtin/pull.c:194
+#: builtin/fetch.c:115 builtin/pull.c:195
 msgid "fetch from all remotes"
 msgstr "hämta från alla fjärrar"
 
-#: builtin/fetch.c:117 builtin/pull.c:197
+#: builtin/fetch.c:117 builtin/pull.c:198
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "lägg till i .git/FETCH_HEAD istället för att skriva över"
 
-#: builtin/fetch.c:119 builtin/pull.c:200
+#: builtin/fetch.c:119 builtin/pull.c:201
 msgid "path to upload pack on remote end"
 msgstr "sökväg till upload pack på fjärren"
 
@@ -10784,7 +11462,7 @@ msgstr "tvinga överskrivning av lokal referens"
 msgid "fetch from multiple remotes"
 msgstr "hämta från flera fjärrar"
 
-#: builtin/fetch.c:124 builtin/pull.c:204
+#: builtin/fetch.c:124 builtin/pull.c:205
 msgid "fetch all tags and associated objects"
 msgstr "hämta alla taggar och associerade objekt"
 
@@ -10796,7 +11474,7 @@ msgstr "hämta inte alla taggar (--no-tags)"
 msgid "number of submodules fetched in parallel"
 msgstr "antal undermoduler som hämtas parallellt"
 
-#: builtin/fetch.c:130 builtin/pull.c:207
+#: builtin/fetch.c:130 builtin/pull.c:208
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "rensa fjärrspårande grenar ej längre på fjärren"
 
@@ -10805,7 +11483,7 @@ msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "rensa lokala taggar inte längre på fjärren och skriv över ändrade taggar"
 
-#: builtin/fetch.c:133 builtin/fetch.c:156 builtin/pull.c:132
+#: builtin/fetch.c:133 builtin/fetch.c:156 builtin/pull.c:133
 msgid "on-demand"
 msgstr "on-demand"
 
@@ -10813,7 +11491,7 @@ msgstr "on-demand"
 msgid "control recursive fetching of submodules"
 msgstr "styr rekursiv hämtning av undermoduler"
 
-#: builtin/fetch.c:138 builtin/pull.c:215
+#: builtin/fetch.c:138 builtin/pull.c:216
 msgid "keep downloaded pack"
 msgstr "behåll hämtade paket"
 
@@ -10821,7 +11499,7 @@ msgstr "behåll hämtade paket"
 msgid "allow updating of HEAD ref"
 msgstr "tillåt uppdatering av HEAD-referens"
 
-#: builtin/fetch.c:143 builtin/fetch.c:149 builtin/pull.c:218
+#: builtin/fetch.c:143 builtin/fetch.c:149 builtin/pull.c:219
 msgid "deepen history of shallow clone"
 msgstr "fördjupa historik för grund klon"
 
@@ -10829,7 +11507,7 @@ msgstr "fördjupa historik för grund klon"
 msgid "deepen history of shallow repository based on time"
 msgstr "fördjupa historik för grund klon baserad på tid"
 
-#: builtin/fetch.c:151 builtin/pull.c:221
+#: builtin/fetch.c:151 builtin/pull.c:222
 msgid "convert to a complete repository"
 msgstr "konvertera till komplett arkiv"
 
@@ -10845,24 +11523,24 @@ msgstr ""
 "standard för rekursiv hämtning av undermoduler (lägre prioritet än "
 "konfigurationsfiler)"
 
-#: builtin/fetch.c:161 builtin/pull.c:224
+#: builtin/fetch.c:161 builtin/pull.c:225
 msgid "accept refs that update .git/shallow"
 msgstr "tar emot referenser som uppdaterar .git/shallow"
 
-#: builtin/fetch.c:162 builtin/pull.c:226
+#: builtin/fetch.c:162 builtin/pull.c:227
 msgid "refmap"
 msgstr "referenskarta"
 
-#: builtin/fetch.c:163 builtin/pull.c:227
+#: builtin/fetch.c:163 builtin/pull.c:228
 msgid "specify fetch refmap"
 msgstr "ange referenskarta för \"fetch\""
 
-#: builtin/fetch.c:164 builtin/ls-remote.c:77 builtin/push.c:582
+#: builtin/fetch.c:164 builtin/ls-remote.c:77 builtin/push.c:585
 #: builtin/send-pack.c:172
 msgid "server-specific"
 msgstr "serverspecifik"
 
-#: builtin/fetch.c:164 builtin/ls-remote.c:77 builtin/push.c:582
+#: builtin/fetch.c:164 builtin/ls-remote.c:77 builtin/push.c:585
 #: builtin/send-pack.c:173
 msgid "option to transmit"
 msgstr ""
@@ -10873,81 +11551,81 @@ msgstr ""
 msgid "report that we have only objects reachable from this object"
 msgstr "rapportera att vi bara har objekt nåbara från detta objektet"
 
-#: builtin/fetch.c:470
+#: builtin/fetch.c:469
 msgid "Couldn't find remote ref HEAD"
 msgstr "Kunde inte hitta fjärr-referensen HEAD"
 
-#: builtin/fetch.c:609
+#: builtin/fetch.c:608
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "konfigurationen för fetch.output innehåller ogiltigt värde %s"
 
-#: builtin/fetch.c:702
+#: builtin/fetch.c:705
 #, c-format
 msgid "object %s not found"
 msgstr "objektet %s hittades inte"
 
-#: builtin/fetch.c:706
+#: builtin/fetch.c:709
 msgid "[up to date]"
 msgstr "[àjour]"
 
-#: builtin/fetch.c:719 builtin/fetch.c:735 builtin/fetch.c:807
+#: builtin/fetch.c:722 builtin/fetch.c:738 builtin/fetch.c:801
 msgid "[rejected]"
 msgstr "[refuserad]"
 
-#: builtin/fetch.c:720
+#: builtin/fetch.c:723
 msgid "can't fetch in current branch"
 msgstr "kan inte hämta i aktuell gren"
 
-#: builtin/fetch.c:730
+#: builtin/fetch.c:733
 msgid "[tag update]"
 msgstr "[uppdaterad tagg]"
 
-#: builtin/fetch.c:731 builtin/fetch.c:771 builtin/fetch.c:787
-#: builtin/fetch.c:802
+#: builtin/fetch.c:734 builtin/fetch.c:771 builtin/fetch.c:784
+#: builtin/fetch.c:796
 msgid "unable to update local ref"
 msgstr "kunde inte uppdatera lokal ref"
 
-#: builtin/fetch.c:735
+#: builtin/fetch.c:738
 msgid "would clobber existing tag"
 msgstr "skulle skriva över befintlig tagg"
 
-#: builtin/fetch.c:757
+#: builtin/fetch.c:760
 msgid "[new tag]"
 msgstr "[ny tagg]"
 
-#: builtin/fetch.c:760
+#: builtin/fetch.c:763
 msgid "[new branch]"
 msgstr "[ny gren]"
 
-#: builtin/fetch.c:763
+#: builtin/fetch.c:766
 msgid "[new ref]"
 msgstr "[ny ref]"
 
-#: builtin/fetch.c:802
+#: builtin/fetch.c:796
 msgid "forced update"
 msgstr "tvingad uppdatering"
 
-#: builtin/fetch.c:807
+#: builtin/fetch.c:801
 msgid "non-fast-forward"
 msgstr "ej snabbspolad"
 
-#: builtin/fetch.c:853
+#: builtin/fetch.c:847
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s sände inte alla nödvändiga objekt\n"
 
-#: builtin/fetch.c:874
+#: builtin/fetch.c:868
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr "avvisa %s då grunda rötter inte kan uppdateras"
 
-#: builtin/fetch.c:963 builtin/fetch.c:1085
+#: builtin/fetch.c:959 builtin/fetch.c:1081
 #, c-format
 msgid "From %.*s\n"
 msgstr "Från %.*s\n"
 
-#: builtin/fetch.c:974
+#: builtin/fetch.c:970
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -10956,56 +11634,58 @@ msgstr ""
 "vissa lokala referenser kunde inte uppdateras; testa att köra\n"
 " \"git remote prune %s\" för att ta bort gamla grenar som står i konflikt"
 
-#: builtin/fetch.c:1055
+#: builtin/fetch.c:1051
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s kommer bli dinglande)"
 
-#: builtin/fetch.c:1056
+#: builtin/fetch.c:1052
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s har blivit dinglande)"
 
-#: builtin/fetch.c:1088
+#: builtin/fetch.c:1084
 msgid "[deleted]"
 msgstr "[borttagen]"
 
-#: builtin/fetch.c:1089 builtin/remote.c:1036
+#: builtin/fetch.c:1085 builtin/remote.c:1036
 msgid "(none)"
 msgstr "(ingen)"
 
-#: builtin/fetch.c:1112
+#: builtin/fetch.c:1108
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr "Vägrar hämta till aktuell gren %s i ett icke-naket arkiv"
 
-#: builtin/fetch.c:1131
+#: builtin/fetch.c:1127
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Flaggan \"%s\" och värdet \"%s\" är inte giltigt för %s"
 
-#: builtin/fetch.c:1134
+#: builtin/fetch.c:1130
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Flaggan \"%s\" ignoreras för %s\n"
 
-#: builtin/fetch.c:1433
+#: builtin/fetch.c:1434
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Hämtar %s\n"
 
-#: builtin/fetch.c:1435 builtin/remote.c:100
+#: builtin/fetch.c:1436 builtin/remote.c:100
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Kunde inte hämta %s"
 
-#: builtin/fetch.c:1481 builtin/fetch.c:1649
+#: builtin/fetch.c:1482
 msgid ""
-"--filter can only be used with the remote configured in core.partialClone"
+"--filter can only be used with the remote configured in extensions."
+"partialClone"
 msgstr ""
-"--filter kan endast användas med fjärren konfigurerad i core.partialClone"
+"--filter kan endast användas med fjärren konfigurerad i extensions."
+"partialClone"
 
-#: builtin/fetch.c:1504
+#: builtin/fetch.c:1506
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -11013,42 +11693,50 @@ msgstr ""
 "Inget fjärrarkiv angavs. Ange antingen en URL eller namnet på ett\n"
 "fjärrarkiv som nya incheckningar skall hämtas från."
 
-#: builtin/fetch.c:1541
+#: builtin/fetch.c:1543
 msgid "You need to specify a tag name."
 msgstr "Du måste ange namnet på en tagg."
 
-#: builtin/fetch.c:1590
+#: builtin/fetch.c:1592
 msgid "Negative depth in --deepen is not supported"
 msgstr "Negativa djup stöds inte i --deepen"
 
-#: builtin/fetch.c:1592
+#: builtin/fetch.c:1594
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen och --depth är ömsesidigt uteslutande"
 
-#: builtin/fetch.c:1597
+#: builtin/fetch.c:1599
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth och --unshallow kan inte användas samtidigt"
 
-#: builtin/fetch.c:1599
+#: builtin/fetch.c:1601
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow kan inte användas på ett komplett arkiv"
 
-#: builtin/fetch.c:1615
+#: builtin/fetch.c:1617
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all tar inte namnet på ett arkiv som argument"
 
-#: builtin/fetch.c:1617
+#: builtin/fetch.c:1619
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all kan inte anges med referensspecifikationer"
 
-#: builtin/fetch.c:1626
+#: builtin/fetch.c:1628
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Fjärren eller fjärrgruppen finns inte: %s"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1635
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr "Kan inte hämta från grupp och ange referensspecifikationer"
+
+#: builtin/fetch.c:1651
+msgid ""
+"--filter can only be used with the remote configured in extensions."
+"partialclone"
+msgstr ""
+"--filter kan endast användas med fjärren konfigurerad i extensions."
+"partialclone"
 
 #: builtin/fmt-merge-msg.c:18
 msgid ""
@@ -11137,67 +11825,252 @@ msgstr "visa endast referenser som innehåller incheckningen"
 msgid "print only refs which don't contain the commit"
 msgstr "visa endast referenser som inte innehåller incheckningen"
 
-#: builtin/fsck.c:598
+#: builtin/fsck.c:88 builtin/fsck.c:160 builtin/fsck.c:161
+msgid "unknown"
+msgstr "okänd"
+
+#. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
+#: builtin/fsck.c:120 builtin/fsck.c:136
+#, c-format
+msgid "error in %s %s: %s"
+msgstr "fel i %s %s: %s"
+
+#. TRANSLATORS: e.g. warning in tree 01bfda: <more explanation>
+#: builtin/fsck.c:131
+#, c-format
+msgid "warning in %s %s: %s"
+msgstr "varning i %s %s: %s"
+
+#: builtin/fsck.c:157 builtin/fsck.c:159
+#, c-format
+msgid "broken link from %7s %s"
+msgstr "trasig länk från %7s %s"
+
+#: builtin/fsck.c:168
+msgid "wrong object type in link"
+msgstr "fel objekttyp i länk"
+
+#: builtin/fsck.c:184
+#, c-format
+msgid ""
+"broken link from %7s %s\n"
+"              to %7s %s"
+msgstr ""
+"trasig länk från %7s %s\n"
+"            till %7s %s"
+
+#: builtin/fsck.c:253
+#, c-format
+msgid "missing %s %s"
+msgstr "saknat %s %s"
+
+#: builtin/fsck.c:279
+#, c-format
+msgid "unreachable %s %s"
+msgstr "onåbart %s %s"
+
+#: builtin/fsck.c:298
+#, c-format
+msgid "dangling %s %s"
+msgstr "hängande %s %s"
+
+#: builtin/fsck.c:307
+msgid "could not create lost-found"
+msgstr "kunde inte skapa lost-found"
+
+#: builtin/fsck.c:318
+#, c-format
+msgid "could not finish '%s'"
+msgstr "kunde inte avsluta \"%s\""
+
+#: builtin/fsck.c:335
+#, c-format
+msgid "Checking %s"
+msgstr "Kontrollerar %s"
+
+# Vague original, not networking-related, but rather related to the actual
+# objects in the database.
+#: builtin/fsck.c:353
+#, c-format
+msgid "Checking connectivity (%d objects)"
+msgstr "Kontrollerar konnektivitet (%d objekt)"
+
+#: builtin/fsck.c:372
+#, c-format
+msgid "Checking %s %s"
+msgstr "Kontrollerar %s %s"
+
+#: builtin/fsck.c:376
+msgid "broken links"
+msgstr "trasiga länkar"
+
+#: builtin/fsck.c:385
+#, c-format
+msgid "root %s"
+msgstr "roten %s"
+
+#: builtin/fsck.c:393
+#, c-format
+msgid "tagged %s %s (%s) in %s"
+msgstr "taggad %s %s (%s) i %s"
+
+#: builtin/fsck.c:422
+#, c-format
+msgid "%s: object corrupt or missing"
+msgstr "%s: objekt trasigt eller saknas"
+
+#: builtin/fsck.c:447
+#, c-format
+msgid "%s: invalid reflog entry %s"
+msgstr "%s: ogiltig reflog-post %s"
+
+#: builtin/fsck.c:461
+#, c-format
+msgid "Checking reflog %s->%s"
+msgstr "Kontrollerar reflog %s->%s"
+
+#: builtin/fsck.c:495
+#, c-format
+msgid "%s: invalid sha1 pointer %s"
+msgstr "%s: ogiltig sha1-pekare %s"
+
+#: builtin/fsck.c:502
+#, c-format
+msgid "%s: not a commit"
+msgstr "%s: inte en incheckning!"
+
+#: builtin/fsck.c:557
+msgid "notice: No default references"
+msgstr "obs: Inga förvalda referenser"
+
+#: builtin/fsck.c:572
+#, c-format
+msgid "%s: object corrupt or missing: %s"
+msgstr "%s: objektet trasigt eller saknas: %s"
+
+#: builtin/fsck.c:585
+#, c-format
+msgid "%s: object could not be parsed: %s"
+msgstr "%s: objektet kunde inte tolkas: %s"
+
+#: builtin/fsck.c:605
+#, c-format
+msgid "bad sha1 file: %s"
+msgstr "ogiltig sha1-fil: %s"
+
+#: builtin/fsck.c:620
+msgid "Checking object directory"
+msgstr "Kontrollerar objektkatalog"
+
+#: builtin/fsck.c:623
 msgid "Checking object directories"
 msgstr "Kontrollerar objektkataloger"
 
-#: builtin/fsck.c:693
+#: builtin/fsck.c:638
+#, c-format
+msgid "Checking %s link"
+msgstr "Kontrollerar %s-länk"
+
+#: builtin/fsck.c:643 builtin/index-pack.c:833
+#, c-format
+msgid "invalid %s"
+msgstr "ogiltigt %s"
+
+#: builtin/fsck.c:650
+#, c-format
+msgid "%s points to something strange (%s)"
+msgstr "%s pekar på något konstigt (%s)"
+
+#: builtin/fsck.c:656
+#, c-format
+msgid "%s: detached HEAD points at nothing"
+msgstr "%s: frånkopplat HEAD pekar på ingenting"
+
+#: builtin/fsck.c:660
+#, c-format
+msgid "notice: %s points to an unborn branch (%s)"
+msgstr "obs: %s pekar på en ofödd gren (%s)"
+
+#: builtin/fsck.c:672
+msgid "Checking cache tree"
+msgstr "Kontrollerar cacheträd"
+
+#: builtin/fsck.c:677
+#, c-format
+msgid "%s: invalid sha1 pointer in cache-tree"
+msgstr "%s: ogiltig sha1-pekare i cacheträd"
+
+#: builtin/fsck.c:688
+msgid "non-tree in cache-tree"
+msgstr "icke-träd i cacheträd"
+
+#: builtin/fsck.c:719
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<flaggor>] [<objekt>...]"
 
-#: builtin/fsck.c:699
+#: builtin/fsck.c:725
 msgid "show unreachable objects"
 msgstr "visa onåbara objekt"
 
-#: builtin/fsck.c:700
+#: builtin/fsck.c:726
 msgid "show dangling objects"
 msgstr "visa dinglande objekt"
 
-#: builtin/fsck.c:701
+#: builtin/fsck.c:727
 msgid "report tags"
 msgstr "rapportera taggar"
 
-#: builtin/fsck.c:702
+#: builtin/fsck.c:728
 msgid "report root nodes"
 msgstr "rapportera rotnoder"
 
-#: builtin/fsck.c:703
+#: builtin/fsck.c:729
 msgid "make index objects head nodes"
 msgstr "gör indexojekt till huvudnoder"
 
-#: builtin/fsck.c:704
+#: builtin/fsck.c:730
 msgid "make reflogs head nodes (default)"
 msgstr "gör refloggar till huvudnoder (standard)"
 
-#: builtin/fsck.c:705
+#: builtin/fsck.c:731
 msgid "also consider packs and alternate objects"
 msgstr "ta även hänsyn till paket och alternativa objekt"
 
 # Vague original, not networking-related, but rather related to the actual
 # objects in the database.
-#: builtin/fsck.c:706
+#: builtin/fsck.c:732
 msgid "check only connectivity"
 msgstr "kontrollera endast konnektivitet"
 
-#: builtin/fsck.c:707
+#: builtin/fsck.c:733
 msgid "enable more strict checking"
 msgstr "aktivera striktare kontroll"
 
-#: builtin/fsck.c:709
+#: builtin/fsck.c:735
 msgid "write dangling objects in .git/lost-found"
 msgstr "skriv dinglande objekt i .git/lost-found"
 
-#: builtin/fsck.c:710 builtin/prune.c:110
+#: builtin/fsck.c:736 builtin/prune.c:110
 msgid "show progress"
 msgstr "visa förlopp"
 
-#: builtin/fsck.c:711
+#: builtin/fsck.c:737
 msgid "show verbose names for reachable objects"
 msgstr "visa ordrika namn för nåbara objekt"
 
-#: builtin/fsck.c:776
+#: builtin/fsck.c:797
 msgid "Checking objects"
 msgstr "Kontrollerar objekt"
+
+#: builtin/fsck.c:825
+#, c-format
+msgid "%s: object missing"
+msgstr "%s: objekt saknas"
+
+#: builtin/fsck.c:837
+#, c-format
+msgid "invalid parameter: expected sha1, got '%s'"
+msgstr "ogiltig parameter: förväntade sha1, fick \"%s\""
 
 #: builtin/gc.c:34
 msgid "git gc [<options>]"
@@ -11286,23 +12159,23 @@ msgstr ""
 "gc körs redan på maskinen \"%s\" pid %<PRIuMAX> (använd --force om så inte "
 "är fallet)"
 
-#: builtin/gc.c:670
+#: builtin/gc.c:672
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Det finns för många onåbara lösa objekt; kör \"git prune\" för att ta bort "
 "dem."
 
-#: builtin/grep.c:28
+#: builtin/grep.c:29
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [<flaggor>] [-e] <mönster> [<rev>...] [[--] <sökväg>...]"
 
-#: builtin/grep.c:224
+#: builtin/grep.c:225
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: misslyckades skapa tråd. %s"
 
-#: builtin/grep.c:278
+#: builtin/grep.c:279
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "felaktigt antal trådar angivet (%d) för %s"
@@ -11311,262 +12184,262 @@ msgstr "felaktigt antal trådar angivet (%d) för %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:286 builtin/index-pack.c:1506 builtin/index-pack.c:1697
-#: builtin/pack-objects.c:2719
+#: builtin/grep.c:287 builtin/index-pack.c:1506 builtin/index-pack.c:1697
+#: builtin/pack-objects.c:2717
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "trådstöd saknas, ignorerar %s"
 
-#: builtin/grep.c:458 builtin/grep.c:579 builtin/grep.c:620
+#: builtin/grep.c:466 builtin/grep.c:590 builtin/grep.c:631
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "kunde inte läsa träd (%s)"
 
-#: builtin/grep.c:635
+#: builtin/grep.c:646
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "kunde inte \"grep\" från objekt av typen %s"
 
-#: builtin/grep.c:701
+#: builtin/grep.c:712
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "flaggan \"%c\" antar ett numeriskt värde"
 
-#: builtin/grep.c:800
+#: builtin/grep.c:811
 msgid "search in index instead of in the work tree"
 msgstr "sök i indexet istället för i arbetskatalogen"
 
-#: builtin/grep.c:802
+#: builtin/grep.c:813
 msgid "find in contents not managed by git"
 msgstr "sök i innehåll som inte hanteras av git"
 
-#: builtin/grep.c:804
+#: builtin/grep.c:815
 msgid "search in both tracked and untracked files"
 msgstr "sök i både spårade och ospårade filer"
 
-#: builtin/grep.c:806
+#: builtin/grep.c:817
 msgid "ignore files specified via '.gitignore'"
 msgstr "ignorera filer angivna i \".gitignore\""
 
-#: builtin/grep.c:808
+#: builtin/grep.c:819
 msgid "recursively search in each submodule"
 msgstr "sök varje undermodul rekursivt"
 
-#: builtin/grep.c:811
+#: builtin/grep.c:822
 msgid "show non-matching lines"
 msgstr "visa rader som inte träffas"
 
-#: builtin/grep.c:813
+#: builtin/grep.c:824
 msgid "case insensitive matching"
 msgstr "skiftlägesokänslig sökning"
 
-#: builtin/grep.c:815
+#: builtin/grep.c:826
 msgid "match patterns only at word boundaries"
 msgstr "matcha endast mönster vid ordgränser"
 
-#: builtin/grep.c:817
+#: builtin/grep.c:828
 msgid "process binary files as text"
 msgstr "hantera binärfiler som text"
 
-#: builtin/grep.c:819
+#: builtin/grep.c:830
 msgid "don't match patterns in binary files"
 msgstr "träffa inte mönster i binärfiler"
 
-#: builtin/grep.c:822
+#: builtin/grep.c:833
 msgid "process binary files with textconv filters"
 msgstr "hantera binärfiler med textconv-filter"
 
-#: builtin/grep.c:824
+#: builtin/grep.c:835
 msgid "search in subdirectories (default)"
 msgstr "sök i underkataloger (standard)"
 
-#: builtin/grep.c:826
+#: builtin/grep.c:837
 msgid "descend at most <depth> levels"
 msgstr "gå som mest ned <djup> nivåer"
 
-#: builtin/grep.c:830
+#: builtin/grep.c:841
 msgid "use extended POSIX regular expressions"
 msgstr "använd utökade POSIX-reguljära uttryck"
 
-#: builtin/grep.c:833
+#: builtin/grep.c:844
 msgid "use basic POSIX regular expressions (default)"
 msgstr "använd grundläggande POSIX-reguljära uttryck (standard)"
 
-#: builtin/grep.c:836
+#: builtin/grep.c:847
 msgid "interpret patterns as fixed strings"
 msgstr "tolka mönster som fixerade strängar"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:850
 msgid "use Perl-compatible regular expressions"
 msgstr "använd Perlkompatibla reguljära uttryck"
 
-#: builtin/grep.c:842
+#: builtin/grep.c:853
 msgid "show line numbers"
 msgstr "visa radnummer"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:854
 msgid "show column number of first match"
 msgstr "visa kolumnnummer för första träff"
 
-#: builtin/grep.c:844
+#: builtin/grep.c:855
 msgid "don't show filenames"
 msgstr "visa inte filnamn"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:856
 msgid "show filenames"
 msgstr "visa filnamn"
 
-#: builtin/grep.c:847
+#: builtin/grep.c:858
 msgid "show filenames relative to top directory"
 msgstr "visa filnamn relativa till toppkatalogen"
 
-#: builtin/grep.c:849
+#: builtin/grep.c:860
 msgid "show only filenames instead of matching lines"
 msgstr "visa endast filnamn istället för träffade rader"
 
-#: builtin/grep.c:851
+#: builtin/grep.c:862
 msgid "synonym for --files-with-matches"
 msgstr "synonym för --files-with-matches"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:865
 msgid "show only the names of files without match"
 msgstr "visa endast namn på filer utan träffar"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:867
 msgid "print NUL after filenames"
 msgstr "skriv NUL efter filnamn"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:870
 msgid "show only matching parts of a line"
 msgstr "visa endast träffade delar av rader"
 
-#: builtin/grep.c:861
+#: builtin/grep.c:872
 msgid "show the number of matches instead of matching lines"
 msgstr "visa antal träffar istället för träffade rader"
 
-#: builtin/grep.c:862
+#: builtin/grep.c:873
 msgid "highlight matches"
 msgstr "ljusmarkera träffar"
 
-#: builtin/grep.c:864
+#: builtin/grep.c:875
 msgid "print empty line between matches from different files"
 msgstr "skriv tomma rader mellan träffar från olika filer"
 
-#: builtin/grep.c:866
+#: builtin/grep.c:877
 msgid "show filename only once above matches from same file"
 msgstr "visa filnamn endast en gång ovanför träffar från samma fil"
 
-#: builtin/grep.c:869
+#: builtin/grep.c:880
 msgid "show <n> context lines before and after matches"
 msgstr "visa <n> rader sammanhang före och efter träffar"
 
-#: builtin/grep.c:872
+#: builtin/grep.c:883
 msgid "show <n> context lines before matches"
 msgstr "visa <n> rader sammanhang före träffar"
 
-#: builtin/grep.c:874
+#: builtin/grep.c:885
 msgid "show <n> context lines after matches"
 msgstr "visa <n> rader sammanhang efter träffar"
 
-#: builtin/grep.c:876
+#: builtin/grep.c:887
 msgid "use <n> worker threads"
 msgstr "använd <n> jobbtrådar"
 
-#: builtin/grep.c:877
+#: builtin/grep.c:888
 msgid "shortcut for -C NUM"
 msgstr "genväg för -C NUM"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:891
 msgid "show a line with the function name before matches"
 msgstr "visa en rad med funktionsnamnet före träffen"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:893
 msgid "show the surrounding function"
 msgstr "visa den omkringliggande funktionen"
 
-#: builtin/grep.c:885
+#: builtin/grep.c:896
 msgid "read patterns from file"
 msgstr "läs mönster från fil"
 
-#: builtin/grep.c:887
+#: builtin/grep.c:898
 msgid "match <pattern>"
 msgstr "träffa <mönster>"
 
-#: builtin/grep.c:889
+#: builtin/grep.c:900
 msgid "combine patterns specified with -e"
 msgstr "kombinera mönster som anges med -e"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:912
 msgid "indicate hit with exit status without output"
 msgstr "ange träff med slutstatuskod utan utdata"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:914
 msgid "show only matches from files that match all patterns"
 msgstr "visa endast träffar från filer som träffar alla mönster"
 
-#: builtin/grep.c:905
+#: builtin/grep.c:916
 msgid "show parse tree for grep expression"
 msgstr "visa analysträd för grep-uttryck"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:920
 msgid "pager"
 msgstr "bläddrare"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:920
 msgid "show matching files in the pager"
 msgstr "visa träffade filer i filbläddraren"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:924
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "tillåt anropa grep(1) (ignoreras av detta bygge)"
 
-#: builtin/grep.c:977
+#: builtin/grep.c:988
 msgid "no pattern given"
 msgstr "inget mönster angavs"
 
-#: builtin/grep.c:1013
+#: builtin/grep.c:1024
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index och --untracked kan inte användas med revisioner"
 
-#: builtin/grep.c:1020
+#: builtin/grep.c:1032
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "kan inte slå upp revision: %s"
 
-#: builtin/grep.c:1051
+#: builtin/grep.c:1063
 msgid "invalid option combination, ignoring --threads"
 msgstr "ogiltig kombination av flaggor, ignorerar --threads"
 
-#: builtin/grep.c:1054 builtin/pack-objects.c:3397
+#: builtin/grep.c:1066 builtin/pack-objects.c:3400
 msgid "no threads support, ignoring --threads"
 msgstr "trådstöd saknas, ignorerar --threads"
 
-#: builtin/grep.c:1057 builtin/index-pack.c:1503 builtin/pack-objects.c:2716
+#: builtin/grep.c:1069 builtin/index-pack.c:1503 builtin/pack-objects.c:2714
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "felaktigt antal trådar angivet (%d)"
 
-#: builtin/grep.c:1080
+#: builtin/grep.c:1092
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "--open-files-in-pager fungerar endast i arbetskatalogen"
 
-#: builtin/grep.c:1103
+#: builtin/grep.c:1115
 msgid "option not supported with --recurse-submodules"
 msgstr "flaggan stöds inte med --recurse-submodules"
 
-#: builtin/grep.c:1109
+#: builtin/grep.c:1121
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached och --untracked kan inte användas med --no-index"
 
-#: builtin/grep.c:1115
+#: builtin/grep.c:1127
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr "--[no-]exclude-standard kan inte användas för spårat innehåll"
 
-#: builtin/grep.c:1123
+#: builtin/grep.c:1135
 msgid "both --cached and trees are given"
 msgstr "både --cached och träd angavs"
 
-#: builtin/hash-object.c:84
+#: builtin/hash-object.c:85
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file> | --no-filters] [--stdin] "
 "[--] <file>..."
@@ -11574,37 +12447,37 @@ msgstr ""
 "git hash-object [-t <typ>] [-w] [--path=<fil> | --no-filters] [--stdin] [--] "
 "<fil>..."
 
-#: builtin/hash-object.c:85
+#: builtin/hash-object.c:86
 msgid "git hash-object  --stdin-paths"
 msgstr "git hash-object  --stdin-paths"
 
-#: builtin/hash-object.c:97
+#: builtin/hash-object.c:98
 msgid "type"
 msgstr "typ"
 
-#: builtin/hash-object.c:97
+#: builtin/hash-object.c:98
 msgid "object type"
 msgstr "objekttyp"
 
-#: builtin/hash-object.c:98
+#: builtin/hash-object.c:99
 msgid "write the object into the object database"
 msgstr "skriv objektet till objektdatabasen"
 
-#: builtin/hash-object.c:100
+#: builtin/hash-object.c:101
 msgid "read the object from stdin"
 msgstr "läs objektet från standard in"
 
-#: builtin/hash-object.c:102
+#: builtin/hash-object.c:103
 msgid "store file as is without filters"
 msgstr "spara filen som den är utan filer"
 
-#: builtin/hash-object.c:103
+#: builtin/hash-object.c:104
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr ""
 "hasha slumpmässigt skräp för att skapa korrupta objekt för felsökning av Git"
 
-#: builtin/hash-object.c:104
+#: builtin/hash-object.c:105
 msgid "process file as it were from this path"
 msgstr "hantera filen som om den kom från sökvägen"
 
@@ -11698,12 +12571,12 @@ msgstr "ingen man-visare hanterade förfrågan"
 msgid "no info viewer handled the request"
 msgstr "ingen info-visare hanterade förfrågan"
 
-#: builtin/help.c:430 builtin/help.c:441 git.c:322
+#: builtin/help.c:430 builtin/help.c:441 git.c:323
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "\"%s\" är ett alias för \"%s\""
 
-#: builtin/help.c:444
+#: builtin/help.c:444 git.c:347
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "felaktig alias.%s-sträng: %s"
@@ -11751,7 +12624,7 @@ msgstr "indataläsfel"
 msgid "used more bytes than were available"
 msgstr "använde fler byte än tillgängligt"
 
-#: builtin/index-pack.c:279 builtin/pack-objects.c:598
+#: builtin/index-pack.c:279 builtin/pack-objects.c:599
 msgid "pack too large for current definition of off_t"
 msgstr "paket för stort för nuvarande definition av off_t"
 
@@ -11759,7 +12632,7 @@ msgstr "paket för stort för nuvarande definition av off_t"
 msgid "pack exceeds maximum allowed size"
 msgstr "paket är större än tillåten maximal storlek"
 
-#: builtin/index-pack.c:297
+#: builtin/index-pack.c:297 builtin/repack.c:250
 #, c-format
 msgid "unable to create '%s'"
 msgstr "kunde inte skapa \"%s\""
@@ -11822,8 +12695,8 @@ msgstr "allvarlig inflate-inkonsekvens"
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "SHA1-KOLLISION UPPTÄCKT VID %s !"
 
-#: builtin/index-pack.c:729 builtin/pack-objects.c:151
-#: builtin/pack-objects.c:211 builtin/pack-objects.c:305
+#: builtin/index-pack.c:729 builtin/pack-objects.c:152
+#: builtin/pack-objects.c:212 builtin/pack-objects.c:306
 #, c-format
 msgid "unable to read %s"
 msgstr "kunde inte läsa %s"
@@ -11846,11 +12719,6 @@ msgstr "ogiltigt blob-objekt %s"
 #: builtin/index-pack.c:817 builtin/index-pack.c:836
 msgid "fsck error in packed object"
 msgstr "fsck-fel i packat objekt"
-
-#: builtin/index-pack.c:833
-#, c-format
-msgid "invalid %s"
-msgstr "ogiltigt %s"
 
 #: builtin/index-pack.c:838
 #, c-format
@@ -11889,7 +12757,7 @@ msgstr "förvirrad bortom vanvett i parse_pack_objects()"
 msgid "Resolving deltas"
 msgstr "Analyserar delta"
 
-#: builtin/index-pack.c:1196 builtin/pack-objects.c:2492
+#: builtin/index-pack.c:1196 builtin/pack-objects.c:2486
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "kunde inte skapa tråd: %s"
@@ -11954,7 +12822,7 @@ msgstr "kan inte spara paketfil"
 msgid "cannot store index file"
 msgstr "kan inte spara indexfil"
 
-#: builtin/index-pack.c:1497 builtin/pack-objects.c:2727
+#: builtin/index-pack.c:1497 builtin/pack-objects.c:2725
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "felaktig pack.indexversion=%<PRIu32>"
@@ -12188,120 +13056,120 @@ msgstr "--trailer med --only-input ger ingen mening"
 msgid "no input file given for in-place editing"
 msgstr "ingen indatafil angiven för redigering på plats"
 
-#: builtin/log.c:54
+#: builtin/log.c:55
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git log [<flaggor>] [<versionsintervall>] [[--] <sökväg>...]"
 
-#: builtin/log.c:55
+#: builtin/log.c:56
 msgid "git show [<options>] <object>..."
 msgstr "git show [<flaggor>] <objekt>..."
 
-#: builtin/log.c:99
+#: builtin/log.c:100
 #, c-format
 msgid "invalid --decorate option: %s"
 msgstr "ogiltig flagga för --decorate: %s"
 
-#: builtin/log.c:162
+#: builtin/log.c:163
 msgid "suppress diff output"
 msgstr "undertryck diff-utdata"
 
-#: builtin/log.c:163
+#: builtin/log.c:164
 msgid "show source"
 msgstr "visa källkod"
 
-#: builtin/log.c:164
+#: builtin/log.c:165
 msgid "Use mail map file"
 msgstr "Använd e-postmappningsfil"
 
-#: builtin/log.c:166
+#: builtin/log.c:167
 msgid "only decorate refs that match <pattern>"
 msgstr "dekorera endast referenser som motsvarar <mönster>"
 
-#: builtin/log.c:168
+#: builtin/log.c:169
 msgid "do not decorate refs that match <pattern>"
 msgstr "dekorera inte referenser som motsvarar <mönster>"
 
-#: builtin/log.c:169
+#: builtin/log.c:170
 msgid "decorate options"
 msgstr "dekoreringsflaggor"
 
-#: builtin/log.c:172
+#: builtin/log.c:173
 msgid "Process line range n,m in file, counting from 1"
 msgstr "Behandla radintervallet n,m i filen, med början på 1"
 
-#: builtin/log.c:270
+#: builtin/log.c:271
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Slututdata: %d %s\n"
 
-#: builtin/log.c:522
+#: builtin/log.c:525
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: felaktig fil"
 
-#: builtin/log.c:537 builtin/log.c:631
+#: builtin/log.c:540 builtin/log.c:634
 #, c-format
 msgid "Could not read object %s"
 msgstr "Kunde inte läsa objektet %s"
 
-#: builtin/log.c:655
+#: builtin/log.c:659
 #, c-format
 msgid "Unknown type: %d"
 msgstr "Okänd typ: %d"
 
-#: builtin/log.c:776
+#: builtin/log.c:780
 msgid "format.headers without value"
 msgstr "format.headers utan värde"
 
-#: builtin/log.c:877
+#: builtin/log.c:881
 msgid "name of output directory is too long"
 msgstr "namnet på utdatakatalogen är för långt"
 
-#: builtin/log.c:893
+#: builtin/log.c:897
 #, c-format
 msgid "Cannot open patch file %s"
 msgstr "Kan inte öppna patchfilen %s"
 
-#: builtin/log.c:910
+#: builtin/log.c:914
 msgid "Need exactly one range."
 msgstr "Behöver precis ett intervall."
 
-#: builtin/log.c:920
+#: builtin/log.c:924
 msgid "Not a range."
 msgstr "Inte ett intervall."
 
-#: builtin/log.c:1043
+#: builtin/log.c:1047
 msgid "Cover letter needs email format"
 msgstr "Omslagsbrevet behöver e-postformat"
 
-#: builtin/log.c:1119
+#: builtin/log.c:1132
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "tokigt in-reply-to: %s"
 
-#: builtin/log.c:1146
+#: builtin/log.c:1159
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<flaggor>] [<sedan> | <revisionsintervall>]"
 
-#: builtin/log.c:1204
+#: builtin/log.c:1217
 msgid "Two output directories?"
 msgstr "Två utdatakataloger?"
 
-#: builtin/log.c:1311 builtin/log.c:2054 builtin/log.c:2056 builtin/log.c:2068
+#: builtin/log.c:1324 builtin/log.c:2068 builtin/log.c:2070 builtin/log.c:2082
 #, c-format
 msgid "Unknown commit %s"
 msgstr "Okänd incheckning %s"
 
-#: builtin/log.c:1321 builtin/notes.c:894 builtin/tag.c:526
+#: builtin/log.c:1334 builtin/notes.c:897 builtin/tag.c:526
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Kunde inte slå upp \"%s\" som en giltig referens."
 
-#: builtin/log.c:1326
+#: builtin/log.c:1339
 msgid "Could not find exact merge base."
 msgstr "Kunde inte hitta exakt sammanslagningsbas."
 
-#: builtin/log.c:1330
+#: builtin/log.c:1343
 msgid ""
 "Failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -12312,382 +13180,382 @@ msgstr ""
 "Eller så kan du ange basincheckning med --base=<bas-inchecknings-id> "
 "manuellt."
 
-#: builtin/log.c:1350
+#: builtin/log.c:1363
 msgid "Failed to find exact merge base"
 msgstr "Kunde inte hitta exakt sammanslagningsbas"
 
-#: builtin/log.c:1361
+#: builtin/log.c:1374
 msgid "base commit should be the ancestor of revision list"
 msgstr "basincheckningen bör vara förfader till revisionslistan"
 
-#: builtin/log.c:1365
+#: builtin/log.c:1378
 msgid "base commit shouldn't be in revision list"
 msgstr "basincheckningen bör inte vara i revisionslistan"
 
-#: builtin/log.c:1418
+#: builtin/log.c:1431
 msgid "cannot get patch id"
 msgstr "kan inte hämta patch-id"
 
-#: builtin/log.c:1470
+#: builtin/log.c:1483
 msgid "failed to infer range-diff ranges"
 msgstr "misslyckades räkna ut intervall range-diff"
 
-#: builtin/log.c:1515
+#: builtin/log.c:1528
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "använd [PATCH n/m] även för en ensam patch"
 
-#: builtin/log.c:1518
+#: builtin/log.c:1531
 msgid "use [PATCH] even with multiple patches"
 msgstr "använd [PATCH] även för flera patchar"
 
-#: builtin/log.c:1522
+#: builtin/log.c:1535
 msgid "print patches to standard out"
 msgstr "skriv patcharna på standard ut"
 
-#: builtin/log.c:1524
+#: builtin/log.c:1537
 msgid "generate a cover letter"
 msgstr "generera ett följebrev"
 
-#: builtin/log.c:1526
+#: builtin/log.c:1539
 msgid "use simple number sequence for output file names"
 msgstr "använd enkel nummersekvens för utdatafilnamn"
 
-#: builtin/log.c:1527
+#: builtin/log.c:1540
 msgid "sfx"
 msgstr "sfx"
 
-#: builtin/log.c:1528
+#: builtin/log.c:1541
 msgid "use <sfx> instead of '.patch'"
 msgstr "använd <sfx> istället för \".patch\""
 
-#: builtin/log.c:1530
+#: builtin/log.c:1543
 msgid "start numbering patches at <n> instead of 1"
 msgstr "börja numrera patchar på <n> istället för 1"
 
-#: builtin/log.c:1532
+#: builtin/log.c:1545
 msgid "mark the series as Nth re-roll"
 msgstr "markera serien som N:te försök"
 
-#: builtin/log.c:1534
+#: builtin/log.c:1547
 msgid "Use [RFC PATCH] instead of [PATCH]"
 msgstr "Använd  [RFC PATCH] istället för [PATCH]"
 
-#: builtin/log.c:1537
+#: builtin/log.c:1550
 msgid "Use [<prefix>] instead of [PATCH]"
 msgstr "Använd [<prefix>] istället för [PATCH]"
 
-#: builtin/log.c:1540
+#: builtin/log.c:1553
 msgid "store resulting files in <dir>"
 msgstr "spara filerna i <katalog>"
 
-#: builtin/log.c:1543
+#: builtin/log.c:1556
 msgid "don't strip/add [PATCH]"
 msgstr "ta inte bort eller lägg till [PATCH]"
 
-#: builtin/log.c:1546
+#: builtin/log.c:1559
 msgid "don't output binary diffs"
 msgstr "skriv inte binära diffar"
 
-#: builtin/log.c:1548
+#: builtin/log.c:1561
 msgid "output all-zero hash in From header"
 msgstr "använd hashvärde med nollor i From-huvud"
 
-#: builtin/log.c:1550
+#: builtin/log.c:1563
 msgid "don't include a patch matching a commit upstream"
 msgstr "ta inte med patchar som motsvarar en uppströmsincheckning"
 
-#: builtin/log.c:1552
+#: builtin/log.c:1565
 msgid "show patch format instead of default (patch + stat)"
 msgstr "visa patchformat istället för standard (patch + stat)"
 
-#: builtin/log.c:1554
+#: builtin/log.c:1567
 msgid "Messaging"
 msgstr "E-post"
 
-#: builtin/log.c:1555
+#: builtin/log.c:1568
 msgid "header"
 msgstr "huvud"
 
-#: builtin/log.c:1556
+#: builtin/log.c:1569
 msgid "add email header"
 msgstr "lägg till e-posthuvud"
 
-#: builtin/log.c:1557 builtin/log.c:1559
+#: builtin/log.c:1570 builtin/log.c:1572
 msgid "email"
 msgstr "epost"
 
-#: builtin/log.c:1557
+#: builtin/log.c:1570
 msgid "add To: header"
 msgstr "lägg till mottagarhuvud (\"To:\")"
 
-#: builtin/log.c:1559
+#: builtin/log.c:1572
 msgid "add Cc: header"
 msgstr "lägg till kopiehuvud (\"Cc:\")"
 
-#: builtin/log.c:1561
+#: builtin/log.c:1574
 msgid "ident"
 msgstr "ident"
 
-#: builtin/log.c:1562
+#: builtin/log.c:1575
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr "sätt Från-adress till <ident> (eller incheckare om ident saknas)"
 
-#: builtin/log.c:1564
+#: builtin/log.c:1577
 msgid "message-id"
 msgstr "meddelande-id"
 
-#: builtin/log.c:1565
+#: builtin/log.c:1578
 msgid "make first mail a reply to <message-id>"
 msgstr "gör det första brevet ett svar till <meddelande-id>"
 
-#: builtin/log.c:1566 builtin/log.c:1569
+#: builtin/log.c:1579 builtin/log.c:1582
 msgid "boundary"
 msgstr "gräns"
 
-#: builtin/log.c:1567
+#: builtin/log.c:1580
 msgid "attach the patch"
 msgstr "bifoga patchen"
 
-#: builtin/log.c:1570
+#: builtin/log.c:1583
 msgid "inline the patch"
 msgstr "gör patchen ett inline-objekt"
 
-#: builtin/log.c:1574
+#: builtin/log.c:1587
 msgid "enable message threading, styles: shallow, deep"
 msgstr "aktivera brevtrådning, typer: shallow, deep"
 
-#: builtin/log.c:1576
+#: builtin/log.c:1589
 msgid "signature"
 msgstr "signatur"
 
-#: builtin/log.c:1577
+#: builtin/log.c:1590
 msgid "add a signature"
 msgstr "lägg till signatur"
 
-#: builtin/log.c:1578
+#: builtin/log.c:1591
 msgid "base-commit"
 msgstr "basincheckning"
 
-#: builtin/log.c:1579
+#: builtin/log.c:1592
 msgid "add prerequisite tree info to the patch series"
 msgstr "lägg till förhandskrävd trädinfo i patchserien"
 
-#: builtin/log.c:1581
+#: builtin/log.c:1594
 msgid "add a signature from a file"
 msgstr "lägg till signatur från fil"
 
-#: builtin/log.c:1582
+#: builtin/log.c:1595
 msgid "don't print the patch filenames"
 msgstr "visa inte filnamn för patchar"
 
-#: builtin/log.c:1584
+#: builtin/log.c:1597
 msgid "show progress while generating patches"
 msgstr "visa förloppsindikator medan patchar skapas"
 
-#: builtin/log.c:1585
+#: builtin/log.c:1598
 msgid "rev"
 msgstr "rev"
 
-#: builtin/log.c:1586
+#: builtin/log.c:1599
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr "visa ändringar mot <rev> i omslagsbrev eller ensam patch"
 
-#: builtin/log.c:1589
+#: builtin/log.c:1602
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr "visa ändringar mot <refspec> i omslagsbrev eller ensam patch"
 
-#: builtin/log.c:1591
+#: builtin/log.c:1604
 msgid "percentage by which creation is weighted"
 msgstr "procent som skapelse vägs med"
 
-#: builtin/log.c:1666
+#: builtin/log.c:1679
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "ogiltig ident-rad: %s"
 
-#: builtin/log.c:1681
+#: builtin/log.c:1694
 msgid "-n and -k are mutually exclusive"
 msgstr "-n och -k kan inte användas samtidigt"
 
-#: builtin/log.c:1683
+#: builtin/log.c:1696
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
 msgstr "--subject-prefix/--rfc och -k kan inte användas samtidigt"
 
-#: builtin/log.c:1691
+#: builtin/log.c:1704
 msgid "--name-only does not make sense"
 msgstr "kan inte använda --name-only"
 
-#: builtin/log.c:1693
+#: builtin/log.c:1706
 msgid "--name-status does not make sense"
 msgstr "kan inte använda --name-status"
 
-#: builtin/log.c:1695
+#: builtin/log.c:1708
 msgid "--check does not make sense"
 msgstr "kan inte använda --check"
 
-#: builtin/log.c:1727
+#: builtin/log.c:1740
 msgid "standard output, or directory, which one?"
 msgstr "standard ut, eller katalog, vilken skall det vara?"
 
-#: builtin/log.c:1729
+#: builtin/log.c:1742
 #, c-format
 msgid "Could not create directory '%s'"
 msgstr "Kunde inte skapa katalogen \"%s\""
 
-#: builtin/log.c:1816
+#: builtin/log.c:1829
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff kräver --cover-letter eller ensam patch"
 
-#: builtin/log.c:1820
+#: builtin/log.c:1833
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:1821
+#: builtin/log.c:1834
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff mot v%d:"
 
-#: builtin/log.c:1827
+#: builtin/log.c:1840
 msgid "--creation-factor requires --range-diff"
 msgstr "--creation-factor kräver --range-diff"
 
-#: builtin/log.c:1831
+#: builtin/log.c:1844
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff kräver --cover-letter eller ensam patch"
 
-#: builtin/log.c:1839
+#: builtin/log.c:1852
 msgid "Range-diff:"
 msgstr "Intervall-diff:"
 
-#: builtin/log.c:1840
+#: builtin/log.c:1853
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Intervall-diff mot v%d:"
 
-#: builtin/log.c:1851
+#: builtin/log.c:1864
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "kunde inte läsa signaturfil \"%s\""
 
-#: builtin/log.c:1887
+#: builtin/log.c:1900
 msgid "Generating patches"
 msgstr "Skapar patchar"
 
-#: builtin/log.c:1931
+#: builtin/log.c:1944
 msgid "Failed to create output files"
 msgstr "Misslyckades skapa utdatafiler"
 
-#: builtin/log.c:1989
+#: builtin/log.c:2003
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<uppström> [<huvud> [<gräns>]]]"
 
-#: builtin/log.c:2043
+#: builtin/log.c:2057
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
 msgstr "Kunde inte hitta en spårad fjärrgren, ange <uppström> manuellt.\n"
 
-#: builtin/ls-files.c:469
+#: builtin/ls-files.c:470
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<flaggor>] [<fil>...]"
 
-#: builtin/ls-files.c:525
+#: builtin/ls-files.c:526
 msgid "identify the file status with tags"
 msgstr "identifiera filstatus med taggar"
 
-#: builtin/ls-files.c:527
+#: builtin/ls-files.c:528
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr "använd små bokstäver för \"anta oförändrade\"-filer"
 
-#: builtin/ls-files.c:529
+#: builtin/ls-files.c:530
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "använd små bokstäver för \"fsmonitor clean\"-filer"
 
-#: builtin/ls-files.c:531
+#: builtin/ls-files.c:532
 msgid "show cached files in the output (default)"
 msgstr "visa cachade filer i utdata (standard)"
 
-#: builtin/ls-files.c:533
+#: builtin/ls-files.c:534
 msgid "show deleted files in the output"
 msgstr "visa borttagna filer i utdata"
 
-#: builtin/ls-files.c:535
+#: builtin/ls-files.c:536
 msgid "show modified files in the output"
 msgstr "visa modifierade filer i utdata"
 
-#: builtin/ls-files.c:537
+#: builtin/ls-files.c:538
 msgid "show other files in the output"
 msgstr "visa andra filer i utdata"
 
-#: builtin/ls-files.c:539
+#: builtin/ls-files.c:540
 msgid "show ignored files in the output"
 msgstr "visa ignorerade filer i utdata"
 
-#: builtin/ls-files.c:542
+#: builtin/ls-files.c:543
 msgid "show staged contents' object name in the output"
 msgstr "visa köat innehålls objektnamn i utdata"
 
-#: builtin/ls-files.c:544
+#: builtin/ls-files.c:545
 msgid "show files on the filesystem that need to be removed"
 msgstr "visa filer i filsystemet som behöver tas bort"
 
-#: builtin/ls-files.c:546
+#: builtin/ls-files.c:547
 msgid "show 'other' directories' names only"
 msgstr "visa endast namn för \"andra\" kataloger"
 
-#: builtin/ls-files.c:548
+#: builtin/ls-files.c:549
 msgid "show line endings of files"
 msgstr "visa radslut i filer"
 
-#: builtin/ls-files.c:550
+#: builtin/ls-files.c:551
 msgid "don't show empty directories"
 msgstr "visa inte tomma kataloger"
 
-#: builtin/ls-files.c:553
+#: builtin/ls-files.c:554
 msgid "show unmerged files in the output"
 msgstr "visa ej sammanslagna filer i utdata"
 
-#: builtin/ls-files.c:555
+#: builtin/ls-files.c:556
 msgid "show resolve-undo information"
 msgstr "visa \"resolve-undo\"-information"
 
-#: builtin/ls-files.c:557
+#: builtin/ls-files.c:558
 msgid "skip files matching pattern"
 msgstr "hoppa över filer som motsvarar mönster"
 
-#: builtin/ls-files.c:560
+#: builtin/ls-files.c:561
 msgid "exclude patterns are read from <file>"
 msgstr "exkludera mönster som läses från <fil>"
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:564
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "läs ytterligare per-katalog-exkluderingsmönster från <fil>"
 
-#: builtin/ls-files.c:565
+#: builtin/ls-files.c:566
 msgid "add the standard git exclusions"
 msgstr "lägg till git:s standardexkluderingar"
 
-#: builtin/ls-files.c:569
+#: builtin/ls-files.c:570
 msgid "make the output relative to the project top directory"
 msgstr "gör utdata relativ till projektets toppkatalog"
 
-#: builtin/ls-files.c:572
+#: builtin/ls-files.c:573
 msgid "recurse through submodules"
 msgstr "rekursera ner i undermoduler"
 
-#: builtin/ls-files.c:574
+#: builtin/ls-files.c:575
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "om en <fil> inte är indexet, betrakta det som ett fel"
 
-#: builtin/ls-files.c:575
+#: builtin/ls-files.c:576
 msgid "tree-ish"
 msgstr "träd-igt"
 
-#: builtin/ls-files.c:576
+#: builtin/ls-files.c:577
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr "låtsas att sökvägar borttagna sedan <träd-igt> fortfarande finns"
 
-#: builtin/ls-files.c:578
+#: builtin/ls-files.c:579
 msgid "show debugging data"
 msgstr "visa felsökningsutdata"
 
@@ -12705,7 +13573,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "visa inte fjärr-URL"
 
-#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:903
+#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1111
 msgid "exec"
 msgstr "exec"
 
@@ -12778,183 +13646,188 @@ msgstr "visa hela trädet; inte bara aktuell katalog (implicerar --full-name)"
 msgid "empty mbox: '%s'"
 msgstr "tom mbox: ”%s”"
 
-#: builtin/merge.c:52
+#: builtin/merge.c:53
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<flaggor>] [<incheckning>...]"
 
-#: builtin/merge.c:53
+#: builtin/merge.c:54
 msgid "git merge --abort"
 msgstr "git merge --abort"
 
-#: builtin/merge.c:54
+#: builtin/merge.c:55
 msgid "git merge --continue"
 msgstr "git merge --continue"
 
-#: builtin/merge.c:111
+#: builtin/merge.c:112
 msgid "switch `m' requires a value"
 msgstr "flaggan \"m\" behöver ett värde"
 
-#: builtin/merge.c:177
+#: builtin/merge.c:132
+#, c-format
+msgid "option `%s' requires a value"
+msgstr "flaggan \"%s\" behöver ett värde"
+
+#: builtin/merge.c:178
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Kunde inte hitta sammanslagningsstrategin \"%s\".\n"
 
-#: builtin/merge.c:178
+#: builtin/merge.c:179
 #, c-format
 msgid "Available strategies are:"
 msgstr "Tillgängliga strategier är:"
 
-#: builtin/merge.c:183
+#: builtin/merge.c:184
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Tillgängliga skräddarsydda strategier är:"
 
-#: builtin/merge.c:234 builtin/pull.c:143
+#: builtin/merge.c:235 builtin/pull.c:144
 msgid "do not show a diffstat at the end of the merge"
 msgstr "visa inte en diffstat när sammanslagningen är färdig"
 
-#: builtin/merge.c:237 builtin/pull.c:146
+#: builtin/merge.c:238 builtin/pull.c:147
 msgid "show a diffstat at the end of the merge"
 msgstr "visa en diffstat när sammanslagningen är färdig"
 
-#: builtin/merge.c:238 builtin/pull.c:149
+#: builtin/merge.c:239 builtin/pull.c:150
 msgid "(synonym to --stat)"
 msgstr "(synonym till --stat)"
 
-#: builtin/merge.c:240 builtin/pull.c:152
+#: builtin/merge.c:241 builtin/pull.c:153
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "lägg till (som mest <n>) poster från shortlog till incheckningsmeddelandet"
 
-#: builtin/merge.c:243 builtin/pull.c:158
+#: builtin/merge.c:244 builtin/pull.c:159
 msgid "create a single commit instead of doing a merge"
 msgstr "skapa en ensam incheckning istället för en sammanslagning"
 
-#: builtin/merge.c:245 builtin/pull.c:161
+#: builtin/merge.c:246 builtin/pull.c:162
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "utför en incheckning om sammanslagningen lyckades (standard)"
 
-#: builtin/merge.c:247 builtin/pull.c:164
+#: builtin/merge.c:248 builtin/pull.c:165
 msgid "edit message before committing"
 msgstr "redigera meddelande innan incheckning"
 
-#: builtin/merge.c:248
+#: builtin/merge.c:249
 msgid "allow fast-forward (default)"
 msgstr "tillåt snabbspolning (standard)"
 
-#: builtin/merge.c:250 builtin/pull.c:170
+#: builtin/merge.c:251 builtin/pull.c:171
 msgid "abort if fast-forward is not possible"
 msgstr "avbryt om snabbspolning inte är möjlig"
 
-#: builtin/merge.c:254 builtin/pull.c:173
+#: builtin/merge.c:255 builtin/pull.c:174
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "bekräfta att den namngivna incheckningen har en giltig GPG-signatur"
 
-#: builtin/merge.c:255 builtin/notes.c:784 builtin/pull.c:177
-#: builtin/rebase.c:916 builtin/rebase--interactive.c:186 builtin/revert.c:110
+#: builtin/merge.c:256 builtin/notes.c:787 builtin/pull.c:178
+#: builtin/rebase.c:1124 builtin/rebase--interactive.c:188 builtin/revert.c:111
 msgid "strategy"
 msgstr "strategi"
 
-#: builtin/merge.c:256 builtin/pull.c:178
+#: builtin/merge.c:257 builtin/pull.c:179
 msgid "merge strategy to use"
 msgstr "sammanslagningsstrategi att använda"
 
-#: builtin/merge.c:257 builtin/pull.c:181
+#: builtin/merge.c:258 builtin/pull.c:182
 msgid "option=value"
 msgstr "alternativ=värde"
 
-#: builtin/merge.c:258 builtin/pull.c:182
+#: builtin/merge.c:259 builtin/pull.c:183
 msgid "option for selected merge strategy"
 msgstr "alternativ för vald sammanslagningsstrategi"
 
-#: builtin/merge.c:260
+#: builtin/merge.c:261
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "incheckningsmeddelande för (icke snabbspolande) sammanslagning"
 
-#: builtin/merge.c:267
+#: builtin/merge.c:268
 msgid "abort the current in-progress merge"
 msgstr "avbryt den pågående sammanslagningen"
 
-#: builtin/merge.c:269
+#: builtin/merge.c:270
 msgid "continue the current in-progress merge"
 msgstr "fortsätt den pågående sammanslagningen"
 
-#: builtin/merge.c:271 builtin/pull.c:189
+#: builtin/merge.c:272 builtin/pull.c:190
 msgid "allow merging unrelated histories"
 msgstr "tillåt sammanslagning av orelaterade historier"
 
-#: builtin/merge.c:277
+#: builtin/merge.c:278
 msgid "verify commit-msg hook"
 msgstr "bekräfta commit-msg-krok"
 
-#: builtin/merge.c:302
+#: builtin/merge.c:303
 msgid "could not run stash."
 msgstr "kunde köra stash."
 
-#: builtin/merge.c:307
+#: builtin/merge.c:308
 msgid "stash failed"
 msgstr "stash misslyckades"
 
-#: builtin/merge.c:312
+#: builtin/merge.c:313
 #, c-format
 msgid "not a valid object: %s"
 msgstr "inte ett giltigt objekt: %s"
 
-#: builtin/merge.c:334 builtin/merge.c:351
+#: builtin/merge.c:335 builtin/merge.c:352
 msgid "read-tree failed"
 msgstr "read-tree misslyckades"
 
-#: builtin/merge.c:381
+#: builtin/merge.c:382
 msgid " (nothing to squash)"
 msgstr " (inget att platta till)"
 
-#: builtin/merge.c:392
+#: builtin/merge.c:393
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Tillplattningsincheckning -- uppdaterar inte HEAD\n"
 
-#: builtin/merge.c:442
+#: builtin/merge.c:443
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Inget sammanslagningsmeddelande -- uppdaterar inte HEAD\n"
 
-#: builtin/merge.c:493
+#: builtin/merge.c:494
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "\"%s\" verkar inte peka på en incheckning"
 
-#: builtin/merge.c:580
+#: builtin/merge.c:581
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Felaktig branch.%s.mergeoptions-sträng: %s"
 
-#: builtin/merge.c:701
+#: builtin/merge.c:702
 msgid "Not handling anything other than two heads merge."
 msgstr "Hanterar inte något annat än en sammanslagning av två huvuden."
 
-#: builtin/merge.c:715
+#: builtin/merge.c:716
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Felaktig flagga för merge-recursive: -X%s"
 
-#: builtin/merge.c:730
+#: builtin/merge.c:731
 #, c-format
 msgid "unable to write %s"
 msgstr "kunde inte skriva %s"
 
-#: builtin/merge.c:782
+#: builtin/merge.c:783
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "Kunde inte läsa från \"%s\""
 
-#: builtin/merge.c:791
+#: builtin/merge.c:792
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Checkar inte in sammanslagningen; använd \"git commit\" för att slutföra "
 "den.\n"
 
-#: builtin/merge.c:797
+#: builtin/merge.c:798
 #, c-format
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
@@ -12970,69 +13843,69 @@ msgstr ""
 "Rader som inleds med \"%c\" kommer ignoreras, och ett tomt meddelande\n"
 "avbryter incheckningen.\n"
 
-#: builtin/merge.c:833
+#: builtin/merge.c:834
 msgid "Empty commit message."
 msgstr "Tomt incheckningsmeddelande."
 
-#: builtin/merge.c:852
+#: builtin/merge.c:853
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Underbart.\n"
 
-#: builtin/merge.c:905
+#: builtin/merge.c:906
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Kunde inte slå ihop automatiskt; fixa konflikter och checka in resultatet.\n"
 
-#: builtin/merge.c:944
+#: builtin/merge.c:945
 msgid "No current branch."
 msgstr "Inte på någon gren."
 
-#: builtin/merge.c:946
+#: builtin/merge.c:947
 msgid "No remote for the current branch."
 msgstr "Ingen fjärr för aktuell gren."
 
-#: builtin/merge.c:948
+#: builtin/merge.c:949
 msgid "No default upstream defined for the current branch."
 msgstr "Ingen standarduppström angiven för aktuell gren."
 
-#: builtin/merge.c:953
+#: builtin/merge.c:954
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Ingen fjärrspårande gren för %s från %s"
 
-#: builtin/merge.c:1010
+#: builtin/merge.c:1011
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Felaktigt värde \"%s\" i miljövariabeln \"%s\""
 
-#: builtin/merge.c:1113
+#: builtin/merge.c:1114
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "inte något vi kan slå ihop med %s: %s"
 
-#: builtin/merge.c:1147
+#: builtin/merge.c:1148
 msgid "not something we can merge"
 msgstr "inte något vi kan slå ihop"
 
-#: builtin/merge.c:1250
+#: builtin/merge.c:1251
 msgid "--abort expects no arguments"
 msgstr "--abort tar inga argument"
 
-#: builtin/merge.c:1254
+#: builtin/merge.c:1255
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Ingen sammanslagning att avbryta (MERGE_HEAD saknas)."
 
-#: builtin/merge.c:1266
+#: builtin/merge.c:1267
 msgid "--continue expects no arguments"
 msgstr "--continue tar inga argument"
 
-#: builtin/merge.c:1270
+#: builtin/merge.c:1271
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Ingen sammanslagning pågår (MERGE_HEAD saknas)."
 
-#: builtin/merge.c:1286
+#: builtin/merge.c:1287
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -13040,7 +13913,7 @@ msgstr ""
 "Du har inte avslutat sammanslagningen (MERGE_HEAD finns).\n"
 "Checka in dina ändringar innan du slår ihop."
 
-#: builtin/merge.c:1293
+#: builtin/merge.c:1294
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -13048,92 +13921,92 @@ msgstr ""
 "Du har inte avslutat din \"cherry-pick\" (CHERRY_PICK_HEAD finns).\n"
 "Checka in dina ändringar innan du slår ihop."
 
-#: builtin/merge.c:1296
+#: builtin/merge.c:1297
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Du har inte avslutat din \"cherry-pick\" (CHERRY_PICK_HEAD finns)."
 
-#: builtin/merge.c:1305
+#: builtin/merge.c:1306
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Du kan inte kombinera --squash med --no-ff."
 
-#: builtin/merge.c:1313
+#: builtin/merge.c:1314
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Ingen incheckning angiven och merge.defaultToUpstream är ej satt."
 
-#: builtin/merge.c:1330
+#: builtin/merge.c:1331
 msgid "Squash commit into empty head not supported yet"
 msgstr "Stöder inte en tillplattningsincheckning på ett tomt huvud ännu"
 
-#: builtin/merge.c:1332
+#: builtin/merge.c:1333
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Icke-snabbspolad incheckning kan inte användas med ett tomt huvud"
 
-#: builtin/merge.c:1337
+#: builtin/merge.c:1338
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - inte något vi kan slå ihop"
 
-#: builtin/merge.c:1339
+#: builtin/merge.c:1340
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Kan endast slå ihop en enda incheckning i ett tomt huvud"
 
-#: builtin/merge.c:1421
+#: builtin/merge.c:1422
 msgid "refusing to merge unrelated histories"
 msgstr "vägrar slå samman orelaterad historik"
 
-#: builtin/merge.c:1430
+#: builtin/merge.c:1431
 msgid "Already up to date."
 msgstr "Redan à jour."
 
-#: builtin/merge.c:1440
+#: builtin/merge.c:1441
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Uppdaterar %s..%s\n"
 
-#: builtin/merge.c:1482
+#: builtin/merge.c:1483
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Försöker riktigt enkel sammanslagning i indexet...\n"
 
-#: builtin/merge.c:1489
+#: builtin/merge.c:1490
 #, c-format
 msgid "Nope.\n"
 msgstr "Nej.\n"
 
-#: builtin/merge.c:1514
+#: builtin/merge.c:1515
 msgid "Already up to date. Yeeah!"
 msgstr "Redan à jour. Toppen!"
 
-#: builtin/merge.c:1520
+#: builtin/merge.c:1521
 msgid "Not possible to fast-forward, aborting."
 msgstr "Kan inte snabbspola, avbryter."
 
-#: builtin/merge.c:1543 builtin/merge.c:1622
+#: builtin/merge.c:1544 builtin/merge.c:1623
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Återspolar trädet till orört...\n"
 
-#: builtin/merge.c:1547
+#: builtin/merge.c:1548
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Försöker sammanslagningsstrategin %s...\n"
 
-#: builtin/merge.c:1613
+#: builtin/merge.c:1614
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Ingen sammanslagningsstrategi hanterade sammanslagningen.\n"
 
-#: builtin/merge.c:1615
+#: builtin/merge.c:1616
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Sammanslagning med strategin %s misslyckades.\n"
 
-#: builtin/merge.c:1624
+#: builtin/merge.c:1625
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
 msgstr "Använder %s för att förbereda lösning för hand.\n"
 
-#: builtin/merge.c:1636
+#: builtin/merge.c:1637
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -13219,33 +14092,33 @@ msgstr "varna inte om konflikter"
 msgid "set labels for file1/orig-file/file2"
 msgstr "sätt etiketter för fil1/origfil/fil2"
 
-#: builtin/merge-recursive.c:45
+#: builtin/merge-recursive.c:46
 #, c-format
 msgid "unknown option %s"
 msgstr "okänd flagga %s"
 
-#: builtin/merge-recursive.c:51
+#: builtin/merge-recursive.c:52
 #, c-format
 msgid "could not parse object '%s'"
 msgstr "kunde inte tolka objektet \"%s\""
 
-#: builtin/merge-recursive.c:55
+#: builtin/merge-recursive.c:56
 #, c-format
 msgid "cannot handle more than %d base. Ignoring %s."
 msgid_plural "cannot handle more than %d bases. Ignoring %s."
 msgstr[0] "kan inte hantera mer än %d bas. Ignorerar %s."
 msgstr[1] "kan inte hantera mer än %d baser. Ignorerar %s."
 
-#: builtin/merge-recursive.c:63
+#: builtin/merge-recursive.c:64
 msgid "not handling anything other than two heads merge."
 msgstr "hanterar inte något annat än en sammanslagning av två huvuden."
 
-#: builtin/merge-recursive.c:69 builtin/merge-recursive.c:71
+#: builtin/merge-recursive.c:70 builtin/merge-recursive.c:72
 #, c-format
 msgid "could not resolve ref '%s'"
 msgstr "kunde inte bestämma referensen ”%s”"
 
-#: builtin/merge-recursive.c:77
+#: builtin/merge-recursive.c:78
 #, c-format
 msgid "Merging %s with %s\n"
 msgstr "Slår ihop %s med %s\n"
@@ -13258,7 +14131,7 @@ msgstr "git mktree [-z] [--missing] [--batch]"
 msgid "input is NUL terminated"
 msgstr "indata är NUL-terminerad"
 
-#: builtin/mktree.c:155 builtin/write-tree.c:25
+#: builtin/mktree.c:155 builtin/write-tree.c:26
 msgid "allow missing objects"
 msgstr "tillåt saknade objekt"
 
@@ -13283,95 +14156,95 @@ msgstr "för många argument"
 msgid "unrecognized verb: %s"
 msgstr "okänt verb: %s"
 
-#: builtin/mv.c:17
+#: builtin/mv.c:18
 msgid "git mv [<options>] <source>... <destination>"
 msgstr "git mv [<flaggor>] <källa>... <mål>"
 
-#: builtin/mv.c:82
+#: builtin/mv.c:83
 #, c-format
 msgid "Directory %s is in index and no submodule?"
 msgstr "Katalogen %s är i indexet och inte en undermodul?"
 
-#: builtin/mv.c:84
+#: builtin/mv.c:85
 msgid "Please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "Köa dina ändringar i .gitmodules eller använd \"stash\" för att fortsätta"
 
-#: builtin/mv.c:102
+#: builtin/mv.c:103
 #, c-format
 msgid "%.*s is in index"
 msgstr "%.*s är i indexet"
 
-#: builtin/mv.c:124
+#: builtin/mv.c:125
 msgid "force move/rename even if target exists"
 msgstr "tvinga flytta/ändra namn även om målet finns"
 
-#: builtin/mv.c:126
+#: builtin/mv.c:127
 msgid "skip move/rename errors"
 msgstr "hoppa över fel vid flytt/namnändring"
 
-#: builtin/mv.c:168
+#: builtin/mv.c:169
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "destinationen \"%s\" är ingen katalog"
 
-#: builtin/mv.c:179
+#: builtin/mv.c:180
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Kontrollerar namnbyte av \"%s\" till \"%s\"\n"
 
-#: builtin/mv.c:183
+#: builtin/mv.c:184
 msgid "bad source"
 msgstr "felaktig källa"
 
-#: builtin/mv.c:186
+#: builtin/mv.c:187
 msgid "can not move directory into itself"
 msgstr "kan inte flytta katalog till sig själv"
 
-#: builtin/mv.c:189
+#: builtin/mv.c:190
 msgid "cannot move directory over file"
 msgstr "kan inte flytta katalog över fil"
 
-#: builtin/mv.c:198
+#: builtin/mv.c:199
 msgid "source directory is empty"
 msgstr "källkatalogen är tom"
 
-#: builtin/mv.c:223
+#: builtin/mv.c:224
 msgid "not under version control"
 msgstr "inte versionshanterad"
 
-#: builtin/mv.c:226
+#: builtin/mv.c:227
 msgid "destination exists"
 msgstr "destinationen finns"
 
-#: builtin/mv.c:234
+#: builtin/mv.c:235
 #, c-format
 msgid "overwriting '%s'"
 msgstr "skriver över \"%s\""
 
-#: builtin/mv.c:237
+#: builtin/mv.c:238
 msgid "Cannot overwrite"
 msgstr "Kan inte skriva över"
 
-#: builtin/mv.c:240
+#: builtin/mv.c:241
 msgid "multiple sources for the same target"
 msgstr "flera källor för samma mål"
 
-#: builtin/mv.c:242
+#: builtin/mv.c:243
 msgid "destination directory does not exist"
 msgstr "destinationskatalogen finns inte"
 
-#: builtin/mv.c:249
+#: builtin/mv.c:250
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, källa=%s, mål=%s"
 
-#: builtin/mv.c:270
+#: builtin/mv.c:271
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Byter namn på %s till %s\n"
 
-#: builtin/mv.c:276 builtin/remote.c:717 builtin/repack.c:511
+#: builtin/mv.c:277 builtin/remote.c:717 builtin/repack.c:513
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "misslyckades byta namn på \"%s\""
@@ -13569,8 +14442,8 @@ msgid "could not open or read '%s'"
 msgstr "kunde inte öppna eller läsa \"%s\""
 
 #: builtin/notes.c:263 builtin/notes.c:313 builtin/notes.c:315
-#: builtin/notes.c:383 builtin/notes.c:438 builtin/notes.c:524
-#: builtin/notes.c:529 builtin/notes.c:607 builtin/notes.c:669
+#: builtin/notes.c:383 builtin/notes.c:438 builtin/notes.c:526
+#: builtin/notes.c:531 builtin/notes.c:610 builtin/notes.c:672
 #, c-format
 msgid "failed to resolve '%s' as a valid ref."
 msgstr "kunde inte slå upp \"%s\" som en giltig referens."
@@ -13603,38 +14476,38 @@ msgstr "misslyckades kopiera anteckningar från \"%s\" till \"%s\""
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr "vägrar utföra \"%s\" på anteckningar i %s (utanför refs/notes/)"
 
-#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:507
-#: builtin/notes.c:519 builtin/notes.c:595 builtin/notes.c:662
-#: builtin/notes.c:812 builtin/notes.c:959 builtin/notes.c:980
+#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
+#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
+#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
 msgid "too many parameters"
 msgstr "för många parametrar"
 
-#: builtin/notes.c:389 builtin/notes.c:675
+#: builtin/notes.c:389 builtin/notes.c:678
 #, c-format
 msgid "no note found for object %s."
 msgstr "inga anteckningar hittades för objektet %s."
 
-#: builtin/notes.c:410 builtin/notes.c:573
+#: builtin/notes.c:410 builtin/notes.c:576
 msgid "note contents as a string"
 msgstr "anteckningsinnehåll som sträng"
 
-#: builtin/notes.c:413 builtin/notes.c:576
+#: builtin/notes.c:413 builtin/notes.c:579
 msgid "note contents in a file"
 msgstr "anteckningsinnehåll i en fil"
 
-#: builtin/notes.c:416 builtin/notes.c:579
+#: builtin/notes.c:416 builtin/notes.c:582
 msgid "reuse and edit specified note object"
 msgstr "återanvänd och redigera angivet anteckningsobjekt"
 
-#: builtin/notes.c:419 builtin/notes.c:582
+#: builtin/notes.c:419 builtin/notes.c:585
 msgid "reuse specified note object"
 msgstr "återanvänd angivet anteckningsobjekt"
 
-#: builtin/notes.c:422 builtin/notes.c:585
+#: builtin/notes.c:422 builtin/notes.c:588
 msgid "allow storing empty note"
 msgstr "tillåt lagra tom anteckning"
 
-#: builtin/notes.c:423 builtin/notes.c:494
+#: builtin/notes.c:423 builtin/notes.c:496
 msgid "replace existing notes"
 msgstr "ersätt befintliga anteckningar"
 
@@ -13647,29 +14520,29 @@ msgstr ""
 "Kan inte lägga till anteckningar. Hittade befintliga anteckningar för "
 "objektet %s. Använd \"-f\" för att skriva över befintliga anteckningar"
 
-#: builtin/notes.c:463 builtin/notes.c:542
+#: builtin/notes.c:463 builtin/notes.c:544
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Skriver över befintliga anteckningar för objektet %s\n"
 
-#: builtin/notes.c:474 builtin/notes.c:634 builtin/notes.c:899
+#: builtin/notes.c:475 builtin/notes.c:637 builtin/notes.c:902
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Tar bort anteckning för objektet %s\n"
 
-#: builtin/notes.c:495
+#: builtin/notes.c:497
 msgid "read objects from stdin"
 msgstr "läs objekt från standard in"
 
-#: builtin/notes.c:497
+#: builtin/notes.c:499
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr "läs omskrivningsinställning för <kommando> (implicerar --stdin)"
 
-#: builtin/notes.c:515
+#: builtin/notes.c:517
 msgid "too few parameters"
 msgstr "för få parametrar"
 
-#: builtin/notes.c:536
+#: builtin/notes.c:538
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
@@ -13678,12 +14551,12 @@ msgstr ""
 "Kan inte kopiera anteckningar. Hittade befintliga anteckningar för objektet "
 "%s. Använd \"-f\" för att skriva över befintliga anteckningar"
 
-#: builtin/notes.c:548
+#: builtin/notes.c:550
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
 msgstr "anteckningar på källobjektet %s saknas. Kan inte kopiera."
 
-#: builtin/notes.c:600
+#: builtin/notes.c:603
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
@@ -13692,52 +14565,52 @@ msgstr ""
 "Flaggorna -m/-F/-c/-C rekommenderas inte för underkommandot \"edit\".\n"
 "Använd \"git notes add -f -m/-F/-c/-C\" istället.\n"
 
-#: builtin/notes.c:695
+#: builtin/notes.c:698
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
 msgstr "misslyckades ta bort referensen NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:697
+#: builtin/notes.c:700
 msgid "failed to delete ref NOTES_MERGE_REF"
 msgstr "misslyckades ta bort referensen NOTES_MERGE_REF"
 
-#: builtin/notes.c:699
+#: builtin/notes.c:702
 msgid "failed to remove 'git notes merge' worktree"
 msgstr "misslyckades ta bort arbetskatalogen för \"git notes merge\""
 
-#: builtin/notes.c:719
+#: builtin/notes.c:722
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
 msgstr "misslyckades läsa references NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:721
+#: builtin/notes.c:724
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
 msgstr "kunde inte hitta incheckning från NOTES_MERGE_PARTIAL."
 
-#: builtin/notes.c:723
+#: builtin/notes.c:726
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
 msgstr "kunde inte tolka incheckning från NOTES_MERGE_PARTIAL."
 
-#: builtin/notes.c:736
+#: builtin/notes.c:739
 msgid "failed to resolve NOTES_MERGE_REF"
 msgstr "misslyckades bestämma NOTES_MERGE_REF"
 
-#: builtin/notes.c:739
+#: builtin/notes.c:742
 msgid "failed to finalize notes merge"
 msgstr "misslyckades färdigställa sammanslagning av anteckningar"
 
-#: builtin/notes.c:765
+#: builtin/notes.c:768
 #, c-format
 msgid "unknown notes merge strategy %s"
 msgstr "okänd sammanslagningsstrategi för anteckningar: %s"
 
-#: builtin/notes.c:781
+#: builtin/notes.c:784
 msgid "General options"
 msgstr "Allmänna flaggor"
 
-#: builtin/notes.c:783
+#: builtin/notes.c:786
 msgid "Merge options"
 msgstr "Flaggor för sammanslagning"
 
-#: builtin/notes.c:785
+#: builtin/notes.c:788
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
@@ -13745,48 +14618,48 @@ msgstr ""
 "läs konflikter i anteckningar med angiven strategi (manual/ours/theirs/union/"
 "cat_sort_uniq)"
 
-#: builtin/notes.c:787
+#: builtin/notes.c:790
 msgid "Committing unmerged notes"
 msgstr "Checkar in ej sammanslagna anteckningar"
 
-#: builtin/notes.c:789
+#: builtin/notes.c:792
 msgid "finalize notes merge by committing unmerged notes"
 msgstr ""
 "färdigställ sammanslagning av anteckningar genom att checka in ej "
 "sammanslagna anteckningar"
 
-#: builtin/notes.c:791
+#: builtin/notes.c:794
 msgid "Aborting notes merge resolution"
 msgstr "Avbryt lösning av sammanslagning av anteckningar"
 
-#: builtin/notes.c:793
+#: builtin/notes.c:796
 msgid "abort notes merge"
 msgstr "avbryt sammanslagning av anteckningar"
 
-#: builtin/notes.c:804
+#: builtin/notes.c:807
 msgid "cannot mix --commit, --abort or -s/--strategy"
 msgstr "kan inte blanda --commit, --abort eller -s/--strategy"
 
-#: builtin/notes.c:809
+#: builtin/notes.c:812
 msgid "must specify a notes ref to merge"
 msgstr "måste ange en antecknings-referens att slå ihop"
 
-#: builtin/notes.c:833
+#: builtin/notes.c:836
 #, c-format
 msgid "unknown -s/--strategy: %s"
 msgstr "okänd -s/--strategy: %s"
 
-#: builtin/notes.c:870
+#: builtin/notes.c:873
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "sammanslagning av anteckningar till %s är redan igångsatt på %s"
 
-#: builtin/notes.c:873
+#: builtin/notes.c:876
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr "misslyckades lagra länk till aktuell anteckningsreferens (%s)"
 
-#: builtin/notes.c:875
+#: builtin/notes.c:878
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -13797,36 +14670,36 @@ msgstr ""
 "%s och checka in resultatet med \"git notes merge --commit\", eller avbryt "
 "sammanslagningen med \"git notes merge --abort\".\n"
 
-#: builtin/notes.c:897
+#: builtin/notes.c:900
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "Objektet %s har ingen anteckning\n"
 
-#: builtin/notes.c:909
+#: builtin/notes.c:912
 msgid "attempt to remove non-existent note is not an error"
 msgstr "försök att ta bort icke-existerande anteckningar är inte ett fel"
 
-#: builtin/notes.c:912
+#: builtin/notes.c:915
 msgid "read object names from the standard input"
 msgstr "läs objektnamn från standard in"
 
-#: builtin/notes.c:950 builtin/prune.c:108 builtin/worktree.c:164
+#: builtin/notes.c:954 builtin/prune.c:108 builtin/worktree.c:165
 msgid "do not remove, show only"
 msgstr "ta inte bort, bara visa"
 
-#: builtin/notes.c:951
+#: builtin/notes.c:955
 msgid "report pruned notes"
 msgstr "rapportera borttagna anteckningar"
 
-#: builtin/notes.c:993
+#: builtin/notes.c:998
 msgid "notes-ref"
 msgstr "anteckningar-ref"
 
-#: builtin/notes.c:994
+#: builtin/notes.c:999
 msgid "use notes from <notes-ref>"
 msgstr "använd anteckningar från <anteckningsref>"
 
-#: builtin/notes.c:1029
+#: builtin/notes.c:1034
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "okänt underkommando: %s"
@@ -13843,125 +14716,125 @@ msgid ""
 msgstr ""
 "git pack-objects [<flaggor>...] <basnamn> [< <reflista> | < <objektlista>]"
 
-#: builtin/pack-objects.c:422
+#: builtin/pack-objects.c:423
 #, c-format
 msgid "bad packed object CRC for %s"
 msgstr "felaktig CRC för packat objekt %s"
 
-#: builtin/pack-objects.c:433
+#: builtin/pack-objects.c:434
 #, c-format
 msgid "corrupt packed object for %s"
 msgstr "trasigt packat objekt för %s"
 
-#: builtin/pack-objects.c:564
+#: builtin/pack-objects.c:565
 #, c-format
 msgid "recursive delta detected for object %s"
 msgstr "rekursivt delta upptäcktes för objektet %s"
 
-#: builtin/pack-objects.c:775
+#: builtin/pack-objects.c:776
 #, c-format
 msgid "ordered %u objects, expected %<PRIu32>"
 msgstr "ordnade %u objekt, förväntade %<PRIu32>"
 
-#: builtin/pack-objects.c:788
+#: builtin/pack-objects.c:789
 #, c-format
 msgid "packfile is invalid: %s"
 msgstr "packfil är ogiltig: %s"
 
-#: builtin/pack-objects.c:792
+#: builtin/pack-objects.c:793
 #, c-format
 msgid "unable to open packfile for reuse: %s"
 msgstr "kan inte öppna packfil för återanvändning: %s"
 
-#: builtin/pack-objects.c:796
+#: builtin/pack-objects.c:797
 msgid "unable to seek in reused packfile"
 msgstr "kan inte söka i återanvänd packfil"
 
-#: builtin/pack-objects.c:807
+#: builtin/pack-objects.c:808
 msgid "unable to read from reused packfile"
 msgstr "kan inte läsa från återanvänd packfil"
 
-#: builtin/pack-objects.c:835
+#: builtin/pack-objects.c:836
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "inaktiverar skrivning av bitkarta, paket delas på grund av pack.packSizeLimit"
 
-#: builtin/pack-objects.c:848
+#: builtin/pack-objects.c:849
 msgid "Writing objects"
 msgstr "Skriver objekt"
 
-#: builtin/pack-objects.c:910 builtin/update-index.c:88
+#: builtin/pack-objects.c:911 builtin/update-index.c:89
 #, c-format
 msgid "failed to stat %s"
 msgstr "misslyckades ta status på %s"
 
-#: builtin/pack-objects.c:963
+#: builtin/pack-objects.c:964
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "skrev %<PRIu32> objekt medan %<PRIu32> förväntades"
 
-#: builtin/pack-objects.c:1157
+#: builtin/pack-objects.c:1158
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr "inaktiverar skrivning av bitkarta då några objekt inte packas"
 
-#: builtin/pack-objects.c:1585
+#: builtin/pack-objects.c:1586
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "deltabasoffset utanför gränsen i pack för %s"
 
-#: builtin/pack-objects.c:1594
+#: builtin/pack-objects.c:1595
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "deltabasoffset utanför gränsvärden för %s"
 
-#: builtin/pack-objects.c:1863
+#: builtin/pack-objects.c:1864
 msgid "Counting objects"
 msgstr "Räknar objekt"
 
-#: builtin/pack-objects.c:1998
+#: builtin/pack-objects.c:1994
 #, c-format
 msgid "unable to get size of %s"
 msgstr "kan inte hämta storlek på %s"
 
-#: builtin/pack-objects.c:2013
+#: builtin/pack-objects.c:2009
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "kunde inte tolka objekthuvud för %s"
 
-#: builtin/pack-objects.c:2083 builtin/pack-objects.c:2099
-#: builtin/pack-objects.c:2109
+#: builtin/pack-objects.c:2079 builtin/pack-objects.c:2095
+#: builtin/pack-objects.c:2105
 #, c-format
 msgid "object %s cannot be read"
 msgstr "objektet %s kunde inte läsas"
 
-#: builtin/pack-objects.c:2086 builtin/pack-objects.c:2113
+#: builtin/pack-objects.c:2082 builtin/pack-objects.c:2109
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr "objektet %s har inkonsistent objektlängd (%<PRIuMAX> mot %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2123
+#: builtin/pack-objects.c:2119
 msgid "suboptimal pack - out of memory"
 msgstr "icke-optimalt pack - minnet slut"
 
-#: builtin/pack-objects.c:2451
+#: builtin/pack-objects.c:2445
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Deltakomprimering använder upp till %d trådar"
 
-#: builtin/pack-objects.c:2583
+#: builtin/pack-objects.c:2577
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "kan inte packa objekt nåbara från taggen %s"
 
-#: builtin/pack-objects.c:2670
+#: builtin/pack-objects.c:2664
 msgid "Compressing objects"
 msgstr "Komprimerar objekt"
 
-#: builtin/pack-objects.c:2676
+#: builtin/pack-objects.c:2670
 msgid "inconsistency with delta count"
 msgstr "deltaräknaren är inkonsekvent"
 
-#: builtin/pack-objects.c:2753
+#: builtin/pack-objects.c:2751
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -13970,7 +14843,7 @@ msgstr ""
 "förväntade kant-objekt-id, fick skräp:\n"
 " %s"
 
-#: builtin/pack-objects.c:2759
+#: builtin/pack-objects.c:2757
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -13979,20 +14852,20 @@ msgstr ""
 "förväntade objekt-id, fick skräp:\n"
 " %s"
 
-#: builtin/pack-objects.c:2857
+#: builtin/pack-objects.c:2855
 msgid "invalid value for --missing"
 msgstr "ogiltigt värde för --missing"
 
-#: builtin/pack-objects.c:2916 builtin/pack-objects.c:3024
+#: builtin/pack-objects.c:2914 builtin/pack-objects.c:3022
 msgid "cannot open pack index"
 msgstr "kan inte öppna paketfilen"
 
-#: builtin/pack-objects.c:2947
+#: builtin/pack-objects.c:2945
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "lösa objekt på %s kunde inte underökas"
 
-#: builtin/pack-objects.c:3032
+#: builtin/pack-objects.c:3030
 msgid "unable to force loose object"
 msgstr "kan inte tvinga lösa objekt"
 
@@ -14129,85 +15002,89 @@ msgid "unpack unreachable objects newer than <time>"
 msgstr "packa upp onåbara objekt nyare än <tid>"
 
 #: builtin/pack-objects.c:3296
+msgid "use the sparse reachability algorithm"
+msgstr "använd gles-nåbarhetsalgoritmen"
+
+#: builtin/pack-objects.c:3298
 msgid "create thin packs"
 msgstr "skapa tunna paket"
 
-#: builtin/pack-objects.c:3298
+#: builtin/pack-objects.c:3300
 msgid "create packs suitable for shallow fetches"
 msgstr "skapa packfiler lämpade för grunda hämtningar"
 
-#: builtin/pack-objects.c:3300
+#: builtin/pack-objects.c:3302
 msgid "ignore packs that have companion .keep file"
 msgstr "ignorera paket som har tillhörande .keep-fil"
 
-#: builtin/pack-objects.c:3302
+#: builtin/pack-objects.c:3304
 msgid "ignore this pack"
 msgstr "ignorera detta paket"
 
-#: builtin/pack-objects.c:3304
+#: builtin/pack-objects.c:3306
 msgid "pack compression level"
 msgstr "komprimeringsgrad för paket"
 
-#: builtin/pack-objects.c:3306
+#: builtin/pack-objects.c:3308
 msgid "do not hide commits by grafts"
 msgstr "göm inte incheckningar med ympningar (\"grafts\")"
 
-#: builtin/pack-objects.c:3308
+#: builtin/pack-objects.c:3310
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr "använd bitkartindex om tillgängligt för att räkna objekt snabbare"
 
-#: builtin/pack-objects.c:3310
+#: builtin/pack-objects.c:3312
 msgid "write a bitmap index together with the pack index"
 msgstr "använd bitkartindex tillsammans med packindexet"
 
-#: builtin/pack-objects.c:3313
+#: builtin/pack-objects.c:3315
 msgid "handling for missing objects"
 msgstr "hantering av saknade objekt"
 
-#: builtin/pack-objects.c:3316
+#: builtin/pack-objects.c:3318
 msgid "do not pack objects in promisor packfiles"
 msgstr "packa inte objekt i kontraktspackfiler"
 
-#: builtin/pack-objects.c:3318
+#: builtin/pack-objects.c:3320
 msgid "respect islands during delta compression"
 msgstr "respektera öar under deltakomprimering"
 
-#: builtin/pack-objects.c:3342
+#: builtin/pack-objects.c:3345
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "deltakedjedjupet %d är för djupt, påtvingar %d"
 
-#: builtin/pack-objects.c:3347
+#: builtin/pack-objects.c:3350
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "pack.deltaCacheLimit är för högt, påtvingar %d"
 
-#: builtin/pack-objects.c:3401
+#: builtin/pack-objects.c:3404
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size kan inte användas för att bygga ett paket som skall överföras"
 
-#: builtin/pack-objects.c:3403
+#: builtin/pack-objects.c:3406
 msgid "minimum pack size limit is 1 MiB"
 msgstr "minsta packstorlek är 1 MiB"
 
-#: builtin/pack-objects.c:3408
+#: builtin/pack-objects.c:3411
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin kan inte användas för att bygga ett indexerbart paket"
 
-#: builtin/pack-objects.c:3411
+#: builtin/pack-objects.c:3414
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable och -unpack-unreachable kan inte användas samtidigt"
 
-#: builtin/pack-objects.c:3417
+#: builtin/pack-objects.c:3420
 msgid "cannot use --filter without --stdout"
 msgstr "kan inte använda --filter utan --stdout"
 
-#: builtin/pack-objects.c:3476
+#: builtin/pack-objects.c:3479
 msgid "Enumerating objects"
 msgstr "Räknar upp objekt"
 
-#: builtin/pack-objects.c:3495
+#: builtin/pack-objects.c:3498
 #, c-format
 msgid "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>)"
 msgstr ""
@@ -14249,57 +15126,57 @@ msgstr "låt tid gå ut för objekt äldre än <tid>"
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr "begränsa vandring av objekt utanför kontraktspackfiler."
 
-#: builtin/prune.c:129
+#: builtin/prune.c:128
 msgid "cannot prune in a precious-objects repo"
 msgstr "kan inte rensa i ett \"precious-objekt\"-arkiv"
 
-#: builtin/pull.c:60 builtin/pull.c:62
+#: builtin/pull.c:61 builtin/pull.c:63
 #, c-format
 msgid "Invalid value for %s: %s"
 msgstr "Felaktigt värde för %s: %s"
 
-#: builtin/pull.c:82
+#: builtin/pull.c:83
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<flaggor>] [<arkiv> [<refspec>...]]"
 
-#: builtin/pull.c:133
+#: builtin/pull.c:134
 msgid "control for recursive fetching of submodules"
 msgstr "styrning för rekursiv hämtning av undermoduler"
 
-#: builtin/pull.c:137
+#: builtin/pull.c:138
 msgid "Options related to merging"
 msgstr "Alternativ gällande sammanslagning"
 
-#: builtin/pull.c:140
+#: builtin/pull.c:141
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "inlemma ändringar genom ombasering i stället för sammanslagning"
 
-#: builtin/pull.c:167 builtin/rebase--interactive.c:147 builtin/revert.c:122
+#: builtin/pull.c:168 builtin/rebase--interactive.c:149 builtin/revert.c:123
 msgid "allow fast-forward"
 msgstr "tillåt snabbspolning"
 
-#: builtin/pull.c:176
+#: builtin/pull.c:177
 msgid "automatically stash/stash pop before and after rebase"
 msgstr "utför automatiskt stash/stash pop före och efter ombasering"
 
-#: builtin/pull.c:192
+#: builtin/pull.c:193
 msgid "Options related to fetching"
 msgstr "Alternativ gällande hämtningar"
 
-#: builtin/pull.c:202
+#: builtin/pull.c:203
 msgid "force overwrite of local branch"
 msgstr "tvinga överskrivning av lokal gren"
 
-#: builtin/pull.c:210
+#: builtin/pull.c:211
 msgid "number of submodules pulled in parallel"
 msgstr "antal undermoduler som hämtas parallellt"
 
-#: builtin/pull.c:305
+#: builtin/pull.c:306
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "Felaktigt värde för pull.ff: %s"
 
-#: builtin/pull.c:421
+#: builtin/pull.c:422
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -14307,14 +15184,14 @@ msgstr ""
 "Det finns ingen kandidat för ombasering bland referenserna du precis har "
 "hämtat."
 
-#: builtin/pull.c:423
+#: builtin/pull.c:424
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Det finns ingen kandidat för sammanslagning bland referenserna du precis har "
 "hämtat."
 
-#: builtin/pull.c:424
+#: builtin/pull.c:425
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -14322,7 +15199,7 @@ msgstr ""
 "Det betyder vanligtvis att du använt en jokertecken-refspec som inte\n"
 "motsvarade något i fjärränden."
 
-#: builtin/pull.c:427
+#: builtin/pull.c:428
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -14333,42 +15210,42 @@ msgstr ""
 "gren. Eftersom det inte är den fjärr som är konfigurerad som\n"
 "standard för aktuell gren måste du ange en gren på kommandoraden."
 
-#: builtin/pull.c:432 builtin/rebase.c:761 git-parse-remote.sh:73
+#: builtin/pull.c:433 builtin/rebase.c:956 git-parse-remote.sh:73
 msgid "You are not currently on a branch."
 msgstr "Du är inte på någon gren för närvarande."
 
-#: builtin/pull.c:434 builtin/pull.c:449 git-parse-remote.sh:79
+#: builtin/pull.c:435 builtin/pull.c:450 git-parse-remote.sh:79
 msgid "Please specify which branch you want to rebase against."
 msgstr "Ange vilken gren du vill ombasera mot."
 
-#: builtin/pull.c:436 builtin/pull.c:451 git-parse-remote.sh:82
+#: builtin/pull.c:437 builtin/pull.c:452 git-parse-remote.sh:82
 msgid "Please specify which branch you want to merge with."
 msgstr "Ange vilken gren du vill slå samman med."
 
-#: builtin/pull.c:437 builtin/pull.c:452
+#: builtin/pull.c:438 builtin/pull.c:453
 msgid "See git-pull(1) for details."
 msgstr "Se git-pull(1) för detaljer."
 
-#: builtin/pull.c:439 builtin/pull.c:445 builtin/pull.c:454
-#: builtin/rebase.c:767 git-parse-remote.sh:64
+#: builtin/pull.c:440 builtin/pull.c:446 builtin/pull.c:455
+#: builtin/rebase.c:962 git-parse-remote.sh:64
 msgid "<remote>"
 msgstr "<fjärr>"
 
-#: builtin/pull.c:439 builtin/pull.c:454 builtin/pull.c:459
-#: git-legacy-rebase.sh:556 git-parse-remote.sh:65
+#: builtin/pull.c:440 builtin/pull.c:455 builtin/pull.c:460
+#: git-legacy-rebase.sh:564 git-parse-remote.sh:65
 msgid "<branch>"
 msgstr "<gren>"
 
-#: builtin/pull.c:447 builtin/rebase.c:759 git-parse-remote.sh:75
+#: builtin/pull.c:448 builtin/rebase.c:954 git-parse-remote.sh:75
 msgid "There is no tracking information for the current branch."
 msgstr "Det finns ingen spårningsinformation för aktuell gren."
 
-#: builtin/pull.c:456 git-parse-remote.sh:95
+#: builtin/pull.c:457 git-parse-remote.sh:95
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr "Om du vill ange spårningsinformation för grenen kan du göra det med:"
 
-#: builtin/pull.c:461
+#: builtin/pull.c:462
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -14377,32 +15254,32 @@ msgstr ""
 "Dina inställningar anger sammanslagning med referensen \"%s\"\n"
 "från fjärren, men någon sådan referens togs inte emot."
 
-#: builtin/pull.c:565
+#: builtin/pull.c:566
 #, c-format
 msgid "unable to access commit %s"
 msgstr "kunde inte komma åt incheckningen %s"
 
-#: builtin/pull.c:843
+#: builtin/pull.c:844
 msgid "ignoring --verify-signatures for rebase"
 msgstr "ignorera --verify-signatures för ombasering"
 
-#: builtin/pull.c:891
+#: builtin/pull.c:892
 msgid "--[no-]autostash option is only valid with --rebase."
 msgstr "--[no-]autostash är endast giltig med --rebase."
 
-#: builtin/pull.c:899
+#: builtin/pull.c:900
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Uppdaterar en ofödd gren med ändringar som lagts till i indexet."
 
-#: builtin/pull.c:902
+#: builtin/pull.c:904
 msgid "pull with rebase"
 msgstr "pull med ombasering"
 
-#: builtin/pull.c:903
+#: builtin/pull.c:905
 msgid "please commit or stash them."
 msgstr "checka in eller använd \"stash\" på dem."
 
-#: builtin/pull.c:928
+#: builtin/pull.c:930
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -14413,7 +15290,7 @@ msgstr ""
 "snabbspolar din arbetskatalog från\n"
 "incheckningen %s."
 
-#: builtin/pull.c:934
+#: builtin/pull.c:936
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -14430,15 +15307,15 @@ msgstr ""
 "$ git reset --hard\n"
 "för att återgå."
 
-#: builtin/pull.c:949
+#: builtin/pull.c:951
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kan inte slå ihop flera grenar i ett tomt huvud."
 
-#: builtin/pull.c:953
+#: builtin/pull.c:955
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kan inte ombasera ovanpå flera grenar."
 
-#: builtin/pull.c:960
+#: builtin/pull.c:962
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr "kan inte ombasera med lokalt lagrade ändringar i undermoful"
 
@@ -14454,7 +15331,7 @@ msgstr "taggförkortning utan <tagg>"
 msgid "--delete only accepts plain target ref names"
 msgstr "--delete godtar endast enkla målreferensnamn"
 
-#: builtin/push.c:165
+#: builtin/push.c:167
 msgid ""
 "\n"
 "To choose either option permanently, see push.default in 'git help config'."
@@ -14463,7 +15340,7 @@ msgstr ""
 "För att välja ett av alternativen permanent, se push.default i \"git help "
 "config\"."
 
-#: builtin/push.c:168
+#: builtin/push.c:170
 #, c-format
 msgid ""
 "The upstream branch of your current branch does not match\n"
@@ -14488,7 +15365,7 @@ msgstr ""
 "    git push %s HEAD\n"
 "%s"
 
-#: builtin/push.c:183
+#: builtin/push.c:185
 #, c-format
 msgid ""
 "You are not currently on a branch.\n"
@@ -14503,7 +15380,7 @@ msgstr ""
 "\n"
 "    git push %s HEAD:<namn-på-fjärrgren>\n"
 
-#: builtin/push.c:197
+#: builtin/push.c:199
 #, c-format
 msgid ""
 "The current branch %s has no upstream branch.\n"
@@ -14516,12 +15393,12 @@ msgstr ""
 "\n"
 "    git push --set-upstream %s %s\n"
 
-#: builtin/push.c:205
+#: builtin/push.c:207
 #, c-format
 msgid "The current branch %s has multiple upstream branches, refusing to push."
 msgstr "Den aktuella grenen %s har flera uppströmsgrenar, vägrar sända."
 
-#: builtin/push.c:208
+#: builtin/push.c:210
 #, c-format
 msgid ""
 "You are pushing to remote '%s', which is not the upstream of\n"
@@ -14532,14 +15409,14 @@ msgstr ""
 "aktuella grenen \"%s\", utan att tala om för mig vad som\n"
 "skall sändas för att uppdatera fjärrgrenen."
 
-#: builtin/push.c:267
+#: builtin/push.c:269
 msgid ""
 "You didn't specify any refspecs to push, and push.default is \"nothing\"."
 msgstr ""
 "Du angav inga referensspecifikationer att sända, och push.default är "
 "\"nothing\"."
 
-#: builtin/push.c:274
+#: builtin/push.c:276
 msgid ""
 "Updates were rejected because the tip of your current branch is behind\n"
 "its remote counterpart. Integrate the remote changes (e.g.\n"
@@ -14551,7 +15428,7 @@ msgstr ""
 "\"git pull ....\") innan du sänder igen.\n"
 "Se avsnittet \"Note about fast-forward\" i \"git push --help\" för detaljer."
 
-#: builtin/push.c:280
+#: builtin/push.c:282
 msgid ""
 "Updates were rejected because a pushed branch tip is behind its remote\n"
 "counterpart. Check out this branch and integrate the remote changes\n"
@@ -14563,7 +15440,7 @@ msgstr ""
 "\"git pull ...\") innan du sänder igen.\n"
 "Se avsnittet \"Note about fast-forward\" i \"git push --help\" för detaljer."
 
-#: builtin/push.c:286
+#: builtin/push.c:288
 msgid ""
 "Updates were rejected because the remote contains work that you do\n"
 "not have locally. This is usually caused by another repository pushing\n"
@@ -14577,11 +15454,11 @@ msgstr ""
 "(t.ex. \"git pull ...\") innan du sänder igen.\n"
 "Se avsnittet \"Note about fast-forwards\" i \"git push --help\" för detaljer."
 
-#: builtin/push.c:293
+#: builtin/push.c:295
 msgid "Updates were rejected because the tag already exists in the remote."
 msgstr "Uppdateringarna avvisades eftersom taggen redan finns på fjärren."
 
-#: builtin/push.c:296
+#: builtin/push.c:298
 msgid ""
 "You cannot update a remote ref that points at a non-commit object,\n"
 "or update a remote ref to make it point at a non-commit object,\n"
@@ -14592,22 +15469,22 @@ msgstr ""
 "pekar på något som inte är en incheckning, utan att använda flaggan\n"
 "\"--force\".\n"
 
-#: builtin/push.c:357
+#: builtin/push.c:359
 #, c-format
 msgid "Pushing to %s\n"
 msgstr "Sänder till %s\n"
 
-#: builtin/push.c:361
+#: builtin/push.c:364
 #, c-format
 msgid "failed to push some refs to '%s'"
 msgstr "misslyckades sända vissa referenser till \"%s\""
 
-#: builtin/push.c:395
+#: builtin/push.c:398
 #, c-format
 msgid "bad repository '%s'"
 msgstr "felaktigt arkiv \"%s\""
 
-#: builtin/push.c:396
+#: builtin/push.c:399
 msgid ""
 "No configured push destination.\n"
 "Either specify the URL from the command-line or configure a remote "
@@ -14628,104 +15505,104 @@ msgstr ""
 "\n"
 "    git push <namn>\n"
 
-#: builtin/push.c:551
+#: builtin/push.c:554
 msgid "repository"
 msgstr "arkiv"
 
-#: builtin/push.c:552 builtin/send-pack.c:164
+#: builtin/push.c:555 builtin/send-pack.c:164
 msgid "push all refs"
 msgstr "sänd alla referenser"
 
-#: builtin/push.c:553 builtin/send-pack.c:166
+#: builtin/push.c:556 builtin/send-pack.c:166
 msgid "mirror all refs"
 msgstr "spegla alla referenser"
 
-#: builtin/push.c:555
+#: builtin/push.c:558
 msgid "delete refs"
 msgstr "ta bort referenser"
 
-#: builtin/push.c:556
+#: builtin/push.c:559
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "sänd taggar (kan inte användas med --all eller --mirror)"
 
-#: builtin/push.c:559 builtin/send-pack.c:167
+#: builtin/push.c:562 builtin/send-pack.c:167
 msgid "force updates"
 msgstr "tvinga uppdateringar"
 
-#: builtin/push.c:561 builtin/send-pack.c:181
+#: builtin/push.c:564 builtin/send-pack.c:181
 msgid "<refname>:<expect>"
 msgstr "<refnamn>:<förvänta>"
 
-#: builtin/push.c:562 builtin/send-pack.c:182
+#: builtin/push.c:565 builtin/send-pack.c:182
 msgid "require old value of ref to be at this value"
 msgstr "kräv att ref:s tidigare värde är detta"
 
-#: builtin/push.c:565
+#: builtin/push.c:568
 msgid "control recursive pushing of submodules"
 msgstr "styr rekursiv insändning av undermoduler"
 
-#: builtin/push.c:567 builtin/send-pack.c:175
+#: builtin/push.c:570 builtin/send-pack.c:175
 msgid "use thin pack"
 msgstr "använd tunna paket"
 
-#: builtin/push.c:568 builtin/push.c:569 builtin/send-pack.c:161
+#: builtin/push.c:571 builtin/push.c:572 builtin/send-pack.c:161
 #: builtin/send-pack.c:162
 msgid "receive pack program"
 msgstr "program för att ta emot paket"
 
-#: builtin/push.c:570
+#: builtin/push.c:573
 msgid "set upstream for git pull/status"
 msgstr "ställ in uppström för git pull/status"
 
-#: builtin/push.c:573
+#: builtin/push.c:576
 msgid "prune locally removed refs"
 msgstr "ta bort lokalt borttagna referenser"
 
-#: builtin/push.c:575
+#: builtin/push.c:578
 msgid "bypass pre-push hook"
 msgstr "förbigå pre-push-krok"
 
-#: builtin/push.c:576
+#: builtin/push.c:579
 msgid "push missing but relevant tags"
 msgstr "sänd in saknade men relevanta taggar"
 
-#: builtin/push.c:579 builtin/send-pack.c:169
+#: builtin/push.c:582 builtin/send-pack.c:169
 msgid "GPG sign the push"
 msgstr "GPG-signera insändningen"
 
-#: builtin/push.c:581 builtin/send-pack.c:176
+#: builtin/push.c:584 builtin/send-pack.c:176
 msgid "request atomic transaction on remote side"
 msgstr "begär atomiska transaktioner på fjärrsidan"
 
-#: builtin/push.c:599
+#: builtin/push.c:602
 msgid "--delete is incompatible with --all, --mirror and --tags"
 msgstr "--delete är inkompatibel med --all, --mirror och --tags"
 
-#: builtin/push.c:601
+#: builtin/push.c:604
 msgid "--delete doesn't make sense without any refs"
 msgstr "--delete kan inte användas utan referenser"
 
-#: builtin/push.c:604
+#: builtin/push.c:607
 msgid "--all and --tags are incompatible"
 msgstr "--all och --tags är inkompatibla"
 
-#: builtin/push.c:606
+#: builtin/push.c:609
 msgid "--all can't be combined with refspecs"
 msgstr "--all kan inte kombineras med referensspecifikationer"
 
-#: builtin/push.c:610
+#: builtin/push.c:613
 msgid "--mirror and --tags are incompatible"
 msgstr "--mirror och --tags är inkompatibla"
 
-#: builtin/push.c:612
+#: builtin/push.c:615
 msgid "--mirror can't be combined with refspecs"
 msgstr "--mirror kan inte kombineras med referensspecifikationer"
 
-#: builtin/push.c:615
+#: builtin/push.c:618
 msgid "--all and --mirror are incompatible"
 msgstr "--all och --mirror är inkompatibla"
 
-#: builtin/push.c:634
+#: builtin/push.c:637
 msgid "push options must not have new line characters"
 msgstr "push-flaggor kan inte innehålla radbrytning"
 
@@ -14763,7 +15640,7 @@ msgstr "ensamt argument måste vara symmetriskt intervall"
 msgid "need two commit ranges"
 msgstr "behöver två incheckningsintervall"
 
-#: builtin/read-tree.c:40
+#: builtin/read-tree.c:41
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
 "[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
@@ -14773,71 +15650,71 @@ msgstr ""
 "[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
 "index-output=<fil>] (--empty | <träd-igt1> [<träd-igt2> [<träd-igt3>]])"
 
-#: builtin/read-tree.c:123
+#: builtin/read-tree.c:124
 msgid "write resulting index to <file>"
 msgstr "skriv resulterande index till <fil>"
 
-#: builtin/read-tree.c:126
+#: builtin/read-tree.c:127
 msgid "only empty the index"
 msgstr "töm bara indexet"
 
-#: builtin/read-tree.c:128
+#: builtin/read-tree.c:129
 msgid "Merging"
 msgstr "Sammanslagning"
 
-#: builtin/read-tree.c:130
+#: builtin/read-tree.c:131
 msgid "perform a merge in addition to a read"
 msgstr "utför en sammanslagning i tillägg till en läsning"
 
-#: builtin/read-tree.c:132
+#: builtin/read-tree.c:133
 msgid "3-way merge if no file level merging required"
 msgstr "3-vägssammanslagning om sammanslagning på filnivå ej krävs"
 
-#: builtin/read-tree.c:134
+#: builtin/read-tree.c:135
 msgid "3-way merge in presence of adds and removes"
 msgstr "3-vägssammanslagning när det finns tillägg och borttagningar"
 
-#: builtin/read-tree.c:136
+#: builtin/read-tree.c:137
 msgid "same as -m, but discard unmerged entries"
 msgstr "som -m, men kasta bort ej sammanslagna poster"
 
-#: builtin/read-tree.c:137
+#: builtin/read-tree.c:138
 msgid "<subdirectory>/"
 msgstr "<underkatalog>/"
 
-#: builtin/read-tree.c:138
+#: builtin/read-tree.c:139
 msgid "read the tree into the index under <subdirectory>/"
 msgstr "läs in trädet i indexet under <underkatalog>/"
 
-#: builtin/read-tree.c:141
+#: builtin/read-tree.c:142
 msgid "update working tree with merge result"
 msgstr "uppdatera arbetskatalogen med resultatet från sammanslagningen"
 
-#: builtin/read-tree.c:143
+#: builtin/read-tree.c:144
 msgid "gitignore"
 msgstr "gitignore"
 
-#: builtin/read-tree.c:144
+#: builtin/read-tree.c:145
 msgid "allow explicitly ignored files to be overwritten"
 msgstr "tillåt explicit ignorerade filer att skrivas över"
 
-#: builtin/read-tree.c:147
+#: builtin/read-tree.c:148
 msgid "don't check the working tree after merging"
 msgstr "kontrollera inte arbetskatalogen efter sammanslagning"
 
-#: builtin/read-tree.c:148
+#: builtin/read-tree.c:149
 msgid "don't update the index or the work tree"
 msgstr "uppdatera inte indexet eller arbetskatalogen"
 
-#: builtin/read-tree.c:150
+#: builtin/read-tree.c:151
 msgid "skip applying sparse checkout filter"
 msgstr "hoppa över att applicera filter för gles utcheckning"
 
-#: builtin/read-tree.c:152
+#: builtin/read-tree.c:153
 msgid "debug unpack-trees"
 msgstr "felsök unpack-trees"
 
-#: builtin/rebase.c:29
+#: builtin/rebase.c:30
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] [<upstream>] "
 "[<branch>]"
@@ -14845,47 +15722,51 @@ msgstr ""
 "git rebase [-i] [flaggor] [--exec <kmd>] [--onto <nybas>] [<uppström>] "
 "[<gren>]"
 
-#: builtin/rebase.c:31
+#: builtin/rebase.c:32
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] --root [<branch>]"
 msgstr ""
 "git rebase [-i] [flaggor] [--exec <kmd>] [--onto <nybas>] --root [<gren>]"
 
-#: builtin/rebase.c:33
+#: builtin/rebase.c:34
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:119
+#: builtin/rebase.c:121 builtin/rebase.c:1437
 #, c-format
 msgid "%s requires an interactive rebase"
 msgstr "%s kräver en interaktiv ombasering"
 
-#: builtin/rebase.c:171
+#: builtin/rebase.c:173
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "kunde inte hämta \"onto\": \"%s\""
 
-#: builtin/rebase.c:186
+#: builtin/rebase.c:188
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "ogiltigt orig-head: \"%s\""
 
-#: builtin/rebase.c:214
+#: builtin/rebase.c:213
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "ignorera ogiltigt allow_rerere_autoupdate: \"%s\""
 
-#: builtin/rebase.c:259
+#: builtin/rebase.c:289
 #, c-format
 msgid "Could not read '%s'"
 msgstr "Kunde inte läsa \"%s\""
 
-#: builtin/rebase.c:277
+#: builtin/rebase.c:307
 #, c-format
 msgid "Cannot store %s"
 msgstr "Kan inte spara %s"
 
-#: builtin/rebase.c:337
+#: builtin/rebase.c:402
+msgid "could not determine HEAD revision"
+msgstr "kunde inte bestämma HEAD-revision"
+
+#: builtin/rebase.c:522
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -14899,11 +15780,26 @@ msgstr ""
 "För att avbryta och återgå till där du var före ombaseringen, kör \"git "
 "rebase --abort\"."
 
-#: builtin/rebase.c:561
-msgid "could not determine HEAD revision"
-msgstr "kunde inte bestämma HEAD-revision"
+#: builtin/rebase.c:603
+#, c-format
+msgid ""
+"\n"
+"git encountered an error while preparing the patches to replay\n"
+"these revisions:\n"
+"\n"
+"    %s\n"
+"\n"
+"As a result, git cannot rebase them."
+msgstr ""
+"\n"
+"git upptäckte ett fel när det skulle förbereda patchar för att\n"
+"återskapa dessa revisioner:\n"
+"\n"
+"    %s\n"
+"\n"
+"Därför kan inte git ombasera dessa."
 
-#: builtin/rebase.c:753
+#: builtin/rebase.c:948
 #, c-format
 msgid ""
 "%s\n"
@@ -14920,7 +15816,7 @@ msgstr ""
 "    git rebase '<gren>'\n"
 "\n"
 
-#: builtin/rebase.c:769
+#: builtin/rebase.c:964
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -14933,148 +15829,160 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<gren> %s\n"
 "\n"
 
-#: builtin/rebase.c:832
+#: builtin/rebase.c:994
+msgid "exec commands cannot contain newlines"
+msgstr "exec-kommandon kan inte innehålla nyradstecken"
+
+#: builtin/rebase.c:998
+msgid "empty exec command"
+msgstr "tomt exec-kommando"
+
+#: builtin/rebase.c:1040
 msgid "rebase onto given branch instead of upstream"
 msgstr "ombasera mot given grenen istället för uppström"
 
-#: builtin/rebase.c:834
+#: builtin/rebase.c:1042
 msgid "allow pre-rebase hook to run"
 msgstr "tillåt pre-rebase-krok att köra"
 
-#: builtin/rebase.c:836
+#: builtin/rebase.c:1044
 msgid "be quiet. implies --no-stat"
 msgstr "var tyst. implicerar --no-stat"
 
-#: builtin/rebase.c:839
+#: builtin/rebase.c:1047
 msgid "display a diffstat of what changed upstream"
 msgstr "vis diffstat för vad som ändrats uppströms"
 
-#: builtin/rebase.c:842
+#: builtin/rebase.c:1050
 msgid "do not show diffstat of what changed upstream"
 msgstr "visa inte en diffstat för vad som ändrats uppströms"
 
-#: builtin/rebase.c:845
+#: builtin/rebase.c:1053
 msgid "add a Signed-off-by: line to each commit"
 msgstr "lägg \"Signed-off-by:\"-rad till varje incheckning"
 
-#: builtin/rebase.c:847 builtin/rebase.c:851 builtin/rebase.c:853
+#: builtin/rebase.c:1055 builtin/rebase.c:1059 builtin/rebase.c:1061
 msgid "passed to 'git am'"
 msgstr "sänds till \"git am\""
 
-#: builtin/rebase.c:855 builtin/rebase.c:857
+#: builtin/rebase.c:1063 builtin/rebase.c:1065
 msgid "passed to 'git apply'"
 msgstr "sänds till \"git apply\""
 
-#: builtin/rebase.c:859 builtin/rebase.c:862
+#: builtin/rebase.c:1067 builtin/rebase.c:1070
 msgid "cherry-pick all commits, even if unchanged"
 msgstr "utför cherry-pick på alla incheckningar, även om oändrad"
 
-#: builtin/rebase.c:864
+#: builtin/rebase.c:1072
 msgid "continue"
 msgstr "fortsätt"
 
-#: builtin/rebase.c:867
+#: builtin/rebase.c:1075
 msgid "skip current patch and continue"
 msgstr "hoppa över nuvarande patch och fortsätt"
 
-#: builtin/rebase.c:869
+#: builtin/rebase.c:1077
 msgid "abort and check out the original branch"
 msgstr "avbryt och checka ut ursprungsgrenen"
 
-#: builtin/rebase.c:872
+#: builtin/rebase.c:1080
 msgid "abort but keep HEAD where it is"
 msgstr "avbryt men behåll HEAD där det är"
 
-#: builtin/rebase.c:873
+#: builtin/rebase.c:1081
 msgid "edit the todo list during an interactive rebase"
 msgstr "redigera attgöra-listan under interaktiv ombasering."
 
-#: builtin/rebase.c:876
+#: builtin/rebase.c:1084
 msgid "show the patch file being applied or merged"
 msgstr "visa patchen som tillämpas eller slås samman"
 
-#: builtin/rebase.c:879
+#: builtin/rebase.c:1087
 msgid "use merging strategies to rebase"
 msgstr "använd sammanslagningsstrategier för sammanslagning"
 
-#: builtin/rebase.c:883
+#: builtin/rebase.c:1091
 msgid "let the user edit the list of commits to rebase"
 msgstr "låt användaren redigera listan över incheckningar att ombasera"
 
-#: builtin/rebase.c:887
+#: builtin/rebase.c:1095
 msgid "try to recreate merges instead of ignoring them"
 msgstr "försök återskapa sammanslagningar istället för att ignorera dem"
 
-#: builtin/rebase.c:891
+#: builtin/rebase.c:1099
 msgid "allow rerere to update index with resolved conflict"
 msgstr "tillåt rerere att uppdatera index med lösa konflikter"
 
-#: builtin/rebase.c:894
+#: builtin/rebase.c:1102
 msgid "preserve empty commits during rebase"
 msgstr "behåll tomma incheckningar under ombasering"
 
-#: builtin/rebase.c:896
+#: builtin/rebase.c:1104
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "flytta incheckningar som börjar med squash!/fixup! under -i"
 
-#: builtin/rebase.c:902
+#: builtin/rebase.c:1110
 msgid "automatically stash/stash pop before and after"
 msgstr "utför automatiskt stash/stash pop före och efter"
 
-#: builtin/rebase.c:904
+#: builtin/rebase.c:1112
 msgid "add exec lines after each commit of the editable list"
 msgstr "lägg till exec-rader efter varje incheckning i den redigerbara listan"
 
-#: builtin/rebase.c:908
+#: builtin/rebase.c:1116
 msgid "allow rebasing commits with empty messages"
 msgstr "tillåt ombasering av incheckningar med tomt meddelande"
 
-#: builtin/rebase.c:911
+#: builtin/rebase.c:1119
 msgid "try to rebase merges instead of skipping them"
 msgstr "försök ombasera sammanslagningar istället för att ignorera dem"
 
-#: builtin/rebase.c:914
+#: builtin/rebase.c:1122
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr "använd \"merge-base --fork-point\" för att förfina uppström"
 
-#: builtin/rebase.c:916
+#: builtin/rebase.c:1124
 msgid "use the given merge strategy"
 msgstr "använd angiven sammanslagningsstrategi"
 
-#: builtin/rebase.c:918 builtin/revert.c:111
+#: builtin/rebase.c:1126 builtin/revert.c:112
 msgid "option"
 msgstr "alternativ"
 
-#: builtin/rebase.c:919
+#: builtin/rebase.c:1127
 msgid "pass the argument through to the merge strategy"
 msgstr "sänd flaggan till sammanslagningsstrategin"
 
-#: builtin/rebase.c:922
+#: builtin/rebase.c:1130
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "ombasera alla nåbara incheckningar upp till roten/rötterna"
 
-#: builtin/rebase.c:938
+#: builtin/rebase.c:1133 builtin/rebase--interactive.c:198
+msgid "automatically re-schedule any `exec` that fails"
+msgstr "kör automatiskt alla \"exec\" som misslyckas på nytt"
+
+#: builtin/rebase.c:1149
 #, c-format
 msgid "could not exec %s"
 msgstr "kunde inte köra %s"
 
-#: builtin/rebase.c:956 git-legacy-rebase.sh:213
+#: builtin/rebase.c:1167 git-legacy-rebase.sh:220
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "Det verkar som en \"git am\" körs. Kan inte ombasera."
 
-#: builtin/rebase.c:997 git-legacy-rebase.sh:395
+#: builtin/rebase.c:1208 git-legacy-rebase.sh:406
 msgid "No rebase in progress?"
 msgstr "Ingen ombasering pågår?"
 
-#: builtin/rebase.c:1001 git-legacy-rebase.sh:406
+#: builtin/rebase.c:1212 git-legacy-rebase.sh:417
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr "Åtgärden --edit-todo kan endast användas under interaktiv ombasering."
 
-#: builtin/rebase.c:1015 git-legacy-rebase.sh:413
+#: builtin/rebase.c:1226 git-legacy-rebase.sh:424
 msgid "Cannot read HEAD"
 msgstr "Kan inte läsa HEAD"
 
-#: builtin/rebase.c:1028 git-legacy-rebase.sh:416
+#: builtin/rebase.c:1238 git-legacy-rebase.sh:427
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -15082,21 +15990,21 @@ msgstr ""
 "Du måste redigera alla sammanslagningskonflikter och\n"
 "därefter markera dem som lösta med git add"
 
-#: builtin/rebase.c:1047
+#: builtin/rebase.c:1257
 msgid "could not discard worktree changes"
 msgstr "kunde inte kasta ändringar i arbetskatalogen"
 
-#: builtin/rebase.c:1066
+#: builtin/rebase.c:1276
 #, c-format
 msgid "could not move back to %s"
 msgstr "kunde inte flytta tillbaka till %s"
 
-#: builtin/rebase.c:1077 builtin/rm.c:368
+#: builtin/rebase.c:1287 builtin/rm.c:369
 #, c-format
 msgid "could not remove '%s'"
 msgstr "kunde inte ta bort \"%s\""
 
-#: builtin/rebase.c:1103
+#: builtin/rebase.c:1313
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -15117,334 +16025,328 @@ msgstr ""
 "och kör programmet igen. Jag avslutar ifall du fortfarande har\n"
 "något av värde där.\n"
 
-#: builtin/rebase.c:1124
+#: builtin/rebase.c:1334
 msgid "switch `C' expects a numerical value"
 msgstr "flaggan \"C\" förväntar ett numeriskt värde"
 
-#: builtin/rebase.c:1161
+#: builtin/rebase.c:1375
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Okänt läge: %s"
 
-#: builtin/rebase.c:1183
+#: builtin/rebase.c:1397
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy kräver --merge eller --interactive"
 
-#: builtin/rebase.c:1226
-#, c-format
-msgid ""
-"error: cannot combine interactive options (--interactive, --exec, --rebase-"
-"merges, --preserve-merges, --keep-empty, --root + --onto) with am options "
-"(%s)"
+#: builtin/rebase.c:1446
+msgid "cannot combine am options with either interactive or merge options"
 msgstr ""
-"fel: kan inte kombinera interaktiva flaggor (--interactive, --exec, --rebase-"
-"merges, --preserve-merges, --keep-empty, --root + --onto) med am-flaggor (%s)"
+"kan inte kombinera am-flaggor med varken interaktiv- eller "
+"sammanslagningsflaggor"
 
-#: builtin/rebase.c:1231
-#, c-format
+#: builtin/rebase.c:1465
+msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
+msgstr "kan inte kombinera \"--preserve-merges\" med \"--rebase-merges\""
+
+#: builtin/rebase.c:1469 git-legacy-rebase.sh:544
 msgid ""
-"error: cannot combine merge options (--merge, --strategy, --strategy-option) "
-"with am options (%s)"
+"error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
-"fel: kan inte kombinera sammanslagningsflaggor (--merge, --strategy, --"
-"strategy-option) med am-flaggor (%s)"
+"fel: kan inte kombinera \"--preserve-merges\" med \"--reschedule-failed-exec"
+"\""
 
-#: builtin/rebase.c:1251 git-legacy-rebase.sh:536
-msgid "error: cannot combine '--preserve-merges' with '--rebase-merges'"
-msgstr "fel: kan inte kombinera \"--preserve-merges\" med \"--rebase-merges\""
+#: builtin/rebase.c:1475
+msgid "cannot combine '--rebase-merges' with '--strategy-option'"
+msgstr "kan inte kombinera \"--rebase-merges\" med \"--strategy-option\""
 
-#: builtin/rebase.c:1256 git-legacy-rebase.sh:542
-msgid "error: cannot combine '--rebase-merges' with '--strategy-option'"
-msgstr "fel: kan inte kombinera \"--rebase-merges\" med \"--strategy-option\""
+#: builtin/rebase.c:1478
+msgid "cannot combine '--rebase-merges' with '--strategy'"
+msgstr "kan inte kombinera \"--rebase-merges\" med \"--strategy\""
 
-#: builtin/rebase.c:1259 git-legacy-rebase.sh:544
-msgid "error: cannot combine '--rebase-merges' with '--strategy'"
-msgstr "fel: kan inte kombinera \"--rebase-merges\" med \"--strategy\""
-
-#: builtin/rebase.c:1283
+#: builtin/rebase.c:1502
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "felaktig uppström ”%s”"
 
-#: builtin/rebase.c:1289
+#: builtin/rebase.c:1508
 msgid "Could not create new root commit"
 msgstr "kunde inte skapa ny rotincheckning"
 
-#: builtin/rebase.c:1307
+#: builtin/rebase.c:1526
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "\"%s\": behöver precis en sammanslagningsbas"
 
-#: builtin/rebase.c:1314
+#: builtin/rebase.c:1533
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "Pekar inte på en giltig incheckning: \"%s\""
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1558
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
 msgstr "ödesdigert: ingen sådan gren/incheckning: \"%s\""
 
-#: builtin/rebase.c:1347 builtin/submodule--helper.c:37
-#: builtin/submodule--helper.c:1930
+#: builtin/rebase.c:1566 builtin/submodule--helper.c:38
+#: builtin/submodule--helper.c:1934
 #, c-format
 msgid "No such ref: %s"
 msgstr "Ingen sådan referens: %s"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1578
 msgid "Could not resolve HEAD to a revision"
 msgstr "Kunde inte bestämma HEAD:s incheckning"
 
-#: builtin/rebase.c:1399 git-legacy-rebase.sh:665
+#: builtin/rebase.c:1619 git-legacy-rebase.sh:673
 msgid "Cannot autostash"
 msgstr "Kan inte utföra \"autostash\""
 
-#: builtin/rebase.c:1402
+#: builtin/rebase.c:1622
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Oväntat svar från stash: \"%s\""
 
-#: builtin/rebase.c:1408
+#: builtin/rebase.c:1628
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Kunde inte skapa katalog för \"%s\""
 
-#: builtin/rebase.c:1411
+#: builtin/rebase.c:1631
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Skapade autostash: %s\n"
 
-#: builtin/rebase.c:1414
+#: builtin/rebase.c:1634
 msgid "could not reset --hard"
 msgstr "kunde inte utföra \"reset --hard\""
 
-#: builtin/rebase.c:1415 builtin/reset.c:113
+#: builtin/rebase.c:1635 builtin/reset.c:114
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD är nu på %s"
 
-#: builtin/rebase.c:1431 git-legacy-rebase.sh:674
+#: builtin/rebase.c:1651 git-legacy-rebase.sh:682
 msgid "Please commit or stash them."
 msgstr "Checka in eller använd \"stash\" på dem."
 
-#: builtin/rebase.c:1458
+#: builtin/rebase.c:1678
 #, c-format
 msgid "could not parse '%s'"
 msgstr "kunde inte tolka \"%s\""
 
-#: builtin/rebase.c:1470
+#: builtin/rebase.c:1691
 #, c-format
 msgid "could not switch to %s"
 msgstr "kunde inte växla till %s"
 
-#: builtin/rebase.c:1481 git-legacy-rebase.sh:697
+#: builtin/rebase.c:1702 git-legacy-rebase.sh:705
 #, sh-format
 msgid "HEAD is up to date."
 msgstr "HEAD är à jour."
 
-#: builtin/rebase.c:1483
+#: builtin/rebase.c:1704
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Aktuell gren %s är à jour.\n"
 
-#: builtin/rebase.c:1491 git-legacy-rebase.sh:707
+#: builtin/rebase.c:1712 git-legacy-rebase.sh:715
 #, sh-format
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD är à jour, ombasering framtvingad."
 
-#: builtin/rebase.c:1493
+#: builtin/rebase.c:1714
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Aktuell gren %s är à jour, ombasering framtvingad.\n"
 
-#: builtin/rebase.c:1501 git-legacy-rebase.sh:208
+#: builtin/rebase.c:1722 git-legacy-rebase.sh:215
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Kroken pre-rebase vägrade ombaseringen."
 
-#: builtin/rebase.c:1508
+#: builtin/rebase.c:1729
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Ändringar till %s:\n"
 
-#: builtin/rebase.c:1511
+#: builtin/rebase.c:1732
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Ändringar från %s till %s:\n"
 
-#: builtin/rebase.c:1536
+#: builtin/rebase.c:1757
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Först, spolar tillbaka huvudet för att spela av ditt arbete ovanpå det...\n"
 
-#: builtin/rebase.c:1543
+#: builtin/rebase.c:1765
 msgid "Could not detach HEAD"
 msgstr "Kunde inte koppla från HEAD"
 
-#: builtin/rebase.c:1552
+#: builtin/rebase.c:1774
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Snabbspolade %s till %s.\n"
 
-#: builtin/rebase--interactive.c:24
+#: builtin/rebase--interactive.c:25
 msgid "no HEAD?"
 msgstr "inget HEAD?"
 
-#: builtin/rebase--interactive.c:51
+#: builtin/rebase--interactive.c:52
 #, c-format
 msgid "could not create temporary %s"
 msgstr "kunde inte skapa temporär %s"
 
-#: builtin/rebase--interactive.c:57
+#: builtin/rebase--interactive.c:58
 msgid "could not mark as interactive"
 msgstr "kunde inte markera som interaktiv"
 
-#: builtin/rebase--interactive.c:101
+#: builtin/rebase--interactive.c:102
 #, c-format
 msgid "could not open %s"
 msgstr "kunde inte öppna %s"
 
-#: builtin/rebase--interactive.c:114
+#: builtin/rebase--interactive.c:115
 msgid "could not generate todo list"
 msgstr "Kunde inte skapa attgöra-lista"
 
-#: builtin/rebase--interactive.c:129
+#: builtin/rebase--interactive.c:131
 msgid "git rebase--interactive [<options>]"
 msgstr "git rebase--interactive [<flaggor>]"
 
-#: builtin/rebase--interactive.c:148
+#: builtin/rebase--interactive.c:150
 msgid "keep empty commits"
 msgstr "behåll tomma incheckningar"
 
-#: builtin/rebase--interactive.c:150 builtin/revert.c:124
+#: builtin/rebase--interactive.c:152 builtin/revert.c:125
 msgid "allow commits with empty messages"
 msgstr "tillåt incheckningar med tomt meddelande"
 
-#: builtin/rebase--interactive.c:151
+#: builtin/rebase--interactive.c:153
 msgid "rebase merge commits"
 msgstr "ombasera sammanslagningar"
 
-#: builtin/rebase--interactive.c:153
+#: builtin/rebase--interactive.c:155
 msgid "keep original branch points of cousins"
 msgstr "behåll ursprungliga förgreningspunkter för kusiner"
 
-#: builtin/rebase--interactive.c:155
+#: builtin/rebase--interactive.c:157
 msgid "move commits that begin with squash!/fixup!"
 msgstr "flytta incheckningar som inleds med squash!/fixup!"
 
-#: builtin/rebase--interactive.c:156
+#: builtin/rebase--interactive.c:158
 msgid "sign commits"
 msgstr "signera incheckningar"
 
-#: builtin/rebase--interactive.c:158
+#: builtin/rebase--interactive.c:160
 msgid "continue rebase"
 msgstr "fortsätt ombasering"
 
-#: builtin/rebase--interactive.c:160
+#: builtin/rebase--interactive.c:162
 msgid "skip commit"
 msgstr "hoppa över incheckning"
 
-#: builtin/rebase--interactive.c:161
+#: builtin/rebase--interactive.c:163
 msgid "edit the todo list"
 msgstr "redigera attgöra-listan"
 
-#: builtin/rebase--interactive.c:163
+#: builtin/rebase--interactive.c:165
 msgid "show the current patch"
 msgstr "visa nuvarande patch"
 
-#: builtin/rebase--interactive.c:166
+#: builtin/rebase--interactive.c:168
 msgid "shorten commit ids in the todo list"
 msgstr "förkorta inchecknings-id i todo-listan"
 
-#: builtin/rebase--interactive.c:168
+#: builtin/rebase--interactive.c:170
 msgid "expand commit ids in the todo list"
 msgstr "utöka inchecknings-id i todo-listan"
 
-#: builtin/rebase--interactive.c:170
+#: builtin/rebase--interactive.c:172
 msgid "check the todo list"
 msgstr "kontrollera todo-listan"
 
-#: builtin/rebase--interactive.c:172
+#: builtin/rebase--interactive.c:174
 msgid "rearrange fixup/squash lines"
 msgstr "ordna om fixup-/squash-rader"
 
-#: builtin/rebase--interactive.c:174
+#: builtin/rebase--interactive.c:176
 msgid "insert exec commands in todo list"
 msgstr "lägg in exec-kommandon i todo-listan"
 
-#: builtin/rebase--interactive.c:175
+#: builtin/rebase--interactive.c:177
 msgid "onto"
 msgstr "ovanpå"
 
-#: builtin/rebase--interactive.c:177
+#: builtin/rebase--interactive.c:179
 msgid "restrict-revision"
 msgstr "restrict-revision"
 
-#: builtin/rebase--interactive.c:177
+#: builtin/rebase--interactive.c:179
 msgid "restrict revision"
 msgstr "begränsa revision"
 
-#: builtin/rebase--interactive.c:178
+#: builtin/rebase--interactive.c:180
 msgid "squash-onto"
 msgstr "squash-onto"
 
-#: builtin/rebase--interactive.c:179
+#: builtin/rebase--interactive.c:181
 msgid "squash onto"
 msgstr "tryck ihop ovanpå"
 
-#: builtin/rebase--interactive.c:181
+#: builtin/rebase--interactive.c:183
 msgid "the upstream commit"
 msgstr "uppströmsincheckningen"
 
-#: builtin/rebase--interactive.c:182
+#: builtin/rebase--interactive.c:184
 msgid "head-name"
 msgstr "head-name"
 
-#: builtin/rebase--interactive.c:182
+#: builtin/rebase--interactive.c:184
 msgid "head name"
 msgstr "namn på huvud"
 
-#: builtin/rebase--interactive.c:187
+#: builtin/rebase--interactive.c:189
 msgid "rebase strategy"
 msgstr "sammanslagningsstrategi"
 
-#: builtin/rebase--interactive.c:188
+#: builtin/rebase--interactive.c:190
 msgid "strategy-opts"
 msgstr "strategy-opts"
 
-#: builtin/rebase--interactive.c:189
+#: builtin/rebase--interactive.c:191
 msgid "strategy options"
 msgstr "strategiflaggor"
 
-#: builtin/rebase--interactive.c:190
+#: builtin/rebase--interactive.c:192
 msgid "switch-to"
 msgstr "switch-to"
 
-#: builtin/rebase--interactive.c:191
+#: builtin/rebase--interactive.c:193
 msgid "the branch or commit to checkout"
 msgstr "gren eller inchecking att checka ut"
 
-#: builtin/rebase--interactive.c:192
+#: builtin/rebase--interactive.c:194
 msgid "onto-name"
 msgstr "onto-name"
 
-#: builtin/rebase--interactive.c:192
+#: builtin/rebase--interactive.c:194
 msgid "onto name"
 msgstr "på-namn"
 
-#: builtin/rebase--interactive.c:193
+#: builtin/rebase--interactive.c:195
 msgid "cmd"
 msgstr "kmd"
 
-#: builtin/rebase--interactive.c:193
+#: builtin/rebase--interactive.c:195
 msgid "the command to run"
 msgstr "kommando att köra"
 
-#: builtin/rebase--interactive.c:220
+#: builtin/rebase--interactive.c:224
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
 msgstr "--[no-]rebase-cousins har ingen effekt utan --rebase-merges"
 
-#: builtin/rebase--interactive.c:226
+#: builtin/rebase--interactive.c:230
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "en basincheckning måste anges med --upstream eller --onto"
 
@@ -15511,10 +16413,65 @@ msgstr "tyst"
 msgid "You must specify a directory."
 msgstr "Du måste ange en katalog."
 
-#: builtin/reflog.c:563 builtin/reflog.c:568
+#: builtin/reflog.c:17
+msgid ""
+"git reflog expire [--expire=<time>] [--expire-unreachable=<time>] [--"
+"rewrite] [--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all] "
+"<refs>..."
+msgstr ""
+"git reflog expire [--expire=<tid>] [--expire-unreachable=<tid>] [--rewrite] "
+"[--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all] "
+"<referenser>..."
+
+#: builtin/reflog.c:22
+msgid ""
+"git reflog delete [--rewrite] [--updateref] [--dry-run | -n] [--verbose] "
+"<refs>..."
+msgstr ""
+"git reflog delete [--rewrite] [--updateref] [--dry-run | -n] [--verbose] "
+"<referenser>..."
+
+#: builtin/reflog.c:25
+msgid "git reflog exists <ref>"
+msgstr "git reflog exists <referens>"
+
+#: builtin/reflog.c:567 builtin/reflog.c:572
 #, c-format
 msgid "'%s' is not a valid timestamp"
 msgstr "\"%s\" är inte en giltig tidsstämpel"
+
+#: builtin/reflog.c:605
+#, c-format
+msgid "Marking reachable objects..."
+msgstr "Markerar nåbara objekt..."
+
+#: builtin/reflog.c:643
+#, c-format
+msgid "%s points nowhere!"
+msgstr "%s pekar ingenstans!"
+
+#: builtin/reflog.c:695
+msgid "no reflog specified to delete"
+msgstr "ingen referenslogg att ta bort angavs"
+
+#: builtin/reflog.c:704
+#, c-format
+msgid "not a reflog: %s"
+msgstr "inte en referenslogg: %s"
+
+#: builtin/reflog.c:709
+#, c-format
+msgid "no reflog for '%s'"
+msgstr "ingen referenslogg för \"%s\""
+
+#: builtin/reflog.c:755
+#, c-format
+msgid "invalid ref format: %s"
+msgstr "felaktigt referensformat: %s"
+
+#: builtin/reflog.c:764
+msgid "git reflog [ show | expire | delete | exists ]"
+msgstr "git reflog [ show | expire | delete | exists ]"
 
 #: builtin/remote.c:16
 msgid "git remote [-v | --verbose]"
@@ -16035,6 +16992,19 @@ msgstr ""
 "Använd --no-write-bitmap-index eller inaktivera inställningen\n"
 "pack.writebitmaps"
 
+#: builtin/repack.c:200
+msgid "could not start pack-objects to repack promisor objects"
+msgstr "kunde inte starta pack-objects för att packa om kontraktsobjekt"
+
+#: builtin/repack.c:239 builtin/repack.c:411
+msgid "repack: Expecting full hex object ID lines only from pack-objects."
+msgstr ""
+"repack: Förväntar kompletta hex-objekt-ID-rader endast från pack-objects."
+
+#: builtin/repack.c:256
+msgid "could not finish pack-objects to repack promisor objects"
+msgstr "kunde inte avsluta pack-objects för att packa om kontraktsobjekt"
+
 #: builtin/repack.c:294
 msgid "pack everything in a single pack"
 msgstr "packa allt i ett enda paket"
@@ -16123,7 +17093,30 @@ msgstr "kan inte ta bort paket i ett \"precious-objects\"-arkiv"
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable och -A kan inte användas samtidigt"
 
-#: builtin/repack.c:527
+#: builtin/repack.c:420
+msgid "Nothing new to pack."
+msgstr "Inget nytt att packa."
+
+#: builtin/repack.c:481
+#, c-format
+msgid ""
+"WARNING: Some packs in use have been renamed by\n"
+"WARNING: prefixing old- to their name, in order to\n"
+"WARNING: replace them with the new version of the\n"
+"WARNING: file.  But the operation failed, and the\n"
+"WARNING: attempt to rename them back to their\n"
+"WARNING: original names also failed.\n"
+"WARNING: Please rename them in %s manually:\n"
+msgstr ""
+"VARNING: Namnen på några paket har bytts genom att\n"
+"VARNING: lägga till old- före namnen, för att byta\n"
+"VARNING: dem mot den nya versionen av filen. Men\n"
+"VARNING: operationen misslyckades, och försöket att\n"
+"VARNING: byta tillbaka till det ursprungliga\n"
+"VARNING: namnet misslyckades också.\n"
+"VARNING: Byt namn på dem i %s manuellt:\n"
+
+#: builtin/repack.c:529
 #, c-format
 msgid "failed to remove '%s'"
 msgstr "misslyckades ta bort \"%s\""
@@ -16388,125 +17381,125 @@ msgstr "registrera rena lösningar i indexet"
 msgid "'git rerere forget' without paths is deprecated"
 msgstr "\"git rerere forget\" utan sökvägar är föråldrat"
 
-#: builtin/rerere.c:111
+#: builtin/rerere.c:113
 #, c-format
 msgid "unable to generate diff for '%s'"
 msgstr "misslyckades skapa diff för \"%s\""
 
-#: builtin/reset.c:31
+#: builtin/reset.c:32
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 msgstr ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<incheckning>]"
 
-#: builtin/reset.c:32
+#: builtin/reset.c:33
 msgid "git reset [-q] [<tree-ish>] [--] <paths>..."
 msgstr "git reset [-q] [<träd-igt>] [--] <sökvägar>..."
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "git reset --patch [<tree-ish>] [--] [<paths>...]"
 msgstr "git reset --patch [<träd-igt>] [--] [<sökvägar>...]"
 
-#: builtin/reset.c:39
+#: builtin/reset.c:40
 msgid "mixed"
 msgstr "blandad"
 
-#: builtin/reset.c:39
+#: builtin/reset.c:40
 msgid "soft"
 msgstr "mjuk"
 
-#: builtin/reset.c:39
+#: builtin/reset.c:40
 msgid "hard"
 msgstr "hård"
 
-#: builtin/reset.c:39
+#: builtin/reset.c:40
 msgid "merge"
 msgstr "sammanslagning"
 
-#: builtin/reset.c:39
+#: builtin/reset.c:40
 msgid "keep"
 msgstr "behåll"
 
-#: builtin/reset.c:80
+#: builtin/reset.c:81
 msgid "You do not have a valid HEAD."
 msgstr "Du har inte en giltig HEAD."
 
-#: builtin/reset.c:82
+#: builtin/reset.c:83
 msgid "Failed to find tree of HEAD."
 msgstr "Kunde inte hitta trädet för HEAD."
 
-#: builtin/reset.c:88
+#: builtin/reset.c:89
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Kunde inte hitta trädet för %s."
 
-#: builtin/reset.c:192
+#: builtin/reset.c:193
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Kan inte utföra en %s återställning mitt i en sammanslagning."
 
-#: builtin/reset.c:292
+#: builtin/reset.c:293
 msgid "be quiet, only report errors"
 msgstr "var tyst, rapportera endast fel"
 
-#: builtin/reset.c:294
+#: builtin/reset.c:295
 msgid "reset HEAD and index"
 msgstr "återställ HEAD och index"
 
-#: builtin/reset.c:295
+#: builtin/reset.c:296
 msgid "reset only HEAD"
 msgstr "återställ endast HEAD"
 
-#: builtin/reset.c:297 builtin/reset.c:299
+#: builtin/reset.c:298 builtin/reset.c:300
 msgid "reset HEAD, index and working tree"
 msgstr "återställ HEAD, index och arbetskatalog"
 
-#: builtin/reset.c:301
+#: builtin/reset.c:302
 msgid "reset HEAD but keep local changes"
 msgstr "återställ HEAD men behåll lokala ändringar"
 
-#: builtin/reset.c:307
+#: builtin/reset.c:308
 msgid "record only the fact that removed paths will be added later"
 msgstr "registrera endast att borttagna sökvägar kommer läggas till senare"
 
-#: builtin/reset.c:325
+#: builtin/reset.c:326
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Kunde inte slå upp \"%s\" som en giltig revision."
 
-#: builtin/reset.c:333
+#: builtin/reset.c:334
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Kunde inte slå upp \"%s\" som ett giltigt träd."
 
-#: builtin/reset.c:342
+#: builtin/reset.c:343
 msgid "--patch is incompatible with --{hard,mixed,soft}"
 msgstr "--patch är inkompatibel med --{hard,mixed,soft}"
 
-#: builtin/reset.c:351
+#: builtin/reset.c:352
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed rekommenderas inte med sökvägar; använd \"git reset -- <sökvägar>\"."
 
-#: builtin/reset.c:353
+#: builtin/reset.c:354
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Kan inte göra %s återställning med sökvägar."
 
-#: builtin/reset.c:363
+#: builtin/reset.c:364
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "%s återställning tillåts inte i ett naket arkiv"
 
-#: builtin/reset.c:367
+#: builtin/reset.c:368
 msgid "-N can only be used with --mixed"
 msgstr "-N kan endast användas med --mixed"
 
-#: builtin/reset.c:387
+#: builtin/reset.c:388
 msgid "Unstaged changes after reset:"
 msgstr "Oköade ändringar efter återställning:"
 
-#: builtin/reset.c:390
+#: builtin/reset.c:391
 #, c-format
 msgid ""
 "\n"
@@ -16520,53 +17513,53 @@ msgstr ""
 "konfigurationsvariabeln\n"
 "reset.quiet till true för att göra detta till förval.\n"
 
-#: builtin/reset.c:400
+#: builtin/reset.c:401
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Kunde inte återställa indexfilen till versionen \"%s\"."
 
-#: builtin/reset.c:404
+#: builtin/reset.c:405
 msgid "Could not write new index file."
 msgstr "Kunde inte skriva ny indexfil."
 
-#: builtin/rev-list.c:403
+#: builtin/rev-list.c:406
 msgid "cannot combine --exclude-promisor-objects and --missing"
 msgstr "kan inte kombinera --exclude-promisor-objects och --missing"
 
-#: builtin/rev-list.c:461
+#: builtin/rev-list.c:464
 msgid "object filtering requires --objects"
 msgstr "objektfiltrering kräver --objects"
 
-#: builtin/rev-list.c:464
+#: builtin/rev-list.c:467
 #, c-format
 msgid "invalid sparse value '%s'"
 msgstr "ogiltigt värde för sparse: \"%s\""
 
-#: builtin/rev-list.c:505
+#: builtin/rev-list.c:508
 msgid "rev-list does not support display of notes"
 msgstr "rev-list stöder inte visning av anteckningar"
 
-#: builtin/rev-list.c:508
+#: builtin/rev-list.c:511
 msgid "cannot combine --use-bitmap-index with object filtering"
 msgstr "kan inte kombinera --use-bitmap-index med objektfiltrering"
 
-#: builtin/rev-parse.c:407
+#: builtin/rev-parse.c:408
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
 msgstr "git rev-parse --parseopt [<options>] -- [<argument>...]"
 
-#: builtin/rev-parse.c:412
+#: builtin/rev-parse.c:413
 msgid "keep the `--` passed as an arg"
 msgstr "behåll \"--\" sänt som argument"
 
-#: builtin/rev-parse.c:414
+#: builtin/rev-parse.c:415
 msgid "stop parsing after the first non-option argument"
 msgstr "sluta tolka efter första argument som inte är flagga"
 
-#: builtin/rev-parse.c:417
+#: builtin/rev-parse.c:418
 msgid "output in stuck long form"
 msgstr "utdata fast i lång form"
 
-#: builtin/rev-parse.c:550
+#: builtin/rev-parse.c:551
 msgid ""
 "git rev-parse --parseopt [<options>] -- [<args>...]\n"
 "   or: git rev-parse --sq-quote [<arg>...]\n"
@@ -16597,72 +17590,77 @@ msgstr "git cherry-pick [<flaggor>] <incheckning-igt>..."
 msgid "git cherry-pick <subcommand>"
 msgstr "git cherry-pick <underkommando>"
 
-#: builtin/revert.c:91
+#: builtin/revert.c:72
+#, c-format
+msgid "option `%s' expects a number greater than zero"
+msgstr "flaggan \"%s\" antar ett numeriskt värde större än noll"
+
+#: builtin/revert.c:92
 #, c-format
 msgid "%s: %s cannot be used with %s"
 msgstr "%s: %s kan inte användas med %s"
 
-#: builtin/revert.c:100
+#: builtin/revert.c:101
 msgid "end revert or cherry-pick sequence"
 msgstr "avsluta revert- eller cherry-pick-sekvens"
 
-#: builtin/revert.c:101
+#: builtin/revert.c:102
 msgid "resume revert or cherry-pick sequence"
 msgstr "återuppta revert- eller cherry-pick-sekvens"
 
-#: builtin/revert.c:102
+#: builtin/revert.c:103
 msgid "cancel revert or cherry-pick sequence"
 msgstr "avbryt revert- eller cherry-pick-sekvens"
 
-#: builtin/revert.c:103
+#: builtin/revert.c:104
 msgid "don't automatically commit"
 msgstr "checka inte in automatiskt"
 
-#: builtin/revert.c:104
+#: builtin/revert.c:105
 msgid "edit the commit message"
 msgstr "redigera incheckningsmeddelandet"
 
-#: builtin/revert.c:107
+#: builtin/revert.c:108
 msgid "parent-number"
 msgstr "nummer-på-förälder"
 
-#: builtin/revert.c:108
+#: builtin/revert.c:109
 msgid "select mainline parent"
 msgstr "välj förälder för huvudlinje"
 
-#: builtin/revert.c:110
+#: builtin/revert.c:111
 msgid "merge strategy"
 msgstr "sammanslagningsstrategi"
 
-#: builtin/revert.c:112
+#: builtin/revert.c:113
 msgid "option for merge strategy"
 msgstr "alternativ för sammanslagningsstrategi"
 
-#: builtin/revert.c:121
+#: builtin/revert.c:122
 msgid "append commit name"
 msgstr "lägg till incheckningsnamn"
 
-#: builtin/revert.c:123
+#: builtin/revert.c:124
 msgid "preserve initially empty commits"
 msgstr "behåll incheckningar som börjar som tomma"
 
-#: builtin/revert.c:125
+#: builtin/revert.c:126
 msgid "keep redundant, empty commits"
 msgstr "behåll redundanta, tomma incheckningar"
 
-#: builtin/revert.c:219
+#: builtin/revert.c:220
 msgid "revert failed"
 msgstr "\"revert\" misslyckades"
 
-#: builtin/revert.c:232
+#: builtin/revert.c:233
 msgid "cherry-pick failed"
 msgstr "\"cherry-pick\" misslyckades"
 
-#: builtin/rm.c:18
+#: builtin/rm.c:19
 msgid "git rm [<options>] [--] <file>..."
 msgstr "git rm [<flaggor>] [--] <fil>..."
 
-#: builtin/rm.c:206
+#: builtin/rm.c:207
 msgid ""
 "the following file has staged content different from both the\n"
 "file and the HEAD:"
@@ -16674,7 +17672,7 @@ msgstr[0] ""
 msgstr[1] ""
 "följande filer har köat innehåll som skiljer sig både från filen och HEAD:"
 
-#: builtin/rm.c:211
+#: builtin/rm.c:212
 msgid ""
 "\n"
 "(use -f to force removal)"
@@ -16682,13 +17680,13 @@ msgstr ""
 "\n"
 "(använd -f för att tvinga borttagning)"
 
-#: builtin/rm.c:215
+#: builtin/rm.c:216
 msgid "the following file has changes staged in the index:"
 msgid_plural "the following files have changes staged in the index:"
 msgstr[0] "följande fil har ändringar köade i indexet:"
 msgstr[1] "följande filer har ändringar köade i indexet:"
 
-#: builtin/rm.c:219 builtin/rm.c:228
+#: builtin/rm.c:220 builtin/rm.c:229
 msgid ""
 "\n"
 "(use --cached to keep the file, or -f to force removal)"
@@ -16696,43 +17694,43 @@ msgstr ""
 "\n"
 "(använd --cached för att behålla filen eller -f för att tvinga borttagning)"
 
-#: builtin/rm.c:225
+#: builtin/rm.c:226
 msgid "the following file has local modifications:"
 msgid_plural "the following files have local modifications:"
 msgstr[0] "följande fil har lokala ändringar:"
 msgstr[1] "följande filer har lokala ändringar:"
 
-#: builtin/rm.c:241
+#: builtin/rm.c:242
 msgid "do not list removed files"
 msgstr "lista inte borttagna filer"
 
-#: builtin/rm.c:242
+#: builtin/rm.c:243
 msgid "only remove from the index"
 msgstr "ta bara bort från indexet"
 
-#: builtin/rm.c:243
+#: builtin/rm.c:244
 msgid "override the up-to-date check"
 msgstr "överstyr àjour-testet"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "allow recursive removal"
 msgstr "tillåt rekursiv borttagning"
 
-#: builtin/rm.c:246
+#: builtin/rm.c:247
 msgid "exit with a zero status even if nothing matched"
 msgstr "avsluta med nollstatus även om inget träffades"
 
-#: builtin/rm.c:288
+#: builtin/rm.c:289
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "löa dina ändringar i .gitmodules eller använd \"stash\" för att fortsätta"
 
-#: builtin/rm.c:306
+#: builtin/rm.c:307
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "tar inte bort \"%s\" rekursivt utan -r"
 
-#: builtin/rm.c:345
+#: builtin/rm.c:346
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: kan inte ta bort %s"
@@ -16809,7 +17807,7 @@ msgstr "<w>[,<i1>[,<i2>]]"
 msgid "Linewrap output"
 msgstr "Radbryt utdata"
 
-#: builtin/shortlog.c:299
+#: builtin/shortlog.c:301
 msgid "too many arguments given outside repository"
 msgstr "för många flaggor givna utanför arkivet"
 
@@ -17001,48 +17999,48 @@ msgstr "git stripspace [-s | --strip-comments]"
 msgid "git stripspace [-c | --comment-lines]"
 msgstr "git stripspace [-c | --comment-lines]"
 
-#: builtin/stripspace.c:36
+#: builtin/stripspace.c:37
 msgid "skip and remove all lines starting with comment character"
 msgstr "hoppa över och ta bort alla rader som inleds med kommentarstecken"
 
-#: builtin/stripspace.c:39
+#: builtin/stripspace.c:40
 msgid "prepend comment character and space to each line"
 msgstr "lägg in kommentarstecken och blanksteg först på varje rad"
 
-#: builtin/submodule--helper.c:44 builtin/submodule--helper.c:1939
+#: builtin/submodule--helper.c:45 builtin/submodule--helper.c:1943
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Förväntade fullt referensnamn, fick %s"
 
-#: builtin/submodule--helper.c:61
+#: builtin/submodule--helper.c:62
 msgid "submodule--helper print-default-remote takes no arguments"
 msgstr "submodule--helper print-default-remote tar inga argument"
 
-#: builtin/submodule--helper.c:99
+#: builtin/submodule--helper.c:100
 #, c-format
 msgid "cannot strip one component off url '%s'"
 msgstr "kan inte ta bort en komponent från url:en \"%s\""
 
-#: builtin/submodule--helper.c:407 builtin/submodule--helper.c:1363
+#: builtin/submodule--helper.c:408 builtin/submodule--helper.c:1367
 msgid "alternative anchor for relative paths"
 msgstr "alternativa ankare för relativa sökvägar"
 
-#: builtin/submodule--helper.c:412
+#: builtin/submodule--helper.c:413
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<sökväg>] [<sökväg>...]"
 
-#: builtin/submodule--helper.c:469 builtin/submodule--helper.c:626
-#: builtin/submodule--helper.c:649
+#: builtin/submodule--helper.c:470 builtin/submodule--helper.c:627
+#: builtin/submodule--helper.c:650
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Hittade ingen url för undermodulsökvägen \"%s\" i .gitmodules"
 
-#: builtin/submodule--helper.c:521
+#: builtin/submodule--helper.c:522
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Går in i \"%s\"\n"
 
-#: builtin/submodule--helper.c:524
+#: builtin/submodule--helper.c:525
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -17051,7 +18049,7 @@ msgstr ""
 "run_command returnerade icke-nollstatus för %s\n"
 "."
 
-#: builtin/submodule--helper.c:545
+#: builtin/submodule--helper.c:546
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -17062,19 +18060,19 @@ msgstr ""
 "undermoduler för %s\n"
 "."
 
-#: builtin/submodule--helper.c:561
+#: builtin/submodule--helper.c:562
 msgid "Suppress output of entering each submodule command"
 msgstr "Dölj utdata från för varje undermodulskommando som startas"
 
-#: builtin/submodule--helper.c:563 builtin/submodule--helper.c:1048
+#: builtin/submodule--helper.c:564 builtin/submodule--helper.c:1049
 msgid "Recurse into nested submodules"
 msgstr "Rekursera in i nästlade undermoduler"
 
-#: builtin/submodule--helper.c:568
+#: builtin/submodule--helper.c:569
 msgid "git submodule--helper foreach [--quiet] [--recursive] <command>"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<kommando>]"
 
-#: builtin/submodule--helper.c:595
+#: builtin/submodule--helper.c:596
 #, c-format
 msgid ""
 "could not look up configuration '%s'. Assuming this repository is its own "
@@ -17083,54 +18081,54 @@ msgstr ""
 "kunde inte slå upp konfigurationen \"%s\". Antar att arkivet är sin eget "
 "officiella uppström."
 
-#: builtin/submodule--helper.c:663
+#: builtin/submodule--helper.c:664
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr "Misslyckades registrera url för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:667
+#: builtin/submodule--helper.c:668
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Undermodulen \"%s\" (%s) registrerad för sökvägen \"%s\"\n"
 
-#: builtin/submodule--helper.c:677
+#: builtin/submodule--helper.c:678
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "varning: kommandouppdateringsläge föreslogs för undermodulen \"%s\"\n"
 
-#: builtin/submodule--helper.c:684
+#: builtin/submodule--helper.c:685
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr "Misslyckades registrera uppdateringsläge för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:706
+#: builtin/submodule--helper.c:707
 msgid "Suppress output for initializing a submodule"
 msgstr "Dölj utdata från initiering av undermodul"
 
-#: builtin/submodule--helper.c:711
+#: builtin/submodule--helper.c:712
 msgid "git submodule--helper init [<path>]"
 msgstr "git submodule--helper init [<sökväg>]"
 
-#: builtin/submodule--helper.c:783 builtin/submodule--helper.c:909
+#: builtin/submodule--helper.c:784 builtin/submodule--helper.c:910
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "hittade ingen undermodulmappning i .gitmodules för sökvägen \"%s\""
 
-#: builtin/submodule--helper.c:822
+#: builtin/submodule--helper.c:823
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "kunde inte bestämma HEAD:s incheckning i undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:849 builtin/submodule--helper.c:1018
+#: builtin/submodule--helper.c:850 builtin/submodule--helper.c:1019
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "misslyckades rekursera in i undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:873 builtin/submodule--helper.c:1182
+#: builtin/submodule--helper.c:874 builtin/submodule--helper.c:1185
 msgid "Suppress submodule status output"
 msgstr "Hindra statusutskrift för undermodul"
 
-#: builtin/submodule--helper.c:874
+#: builtin/submodule--helper.c:875
 msgid ""
 "Use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -17138,47 +18136,47 @@ msgstr ""
 "Visa incheckning från indexet istället för den som lagrats i undermodulens "
 "HEAD"
 
-#: builtin/submodule--helper.c:875
+#: builtin/submodule--helper.c:876
 msgid "recurse into nested submodules"
 msgstr "rekursera in i nästlade undermoduler"
 
-#: builtin/submodule--helper.c:880
+#: builtin/submodule--helper.c:881
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quitet] [--cached] [--recursive] [<sökväg>...]"
 
-#: builtin/submodule--helper.c:904
+#: builtin/submodule--helper.c:905
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <sökväg>"
 
-#: builtin/submodule--helper.c:968
+#: builtin/submodule--helper.c:969
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Synkroniserar undermodul-url för \"%s\"\n"
 
-#: builtin/submodule--helper.c:974
+#: builtin/submodule--helper.c:975
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "misslyckades registrera url för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:988
+#: builtin/submodule--helper.c:989
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "misslyckades hämta standardfjärr för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:999
+#: builtin/submodule--helper.c:1000
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "misslyckades uppdatera fjärr för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:1046
+#: builtin/submodule--helper.c:1047
 msgid "Suppress output of synchronizing submodule url"
 msgstr "Dölj utdata från synkroniering av undermodul-url"
 
-#: builtin/submodule--helper.c:1053
+#: builtin/submodule--helper.c:1054
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<sökväg>]"
 
-#: builtin/submodule--helper.c:1107
+#: builtin/submodule--helper.c:1108
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -17187,7 +18185,7 @@ msgstr ""
 "Undermodulsarbetskatalogen \"%s\" innehåller en .git-katalog (använd \"rm -rf"
 "\" om du verkligen vill ta bort den och all dess historik)"
 
-#: builtin/submodule--helper.c:1119
+#: builtin/submodule--helper.c:1120
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -17196,81 +18194,81 @@ msgstr ""
 "Undermodulens arbetskatalog \"%s\" har lokala ändringar; \"-f\" kastar bort "
 "dem"
 
-#: builtin/submodule--helper.c:1127
+#: builtin/submodule--helper.c:1128
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Rensade katalogen \"%s\"\n"
 
-#: builtin/submodule--helper.c:1129
+#: builtin/submodule--helper.c:1130
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Kunde inte ta bort undermodulens arbetskatalog \"%s\"\n"
 
-#: builtin/submodule--helper.c:1138
+#: builtin/submodule--helper.c:1141
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "kunde inte skapa tom undermodulskatalog %s"
 
-#: builtin/submodule--helper.c:1154
+#: builtin/submodule--helper.c:1157
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Undermodulen \"%s\" (%s) registrerad för sökvägen \"%s\"\n"
 
-#: builtin/submodule--helper.c:1183
+#: builtin/submodule--helper.c:1186
 msgid "Remove submodule working trees even if they contain local changes"
 msgstr ""
 "Ta bort undermodulers arbetskataloger även om de innehåller lokala ändringar"
 
-#: builtin/submodule--helper.c:1184
+#: builtin/submodule--helper.c:1187
 msgid "Unregister all submodules"
 msgstr "Avregistrera alla undermoduler"
 
-#: builtin/submodule--helper.c:1189
+#: builtin/submodule--helper.c:1192
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<sökväg>...]]"
 
-#: builtin/submodule--helper.c:1203
+#: builtin/submodule--helper.c:1206
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Använd \"--all\" om du verkligen vill avinitiera alla undermoduler"
 
-#: builtin/submodule--helper.c:1297 builtin/submodule--helper.c:1300
+#: builtin/submodule--helper.c:1301 builtin/submodule--helper.c:1304
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "undermodulen \"%s\" kan inte lägga till alternativ: %s"
 
-#: builtin/submodule--helper.c:1336
+#: builtin/submodule--helper.c:1340
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Värdet \"%s\" i submodule.alternateErrorStrategy förstås inte"
 
-#: builtin/submodule--helper.c:1343
+#: builtin/submodule--helper.c:1347
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Värdet \"%s\" i submodule.alternateLocation förstås inte"
 
-#: builtin/submodule--helper.c:1366
+#: builtin/submodule--helper.c:1370
 msgid "where the new submodule will be cloned to"
 msgstr "var den nya undermodulen skall klonas till"
 
-#: builtin/submodule--helper.c:1369
+#: builtin/submodule--helper.c:1373
 msgid "name of the new submodule"
 msgstr "namn på den nya undermodulen"
 
-#: builtin/submodule--helper.c:1372
+#: builtin/submodule--helper.c:1376
 msgid "url where to clone the submodule from"
 msgstr "URL att klona undermodulen från"
 
-#: builtin/submodule--helper.c:1380
+#: builtin/submodule--helper.c:1384
 msgid "depth for shallow clones"
 msgstr "djup för grunda kloner"
 
-#: builtin/submodule--helper.c:1383 builtin/submodule--helper.c:1868
+#: builtin/submodule--helper.c:1387 builtin/submodule--helper.c:1872
 msgid "force cloning progress"
 msgstr "tvinga kloningsförlopp"
 
-#: builtin/submodule--helper.c:1388
+#: builtin/submodule--helper.c:1392
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] --url <url> --path <path>"
@@ -17278,93 +18276,93 @@ msgstr ""
 "git submodule--helper clone [--prefix=<sökväg>] [--quiet] [--reference "
 "<arkvi>] [--name <namn>] [--depth <djup>] --url <url> --path <sökväg>"
 
-#: builtin/submodule--helper.c:1419
+#: builtin/submodule--helper.c:1423
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "misslyckades klona \"%s\" till undermodulsökvägen ”%s”"
 
-#: builtin/submodule--helper.c:1433
+#: builtin/submodule--helper.c:1437
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "kunde inte få tag i undermodulkatalog för \"%s\""
 
-#: builtin/submodule--helper.c:1469
+#: builtin/submodule--helper.c:1473
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Ogiltigt uppdateringsläge \"%s\" för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:1473
+#: builtin/submodule--helper.c:1477
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Ogiltigt uppdateringsläge \"%s\" konfigurerat för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:1566
+#: builtin/submodule--helper.c:1570
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Undermodulsökvägen \"%s\" har inte initierats"
 
-#: builtin/submodule--helper.c:1570
+#: builtin/submodule--helper.c:1574
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Kanske menade du att använda \"update --init\"?"
 
-#: builtin/submodule--helper.c:1600
+#: builtin/submodule--helper.c:1604
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Hoppar över ej sammanslagen undermodul %s"
 
-#: builtin/submodule--helper.c:1629
+#: builtin/submodule--helper.c:1633
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Hoppar över undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:1773
+#: builtin/submodule--helper.c:1777
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Misslyckades klona \"%s\". Nytt försök planlagt"
 
-#: builtin/submodule--helper.c:1784
+#: builtin/submodule--helper.c:1788
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Misslyckades klona \"%s\" för andra gången, avbryter"
 
-#: builtin/submodule--helper.c:1847 builtin/submodule--helper.c:2089
+#: builtin/submodule--helper.c:1851 builtin/submodule--helper.c:2093
 msgid "path into the working tree"
 msgstr "sökväg inuti arbetskatalogen"
 
-#: builtin/submodule--helper.c:1850
+#: builtin/submodule--helper.c:1854
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "sökväg inuti arbetskatalogen, genom nästlade undermodulgränser"
 
-#: builtin/submodule--helper.c:1854
+#: builtin/submodule--helper.c:1858
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout eller none"
 
-#: builtin/submodule--helper.c:1860
+#: builtin/submodule--helper.c:1864
 msgid "Create a shallow clone truncated to the specified number of revisions"
 msgstr "Skapa en grund klon trunkerad till angivet antal revisioner"
 
-#: builtin/submodule--helper.c:1863
+#: builtin/submodule--helper.c:1867
 msgid "parallel jobs"
 msgstr "parallella jobb"
 
-#: builtin/submodule--helper.c:1865
+#: builtin/submodule--helper.c:1869
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "om den första klonen skall följa rekommendation för grund kloning"
 
-#: builtin/submodule--helper.c:1866
+#: builtin/submodule--helper.c:1870
 msgid "don't print cloning progress"
 msgstr "skriv inte klonförlopp"
 
-#: builtin/submodule--helper.c:1873
+#: builtin/submodule--helper.c:1877
 msgid "git submodule--helper update_clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update_clone [--prefix=<sökväg>] [<sökväg>...]"
 
-#: builtin/submodule--helper.c:1886
+#: builtin/submodule--helper.c:1890
 msgid "bad value for update parameter"
 msgstr "felaktigt värde för parametern update"
 
-#: builtin/submodule--helper.c:1934
+#: builtin/submodule--helper.c:1938
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -17373,42 +18371,42 @@ msgstr ""
 "Undermodulens (%s) gren inställd på att ärva gren från huvudprojektet, men "
 "huvudprojektet är inte på någon gren"
 
-#: builtin/submodule--helper.c:2057
+#: builtin/submodule--helper.c:2061
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "kunde inte få tag i arkivhandtag för undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:2090
+#: builtin/submodule--helper.c:2094
 msgid "recurse into submodules"
 msgstr "rekursera ner i undermoduler"
 
-#: builtin/submodule--helper.c:2096
+#: builtin/submodule--helper.c:2100
 msgid "git submodule--helper embed-git-dir [<path>...]"
 msgstr "git submodule--helper embed-git-dir [<sökväg>...]"
 
-#: builtin/submodule--helper.c:2152
+#: builtin/submodule--helper.c:2156
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "se om det är säkert att skriva till .gitmodules-filen"
 
-#: builtin/submodule--helper.c:2157
+#: builtin/submodule--helper.c:2161
 msgid "git submodule--helper config name [value]"
 msgstr "git submodule--helper config name <värde>"
 
-#: builtin/submodule--helper.c:2158
+#: builtin/submodule--helper.c:2162
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2175 git-submodule.sh:169
+#: builtin/submodule--helper.c:2179 git-submodule.sh:169
 #, sh-format
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "se till att .gitmodules finns i arbetskatalogen"
 
-#: builtin/submodule--helper.c:2225
+#: builtin/submodule--helper.c:2229 git.c:413 git.c:658
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s stöder inte --super-prefix"
 
-#: builtin/submodule--helper.c:2231
+#: builtin/submodule--helper.c:2235
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "\"%s\" är inte ett giltigt underkommando till submodule--helper"
@@ -17654,199 +18652,199 @@ msgstr "Uppdaterad tagg \"%s\" (var %s)\n"
 msgid "Unpacking objects"
 msgstr "Packar upp objekt"
 
-#: builtin/update-index.c:82
+#: builtin/update-index.c:83
 #, c-format
 msgid "failed to create directory %s"
 msgstr "misslyckades skapa katalogen %s"
 
-#: builtin/update-index.c:98
+#: builtin/update-index.c:99
 #, c-format
 msgid "failed to create file %s"
 msgstr "misslyckades skapa filen %s"
 
-#: builtin/update-index.c:106
+#: builtin/update-index.c:107
 #, c-format
 msgid "failed to delete file %s"
 msgstr "misslyckades ta bort filen %s"
 
-#: builtin/update-index.c:113 builtin/update-index.c:219
+#: builtin/update-index.c:114 builtin/update-index.c:220
 #, c-format
 msgid "failed to delete directory %s"
 msgstr "misslyckades ta bort katalogen %s"
 
-#: builtin/update-index.c:138
+#: builtin/update-index.c:139
 #, c-format
 msgid "Testing mtime in '%s' "
 msgstr "Testar mtime i \"%s\" "
 
-#: builtin/update-index.c:152
+#: builtin/update-index.c:153
 msgid "directory stat info does not change after adding a new file"
 msgstr "stat-informationen för en katalog ändras inte när nya filer läggs till"
 
-#: builtin/update-index.c:165
+#: builtin/update-index.c:166
 msgid "directory stat info does not change after adding a new directory"
 msgstr ""
 "stat-informationen för en katalog ändras inte när nya kataloger läggs till"
 
-#: builtin/update-index.c:178
+#: builtin/update-index.c:179
 msgid "directory stat info changes after updating a file"
 msgstr "stat-informationen för en katalog ändras när filer uppdateras"
 
-#: builtin/update-index.c:189
+#: builtin/update-index.c:190
 msgid "directory stat info changes after adding a file inside subdirectory"
 msgstr ""
 "stat-informationen för en katalog ändras när filer läggs till i en "
 "underkatalog"
 
-#: builtin/update-index.c:200
+#: builtin/update-index.c:201
 msgid "directory stat info does not change after deleting a file"
 msgstr "stat-informationen för en katalog ändras inte när en fil tas bort"
 
-#: builtin/update-index.c:213
+#: builtin/update-index.c:214
 msgid "directory stat info does not change after deleting a directory"
 msgstr "stat-informationen för en katalog ändras inte när en katalog tas bort"
 
-#: builtin/update-index.c:220
+#: builtin/update-index.c:221
 msgid " OK"
 msgstr " OK"
 
-#: builtin/update-index.c:588
+#: builtin/update-index.c:589
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr "git update-index [<flaggor>] [--] [<fil>...]"
 
-#: builtin/update-index.c:961
+#: builtin/update-index.c:962
 msgid "continue refresh even when index needs update"
 msgstr "fortsätt uppdatera även när index inte är àjour"
 
-#: builtin/update-index.c:964
+#: builtin/update-index.c:965
 msgid "refresh: ignore submodules"
 msgstr "refresh: ignorera undermoduler"
 
-#: builtin/update-index.c:967
+#: builtin/update-index.c:968
 msgid "do not ignore new files"
 msgstr "ignorera inte nya filer"
 
-#: builtin/update-index.c:969
+#: builtin/update-index.c:970
 msgid "let files replace directories and vice-versa"
 msgstr "låt filer ersätta kataloger och omvänt"
 
-#: builtin/update-index.c:971
+#: builtin/update-index.c:972
 msgid "notice files missing from worktree"
 msgstr "lägg märke till filer som saknas i arbetskatalogen"
 
-#: builtin/update-index.c:973
+#: builtin/update-index.c:974
 msgid "refresh even if index contains unmerged entries"
 msgstr "uppdatera även om indexet innehåller ej sammanslagna poster"
 
-#: builtin/update-index.c:976
+#: builtin/update-index.c:977
 msgid "refresh stat information"
 msgstr "uppdatera statusinformation"
 
-#: builtin/update-index.c:980
+#: builtin/update-index.c:981
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr "som --refresh, men ignorera assume-unchanged-inställning"
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:985
 msgid "<mode>,<object>,<path>"
 msgstr "<läge>,<objekt>,<sökväg>"
 
-#: builtin/update-index.c:985
+#: builtin/update-index.c:986
 msgid "add the specified entry to the index"
 msgstr "lägg till angiven post i indexet"
 
-#: builtin/update-index.c:994
+#: builtin/update-index.c:995
 msgid "mark files as \"not changing\""
 msgstr "markera filer som \"ändras inte\""
 
-#: builtin/update-index.c:997
+#: builtin/update-index.c:998
 msgid "clear assumed-unchanged bit"
 msgstr "rensa \"assume-unchanged\"-biten"
 
-#: builtin/update-index.c:1000
+#: builtin/update-index.c:1001
 msgid "mark files as \"index-only\""
 msgstr "markera filer som \"endast index\""
 
-#: builtin/update-index.c:1003
+#: builtin/update-index.c:1004
 msgid "clear skip-worktree bit"
 msgstr "töm \"skip-worktree\"-biten"
 
-#: builtin/update-index.c:1006
+#: builtin/update-index.c:1007
 msgid "add to index only; do not add content to object database"
 msgstr "lägg endast till indexet; lägg inte till innehållet i objektdatabasen"
 
-#: builtin/update-index.c:1008
+#: builtin/update-index.c:1009
 msgid "remove named paths even if present in worktree"
 msgstr "ta bort namngivna sökvägar även om de finns i arbetskatalogen"
 
-#: builtin/update-index.c:1010
+#: builtin/update-index.c:1011
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr "med --stdin: indatarader termineras med null-byte"
 
-#: builtin/update-index.c:1012
+#: builtin/update-index.c:1013
 msgid "read list of paths to be updated from standard input"
 msgstr "läs lista över sökvägar att uppdatera från standard in"
 
-#: builtin/update-index.c:1016
+#: builtin/update-index.c:1017
 msgid "add entries from standard input to the index"
 msgstr "lägg poster från standard in till indexet"
 
-#: builtin/update-index.c:1020
+#: builtin/update-index.c:1021
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr "återfyll etapp 2 och 3 från angivna sökvägar"
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1025
 msgid "only update entries that differ from HEAD"
 msgstr "uppdatera endast poster som skiljer sig från HEAD"
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1029
 msgid "ignore files missing from worktree"
 msgstr "ignorera filer som saknas i arbetskatalogen"
 
-#: builtin/update-index.c:1031
+#: builtin/update-index.c:1032
 msgid "report actions to standard output"
 msgstr "rapportera åtgärder på standard ut"
 
-#: builtin/update-index.c:1033
+#: builtin/update-index.c:1034
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr "(för porslin) glöm sparade olösta konflikter"
 
-#: builtin/update-index.c:1037
+#: builtin/update-index.c:1038
 msgid "write index in this format"
 msgstr "skriv index i detta format"
 
-#: builtin/update-index.c:1039
+#: builtin/update-index.c:1040
 msgid "enable or disable split index"
 msgstr "aktivera eller inaktivera delat index"
 
-#: builtin/update-index.c:1041
+#: builtin/update-index.c:1042
 msgid "enable/disable untracked cache"
 msgstr "aktivera/inaktivera ospårad cache"
 
-#: builtin/update-index.c:1043
+#: builtin/update-index.c:1044
 msgid "test if the filesystem supports untracked cache"
 msgstr "testa om filsystemet stöder ospårad cache"
 
-#: builtin/update-index.c:1045
+#: builtin/update-index.c:1046
 msgid "enable untracked cache without testing the filesystem"
 msgstr "aktivera ospårad cache utan att testa filsystemet"
 
-#: builtin/update-index.c:1047
+#: builtin/update-index.c:1048
 msgid "write out the index even if is not flagged as changed"
 msgstr "skriv ut indexet även om det inte angivits som ändrat"
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1050
 msgid "enable or disable file system monitor"
 msgstr "aktivera eller inaktivera filsystemsövervakning"
 
-#: builtin/update-index.c:1051
+#: builtin/update-index.c:1052
 msgid "mark files as fsmonitor valid"
 msgstr "markera filer som \"fsmonitor valid\""
 
-#: builtin/update-index.c:1054
+#: builtin/update-index.c:1055
 msgid "clear fsmonitor valid bit"
 msgstr "töm \"fsmonitor valid\"-bit"
 
-#: builtin/update-index.c:1153
+#: builtin/update-index.c:1156
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
@@ -17854,7 +18852,7 @@ msgstr ""
 "core.splitIndex är satt till false; ta bort eller ändra det om du verkligen "
 "vill aktivera delat index"
 
-#: builtin/update-index.c:1162
+#: builtin/update-index.c:1165
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
@@ -17862,7 +18860,7 @@ msgstr ""
 "core.splitIndex är satt till true; ta bort eller ändra det om du verkligen "
 "vill inaktivera delat index"
 
-#: builtin/update-index.c:1173
+#: builtin/update-index.c:1176
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
@@ -17870,11 +18868,11 @@ msgstr ""
 "core.untrackedCache är satt till true; ta bort eller ändra det om du "
 "verkligen vill inaktivera den ospårade cachen"
 
-#: builtin/update-index.c:1177
+#: builtin/update-index.c:1180
 msgid "Untracked cache disabled"
 msgstr "Ospårad cache är inaktiverad"
 
-#: builtin/update-index.c:1185
+#: builtin/update-index.c:1188
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
@@ -17882,26 +18880,26 @@ msgstr ""
 "core.untrackedCache är satt till false; ta bort eller ändra det om du "
 "verkligen vill aktivera den ospårade cachen"
 
-#: builtin/update-index.c:1189
+#: builtin/update-index.c:1192
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr "Ospårad cache är aktiverad för \"%s\""
 
-#: builtin/update-index.c:1197
+#: builtin/update-index.c:1200
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr "core.fsmonitor inte satt; sätt om du verkligen vill aktivera fsmonitor"
 
-#: builtin/update-index.c:1201
+#: builtin/update-index.c:1204
 msgid "fsmonitor enabled"
 msgstr "fsmonitor aktiverat"
 
-#: builtin/update-index.c:1204
+#: builtin/update-index.c:1207
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
 "core.fsmonitor är satt; ta bort om du verkligen vill inaktivera fsmonitor"
 
-#: builtin/update-index.c:1208
+#: builtin/update-index.c:1211
 msgid "fsmonitor disabled"
 msgstr "fsmonitor inaktiverat"
 
@@ -17989,55 +18987,55 @@ msgstr "git verify-tag [-v | --verbose] [--format=<format] <tagg>..."
 msgid "print tag contents"
 msgstr "visa innehåll för tag"
 
-#: builtin/worktree.c:17
+#: builtin/worktree.c:18
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
 msgstr "git worktree add [<flaggor>] <sökväg> [<incheckning-igt>]"
 
-#: builtin/worktree.c:18
+#: builtin/worktree.c:19
 msgid "git worktree list [<options>]"
 msgstr "git worktree list [<flaggor>]"
 
-#: builtin/worktree.c:19
+#: builtin/worktree.c:20
 msgid "git worktree lock [<options>] <path>"
 msgstr "git worktree lock [<flaggor>] <sökväg>"
 
-#: builtin/worktree.c:20
+#: builtin/worktree.c:21
 msgid "git worktree move <worktree> <new-path>"
 msgstr "git worktree move <arbetskatalog> <ny-sökväg>"
 
-#: builtin/worktree.c:21
+#: builtin/worktree.c:22
 msgid "git worktree prune [<options>]"
 msgstr "git worktree prune [<flaggor>]"
 
-#: builtin/worktree.c:22
+#: builtin/worktree.c:23
 msgid "git worktree remove [<options>] <worktree>"
 msgstr "git worktree remove [<flaggor>] <arbetskatalog>"
 
-#: builtin/worktree.c:23
+#: builtin/worktree.c:24
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <sökväg>"
 
-#: builtin/worktree.c:60 builtin/worktree.c:871
+#: builtin/worktree.c:61 builtin/worktree.c:888
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "misslyckades ta bort \"%s\""
 
-#: builtin/worktree.c:79
+#: builtin/worktree.c:80
 #, c-format
 msgid "Removing worktrees/%s: not a valid directory"
 msgstr "Tar bort worktrees/%s: inte en giltig katalog"
 
-#: builtin/worktree.c:85
+#: builtin/worktree.c:86
 #, c-format
 msgid "Removing worktrees/%s: gitdir file does not exist"
 msgstr "Tar bort worktrees/%s: gitdir-filen existerar inte"
 
-#: builtin/worktree.c:90 builtin/worktree.c:99
+#: builtin/worktree.c:91 builtin/worktree.c:100
 #, c-format
 msgid "Removing worktrees/%s: unable to read gitdir file (%s)"
 msgstr "Tar bort worktrees/%s: kan inte läsa gitdir-filen (%s)"
 
-#: builtin/worktree.c:109
+#: builtin/worktree.c:110
 #, c-format
 msgid ""
 "Removing worktrees/%s: short read (expected %<PRIuMAX> bytes, read "
@@ -18046,35 +19044,35 @@ msgstr ""
 "Tar bort worktrees/%s: kort läsning (förväntade %<PRIuMAX> byte, läste "
 "%<PRIuMAX>)"
 
-#: builtin/worktree.c:117
+#: builtin/worktree.c:118
 #, c-format
 msgid "Removing worktrees/%s: invalid gitdir file"
 msgstr "Tar bort worktrees/%s: felaktig gitdir-fil"
 
-#: builtin/worktree.c:126
+#: builtin/worktree.c:127
 #, c-format
 msgid "Removing worktrees/%s: gitdir file points to non-existent location"
 msgstr "Tar bort worktrees/%s: gitdir-filen pekar på en ickeexisterande plats"
 
-#: builtin/worktree.c:165
+#: builtin/worktree.c:166
 msgid "report pruned working trees"
 msgstr "rapportera borttagna arbetskataloger"
 
-#: builtin/worktree.c:167
+#: builtin/worktree.c:168
 msgid "expire working trees older than <time>"
 msgstr "låt tid gå ut för arbetskataloger äldre än <tid>"
 
-#: builtin/worktree.c:234
+#: builtin/worktree.c:235
 #, c-format
 msgid "'%s' already exists"
 msgstr "\"%s\" finns redan"
 
-#: builtin/worktree.c:251
+#: builtin/worktree.c:252
 #, c-format
 msgid "unable to re-add worktree '%s'"
 msgstr "kunde inte lägga in arbetskatalogen \"%s\" igen"
 
-#: builtin/worktree.c:256
+#: builtin/worktree.c:257
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
@@ -18084,7 +19082,7 @@ msgstr ""
 "använd \"add -f -f\" för att överstyra, eller \"unlock\" och \"prune\" eller "
 "\"remove\" för att rensa"
 
-#: builtin/worktree.c:258
+#: builtin/worktree.c:259
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
@@ -18094,121 +19092,121 @@ msgstr ""
 "använd \"add -f\" för att överstyra, eller \"prune\" eller \"remove\" för "
 "att rensa"
 
-#: builtin/worktree.c:309
+#: builtin/worktree.c:310
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr "kunde inte skapa katalogen \"%s\""
 
-#: builtin/worktree.c:428 builtin/worktree.c:434
+#: builtin/worktree.c:429 builtin/worktree.c:435
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Förbereder arbetskatalog (ny gren \"%s\")"
 
-#: builtin/worktree.c:430
+#: builtin/worktree.c:431
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr "Förbereder arbetskatalog (återställer gren \"%s\"; var på %s)"
 
-#: builtin/worktree.c:439
+#: builtin/worktree.c:440
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Förbereder arbetskatalog (checkar ut \"%s\")"
 
-#: builtin/worktree.c:445
+#: builtin/worktree.c:446
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Förbereder arbetskatalog (frånkopplat HEAD %s)"
 
-#: builtin/worktree.c:486
+#: builtin/worktree.c:487
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 "checka ut <gren> även om den redan är utcheckad i en annan arbetskatalog"
 
-#: builtin/worktree.c:489
+#: builtin/worktree.c:490
 msgid "create a new branch"
 msgstr "skapa en ny gren"
 
-#: builtin/worktree.c:491
+#: builtin/worktree.c:492
 msgid "create or reset a branch"
 msgstr "skapa eller återställ en gren"
 
-#: builtin/worktree.c:493
+#: builtin/worktree.c:494
 msgid "populate the new working tree"
 msgstr "befolka den nya arbetskatalogen"
 
-#: builtin/worktree.c:494
+#: builtin/worktree.c:495
 msgid "keep the new working tree locked"
 msgstr "låt arbetskatalogen förbli låst"
 
-#: builtin/worktree.c:497
+#: builtin/worktree.c:498
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "ställ in spårningsläge (se git-branch(1))"
 
-#: builtin/worktree.c:500
+#: builtin/worktree.c:501
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr "försök matcha namn på ny gren mot en fjärrspårande gren"
 
-#: builtin/worktree.c:508
+#: builtin/worktree.c:509
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "-b, -B och --detach är ömsesidigt uteslutande"
 
-#: builtin/worktree.c:569
+#: builtin/worktree.c:570
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "--[no-]track kan endast användas när ny gran skapas"
 
-#: builtin/worktree.c:669
+#: builtin/worktree.c:670
 msgid "reason for locking"
 msgstr "orsak till lås"
 
-#: builtin/worktree.c:681 builtin/worktree.c:714 builtin/worktree.c:772
-#: builtin/worktree.c:899
+#: builtin/worktree.c:682 builtin/worktree.c:715 builtin/worktree.c:789
+#: builtin/worktree.c:916
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "\"%s\" är inte en arbetskatalog"
 
-#: builtin/worktree.c:683 builtin/worktree.c:716
+#: builtin/worktree.c:684 builtin/worktree.c:717
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Huvudarbetskatalogen kan inte låsas eller låsas upp"
 
-#: builtin/worktree.c:688
+#: builtin/worktree.c:689
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "\"%s\" är redan låst, orsak: %s"
 
-#: builtin/worktree.c:690
+#: builtin/worktree.c:691
 #, c-format
 msgid "'%s' is already locked"
 msgstr "\"%s\" är redan låst"
 
-#: builtin/worktree.c:718
+#: builtin/worktree.c:719
 #, c-format
 msgid "'%s' is not locked"
 msgstr "\"%s\" är inte låst"
 
-#: builtin/worktree.c:743
+#: builtin/worktree.c:760
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr "arbetskataloger med undermoduler kan inte flyttas eller tas bort"
 
-#: builtin/worktree.c:751
+#: builtin/worktree.c:768
 msgid "force move even if worktree is dirty or locked"
 msgstr "tvinga flyttning även om arbetskatalogen är smutsig eller låst"
 
-#: builtin/worktree.c:774 builtin/worktree.c:901
+#: builtin/worktree.c:791 builtin/worktree.c:918
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "\"%s\" är inte en huvudarbetskatalog"
 
-#: builtin/worktree.c:779
+#: builtin/worktree.c:796
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "kunde inte lista ut målnamn från \"%s\""
 
-#: builtin/worktree.c:785
+#: builtin/worktree.c:802
 #, c-format
 msgid "target '%s' already exists"
 msgstr "målet \"%s\" finns redan"
 
-#: builtin/worktree.c:793
+#: builtin/worktree.c:810
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -18217,7 +19215,7 @@ msgstr ""
 "kan inte flytta en låst arbetskatalog, orsak till lås: %s\n"
 "använd \"move -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:795
+#: builtin/worktree.c:812
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -18225,36 +19223,36 @@ msgstr ""
 "kan inte flytta en låst arbetskatalog;\n"
 "använd \"move -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:798
+#: builtin/worktree.c:815
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "kontroll misslyckades, kan inte flytta arbetskatalog: %s"
 
-#: builtin/worktree.c:803
+#: builtin/worktree.c:820
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "misslyckades flytta \"%s\" till \"%s\""
 
-#: builtin/worktree.c:851
+#: builtin/worktree.c:868
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "misslyckades köra \"git status\" på \"%s\""
 
-#: builtin/worktree.c:855
+#: builtin/worktree.c:872
 #, c-format
 msgid "'%s' is dirty, use --force to delete it"
 msgstr "\"%s\" är smutsigt, använd --force för att ta bort det"
 
-#: builtin/worktree.c:860
+#: builtin/worktree.c:877
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "misslyckades köra \"git status\" på \"%s\", kod %d"
 
-#: builtin/worktree.c:883
+#: builtin/worktree.c:900
 msgid "force removal even if worktree is dirty or locked"
 msgstr "tvinga ta bort även om arbetskatalogen är smutsig eller låst"
 
-#: builtin/worktree.c:906
+#: builtin/worktree.c:923
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -18263,7 +19261,7 @@ msgstr ""
 "kan inte ta bort en låst arbetskatalog, orsak till låset: %s\n"
 "använd \"remove -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:908
+#: builtin/worktree.c:925
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -18271,28 +19269,28 @@ msgstr ""
 "kan inte ta bort en låst arbetskatalog;\n"
 "använd \"remove -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:911
+#: builtin/worktree.c:928
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "kontroll misslyckades, kan inte ta bort arbetskatalog: %s"
 
-#: builtin/write-tree.c:14
+#: builtin/write-tree.c:15
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
 msgstr "git write-tree [--missing-ok] [--prefix=<prefix>/]"
 
-#: builtin/write-tree.c:27
+#: builtin/write-tree.c:28
 msgid "<prefix>/"
 msgstr "<prefix>/"
 
-#: builtin/write-tree.c:28
+#: builtin/write-tree.c:29
 msgid "write tree object for a subdirectory <prefix>"
 msgstr "visa trädobjekt för underkatalogen <prefix>"
 
-#: builtin/write-tree.c:30
+#: builtin/write-tree.c:31
 msgid "only useful for debugging"
 msgstr "endast användbart vid felsökning"
 
-#: credential-cache--daemon.c:222
+#: credential-cache--daemon.c:223
 #, c-format
 msgid ""
 "The permissions on your socket directory are too loose; other\n"
@@ -18305,7 +19303,7 @@ msgstr ""
 "\n"
 "\tchmod 0700 %s"
 
-#: credential-cache--daemon.c:271
+#: credential-cache--daemon.c:272
 msgid "print debugging messages to stderr"
 msgstr "skriv felsökningsmeddelanden på standard fel"
 
@@ -18345,94 +19343,144 @@ msgstr ""
 "några konceptvägledningar. Se \"git help <kommando>\" eller \"git help\n"
 "<koncept>\" för att läsa mer om specifika underkommandon och koncept."
 
-#: git.c:173
+#: git.c:174
 #, c-format
 msgid "no directory given for --git-dir\n"
 msgstr "ingen katalog angavs för --git-dir\n"
 
-#: git.c:187
+#: git.c:188
 #, c-format
 msgid "no namespace given for --namespace\n"
 msgstr "ingen namnrymd angavs för --namespace\n"
 
-#: git.c:201
+#: git.c:202
 #, c-format
 msgid "no directory given for --work-tree\n"
 msgstr "ingen katalog angavs för --work-tree\n"
 
-#: git.c:215
+#: git.c:216
 #, c-format
 msgid "no prefix given for --super-prefix\n"
 msgstr "inget prefix angavs för --super-prefix\n"
 
-#: git.c:237
+#: git.c:238
 #, c-format
 msgid "-c expects a configuration string\n"
 msgstr "-c förväntar en konfigurationssträng\n"
 
-#: git.c:275
+#: git.c:276
 #, c-format
 msgid "no directory given for -C\n"
 msgstr "ingen katalog angavs för -C\n"
 
-#: git.c:300
+#: git.c:301
 #, c-format
 msgid "unknown option: %s\n"
 msgstr "okänd flagga: %s\n"
 
-#: git.c:719
+#: git.c:342
+#, c-format
+msgid "while expanding alias '%s': '%s'"
+msgstr "vid expandering av aliaset \"%s\": \"%s\""
+
+#: git.c:351
+#, c-format
+msgid ""
+"alias '%s' changes environment variables.\n"
+"You can use '!git' in the alias to do this"
+msgstr ""
+"aliaset \"%s\" ändrar miljövariabler.\n"
+"Du kan använda \"!git\" i aliaset för att göra det"
+
+#: git.c:359
+#, c-format
+msgid "empty alias for %s"
+msgstr "tomt alias för %s"
+
+#: git.c:362
+#, c-format
+msgid "recursive alias: %s"
+msgstr "rekursivt alias: %s"
+
+#: git.c:437
+msgid "write failure on standard output"
+msgstr "skrivfel på standard ut"
+
+#: git.c:439
+msgid "unknown write failure on standard output"
+msgstr "okänt skrivfel på standard ut"
+
+#: git.c:441
+msgid "close failed on standard output"
+msgstr "stäng misslyckades på standard ut"
+
+#: git.c:720
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "alias-slinga detekterades: expansionen av \"%s\" avslutas aldrig:%s"
 
-#: git.c:802
+#: git.c:770
+#, c-format
+msgid "cannot handle %s as a builtin"
+msgstr "kan inte hantera %s som inbyggd"
+
+#: git.c:783
+#, c-format
+msgid ""
+"usage: %s\n"
+"\n"
+msgstr ""
+"användning: %s\n"
+"\n"
+
+#: git.c:803
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr ""
 "expandering av alias \"%s\" misslyckades; \"%s\" är inte ett git-kommando\n"
 
-#: git.c:814
+#: git.c:815
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "misslyckades köra kommandot \"%s\": %s\n"
 
-#: http.c:374
+#: http.c:378
 #, c-format
 msgid "negative value for http.postbuffer; defaulting to %d"
 msgstr "http.postbuffer har negativt värde; använder förvalet %d"
 
-#: http.c:395
+#: http.c:399
 msgid "Delegation control is not supported with cURL < 7.22.0"
 msgstr "Delegerad styrning stöds inte av cURL < 7.22.0"
 
-#: http.c:404
+#: http.c:408
 msgid "Public key pinning not supported with cURL < 7.44.0"
 msgstr "Fastnålning av öppen nyckel stöds inte av cURL < 7.44.0"
 
-#: http.c:837
+#: http.c:876
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
 msgstr "CURLSSLOPT_NO_REVOKE stöds inte av cURL < 7.44.0"
 
-#: http.c:910
+#: http.c:949
 msgid "Protocol restrictions not supported with cURL < 7.19.4"
 msgstr "Prtokollbegränsningar stöds inte av cURL < 7.19.4"
 
-#: http.c:1046
+#: http.c:1085
 #, c-format
 msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
 msgstr "SSL-bakändan \"%s\" stöds inte. Dessa SSL-bakändor stöds:"
 
-#: http.c:1053
+#: http.c:1092
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
 msgstr "Kan inte sätta SSL-bakända till \"%s\": cURL byggdes utan SSL-bakändor"
 
-#: http.c:1057
+#: http.c:1096
 #, c-format
 msgid "Could not set SSL backend to '%s': already set"
 msgstr "Kunde inte sätta SSL-bakända till \"%s\": redan valt"
 
-#: http.c:1921
+#: http.c:1959
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -18443,18 +19491,10 @@ msgstr ""
 "        bad om: %s\n"
 "  omdirigering: %s"
 
-#: remote-curl.c:401
+#: remote-curl.c:455
 #, c-format
 msgid "redirecting to %s"
 msgstr "omdirigerar till %s"
-
-#: list-objects-filter-options.h:60
-msgid "args"
-msgstr "argument"
-
-#: list-objects-filter-options.h:61
-msgid "object filtering"
-msgstr "objektfiltrering"
 
 #: parse-options.h:154
 msgid "expiry-date"
@@ -18464,15 +19504,15 @@ msgstr "giltig-till"
 msgid "no-op (backward compatibility)"
 msgstr "ingen funktion (bakåtkompatibilitet)"
 
-#: parse-options.h:261
+#: parse-options.h:259
 msgid "be more verbose"
 msgstr "var mer pratsam"
 
-#: parse-options.h:263
+#: parse-options.h:261
 msgid "be more quiet"
 msgstr "var mer tyst"
 
-#: parse-options.h:269
+#: parse-options.h:267
 msgid "use <n> digits to display SHA-1s"
 msgstr "använd <n> siffror för att visa SHA-1:or"
 
@@ -18635,7 +19675,7 @@ msgstr "Jämför en träd med arbetskatalogen eller indexet"
 
 #: command-list.h:89
 msgid "Compares the content and mode of blobs found via two tree objects"
-msgstr "Visar innehåll och läge för blob:ar som hittats via två trädobjekt"
+msgstr "Visar innehåll och läge för blobbar som hittats via två trädobjekt"
 
 #: command-list.h:90
 msgid "Show changes using common diff tools"
@@ -19115,6 +20155,14 @@ msgstr "Introduktion till Git"
 msgid "An overview of recommended workflows with Git"
 msgstr "Översikt över rekommenderade arbetsflöden med Git"
 
+#: list-objects-filter-options.h:63
+msgid "args"
+msgstr "argument"
+
+#: list-objects-filter-options.h:64
+msgid "object filtering"
+msgstr "objektfiltrering"
+
 #: rerere.h:44
 msgid "update the index with reused conflict resolution if possible"
 msgstr "uppdatera indexet med återanvänd konfliktlösning om möjligt"
@@ -19130,140 +20178,49 @@ msgstr "Du måste starta med \"git bisect start\""
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "Vill du att jag ska göra det åt dig [Y=ja/N=nej]? "
 
-#: git-bisect.sh:121
-#, sh-format
-msgid "unrecognised option: '$arg'"
-msgstr "flaggan känns inte igen: \"$arg\""
-
-#: git-bisect.sh:125
-#, sh-format
-msgid "'$arg' does not appear to be a valid revision"
-msgstr "\"$arg\" verkar inte vara en giltig revision"
-
-#: git-bisect.sh:154
-msgid "Bad HEAD - I need a HEAD"
-msgstr "Felaktigt HEAD - Jag behöver ett HEAD"
-
-#: git-bisect.sh:167
-#, sh-format
-msgid ""
-"Checking out '$start_head' failed. Try 'git bisect reset <valid-branch>'."
-msgstr ""
-"Misslyckades checka ut \"$start_head\". Försök \"git bisect reset "
-"<giltig_gren>”."
-
-# cogito-relaterat
-#: git-bisect.sh:177
-msgid "won't bisect on cg-seek'ed tree"
-msgstr "kör inte \"bisect\" på träd där \"cg-seek\" använts"
-
-#: git-bisect.sh:181
-msgid "Bad HEAD - strange symbolic ref"
-msgstr "Felaktigt HEAD - konstig symbolisk referens"
-
-#: git-bisect.sh:233
-#, sh-format
-msgid "Bad bisect_write argument: $state"
-msgstr "Felaktigt argument till bisect_write: $state"
-
-#: git-bisect.sh:246
+#: git-bisect.sh:101
 #, sh-format
 msgid "Bad rev input: $arg"
 msgstr "Felaktig rev-indata: $arg"
 
-#: git-bisect.sh:265
+#: git-bisect.sh:121
 #, sh-format
 msgid "Bad rev input: $bisected_head"
 msgstr "Felaktig rev-indata: $bisected_head"
 
-#: git-bisect.sh:274
+#: git-bisect.sh:130
 #, sh-format
 msgid "Bad rev input: $rev"
 msgstr "Felaktig rev-indata: $rev"
 
-#: git-bisect.sh:283
+#: git-bisect.sh:139
 #, sh-format
 msgid "'git bisect $TERM_BAD' can take only one argument."
 msgstr "\"git bisect $TERM_BAD\" kan bara ta ett argument."
 
-#: git-bisect.sh:306
-#, sh-format
-msgid "Warning: bisecting only with a $TERM_BAD commit."
-msgstr ""
-"Varning: utför \"bisect\" med endast en dålig (\"$TERM_BAD\") incheckning."
-
-#. TRANSLATORS: Make sure to include [Y] and [n] in your
-#. translation. The program will only accept English input
-#. at this point.
-#: git-bisect.sh:312
-msgid "Are you sure [Y/n]? "
-msgstr "Är du säker [Y=ja/N=nej]? "
-
-#: git-bisect.sh:324
-#, sh-format
-msgid ""
-"You need to give me at least one $bad_syn and one $good_syn revision.\n"
-"(You can use \"git bisect $bad_syn\" and \"git bisect $good_syn\" for that.)"
-msgstr ""
-"Du måste ange åtminstone en dålig (\"$bad_syn\") och en bra (\"$good_syn\") "
-"version.\n"
-"(Du kan använda \"git bisect $bad_syn\" och \"git bisect $good_syn\" för "
-"detta.)"
-
-#: git-bisect.sh:327
-#, sh-format
-msgid ""
-"You need to start by \"git bisect start\".\n"
-"You then need to give me at least one $good_syn and one $bad_syn revision.\n"
-"(You can use \"git bisect $bad_syn\" and \"git bisect $good_syn\" for that.)"
-msgstr ""
-"Du måste starta med \"git bisect start\".\n"
-"Du måste sedan ange åtminstone en bra (\"$good_syn\") och en dålig "
-"(\"$bad_syn\") version.\n"
-"(Du kan använda \"git bisect $bad_syn\" och \"git bisect $good_syn\" för "
-"detta.)"
-
-#: git-bisect.sh:398 git-bisect.sh:512
-msgid "We are not bisecting."
-msgstr "Vi utför ingen bisect för tillfället."
-
-#: git-bisect.sh:405
-#, sh-format
-msgid "'$invalid' is not a valid commit"
-msgstr "\"$invalid\" är inte en giltig incheckning"
-
-#: git-bisect.sh:414
-#, sh-format
-msgid ""
-"Could not check out original HEAD '$branch'.\n"
-"Try 'git bisect reset <commit>'."
-msgstr ""
-"Kunde inte checka ut original-HEAD \"$branch\".\n"
-"Försök \"git bisect reset <incheckning>\"."
-
-#: git-bisect.sh:422
+#: git-bisect.sh:209
 msgid "No logfile given"
 msgstr "Ingen loggfil angiven"
 
-#: git-bisect.sh:423
+#: git-bisect.sh:210
 #, sh-format
 msgid "cannot read $file for replaying"
 msgstr "kan inte läsa $file för uppspelning"
 
-#: git-bisect.sh:444
+#: git-bisect.sh:232
 msgid "?? what are you talking about?"
 msgstr "?? vad menar du?"
 
-#: git-bisect.sh:453
+#: git-bisect.sh:241
 msgid "bisect run failed: no command provided."
 msgstr "bisect-körning misslyckades: inget kommando gavs."
 
-#: git-bisect.sh:458
+#: git-bisect.sh:246
 #, sh-format
 msgid "running $command"
 msgstr "kör $command"
 
-#: git-bisect.sh:465
+#: git-bisect.sh:253
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -19272,11 +20229,11 @@ msgstr ""
 "\"bisect\"-körningen misslyckades:\n"
 "felkod $res från \"$command\" är < 0 eller >= 128"
 
-#: git-bisect.sh:491
+#: git-bisect.sh:279
 msgid "bisect run cannot continue any more"
 msgstr "\"bisect\"-körningen kan inte fortsätta längre"
 
-#: git-bisect.sh:497
+#: git-bisect.sh:285
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -19285,28 +20242,13 @@ msgstr ""
 "\"bisect\"-körningen misslyckades:\n"
 "\"bisect_state $state\" avslutades med felkoden $res"
 
-#: git-bisect.sh:504
+#: git-bisect.sh:292
 msgid "bisect run success"
 msgstr "\"bisect\"-körningen lyckades"
 
-#: git-bisect.sh:533
-#, sh-format
-msgid "Invalid command: you're currently in a $TERM_BAD/$TERM_GOOD bisect."
-msgstr ""
-"Ogiltigt kommando: du utför just nu en \"bisect\" med $TERM_BAD/$TERM_GOOD."
-
-#: git-bisect.sh:567
-msgid "no terms defined"
-msgstr "inga termer angivna"
-
-#: git-bisect.sh:584
-#, sh-format
-msgid ""
-"invalid argument $arg for 'git bisect terms'.\n"
-"Supported options are: --term-good|--term-old and --term-bad|--term-new."
-msgstr ""
-"ogiltigt argument $arg för \"git bisect terms\".\n"
-"Flaggor som stöds är: --term-good|--term-old och --term-bad|--term-new."
+#: git-bisect.sh:300
+msgid "We are not bisecting."
+msgstr "Vi utför ingen bisect för tillfället."
 
 #: git-merge-octopus.sh:46
 msgid ""
@@ -19348,12 +20290,12 @@ msgstr "Försök enkel sammanslagning med $pretty_name"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Enkel sammanslagning misslyckades, försöker automatisk sammanslagning."
 
-#: git-legacy-rebase.sh:434
+#: git-legacy-rebase.sh:445
 #, sh-format
 msgid "Could not move back to $head_name"
 msgstr "Kunde inte flytta tillbaka till $head_name"
 
-#: git-legacy-rebase.sh:460
+#: git-legacy-rebase.sh:471
 #, sh-format
 msgid ""
 "It seems that there is already a $state_dir_base directory, and\n"
@@ -19374,213 +20316,234 @@ msgstr ""
 "och kör programmet igen. Jag avslutar ifall du fortfarande har\n"
 "något av värde där."
 
-#: git-legacy-rebase.sh:525
-msgid "error: cannot combine '--signoff' with '--preserve-merges'"
-msgstr "fel: kan inte kombinera \"--signoff\" med \"--preserve-merges\""
+#: git-legacy-rebase.sh:523
+msgid ""
+"fatal: cannot combine am options with either interactive or merge options"
+msgstr ""
+"ödesdigert: kan inte kombinera am-flaggor med antingen interaktiv- eller "
+"sammanslagningsflaggor"
 
-#: git-legacy-rebase.sh:570
+#: git-legacy-rebase.sh:530
+msgid "fatal: cannot combine '--signoff' with '--preserve-merges'"
+msgstr "ödesdigert: kan inte kombinera \"--signoff\" med \"--preserve-merges\""
+
+#: git-legacy-rebase.sh:541
+msgid "fatal: cannot combine '--preserve-merges' with '--rebase-merges'"
+msgstr ""
+"ödesdigert: kan inte kombinera \"--preserve-merges\" med \"--rebase-merges\""
+
+#: git-legacy-rebase.sh:550
+msgid "fatal: cannot combine '--rebase-merges' with '--strategy-option'"
+msgstr ""
+"ödesdigert: kan inte kombinera \"--rebase-merges\" med \"--strategy-option\""
+
+#: git-legacy-rebase.sh:552
+msgid "fatal: cannot combine '--rebase-merges' with '--strategy'"
+msgstr "ödesdigert: kan inte kombinera \"--rebase-merges\" med \"--strategy\""
+
+#: git-legacy-rebase.sh:578
 #, sh-format
 msgid "invalid upstream '$upstream_name'"
 msgstr "ogiltig uppström \"$upstream_name\""
 
-#: git-legacy-rebase.sh:594
+#: git-legacy-rebase.sh:602
 #, sh-format
 msgid "$onto_name: there are more than one merge bases"
 msgstr "$onto_name: mer än en sammanslagningsbas finns"
 
-#: git-legacy-rebase.sh:597 git-legacy-rebase.sh:601
+#: git-legacy-rebase.sh:605 git-legacy-rebase.sh:609
 #, sh-format
 msgid "$onto_name: there is no merge base"
 msgstr "$onto_name: ingen sammanslagningsbas finns"
 
-#: git-legacy-rebase.sh:606
+#: git-legacy-rebase.sh:614
 #, sh-format
 msgid "Does not point to a valid commit: $onto_name"
 msgstr "Peka på en giltig incheckning: $onto_name"
 
-#: git-legacy-rebase.sh:632
+#: git-legacy-rebase.sh:640
 #, sh-format
 msgid "fatal: no such branch/commit '$branch_name'"
 msgstr "ödesdigert: ingen sådan gren/incheckning: $branch_name"
 
-#: git-legacy-rebase.sh:670
+#: git-legacy-rebase.sh:678
 #, sh-format
 msgid "Created autostash: $stash_abbrev"
 msgstr "Skapade autostash: $stash_abbrev"
 
-#: git-legacy-rebase.sh:699
+#: git-legacy-rebase.sh:707
 #, sh-format
 msgid "Current branch $branch_name is up to date."
 msgstr "Aktuell gren $branch_name är à jour."
 
-#: git-legacy-rebase.sh:709
+#: git-legacy-rebase.sh:717
 #, sh-format
 msgid "Current branch $branch_name is up to date, rebase forced."
 msgstr "Aktuell gren $branch_name är à jour, ombasering framtvingad."
 
-#: git-legacy-rebase.sh:723
+#: git-legacy-rebase.sh:731
 #, sh-format
 msgid "Changes to $onto:"
 msgstr "Ändringar till $onto:"
 
-#: git-legacy-rebase.sh:725
+#: git-legacy-rebase.sh:733
 #, sh-format
 msgid "Changes from $mb to $onto:"
 msgstr "Ändringar från $mb till $onto:"
 
-#: git-legacy-rebase.sh:736
-msgid "First, rewinding head to replay your work on top of it..."
-msgstr ""
-"Först, spolar tillbaka huvudet för att spela av ditt arbete ovanpå det..."
-
-#: git-legacy-rebase.sh:746
+#: git-legacy-rebase.sh:743
 #, sh-format
 msgid "Fast-forwarded $branch_name to $onto_name."
 msgstr "Snabbspolade $branch_name till $onto_name."
 
-#: git-stash.sh:61
+#: git-legacy-rebase.sh:757
+msgid "First, rewinding head to replay your work on top of it..."
+msgstr ""
+"Först, spolar tillbaka huvudet för att spela av ditt arbete ovanpå det..."
+
+#: git-stash.sh:75
 msgid "git stash clear with parameters is unimplemented"
 msgstr "\"git stash clear\" med parametrar har inte implementerats"
 
-#: git-stash.sh:108
+#: git-stash.sh:125
 msgid "You do not have the initial commit yet"
 msgstr "Du har inte den första incheckningen ännu"
 
-#: git-stash.sh:123
+#: git-stash.sh:140
 msgid "Cannot save the current index state"
 msgstr "Kan inte spara aktuellt tillstånd för indexet"
 
-#: git-stash.sh:138
+#: git-stash.sh:155
 msgid "Cannot save the untracked files"
 msgstr "Kan inte spara ospårade filer"
 
-#: git-stash.sh:158 git-stash.sh:171
+#: git-stash.sh:175 git-stash.sh:188
 msgid "Cannot save the current worktree state"
 msgstr "Kan inte spara aktuellt tillstånd för arbetskatalogen"
 
-#: git-stash.sh:175
+#: git-stash.sh:192
 msgid "No changes selected"
 msgstr "Inga ändringar valda"
 
-#: git-stash.sh:178
+#: git-stash.sh:195
 msgid "Cannot remove temporary index (can't happen)"
 msgstr "Kan inte ta bort temporärt index (kan inte inträffa)"
 
-#: git-stash.sh:191
+#: git-stash.sh:208
 msgid "Cannot record working tree state"
 msgstr "Kan inte registrera tillstånd för arbetskatalog"
 
-#: git-stash.sh:229
+#: git-stash.sh:246
 #, sh-format
 msgid "Cannot update $ref_stash with $w_commit"
 msgstr "Kan inte uppdatera $ref_stash med $w_commit"
 
-#: git-stash.sh:281
+#: git-stash.sh:298
 #, sh-format
 msgid "error: unknown option for 'stash push': $option"
 msgstr "fel: okänd flagga för \"stash push\": $option"
 
-#: git-stash.sh:295
+#: git-stash.sh:312
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "Kan inte använda --patch och --include-untracked eller --all samtidigt"
 
-#: git-stash.sh:303
+#: git-stash.sh:320
 msgid "No local changes to save"
 msgstr "Inga lokala ändringar att spara"
 
-#: git-stash.sh:308
+#: git-stash.sh:325
 msgid "Cannot initialize stash"
 msgstr "Kan inte initiera \"stash\""
 
-#: git-stash.sh:312
+#: git-stash.sh:329
 msgid "Cannot save the current status"
 msgstr "Kan inte spara aktuell status"
 
-#: git-stash.sh:313
+#: git-stash.sh:330
 #, sh-format
 msgid "Saved working directory and index state $stash_msg"
 msgstr "Sparade arbetskatalogen och indexstatus $stash_msg"
 
-#: git-stash.sh:342
+#: git-stash.sh:359
 msgid "Cannot remove worktree changes"
 msgstr "Kan inte ta bort ändringar i arbetskatalogen"
 
-#: git-stash.sh:490
+#: git-stash.sh:507
 #, sh-format
 msgid "unknown option: $opt"
 msgstr "okänd flagga: $opt"
 
-#: git-stash.sh:503
+#: git-stash.sh:520
 msgid "No stash entries found."
 msgstr "Inga \"stash”-poster hittades."
 
-#: git-stash.sh:510
+#: git-stash.sh:527
 #, sh-format
 msgid "Too many revisions specified: $REV"
 msgstr "För många revisioner angivna: $REV"
 
-#: git-stash.sh:525
+#: git-stash.sh:542
 #, sh-format
 msgid "$reference is not a valid reference"
 msgstr "$reference är inte en giltig referens"
 
-#: git-stash.sh:553
+#: git-stash.sh:570
 #, sh-format
 msgid "'$args' is not a stash-like commit"
 msgstr "\"$args\" är inte en \"stash\"-liknande incheckning"
 
-#: git-stash.sh:564
+#: git-stash.sh:581
 #, sh-format
 msgid "'$args' is not a stash reference"
 msgstr "\"$args\" är inte en \"stash\"-referens"
 
-#: git-stash.sh:572
+#: git-stash.sh:589
 msgid "unable to refresh index"
 msgstr "kan inte uppdatera indexet"
 
-#: git-stash.sh:576
+#: git-stash.sh:593
 msgid "Cannot apply a stash in the middle of a merge"
 msgstr "Kan inte tillämpa en \"stash\" mitt i en sammanslagning"
 
-#: git-stash.sh:584
+#: git-stash.sh:601
 msgid "Conflicts in index. Try without --index."
 msgstr "Konflikter i indexet. Testa utan --index."
 
-#: git-stash.sh:586
+#: git-stash.sh:603
 msgid "Could not save index tree"
 msgstr "Kunde inte spara indexträd"
 
-#: git-stash.sh:595
+#: git-stash.sh:612
 msgid "Could not restore untracked files from stash entry"
 msgstr "Kunde inte återställa ospårade filer från stash-post"
 
-#: git-stash.sh:620
+#: git-stash.sh:637
 msgid "Cannot unstage modified files"
 msgstr "Kan inte ta bort ändrade filer ur kön"
 
-#: git-stash.sh:635
+#: git-stash.sh:652
 msgid "Index was not unstashed."
 msgstr "Indexet har inte tagits ur kön."
 
-#: git-stash.sh:649
+#: git-stash.sh:666
 msgid "The stash entry is kept in case you need it again."
 msgstr "Stash-posten behålls ifall du behöver den igen."
 
-#: git-stash.sh:658
+#: git-stash.sh:675
 #, sh-format
 msgid "Dropped ${REV} ($s)"
 msgstr "Kastade ${REV} ($s)"
 
-#: git-stash.sh:659
+#: git-stash.sh:676
 #, sh-format
 msgid "${REV}: Could not drop stash entry"
 msgstr "${REV}: Kunde inte kasta \"stash\"-post"
 
-#: git-stash.sh:667
+#: git-stash.sh:684
 msgid "No branch name specified"
 msgstr "Inget grennamn angavs"
 
-#: git-stash.sh:746
+#: git-stash.sh:763
 msgid "(To restore them type \"git stash apply\")"
 msgstr "(För att återställa dem, skriv \"git stash apply\")"
 
@@ -21028,15 +21991,63 @@ msgstr ""
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 
+#~ msgid "--reschedule-failed-exec requires an interactive rebase"
+#~ msgstr "--reschedule-failed-exec kräver en interaktiv ombasering"
+
+#~ msgid "ignoring unknown color-moved-ws mode '%s'"
+#~ msgstr "ignorerar okänt läge för color-mode-ws \"%s\""
+
+#~ msgid "only 'tree:0' is supported"
+#~ msgstr "endast \"tree:0\" stöds"
+
+#~ msgid "Renaming %s to %s and %s to %s instead"
+#~ msgstr "Byter namn på %s till %s och %s till %s istället"
+
+#~ msgid "Adding merged %s"
+#~ msgstr "Lägger till sammanslagen %s"
+
+#~ msgid "Internal error"
+#~ msgstr "Internt fel"
+
+#~ msgid "mainline was specified but commit %s is not a merge."
+#~ msgstr "huvudlinje angavs, men incheckningen %s är inte en sammanslagning."
+
+#~ msgid "unable to write sha1 filename %s"
+#~ msgstr "kan inte skriva sha1-filnamn %s"
+
+#~ msgid "unable to write sha1 file"
+#~ msgstr "kan inte skriva sha1-filen"
+
+#~ msgid "cannot read sha1_file for %s"
+#~ msgstr "kan inte läsa sha1_file för %s"
+
+#~ msgid ""
+#~ "error: cannot combine interactive options (--interactive, --exec, --"
+#~ "rebase-merges, --preserve-merges, --keep-empty, --root + --onto) with am "
+#~ "options (%s)"
+#~ msgstr ""
+#~ "fel: kan inte kombinera interaktiva flaggor (--interactive, --exec, --"
+#~ "rebase-merges, --preserve-merges, --keep-empty, --root + --onto) med am-"
+#~ "flaggor (%s)"
+
+#~ msgid ""
+#~ "error: cannot combine merge options (--merge, --strategy, --strategy-"
+#~ "option) with am options (%s)"
+#~ msgstr ""
+#~ "fel: kan inte kombinera sammanslagningsflaggor (--merge, --strategy, --"
+#~ "strategy-option) med am-flaggor (%s)"
+
+#~ msgid "unrecognised option: '$arg'"
+#~ msgstr "flaggan känns inte igen: \"$arg\""
+
+#~ msgid "'$invalid' is not a valid commit"
+#~ msgstr "\"$invalid\" är inte en giltig incheckning"
+
 #~ msgid "could not parse '%s' (looking for '%s')"
 #~ msgstr "kunde inte tolka \"%s\" (letar efter \"%s\")"
 
 #~ msgid "bad quoting on %s value in '%s'"
 #~ msgstr "felaktig citering på %s-värde i \"%s\""
-
-#~ msgid "Could not unset core.worktree setting in submodule '%s'"
-#~ msgstr ""
-#~ "Kunde inte ta bort inställningen core.worktree i undermodulen \"%s\""
 
 #~ msgid "deprecated synonym for --create-reflog"
 #~ msgstr "avrådd synonym för --create-reflog"
@@ -21158,9 +22169,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 #~ msgid "could not truncate '%s'"
 #~ msgstr "kunde inte trunkera \"%s\""
 
-#~ msgid "could not finish '%s'"
-#~ msgstr "kunde inte avsluta \"%s\""
-
 #~ msgid "could not close %s"
 #~ msgstr "kunde inte stänga %s"
 
@@ -21249,9 +22257,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 #~ msgid "Or you can abort the rebase with 'git rebase --abort'."
 #~ msgstr "Eller så kan du avbryta ombaseringen med \"git rebase --abort\"."
 
-#~ msgid "Could not open file '%s'"
-#~ msgstr "Kunde inte öppna filen \"%s\""
-
 #~ msgid "in %0.1f seconds automatically..."
 #~ msgstr "automatiskt om %0.1f sekunder..."
 
@@ -21319,9 +22324,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 
 #~ msgid "ref '%s' does not have %ld components to :strip"
 #~ msgstr "referensen \"%s\" har inte %ld komponenter för :strip"
-
-#~ msgid "unknown %.*s format %s"
-#~ msgstr "okänt \"%.*s\"-format %s"
 
 #~ msgid "[%s: gone]"
 #~ msgstr "[%s: försvunnen]"
@@ -21412,9 +22414,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 
 #~ msgid "%s: %s"
 #~ msgstr "%s: %s"
-
-#~ msgid "cannot open %s: %s"
-#~ msgstr "kan inte öppna %s: %s"
 
 #~ msgid "You need to set your committer info first"
 #~ msgstr "Du måste ställa in din incheckarinformation först"
@@ -21664,9 +22663,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 #~ msgid "failed to remove: %s"
 #~ msgstr "misslyckades ta bort: %s"
 
-#~ msgid "The --exec option must be used with the --interactive option"
-#~ msgstr "Flaggan --exec måste användas tillsammans med flaggan --interactive"
-
 #~ msgid ""
 #~ "Submodule path '$displaypath' not initialized\n"
 #~ "Maybe you want to use 'update --init'?"
@@ -21897,9 +22893,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 
 #~ msgid "%s: cannot lock the ref"
 #~ msgstr "%s: kan inte låsa referensen"
-
-#~ msgid "%s: cannot update the ref"
-#~ msgstr "%s: kan inte uppdatera referensen"
 
 #~ msgid "commit has empty message"
 #~ msgstr "incheckningen har ett tomt meddelande"


### PR DESCRIPTION
Trying again, now the two commits are squashed together and rebased on top of the git-l10n master.