### PR TITLE
po/it.po: Remove space between the dashes and start of an option's name in the Italian translation

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -566,7 +566,7 @@ msgstr "è già in corso un'operazione di cherry-pick o di revert"
 
 #: sequencer.c:740
 msgid "try \"git cherry-pick (--continue | --quit | --abort)\""
-msgstr "prova \"git cherry-pick (--continue | --quit | -- abort)\""
+msgstr "prova \"git cherry-pick (--continue | --quit | --abort)\""
 
 #: sequencer.c:744
 #, c-format


### PR DESCRIPTION
Signed-off-by: Carmine Zaccagnino <carmine@carminezacc.com>

As I was asked in response to https://github.com/git/git/pull/555#event-2431000862