### PR TITLE
certifica-se -> certifique-se

### DIFF
--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1396,7 +1396,7 @@ msgid ""
 msgstr ""
 "Não foi possível ler do repositório remoto.\n"
 "\n"
-"Certifica-se que tem os direitos de acesso corretos\n"
+"Certifique-se que tem os direitos de acesso corretos\n"
 "e que o repositório existe."
 
 #: connected.c:63 builtin/fsck.c:190 builtin/prune.c:140


### PR DESCRIPTION
It is not a sintax error but a wrong verbal form.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
