### PR TITLE
l10n: it.po: update the Italian translation for Git 2.26.0 round 1

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -6,13 +6,13 @@
 # Thanks to the former translators, Marco Paolone <marcopaolone AT gmail.com>
 # and Stefano Lattarini <stefano.lattarini AT gmail.com>, for their
 # contributions.
-# Alessandro Menti <alessandro.menti@alessandromenti.it>, 2019.
+# Alessandro Menti <alessandro.menti@alessandromenti.it>, 2019, 2020.
 msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2019-12-30 08:48+0800\n"
-"PO-Revision-Date: 2019-12-30 09:23+0100\n"
+"POT-Creation-Date: 2020-03-06 14:25+0800\n"
+"PO-Revision-Date: 2020-03-07 09:36+0100\n"
 "Last-Translator: Alessandro Menti <alessandro.menti@alessandromenti.it>\n"
 "Language-Team: Italian <>\n"
 "Language: it\n"
@@ -20,259 +20,535 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Lokalize 19.12.0\n"
+"X-Generator: Lokalize 19.12.2\n"
 
-#: add-interactive.c:347
+#: add-interactive.c:368
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Eh (%s)?"
 
-#: add-interactive.c:500 add-interactive.c:801 sequencer.c:3216
-#: sequencer.c:3656 builtin/rebase.c:871 builtin/rebase.c:1643
-#: builtin/rebase.c:2019 builtin/rebase.c:2063
+#: add-interactive.c:521 add-interactive.c:822 sequencer.c:3124
+#: sequencer.c:3562 builtin/rebase.c:875 builtin/rebase.c:1687
+#: builtin/rebase.c:2086 builtin/rebase.c:2130
 msgid "could not read index"
 msgstr "impossibile leggere l'indice"
 
-#: add-interactive.c:555 git-add--interactive.perl:269
+#: add-interactive.c:576 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "binario"
 
-#: add-interactive.c:613 git-add--interactive.perl:278
+#: add-interactive.c:634 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "non fare nulla"
 
-#: add-interactive.c:614 git-add--interactive.perl:314
+#: add-interactive.c:635 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "non modificato"
 
-#: add-interactive.c:651 git-add--interactive.perl:643
+#: add-interactive.c:672 git-add--interactive.perl:643
 msgid "Update"
 msgstr "Aggiorna"
 
-#: add-interactive.c:668 add-interactive.c:856
+#: add-interactive.c:689 add-interactive.c:877
 #, c-format
 msgid "could not stage '%s'"
 msgstr "impossibile aggiungere '%s' all'area di staging"
 
-#: add-interactive.c:674 add-interactive.c:863 sequencer.c:3409
-#: builtin/rebase.c:895
+#: add-interactive.c:695 add-interactive.c:884 sequencer.c:3317
+#: builtin/rebase.c:899
 msgid "could not write index"
 msgstr "impossibile scrivere l'indice"
 
-#: add-interactive.c:677 git-add--interactive.perl:628
+#: add-interactive.c:698 git-add--interactive.perl:628
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "aggiornato %d percorso\n"
 msgstr[1] "aggiornati %d percorsi\n"
 
-#: add-interactive.c:695 git-add--interactive.perl:678
+#: add-interactive.c:716 git-add--interactive.perl:678
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "nota: %s ora non è tracciato.\n"
 
-#: add-interactive.c:700 apply.c:4108 builtin/checkout.c:281
+#: add-interactive.c:721 apply.c:4110 builtin/checkout.c:281
 #: builtin/reset.c:144
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry non riuscito per il percorso '%s'"
 
-#: add-interactive.c:730 git-add--interactive.perl:655
+#: add-interactive.c:751 git-add--interactive.perl:655
 msgid "Revert"
 msgstr "Esegui il revert"
 
-#: add-interactive.c:746
+#: add-interactive.c:767
 msgid "Could not parse HEAD^{tree}"
 msgstr "Impossibile analizzare HEAD^{tree}"
 
-#: add-interactive.c:784 git-add--interactive.perl:631
+#: add-interactive.c:805 git-add--interactive.perl:631
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "ripristinato %d percorso\n"
 msgstr[1] "ripristinati %d percorsi\n"
 
-#: add-interactive.c:835 git-add--interactive.perl:695
+#: add-interactive.c:856 git-add--interactive.perl:695
 #, c-format
 msgid "No untracked files.\n"
 msgstr "Nessun file non tracciato.\n"
 
-#: add-interactive.c:839 git-add--interactive.perl:689
+#: add-interactive.c:860 git-add--interactive.perl:689
 msgid "Add untracked"
 msgstr "Aggiungi file non tracciati"
 
-#: add-interactive.c:866 git-add--interactive.perl:625
+#: add-interactive.c:887 git-add--interactive.perl:625
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "aggiunto %d percorso\n"
 msgstr[1] "aggiunti %d percorsi\n"
 
-#: add-interactive.c:896
+#: add-interactive.c:917
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "ignoro ciò che non è stato sottoposto a merge: %s"
 
-#: add-interactive.c:908 add-patch.c:1331 git-add--interactive.perl:1366
+#: add-interactive.c:929 add-patch.c:1675 git-add--interactive.perl:1366
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Sono stati modificati solo file binari.\n"
 
-#: add-interactive.c:910 add-patch.c:1329 git-add--interactive.perl:1368
+#: add-interactive.c:931 add-patch.c:1673 git-add--interactive.perl:1368
 #, c-format
 msgid "No changes.\n"
 msgstr "Nessuna modifica.\n"
 
-#: add-interactive.c:914 git-add--interactive.perl:1376
+#: add-interactive.c:935 git-add--interactive.perl:1376
 msgid "Patch update"
 msgstr "Aggiornamento patch"
 
-#: add-interactive.c:953 git-add--interactive.perl:1754
+#: add-interactive.c:974 git-add--interactive.perl:1754
 msgid "Review diff"
 msgstr "Rivedi diff"
 
-#: add-interactive.c:981
+#: add-interactive.c:1002
 msgid "show paths with changes"
 msgstr "visualizza i percorsi modificati"
 
-#: add-interactive.c:983
+#: add-interactive.c:1004
 msgid "add working tree state to the staged set of changes"
 msgstr ""
-"aggiungi lo stato dall'albero di lavoro all'insieme delle modifiche nell'area"
-" di staging"
+"aggiungi lo stato dall'albero di lavoro all'insieme delle modifiche "
+"nell'area di staging"
 
-#: add-interactive.c:985
+#: add-interactive.c:1006
 msgid "revert staged set of changes back to the HEAD version"
 msgstr ""
 "ripristina l'insieme delle modifiche nell'area di staging alla versione HEAD"
 
-#: add-interactive.c:987
+#: add-interactive.c:1008
 msgid "pick hunks and update selectively"
 msgstr ""
-"seleziona gli hunk in modalità interattiva ed esegui l'aggiornamento in modo"
-" selettivo"
+"seleziona gli hunk in modalità interattiva ed esegui l'aggiornamento in modo "
+"selettivo"
 
-#: add-interactive.c:989
+#: add-interactive.c:1010
 msgid "view diff between HEAD and index"
 msgstr "visualizza il diff fra HEAD e l'indice"
 
-#: add-interactive.c:991
+#: add-interactive.c:1012
 msgid "add contents of untracked files to the staged set of changes"
 msgstr ""
-"aggiungi i contenuti dei file non tracciati all'insieme delle modifiche"
-" nell'area di staging"
+"aggiungi i contenuti dei file non tracciati all'insieme delle modifiche "
+"nell'area di staging"
 
-#: add-interactive.c:999 add-interactive.c:1048
+#: add-interactive.c:1020 add-interactive.c:1069
 msgid "Prompt help:"
 msgstr "Guida prompt:"
 
-#: add-interactive.c:1001
+#: add-interactive.c:1022
 msgid "select a single item"
 msgstr "seleziona un singolo elemento"
 
-#: add-interactive.c:1003
+#: add-interactive.c:1024
 msgid "select a range of items"
 msgstr "seleziona un intervallo di elementi"
 
-#: add-interactive.c:1005
+#: add-interactive.c:1026
 msgid "select multiple ranges"
 msgstr "seleziona più intervalli"
 
-#: add-interactive.c:1007 add-interactive.c:1052
+#: add-interactive.c:1028 add-interactive.c:1073
 msgid "select item based on unique prefix"
 msgstr "seleziona un elemento basandoti su un prefisso univoco"
 
-#: add-interactive.c:1009
+#: add-interactive.c:1030
 msgid "unselect specified items"
 msgstr "deseleziona gli elementi specificati"
 
-#: add-interactive.c:1011
+#: add-interactive.c:1032
 msgid "choose all items"
 msgstr "seleziona tutti gli elementi"
 
-#: add-interactive.c:1013
+#: add-interactive.c:1034
 msgid "(empty) finish selecting"
 msgstr "(vuoto) termina la selezione"
 
-#: add-interactive.c:1050
+#: add-interactive.c:1071
 msgid "select a numbered item"
 msgstr "seleziona un elemento numerato"
 
-#: add-interactive.c:1054
+#: add-interactive.c:1075
 msgid "(empty) select nothing"
 msgstr "(vuoto) non selezionare nulla"
 
-#: add-interactive.c:1062 builtin/clean.c:822 git-add--interactive.perl:1851
+#: add-interactive.c:1083 builtin/clean.c:822 git-add--interactive.perl:1851
 msgid "*** Commands ***"
 msgstr "*** Comandi ***"
 
-#: add-interactive.c:1063 builtin/clean.c:823 git-add--interactive.perl:1848
+#: add-interactive.c:1084 builtin/clean.c:823 git-add--interactive.perl:1848
 msgid "What now"
 msgstr "Cosa faccio ora"
 
-#: add-interactive.c:1115 git-add--interactive.perl:213
+#: add-interactive.c:1136 git-add--interactive.perl:213
 msgid "staged"
 msgstr "nell'area di staging"
 
-#: add-interactive.c:1115 git-add--interactive.perl:213
+#: add-interactive.c:1136 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "rimosso dall'area di staging"
 
-#: add-interactive.c:1115 apply.c:4965 apply.c:4968 builtin/am.c:2197
+#: add-interactive.c:1136 apply.c:4967 apply.c:4970 builtin/am.c:2197
 #: builtin/am.c:2200 builtin/clone.c:123 builtin/fetch.c:144
-#: builtin/merge.c:273 builtin/pull.c:209 builtin/submodule--helper.c:409
-#: builtin/submodule--helper.c:1379 builtin/submodule--helper.c:1382
-#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:1878
-#: builtin/submodule--helper.c:2119 git-add--interactive.perl:213
+#: builtin/merge.c:274 builtin/pull.c:189 builtin/submodule--helper.c:409
+#: builtin/submodule--helper.c:1394 builtin/submodule--helper.c:1397
+#: builtin/submodule--helper.c:1902 builtin/submodule--helper.c:1905
+#: builtin/submodule--helper.c:2148 git-add--interactive.perl:213
 msgid "path"
 msgstr "percorso"
 
-#: add-interactive.c:1122
+#: add-interactive.c:1143
 msgid "could not refresh index"
 msgstr "impossibile aggiornare l'indice"
 
-#: add-interactive.c:1136 builtin/clean.c:787 git-add--interactive.perl:1765
+#: add-interactive.c:1157 builtin/clean.c:787 git-add--interactive.perl:1765
 #, c-format
 msgid "Bye.\n"
 msgstr "Ciao.\n"
 
-#: add-patch.c:15
-#, c-format
-msgid "Stage mode change [y,n,a,q,d%s,?]? "
-msgstr "Modifica modo stage [y,n,a,q,d%s,?]? "
+#: add-patch.c:33 git-add--interactive.perl:1428
+#, c-format, perl-format
+msgid "Stage mode change [y,n,q,a,d%s,?]? "
+msgstr "Modifica modo stage [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:16
-#, c-format
-msgid "Stage deletion [y,n,a,q,d%s,?]? "
-msgstr "Eliminazione stage [y,n,a,q,d%s,?]? "
+#: add-patch.c:34 git-add--interactive.perl:1429
+#, c-format, perl-format
+msgid "Stage deletion [y,n,q,a,d%s,?]? "
+msgstr "Eliminazione stage [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:17
-#, c-format
-msgid "Stage this hunk [y,n,a,q,d%s,?]? "
-msgstr "Eseguire lo stage di quest'hunk [y,n,a,q,d%s,?]? "
+#: add-patch.c:35 git-add--interactive.perl:1430
+#, c-format, perl-format
+msgid "Stage this hunk [y,n,q,a,d%s,?]? "
+msgstr "Eseguire lo stage di quest'hunk [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:111
+#: add-patch.c:37
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"staging."
+msgstr ""
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
+" contrassegnato immediatamente per l'aggiunta all'area di staging."
+
+#: add-patch.c:40
+msgid ""
+"y - stage this hunk\n"
+"n - do not stage this hunk\n"
+"q - quit; do not stage this hunk or any of the remaining ones\n"
+"a - stage this hunk and all later hunks in the file\n"
+"d - do not stage this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - aggiungi quest'hunk all'area di staging\n"
+"n - non aggiungere quest'hunk all'area di staging\n"
+"q - esci; non aggiungere né quest'hunk né quelli rimanenti all'area di "
+"staging\n"
+"a - aggiungi quest'hunk e tutti quelli successivi nel file all'area di "
+"staging\n"
+"d - non aggiungere né quest'hunk né quelli successivi nel file all'area di "
+"staging\n"
+
+#: add-patch.c:54 git-add--interactive.perl:1433
+#, c-format, perl-format
+msgid "Stash mode change [y,n,q,a,d%s,?]? "
+msgstr "Modifica modo stash [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:55 git-add--interactive.perl:1434
+#, c-format, perl-format
+msgid "Stash deletion [y,n,q,a,d%s,?]? "
+msgstr "Eliminazione stash [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:56 git-add--interactive.perl:1435
+#, c-format, perl-format
+msgid "Stash this hunk [y,n,q,a,d%s,?]? "
+msgstr "Eseguire lo stash di quest'hunk [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:58
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"stashing."
+msgstr ""
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
+" contrassegnato immediatamente per lo stash."
+
+#: add-patch.c:61
+msgid ""
+"y - stash this hunk\n"
+"n - do not stash this hunk\n"
+"q - quit; do not stash this hunk or any of the remaining ones\n"
+"a - stash this hunk and all later hunks in the file\n"
+"d - do not stash this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - esegui lo stash di quest'hunk\n"
+"n - non eseguire lo stash di quest'hunk\n"
+"q - esci; non eseguire lo stash di quest'hunk né di quelli rimanenti\n"
+"a - esegui lo stash di quest'hunk e di tutti quelli successivi nel file\n"
+"d - non eseguire lo stash né di quest'hunk né di quelli successivi nel file\n"
+
+#: add-patch.c:77 git-add--interactive.perl:1438
+#, c-format, perl-format
+msgid "Unstage mode change [y,n,q,a,d%s,?]? "
+msgstr "Rimozione modifica modo dall'area di staging [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:78 git-add--interactive.perl:1439
+#, c-format, perl-format
+msgid "Unstage deletion [y,n,q,a,d%s,?]? "
+msgstr "Rimozione eliminazione dall'area di staging [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:79 git-add--interactive.perl:1440
+#, c-format, perl-format
+msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
+msgstr "Rimuovere quest'hunk dall'area di staging [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:81
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"unstaging."
+msgstr ""
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
+" contrassegnato immediatamente per la rimozione dall'area di staging."
+
+#: add-patch.c:84
+msgid ""
+"y - unstage this hunk\n"
+"n - do not unstage this hunk\n"
+"q - quit; do not unstage this hunk or any of the remaining ones\n"
+"a - unstage this hunk and all later hunks in the file\n"
+"d - do not unstage this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - rimuovi quest'hunk dall'area di staging\n"
+"n - non rimuovere quest'hunk dall'area di staging\n"
+"q - esci; non rimuovere né quest'hunk né quelli rimanenti dall'area di "
+"staging\n"
+"a - rimuovi quest'hunk e tutti quelli successivi nel file dall'area di "
+"staging\n"
+"d - non rimuovere né quest'hunk né quelli successivi nel file dall'area di "
+"staging\n"
+
+#: add-patch.c:99 git-add--interactive.perl:1443
+#, c-format, perl-format
+msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
+msgstr "Applicare la modifica modo all'indice [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:100 git-add--interactive.perl:1444
+#, c-format, perl-format
+msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
+msgstr "Applicare l'eliminazione all'indice [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:101 git-add--interactive.perl:1445
+#, c-format, perl-format
+msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
+msgstr "Applicare quest'hunk all'indice [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:103 add-patch.c:168 add-patch.c:211
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"applying."
+msgstr ""
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
+" contrassegnato immediatamente per l'applicazione."
+
+#: add-patch.c:106
+msgid ""
+"y - apply this hunk to index\n"
+"n - do not apply this hunk to index\n"
+"q - quit; do not apply this hunk or any of the remaining ones\n"
+"a - apply this hunk and all later hunks in the file\n"
+"d - do not apply this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - applica quest'hunk all'indice\n"
+"n - non applicare quest'hunk all'indice\n"
+"q - esci; non applicare né quest'hunk né quelli rimanenti\n"
+"a - applica quest'hunk e tutti quelli successivi nel file\n"
+"d - non applicare né quest'hunk né quelli successivi nel file\n"
+
+#: add-patch.c:121 git-add--interactive.perl:1448
+#: git-add--interactive.perl:1463
+#, c-format, perl-format
+msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
+msgstr "Scartare le modifiche modo dall'albero di lavoro [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:122 git-add--interactive.perl:1449
+#: git-add--interactive.perl:1464
+#, c-format, perl-format
+msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
+msgstr "Scartare l'eliminazione dall'albero di lavoro [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:123 git-add--interactive.perl:1450
+#: git-add--interactive.perl:1465
+#, c-format, perl-format
+msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
+msgstr "Scartare quest'hunk dall'albero di lavoro [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:125 add-patch.c:147 add-patch.c:190
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"discarding."
+msgstr ""
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
+" contrassegnato immediatamente per la rimozione."
+
+#: add-patch.c:128 add-patch.c:193
+msgid ""
+"y - discard this hunk from worktree\n"
+"n - do not discard this hunk from worktree\n"
+"q - quit; do not discard this hunk or any of the remaining ones\n"
+"a - discard this hunk and all later hunks in the file\n"
+"d - do not discard this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - rimuovi quest'hunk dall'albero di lavoro\n"
+"n - non rimuovere quest'hunk dall'albero di lavoro\n"
+"q - esci; non rimuovere né quest'hunk né quelli rimanenti\n"
+"a - rimuovi quest'hunk e tutti quelli successivi nel file\n"
+"d - non rimuovere né quest'hunk né quelli successivi nel file\n"
+
+#: add-patch.c:143 add-patch.c:186 git-add--interactive.perl:1453
+#, c-format, perl-format
+msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+"Scartare la modifica modo dall'indice e dall'albero di lavoro [y,n,q,a,d"
+"%s,?]? "
+
+#: add-patch.c:144 add-patch.c:187 git-add--interactive.perl:1454
+#, c-format, perl-format
+msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+"Scartare l'eliminazione dall'indice e dall'albero di lavoro [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:145 add-patch.c:188 git-add--interactive.perl:1455
+#, c-format, perl-format
+msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+"Scartare quest'hunk dall'indice e dall'albero di lavoro [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:150
+msgid ""
+"y - discard this hunk from index and worktree\n"
+"n - do not discard this hunk from index and worktree\n"
+"q - quit; do not discard this hunk or any of the remaining ones\n"
+"a - discard this hunk and all later hunks in the file\n"
+"d - do not discard this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - rimuovi quest'hunk dall'indice e dall'albero di lavoro\n"
+"n - non rimuovere quest'hunk dall'indice e dall'albero di lavoro\n"
+"q - esci; non rimuovere né quest'hunk né quelli rimanenti\n"
+"a - rimuovi quest'hunk e tutti quelli successivi nel file\n"
+"d - non rimuovere né quest'hunk né quelli successivi nel file\n"
+
+#: add-patch.c:164 add-patch.c:207 git-add--interactive.perl:1458
+#, c-format, perl-format
+msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+"Applicare la modifica modo all'indice e all'albero di lavoro [y,n,q,a,d"
+"%s,?]? "
+
+#: add-patch.c:165 add-patch.c:208 git-add--interactive.perl:1459
+#, c-format, perl-format
+msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+"Applicare l'eliminazione all'indice e all'albero di lavoro [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:166 add-patch.c:209 git-add--interactive.perl:1460
+#, c-format, perl-format
+msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+"Applicare quest'hunk all'indice e all'albero di lavoro [y,n,q,a,d%s,?]? "
+
+#: add-patch.c:171
+msgid ""
+"y - apply this hunk to index and worktree\n"
+"n - do not apply this hunk to index and worktree\n"
+"q - quit; do not apply this hunk or any of the remaining ones\n"
+"a - apply this hunk and all later hunks in the file\n"
+"d - do not apply this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - applica quest'hunk all'indice e all'albero di lavoro\n"
+"n - non applicare quest'hunk all'indice e all'albero di lavoro\n"
+"q - esci; non applicare né quest'hunk né quelli rimanenti\n"
+"a - applica quest'hunk e tutti quelli successivi nel file\n"
+"d - non applicare né quest'hunk né quelli successivi nel file\n"
+
+#: add-patch.c:214
+msgid ""
+"y - apply this hunk to worktree\n"
+"n - do not apply this hunk to worktree\n"
+"q - quit; do not apply this hunk or any of the remaining ones\n"
+"a - apply this hunk and all later hunks in the file\n"
+"d - do not apply this hunk or any of the later hunks in the file\n"
+msgstr ""
+"y - applica quest'hunk all'albero di lavoro\n"
+"n - non applicare quest'hunk all'albero di lavoro\n"
+"q - esci; non applicare né quest'hunk né quelli rimanenti\n"
+"a - applica quest'hunk e tutti quelli successivi nel file\n"
+"d - non applicare né quest'hunk né quelli successivi nel file\n"
+
+#: add-patch.c:318
 #, c-format
 msgid "could not parse hunk header '%.*s'"
 msgstr "impossibile analizzare l'header hunk '%.*s'"
 
-#: add-patch.c:130 add-patch.c:134
+#: add-patch.c:337 add-patch.c:341
 #, c-format
 msgid "could not parse colored hunk header '%.*s'"
 msgstr "impossibile analizzare l'header hunk colorato '%.*s'"
 
-#: add-patch.c:176
+#: add-patch.c:395
 msgid "could not parse diff"
 msgstr "impossibile analizzare il diff"
 
-#: add-patch.c:194
+#: add-patch.c:414
 msgid "could not parse colored diff"
 msgstr "impossibile analizzare il diff colorato"
 
-#: add-patch.c:508
+#: add-patch.c:428
+#, c-format
+msgid "failed to run '%s'"
+msgstr "esecuzione di '%s' non riuscita"
+
+#: add-patch.c:587
+msgid "mismatched output from interactive.diffFilter"
+msgstr "output di interactive.diffFilter non corrispondente"
+
+#: add-patch.c:588
+msgid ""
+"Your filter must maintain a one-to-one correspondence\n"
+"between its input and output lines."
+msgstr ""
+"Il filtro deve mantenere una corrispondenza uno a uno\n"
+"fra le righe di input e di output."
+
+#: add-patch.c:761
 #, c-format
 msgid ""
 "expected context line #%d in\n"
@@ -281,7 +557,7 @@ msgstr ""
 "attesa riga contesto %d in\n"
 "%.*s"
 
-#: add-patch.c:523
+#: add-patch.c:776
 #, c-format
 msgid ""
 "hunks do not overlap:\n"
@@ -294,13 +570,13 @@ msgstr ""
 "\tnon termina con:\n"
 "%.*s"
 
-#: add-patch.c:799 git-add--interactive.perl:1112
+#: add-patch.c:1052 git-add--interactive.perl:1112
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
 msgstr ""
 "Modalità manuale modifica hunt - vedi la fine del file per una guida "
 "veloce.\n"
 
-#: add-patch.c:803
+#: add-patch.c:1056
 #, c-format
 msgid ""
 "---\n"
@@ -313,16 +589,8 @@ msgstr ""
 "Per rimuovere '%c' righe, eliminale.\n"
 "Le righe che iniziano con %c saranno rimosse.\n"
 
-#: add-patch.c:810
-msgid ""
-"If the patch applies cleanly, the edited hunk will immediately be\n"
-"marked for staging.\n"
-msgstr ""
-"Se la patch viene applicata senza problemi, l'hunk modificato sarà\n"
-"contrassegnato immediatamente per l'aggiunta all'area di staging.\n"
-
 #. TRANSLATORS: 'it' refers to the patch mentioned in the previous messages.
-#: add-patch.c:818 git-add--interactive.perl:1126
+#: add-patch.c:1070 git-add--interactive.perl:1126
 msgid ""
 "If it does not apply cleanly, you will be given an opportunity to\n"
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
@@ -332,11 +600,11 @@ msgstr ""
 "di modificarla di nuovo. Se tutte le righe dell'hunk saranno state\n"
 "rimosse, la modifica sarà interrotta e l'hunk non sarà modificato.\n"
 
-#: add-patch.c:851
+#: add-patch.c:1103
 msgid "could not parse hunk header"
 msgstr "impossibile analizzare l'header hunk"
 
-#: add-patch.c:895 add-patch.c:1294
+#: add-patch.c:1148
 msgid "'git apply --cached' failed"
 msgstr "'git apply --cached' non riuscito"
 
@@ -352,31 +620,26 @@ msgstr "'git apply --cached' non riuscito"
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:952 git-add--interactive.perl:1239
+#: add-patch.c:1218 git-add--interactive.perl:1239
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
 "L'hunk modificato non può essere applicato senza problemi. Modificarlo di "
 "nuovo (se rispondi \"no\", sarà eliminato!) [y/n]? "
 
-#: add-patch.c:1009
-msgid ""
-"y - stage this hunk\n"
-"n - do not stage this hunk\n"
-"q - quit; do not stage this hunk or any of the remaining ones\n"
-"a - stage this and all the remaining hunks\n"
-"d - do not stage this hunk nor any of the remaining hunks\n"
-msgstr ""
-"y - aggiungi quest'hunk all'area di staging\n"
-"n - non aggiungere quest'hunk all'area di staging\n"
-"q - esci; non aggiungere né quest'hunk né quelli rimanenti all'area di "
-"staging\n"
-"a - aggiungi quest'hunk e tutti quelli successivi nel file all'area di "
-"staging\n"
-"d - non aggiungere né quest'hunk né quelli successivi nel file all'area di "
-"staging\n"
+#: add-patch.c:1261
+msgid "The selected hunks do not apply to the index!"
+msgstr "Gli hunk selezionati non si applicano senza problemi all'indice!"
 
-#: add-patch.c:1016
+#: add-patch.c:1262 git-add--interactive.perl:1343
+msgid "Apply them to the worktree anyway? "
+msgstr "Vuoi comunque applicarli all'albero di lavoro? "
+
+#: add-patch.c:1269 git-add--interactive.perl:1346
+msgid "Nothing was applied.\n"
+msgstr "Non è stato applicato nulla.\n"
+
+#: add-patch.c:1326
 msgid ""
 "j - leave this hunk undecided, see next undecided hunk\n"
 "J - leave this hunk undecided, see next hunk\n"
@@ -400,111 +663,115 @@ msgstr ""
 "e - modifica manualmente l'hunk corrente\n"
 "? - stampa una guida\n"
 
-#: add-patch.c:1137 add-patch.c:1147
+#: add-patch.c:1447 add-patch.c:1457
 msgid "No previous hunk"
 msgstr "Nessun hunk precedente"
 
-#: add-patch.c:1142 add-patch.c:1152
+#: add-patch.c:1452 add-patch.c:1462
 msgid "No next hunk"
 msgstr "Nessun hunk successivo"
 
-#: add-patch.c:1158
+#: add-patch.c:1468
 msgid "No other hunks to goto"
 msgstr "Nessun altro hunk a cui andare"
 
-#: add-patch.c:1169 git-add--interactive.perl:1577
+#: add-patch.c:1479 git-add--interactive.perl:1577
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "a quale hunk desideri andare (premi <Invio> per vederne altri)? "
 
-#: add-patch.c:1170 git-add--interactive.perl:1579
+#: add-patch.c:1480 git-add--interactive.perl:1579
 msgid "go to which hunk? "
 msgstr "a quale hunk desideri andare? "
 
-#: add-patch.c:1181
+#: add-patch.c:1491
 #, c-format
 msgid "Invalid number: '%s'"
 msgstr "Numero non valido: '%s'"
 
-#: add-patch.c:1186
+#: add-patch.c:1496
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
 msgstr[0] "Mi dispiace, è disponibile solo %d hunk."
 msgstr[1] "Mi dispiace, sono disponibili solo %d hunk."
 
-#: add-patch.c:1195
+#: add-patch.c:1505
 msgid "No other hunks to search"
 msgstr "Nessun altro hunk in cui eseguire la ricerca"
 
-#: add-patch.c:1201 git-add--interactive.perl:1623
+#: add-patch.c:1511 git-add--interactive.perl:1623
 msgid "search for regex? "
 msgstr "cercare un'espressione regolare? "
 
-#: add-patch.c:1216
+#: add-patch.c:1526
 #, c-format
 msgid "Malformed search regexp %s: %s"
 msgstr "Espressione regolare di ricerca %s malformata: %s"
 
-#: add-patch.c:1233
+#: add-patch.c:1543
 msgid "No hunk matches the given pattern"
 msgstr "Nessun hunk corrisponde al pattern fornito"
 
-#: add-patch.c:1240
+#: add-patch.c:1550
 msgid "Sorry, cannot split this hunk"
 msgstr "Mi dispiace, non posso suddividere quest'hunk"
 
-#: add-patch.c:1244
+#: add-patch.c:1554
 #, c-format
 msgid "Split into %d hunks."
 msgstr "Suddiviso in %d hunk."
 
-#: add-patch.c:1248
+#: add-patch.c:1558
 msgid "Sorry, cannot edit this hunk"
 msgstr "Mi dispiace, non posso modificare quest'hunk"
 
-#: advice.c:111
+#: add-patch.c:1609
+msgid "'git apply' failed"
+msgstr "'git apply' non riuscito"
+
+#: advice.c:115
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%ssuggerimento: %.*s%s\n"
 
-#: advice.c:164
+#: advice.c:168
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 "Il cherry picking non è possibile perché ci sono file di cui non è stato "
 "eseguito il merge."
 
-#: advice.c:166
+#: advice.c:170
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 "Il commit non è possibile perché ci sono file di cui non è stato eseguito il "
 "merge."
 
-#: advice.c:168
+#: advice.c:172
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 "Il merge non è possibile perché ci sono file di cui non è stato eseguito il "
 "merge."
 
-#: advice.c:170
+#: advice.c:174
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 "Il pull non è possibile perché ci sono file di cui non è stato eseguito il "
 "merge."
 
-#: advice.c:172
+#: advice.c:176
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 "Il revert non è possibile perché ci sono file di cui non è stato eseguito il "
 "merge."
 
-#: advice.c:174
+#: advice.c:178
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr ""
 "Impossibile eseguire il %s perché ci sono file di cui non è stato eseguito "
 "il merge."
 
-#: advice.c:182
+#: advice.c:186
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -512,23 +779,23 @@ msgstr ""
 "Correggili nell'albero di lavoro, quindi usa 'git add/rm <file>...' come "
 "appropriato per risolverli ed esegui un commit."
 
-#: advice.c:190
+#: advice.c:194
 msgid "Exiting because of an unresolved conflict."
 msgstr "Esco a causa di un conflitto non risolto."
 
-#: advice.c:195 builtin/merge.c:1332
+#: advice.c:199 builtin/merge.c:1335
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Il merge non è stato concluso (esiste MERGE_HEAD)."
 
-#: advice.c:197
+#: advice.c:201
 msgid "Please, commit your changes before merging."
 msgstr "Esegui il commit delle modifiche prima di eseguire il merge."
 
-#: advice.c:198
+#: advice.c:202
 msgid "Exiting because of unfinished merge."
 msgstr "Esco a causa di un merge non terminato."
 
-#: advice.c:204
+#: advice.c:208
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -787,7 +1054,7 @@ msgstr ""
 "impossibile applicare una patch binaria a '%s' senza la riga d'indice "
 "completa"
 
-#: apply.c:3162
+#: apply.c:3163
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
@@ -795,418 +1062,418 @@ msgstr ""
 "la patch si applica a '%s' (%s), che non corrisponde ai contenuti correnti "
 "del file."
 
-#: apply.c:3170
+#: apply.c:3171
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "la patch si applica a un file vuoto '%s' ma il file non è vuoto"
 
-#: apply.c:3188
+#: apply.c:3189
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr "impossibile leggere la postimmagine %s necessaria per '%s'"
 
-#: apply.c:3201
+#: apply.c:3202
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "la patch binaria non si applica correttamente a '%s'"
 
-#: apply.c:3207
+#: apply.c:3209
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "la patch binaria su '%s' crea risultati non corretti (atteso %s, ricevuto %s)"
 
-#: apply.c:3228
+#: apply.c:3230
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "patch non riuscita: %s:%ld"
 
-#: apply.c:3351
+#: apply.c:3353
 #, c-format
 msgid "cannot checkout %s"
 msgstr "impossibile eseguire il checkout di '%s'"
 
-#: apply.c:3403 apply.c:3414 apply.c:3460 midx.c:61 setup.c:280
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:61 setup.c:298
 #, c-format
 msgid "failed to read %s"
 msgstr "lettura di %s non riuscita"
 
-#: apply.c:3411
+#: apply.c:3413
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "lettura di '%s' oltre un collegamento simbolico"
 
-#: apply.c:3440 apply.c:3683
+#: apply.c:3442 apply.c:3685
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "il percorso %s è stato rinominato/eliminato"
 
-#: apply.c:3526 apply.c:3698
+#: apply.c:3528 apply.c:3700
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: non esiste nell'indice"
 
-#: apply.c:3535 apply.c:3706
+#: apply.c:3537 apply.c:3708
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: non corrisponde all'indice"
 
-#: apply.c:3570
+#: apply.c:3572
 msgid "repository lacks the necessary blob to fall back on 3-way merge."
 msgstr ""
 "dal repository manca il blob necessario per ripiegare sul merge a tre vie."
 
-#: apply.c:3573
+#: apply.c:3575
 #, c-format
 msgid "Falling back to three-way merge...\n"
 msgstr "Ripiego sul merge a tre vie...\n"
 
-#: apply.c:3589 apply.c:3593
+#: apply.c:3591 apply.c:3595
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "impossibile leggere i contenuti correnti di '%s'"
 
-#: apply.c:3605
+#: apply.c:3607
 #, c-format
 msgid "Failed to fall back on three-way merge...\n"
 msgstr "Ripiego sul merge a tre vie non riuscito...\n"
 
-#: apply.c:3619
+#: apply.c:3621
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Patch applicata a '%s' con conflitti.\n"
 
-#: apply.c:3624
+#: apply.c:3626
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Patch '%s' applicata correttamente.\n"
 
-#: apply.c:3650
+#: apply.c:3652
 msgid "removal patch leaves file contents"
 msgstr "la rimozione della patch lascia contenuti del file"
 
-#: apply.c:3723
+#: apply.c:3725
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: tipo errato"
 
-#: apply.c:3725
+#: apply.c:3727
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s ha il tipo %o, atteso %o"
 
-#: apply.c:3876 apply.c:3878 read-cache.c:830 read-cache.c:856
-#: read-cache.c:1320
+#: apply.c:3878 apply.c:3880 read-cache.c:830 read-cache.c:856
+#: read-cache.c:1325
 #, c-format
 msgid "invalid path '%s'"
 msgstr "percorso '%s' non valido"
 
-#: apply.c:3934
+#: apply.c:3936
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: esiste già nell'indice"
 
-#: apply.c:3937
+#: apply.c:3939
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: esiste già nella directory di lavoro"
 
-#: apply.c:3957
+#: apply.c:3959
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "il nuovo modo (%o) di %s non corrisponde al vecchio modo (%o)"
 
-#: apply.c:3962
+#: apply.c:3964
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "il nuovo modo (%o) di %s non corrisponde al vecchio modo (%o) di %s"
 
-#: apply.c:3982
+#: apply.c:3984
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "il file interessato '%s' si trova oltre un collegamento simbolico"
 
-#: apply.c:3986
+#: apply.c:3988
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: la patch non si applica correttamente"
 
-#: apply.c:4001
+#: apply.c:4003
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Controllo della patch %s in corso..."
 
-#: apply.c:4093
+#: apply.c:4095
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "le informazioni SHA1 per il sottomodulo %s sono mancanti o inutili"
 
-#: apply.c:4100
+#: apply.c:4102
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "modifica modo per %s che non è nell'HEAD corrente"
 
-#: apply.c:4103
+#: apply.c:4105
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "le informazioni SHA1 sono mancanti o inutili (%s)."
 
-#: apply.c:4112
+#: apply.c:4114
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "impossibile aggiungere %s all'indice temporaneo"
 
-#: apply.c:4122
+#: apply.c:4124
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "impossibile scrivere l'indice temporaneo in %s"
 
-#: apply.c:4260
+#: apply.c:4262
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "impossibile rimuovere %s dall'indice"
 
-#: apply.c:4294
+#: apply.c:4296
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "patch corrotta per il sottomodulo %s"
 
-#: apply.c:4300
+#: apply.c:4302
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "impossibile eseguire lo stat del file appena creato '%s'"
 
-#: apply.c:4308
+#: apply.c:4310
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "impossibile creare l'archivio di backup per il file appena creato %s"
 
-#: apply.c:4314 apply.c:4459
+#: apply.c:4316 apply.c:4461
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "impossibile aggiungere la voce della cache per %s"
 
-#: apply.c:4357
+#: apply.c:4359
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "scrittura in '%s' non riuscita"
 
-#: apply.c:4361
+#: apply.c:4363
 #, c-format
 msgid "closing file '%s'"
 msgstr "chiusura del file '%s' in corso"
 
-#: apply.c:4431
+#: apply.c:4433
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "impossibile scrivere il file '%s' con modo %o"
 
-#: apply.c:4529
+#: apply.c:4531
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Patch %s applicata correttamente."
 
-#: apply.c:4537
+#: apply.c:4539
 msgid "internal error"
 msgstr "errore interno"
 
-#: apply.c:4540
+#: apply.c:4542
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Applicazione della patch %%s con %d frammento respinto..."
 msgstr[1] "Applicazione della patch %%s con %d frammenti respinti..."
 
-#: apply.c:4551
+#: apply.c:4553
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "nome file .rej troncato a %.*s.rej"
 
-#: apply.c:4559 builtin/fetch.c:901 builtin/fetch.c:1192
+#: apply.c:4561 builtin/fetch.c:901 builtin/fetch.c:1201
 #, c-format
 msgid "cannot open %s"
 msgstr "impossibile aprire %s"
 
-#: apply.c:4573
+#: apply.c:4575
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Frammento %d applicato correttamente."
 
-#: apply.c:4577
+#: apply.c:4579
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Frammento %d respinto."
 
-#: apply.c:4696
+#: apply.c:4698
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Patch '%s' ignorata."
 
-#: apply.c:4704
+#: apply.c:4706
 msgid "unrecognized input"
 msgstr "input non riconosciuto"
 
-#: apply.c:4724
+#: apply.c:4726
 msgid "unable to read index file"
 msgstr "impossibile leggere il file index"
 
-#: apply.c:4881
+#: apply.c:4883
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "impossibile aprire la patch '%s': %s"
 
-#: apply.c:4908
+#: apply.c:4910
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "%d errore di spazi bianchi soppresso"
 msgstr[1] "%d errori di spazi bianchi soppressi"
 
-#: apply.c:4914 apply.c:4929
+#: apply.c:4916 apply.c:4931
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d riga aggiunge errori di spazi bianchi."
 msgstr[1] "%d righe aggiungono errori di spazi bianchi."
 
-#: apply.c:4922
+#: apply.c:4924
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d riga applicata dopo la correzione di errori di spazi bianchi."
 msgstr[1] "%d righe applicate dopo la correzione di errori di spazi bianchi."
 
-#: apply.c:4938 builtin/add.c:579 builtin/mv.c:301 builtin/rm.c:390
+#: apply.c:4940 builtin/add.c:612 builtin/mv.c:301 builtin/rm.c:390
 msgid "Unable to write new index file"
 msgstr "Impossibile scrivere il nuovo file index"
 
-#: apply.c:4966
+#: apply.c:4968
 msgid "don't apply changes matching the given path"
 msgstr "non applicare le modifiche corrispondenti al percorso specificato"
 
-#: apply.c:4969
+#: apply.c:4971
 msgid "apply changes matching the given path"
 msgstr "applica le modifiche corrispondenti al percorso specificato"
 
-#: apply.c:4971 builtin/am.c:2206
+#: apply.c:4973 builtin/am.c:2206
 msgid "num"
 msgstr "num"
 
-#: apply.c:4972
+#: apply.c:4974
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "rimuovi <num> barre iniziali dai percorsi diff tradizionali"
 
-#: apply.c:4975
+#: apply.c:4977
 msgid "ignore additions made by the patch"
 msgstr "ignora le aggiunte create dalla patch"
 
-#: apply.c:4977
+#: apply.c:4979
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "invece di applicare la patch, visualizza l'output di diffstat per l'input"
 
-#: apply.c:4981
+#: apply.c:4983
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "visualizza il numero di righe aggiunte ed eliminate in notazione decimale"
 
-#: apply.c:4983
+#: apply.c:4985
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "invece di applicare la patch, visualizza un riassunto per l'input"
 
-#: apply.c:4985
+#: apply.c:4987
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "invece di applicare la patch, verifica se può essere applicata"
 
-#: apply.c:4987
+#: apply.c:4989
 msgid "make sure the patch is applicable to the current index"
 msgstr "assicura che la patch sia applicabile all'indice corrente"
 
-#: apply.c:4989
+#: apply.c:4991
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "contrassegna i nuovi file con `git add --intent-to-add`"
 
-#: apply.c:4991
+#: apply.c:4993
 msgid "apply a patch without touching the working tree"
 msgstr "applica una patch senza modificare l'albero di lavoro"
 
-#: apply.c:4993
+#: apply.c:4995
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 "accetta una patch che apporta modifiche al di fuori dell'area di lavoro"
 
-#: apply.c:4996
+#: apply.c:4998
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "applica anche la patch (da usare con --stat/--summary/--check)"
 
-#: apply.c:4998
+#: apply.c:5000
 msgid "attempt three-way merge if a patch does not apply"
 msgstr "prova un merge a tre vie se la patch non si applica correttamente"
 
-#: apply.c:5000
+#: apply.c:5002
 msgid "build a temporary index based on embedded index information"
 msgstr "compila un index temporaneo basato sulle informazioni indice incluse"
 
-#: apply.c:5003 builtin/checkout-index.c:173 builtin/ls-files.c:524
+#: apply.c:5005 builtin/checkout-index.c:173 builtin/ls-files.c:524
 msgid "paths are separated with NUL character"
 msgstr "i percorsi sono separati con un carattere NUL"
 
-#: apply.c:5005
+#: apply.c:5007
 msgid "ensure at least <n> lines of context match"
 msgstr "assicura che almeno <n> righe di contesto corrispondano"
 
-#: apply.c:5006 builtin/am.c:2185 builtin/interpret-trailers.c:98
+#: apply.c:5008 builtin/am.c:2185 builtin/interpret-trailers.c:98
 #: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
-#: builtin/pack-objects.c:3310 builtin/rebase.c:1474
+#: builtin/pack-objects.c:3457 builtin/rebase.c:1508
 msgid "action"
 msgstr "azione"
 
-#: apply.c:5007
+#: apply.c:5009
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "rileva righe nuove o modificate che hanno errori di spazi bianchi"
 
-#: apply.c:5010 apply.c:5013
+#: apply.c:5012 apply.c:5015
 msgid "ignore changes in whitespace when finding context"
 msgstr "ignora modifiche agli spazi bianchi durante la ricerca dei contesti"
 
-#: apply.c:5016
+#: apply.c:5018
 msgid "apply the patch in reverse"
 msgstr "applica la patch in maniera inversa"
 
-#: apply.c:5018
+#: apply.c:5020
 msgid "don't expect at least one line of context"
 msgstr "non aspettare almeno una riga di contesto"
 
-#: apply.c:5020
+#: apply.c:5022
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "lascia i frammenti respinti nei file *.rej corrispondenti"
 
-#: apply.c:5022
+#: apply.c:5024
 msgid "allow overlapping hunks"
 msgstr "consenti la sovrapposizione dei frammenti"
 
-#: apply.c:5023 builtin/add.c:309 builtin/check-ignore.c:22
-#: builtin/commit.c:1355 builtin/count-objects.c:98 builtin/fsck.c:774
+#: apply.c:5025 builtin/add.c:323 builtin/check-ignore.c:22
+#: builtin/commit.c:1360 builtin/count-objects.c:98 builtin/fsck.c:774
 #: builtin/log.c:2166 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr "visualizza ulteriori dettagli"
 
-#: apply.c:5025
+#: apply.c:5027
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr ""
 "tollera carattere fine riga rilevato erroneamente come mancante alla fine "
 "del file"
 
-#: apply.c:5028
+#: apply.c:5030
 msgid "do not trust the line counts in the hunk headers"
 msgstr ""
 "non fare affidamento sul numero di righe nelle intestazioni dei frammenti"
 
-#: apply.c:5030 builtin/am.c:2194
+#: apply.c:5032 builtin/am.c:2194
 msgid "root"
 msgstr "radice"
 
-#: apply.c:5031
+#: apply.c:5033
 msgid "prepend <root> to all filenames"
 msgstr "anteponi <radice> a tutti i nomi file"
 
@@ -1229,7 +1496,7 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <repository> [--exec <comando>] --list"
 
-#: archive.c:372 builtin/add.c:180 builtin/add.c:555 builtin/rm.c:299
+#: archive.c:372 builtin/add.c:181 builtin/add.c:588 builtin/rm.c:299
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "lo specificatore percorso '%s' non corrisponde ad alcun file"
@@ -1270,8 +1537,8 @@ msgid "prepend prefix to each pathname in the archive"
 msgstr "anteponi <prefisso> a ogni nome percorso nell'archivio"
 
 #: archive.c:460 builtin/blame.c:861 builtin/blame.c:865 builtin/blame.c:866
-#: builtin/commit-tree.c:117 builtin/config.c:129 builtin/fast-export.c:1162
-#: builtin/fast-export.c:1164 builtin/fast-export.c:1168 builtin/grep.c:899
+#: builtin/commit-tree.c:117 builtin/config.c:130 builtin/fast-export.c:1162
+#: builtin/fast-export.c:1164 builtin/fast-export.c:1168 builtin/grep.c:887
 #: builtin/hash-object.c:105 builtin/ls-files.c:560 builtin/ls-files.c:563
 #: builtin/notes.c:412 builtin/notes.c:578 builtin/read-tree.c:123
 #: parse-options.h:190
@@ -1307,7 +1574,7 @@ msgid "list supported archive formats"
 msgstr "elenca i formati archivio supportati"
 
 #: archive.c:479 builtin/archive.c:91 builtin/clone.c:113 builtin/clone.c:116
-#: builtin/submodule--helper.c:1391 builtin/submodule--helper.c:1884
+#: builtin/submodule--helper.c:1406 builtin/submodule--helper.c:1911
 msgid "repo"
 msgstr "repository"
 
@@ -1346,17 +1613,17 @@ msgstr "Formato archivio '%s' sconosciuto"
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argomento non supportato per il formato '%s': -%d"
 
-#: archive-tar.c:125 archive-zip.c:350
+#: archive-tar.c:125 archive-zip.c:351
 #, c-format
 msgid "cannot stream blob %s"
 msgstr "impossibile eseguire lo streaming del blob %s"
 
-#: archive-tar.c:266 archive-zip.c:368
+#: archive-tar.c:266 archive-zip.c:369
 #, c-format
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "modo file non supportato: 0%o (SHA1: %s)"
 
-#: archive-tar.c:293 archive-zip.c:358
+#: archive-tar.c:293 archive-zip.c:359
 #, c-format
 msgid "cannot read %s"
 msgstr "impossibile leggere %s"
@@ -1385,12 +1652,12 @@ msgstr "il percorso non è codificato validamente in UTF-8: %s"
 msgid "path too long (%d chars, SHA1: %s): %s"
 msgstr "percorso troppo lungo (%d caratteri, SHA1: %s): %s"
 
-#: archive-zip.c:479 builtin/pack-objects.c:230 builtin/pack-objects.c:233
+#: archive-zip.c:480 builtin/pack-objects.c:231 builtin/pack-objects.c:234
 #, c-format
 msgid "deflate error (%d)"
 msgstr "errore deflate (%d)"
 
-#: archive-zip.c:614
+#: archive-zip.c:615
 #, c-format
 msgid "timestamp too large for this system: %<PRIuMAX>"
 msgstr "timestamp troppo grande per questo sistema: %<PRIuMAX>"
@@ -1423,12 +1690,12 @@ msgstr "Contenuto mal racchiuso fra virgolette nel file '%s': %s"
 msgid "We cannot bisect more!\n"
 msgstr "Impossibile eseguire un'ulteriore bisezione!\n"
 
-#: bisect.c:733
+#: bisect.c:745
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "%s non è un nome commit valido"
 
-#: bisect.c:758
+#: bisect.c:770
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1437,7 +1704,7 @@ msgstr ""
 "La base del merge %s non funziona.\n"
 "Ciò significa che il bug è stato corretto fra %s e [%s].\n"
 
-#: bisect.c:763
+#: bisect.c:775
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1446,7 +1713,7 @@ msgstr ""
 "La base del merge %s è nuova.\n"
 "La proprietà è stata modificata fra %s e [%s].\n"
 
-#: bisect.c:768
+#: bisect.c:780
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1455,7 +1722,7 @@ msgstr ""
 "La base del merge %s è %s.\n"
 "Ciò significa che il primo commit '%s' è fra %s e [%s].\n"
 
-#: bisect.c:776
+#: bisect.c:788
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1466,7 +1733,7 @@ msgstr ""
 "git bisect non può funzionare correttamente in questo caso.\n"
 "Forse hai confuso le revisioni %s con quelle %s?\n"
 
-#: bisect.c:789
+#: bisect.c:801
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1477,36 +1744,36 @@ msgstr ""
 "Non è possibile essere sicuri che il primo commit %s sia fra %s e %s.\n"
 "Continuo comunque."
 
-#: bisect.c:822
+#: bisect.c:840
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Bisezione: dev'essere testata una base del merge\n"
 
-#: bisect.c:865
+#: bisect.c:890
 #, c-format
 msgid "a %s revision is needed"
 msgstr "è richiesta una revisione %s"
 
-#: bisect.c:884 builtin/notes.c:177 builtin/tag.c:254
+#: bisect.c:920 builtin/notes.c:177 builtin/tag.c:254
 #, c-format
 msgid "could not create file '%s'"
 msgstr "impossibile creare il file '%s'"
 
-#: bisect.c:928 builtin/merge.c:148
+#: bisect.c:966 builtin/merge.c:149
 #, c-format
 msgid "could not read file '%s'"
 msgstr "impossibile leggere il file '%s'"
 
-#: bisect.c:958
+#: bisect.c:997
 msgid "reading bisect refs failed"
 msgstr "lettura riferimenti della bisezione non riuscita"
 
-#: bisect.c:977
+#: bisect.c:1019
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s era sia %s sia %s\n"
 
-#: bisect.c:985
+#: bisect.c:1028
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1515,7 +1782,7 @@ msgstr ""
 "Nessun commit testabile trovato.\n"
 "Forse hai iniziato il procedimento specificando parametri percorso errati?\n"
 
-#: bisect.c:1004
+#: bisect.c:1057
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1525,7 +1792,7 @@ msgstr[1] "(circa %d passi)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1010
+#: bisect.c:1063
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
@@ -1548,10 +1815,10 @@ msgstr ""
 "le opzioni --reverse e --first-parent se usate insieme richiedono che sia "
 "specificato l'ultimo commit"
 
-#: blame.c:2744 bundle.c:167 ref-filter.c:2203 remote.c:1941 sequencer.c:2093
-#: sequencer.c:4460 builtin/commit.c:1040 builtin/log.c:388 builtin/log.c:991
-#: builtin/log.c:1520 builtin/log.c:1925 builtin/log.c:2215 builtin/merge.c:411
-#: builtin/pack-objects.c:3128 builtin/pack-objects.c:3143
+#: blame.c:2744 bundle.c:167 ref-filter.c:2203 remote.c:1942 sequencer.c:2006
+#: sequencer.c:4358 submodule.c:847 builtin/commit.c:1045 builtin/log.c:388
+#: builtin/log.c:991 builtin/log.c:1520 builtin/log.c:1925 builtin/log.c:2215
+#: builtin/merge.c:412 builtin/pack-objects.c:3275 builtin/pack-objects.c:3290
 #: builtin/shortlog.c:192
 msgid "revision walk setup failed"
 msgstr "impostazione percorso revisioni non riuscita"
@@ -1730,8 +1997,8 @@ msgstr "'%s' non sembra essere un file bundle v2"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "intestazione non riconosciuta: %s%s (%d)"
 
-#: bundle.c:90 rerere.c:480 rerere.c:690 sequencer.c:2344 sequencer.c:3108
-#: builtin/commit.c:811
+#: bundle.c:90 rerere.c:480 rerere.c:690 sequencer.c:2258 sequencer.c:3016
+#: builtin/commit.c:815
 #, c-format
 msgid "could not open '%s'"
 msgstr "impossibile aprire '%s'"
@@ -1801,13 +2068,13 @@ msgstr "impossibile creare '%s'"
 msgid "index-pack died"
 msgstr "comando index-pack morto"
 
-#: color.c:296
+#: color.c:329
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "valore colore non valido: %.*s"
 
-#: commit.c:51 sequencer.c:2811 builtin/am.c:354 builtin/am.c:398
-#: builtin/am.c:1366 builtin/am.c:2009 builtin/replace.c:456
+#: commit.c:51 sequencer.c:2719 builtin/am.c:354 builtin/am.c:398
+#: builtin/am.c:1366 builtin/am.c:2009 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "impossibile analizzare %s"
@@ -1837,27 +2104,27 @@ msgstr ""
 "Per disabilitare questo messaggio, esegui\n"
 "\"git config advice.graftFileDeprecated false\""
 
-#: commit.c:1152
+#: commit.c:1153
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr "Il commit %s ha una firma GPG non affidabile, presumibilmente di %s."
 
-#: commit.c:1155
+#: commit.c:1157
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "Il commit %s ha una firma GPG non valida presumibilmente di %s."
 
-#: commit.c:1158
+#: commit.c:1160
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Il commit %s non ha una firma GPG."
 
-#: commit.c:1161
+#: commit.c:1163
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Il commit %s ha una firma GPG valida di %s\n"
 
-#: commit.c:1415
+#: commit.c:1417
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -1868,113 +2135,113 @@ msgstr ""
 "la variabile di configurazione i18n.commitencoding alla codifica usata\n"
 "dal tuo progetto.\n"
 
-#: commit-graph.c:130
+#: commit-graph.c:122
 msgid "commit-graph file is too small"
 msgstr "il file grafo dei commit %s è troppo piccolo"
 
-#: commit-graph.c:195
+#: commit-graph.c:189
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "la firma del grafo dei commit %X non corrisponde alla firma %X"
 
-#: commit-graph.c:202
+#: commit-graph.c:196
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "la versione del grafo dei commit %X non corrisponde alla versione %X"
 
-#: commit-graph.c:209
+#: commit-graph.c:203
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr ""
 "la versione hash del grafo dei commit %X non corrisponde alla versione %X"
 
-#: commit-graph.c:232
+#: commit-graph.c:226
 msgid "commit-graph chunk lookup table entry missing; file may be incomplete"
 msgstr ""
 "voce blocco grafo dei commit mancante nella tabella di ricerca; il file "
 "potrebbe non essere completo"
 
-#: commit-graph.c:243
+#: commit-graph.c:237
 #, c-format
 msgid "commit-graph improper chunk offset %08x%08x"
 msgstr "offset blocco grafo dei commit improprio %08x%08x"
 
-#: commit-graph.c:286
+#: commit-graph.c:280
 #, c-format
 msgid "commit-graph chunk id %08x appears multiple times"
 msgstr "l'ID del blocco grafo dei commit %08x compare più volte"
 
-#: commit-graph.c:350
+#: commit-graph.c:343
 msgid "commit-graph has no base graphs chunk"
 msgstr "il grafo dei commit non ha un blocco grafi di base"
 
-#: commit-graph.c:360
+#: commit-graph.c:353
 msgid "commit-graph chain does not match"
 msgstr "la catena del grafo dei commit non corrisponde"
 
-#: commit-graph.c:407
+#: commit-graph.c:401
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "catena grafo dei commit non valida: la riga '%s' non è un hash"
 
-#: commit-graph.c:433
+#: commit-graph.c:425
 msgid "unable to find all commit-graph files"
 msgstr "impossibile trovare tutti i file grafo dei commit"
 
-#: commit-graph.c:564 commit-graph.c:624
+#: commit-graph.c:558 commit-graph.c:618
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "posizione commit non valida. Il grafo dei commit è probabilmente corrotto"
 
-#: commit-graph.c:585
+#: commit-graph.c:579
 #, c-format
 msgid "could not find commit %s"
 msgstr "impossibile trovare il commit %s"
 
-#: commit-graph.c:858 builtin/am.c:1287
+#: commit-graph.c:852 builtin/am.c:1287
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "impossibile analizzare il commit %s"
 
-#: commit-graph.c:1017 builtin/pack-objects.c:2641
+#: commit-graph.c:1011 builtin/pack-objects.c:2782
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "impossibile recuperare il tipo dell'oggetto %s"
 
-#: commit-graph.c:1049
+#: commit-graph.c:1043
 msgid "Loading known commits in commit graph"
 msgstr "Caricamento commit noti nel grafo dei commit in corso"
 
-#: commit-graph.c:1066
+#: commit-graph.c:1060
 msgid "Expanding reachable commits in commit graph"
 msgstr "Espansione dei commit raggiungibili nel grafo dei commit in corso"
 
-#: commit-graph.c:1085
+#: commit-graph.c:1079
 msgid "Clearing commit marks in commit graph"
 msgstr "Rimozione dei contrassegni commit nel grafo dei commit in corso"
 
-#: commit-graph.c:1104
+#: commit-graph.c:1098
 msgid "Computing commit graph generation numbers"
 msgstr "Calcolo numeri generazione del grafo dei commit in corso"
 
-#: commit-graph.c:1179
+#: commit-graph.c:1173
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Ricerca dei commit per il grafo dei commit in %d pack in corso"
 msgstr[1] "Ricerca dei commit per il grafo dei commit in %d pack in corso"
 
-#: commit-graph.c:1192
+#: commit-graph.c:1186
 #, c-format
 msgid "error adding pack %s"
 msgstr "errore durante l'aggiunta del pack %s"
 
-#: commit-graph.c:1196
+#: commit-graph.c:1190
 #, c-format
 msgid "error opening index for %s"
 msgstr "errore durante l'apertura dell'indice per %s"
 
-#: commit-graph.c:1220
+#: commit-graph.c:1214
 #, c-format
 msgid "Finding commits for commit graph from %d ref"
 msgid_plural "Finding commits for commit graph from %d refs"
@@ -1983,137 +2250,137 @@ msgstr[0] ""
 msgstr[1] ""
 "Ricerca dei commit per il grafo dei commit da %d riferimenti in corso"
 
-#: commit-graph.c:1240
+#: commit-graph.c:1234
 #, c-format
 msgid "invalid commit object id: %s"
 msgstr "ID oggetto commit non valido: %s"
 
-#: commit-graph.c:1255
+#: commit-graph.c:1249
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 "Ricerca dei commit per il grafo dei commit fra gli oggetti nei pack in corso"
 
-#: commit-graph.c:1270
+#: commit-graph.c:1264
 msgid "Counting distinct commits in commit graph"
 msgstr "Conteggio commit distinti nel grafo dei commit in corso"
 
-#: commit-graph.c:1300
+#: commit-graph.c:1294
 msgid "Finding extra edges in commit graph"
 msgstr "Ricerca degli archi aggiuntivi nel grafo dei commit in corso"
 
-#: commit-graph.c:1346
+#: commit-graph.c:1340
 msgid "failed to write correct number of base graph ids"
 msgstr "impossibile scrivere il numero esatto degli ID grafo di base"
 
-#: commit-graph.c:1379 midx.c:814
+#: commit-graph.c:1373 midx.c:814
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "impossibile creare le prime directory di %s"
 
-#: commit-graph.c:1391 builtin/index-pack.c:306 builtin/repack.c:248
+#: commit-graph.c:1385 builtin/index-pack.c:306 builtin/repack.c:248
 #, c-format
 msgid "unable to create '%s'"
 msgstr "impossibile creare '%s'"
 
-#: commit-graph.c:1451
+#: commit-graph.c:1445
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Scrittura in %d passaggio del grafo dei commit in corso"
 msgstr[1] "Scrittura in %d passaggi del grafo dei commit in corso"
 
-#: commit-graph.c:1492
+#: commit-graph.c:1486
 msgid "unable to open commit-graph chain file"
 msgstr "impossibile aprire il file catena grafo dei commit"
 
-#: commit-graph.c:1504
+#: commit-graph.c:1498
 msgid "failed to rename base commit-graph file"
 msgstr "impossibile ridenominare il file di base grafo dei commit"
 
-#: commit-graph.c:1524
+#: commit-graph.c:1518
 msgid "failed to rename temporary commit-graph file"
 msgstr "impossibile ridenominare il file temporaneo grafo dei commit"
 
-#: commit-graph.c:1635
+#: commit-graph.c:1631
 msgid "Scanning merged commits"
 msgstr "Scansione dei commit sottoposti a merge in corso"
 
-#: commit-graph.c:1646
+#: commit-graph.c:1642
 #, c-format
 msgid "unexpected duplicate commit id %s"
 msgstr "ID commit duplicato inatteso: %s"
 
-#: commit-graph.c:1670
+#: commit-graph.c:1665
 msgid "Merging commit-graph"
 msgstr "Merge del grafo dei commit in corso"
 
-#: commit-graph.c:1860
+#: commit-graph.c:1844
 #, c-format
 msgid "the commit graph format cannot write %d commits"
 msgstr ""
 "il formato del grafo dei commit non può essere usato per scrivere %d commit"
 
-#: commit-graph.c:1871
+#: commit-graph.c:1855
 msgid "too many commits to write graph"
 msgstr "troppi commit da scrivere nel grafo"
 
-#: commit-graph.c:1961
+#: commit-graph.c:1944
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "il file del grafo dei commit ha un checksum non corretto e probabilmente è "
 "corrotto"
 
-#: commit-graph.c:1971
+#: commit-graph.c:1954
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "il grafo dei commit ha un ordine OID non corretto: %s seguito da %s"
 
-#: commit-graph.c:1981 commit-graph.c:1996
+#: commit-graph.c:1964 commit-graph.c:1979
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "il grafo dei commit ha un valore fanout non corretto: fanout[%d] = %u != %u"
 
-#: commit-graph.c:1988
+#: commit-graph.c:1971
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "impossibile analizzare il commit %s nel grafo dei commit"
 
-#: commit-graph.c:2006
+#: commit-graph.c:1989
 msgid "Verifying commits in commit graph"
 msgstr "Verifica dei commit nel grafo dei commit in corso"
 
-#: commit-graph.c:2020
+#: commit-graph.c:2003
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "impossibile analizzare il commit %s dal database oggetti per il grafo dei "
 "commit"
 
-#: commit-graph.c:2027
+#: commit-graph.c:2010
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "l'OID dell'albero radice per il commit %s nel grafo dei commit è %s != %s"
 
-#: commit-graph.c:2037
+#: commit-graph.c:2020
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "l'elenco genitori nel grafo dei commit per il commit %s è troppo lungo"
 
-#: commit-graph.c:2046
+#: commit-graph.c:2029
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "il genitore nel grafo dei commit per %s è %s != %s"
 
-#: commit-graph.c:2059
+#: commit-graph.c:2042
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 "l'elenco genitori nel grafo dei commit per il commit %s è finito prima del "
 "previsto"
 
-#: commit-graph.c:2064
+#: commit-graph.c:2047
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2121,7 +2388,7 @@ msgstr ""
 "il grafo dei commit ha un numero generazione zero per il commit %s ma non "
 "pari a zero per gli altri"
 
-#: commit-graph.c:2068
+#: commit-graph.c:2051
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2129,12 +2396,12 @@ msgstr ""
 "il grafo dei commit ha un numero generazione non pari a zero per il commit "
 "%s ma pari a zero per gli altri"
 
-#: commit-graph.c:2083
+#: commit-graph.c:2066
 #, c-format
 msgid "commit-graph generation for commit %s is %u != %u"
 msgstr "il numero generazione nel grafo dei commit per il commit %s è %u != %u"
 
-#: commit-graph.c:2089
+#: commit-graph.c:2072
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
@@ -2183,7 +2450,7 @@ msgstr "la chiave non contiene una sezione: %s"
 msgid "key does not contain variable name: %s"
 msgstr "la chiave non contiene un nome variabile: %s"
 
-#: config.c:406 sequencer.c:2530
+#: config.c:406 sequencer.c:2444
 #, c-format
 msgid "invalid key: %s"
 msgstr "chiave non valida: %s"
@@ -2324,7 +2591,7 @@ msgstr "valore malformato per %s: %s"
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "dev'essere nothing, matching, simple, upstream o current"
 
-#: config.c:1518 builtin/pack-objects.c:3394
+#: config.c:1518 builtin/pack-objects.c:3541
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "livello compressione pack %d non valido"
@@ -2349,109 +2616,109 @@ msgstr "impossibile risolvere il blob configurazione '%s'"
 msgid "failed to parse %s"
 msgstr "analisi di %s non riuscita"
 
-#: config.c:1745
+#: config.c:1743
 msgid "unable to parse command-line config"
 msgstr "impossibile analizzare la configurazione a riga di comando"
 
-#: config.c:2096
+#: config.c:2097
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "si è verificato un errore imprevisto durante la lettura dei file di "
 "configurazione"
 
-#: config.c:2266
+#: config.c:2267
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s non valido: '%s'"
 
-#: config.c:2311
+#: config.c:2312
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "il valore splitIndex.maxPercentChange '%d' dovrebbe essere compreso fra 0 e "
 "100"
 
-#: config.c:2357
+#: config.c:2358
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "impossibile analizzare '%s' dalla configurazione a riga di comando"
 
-#: config.c:2359
+#: config.c:2360
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "variabile configurazione '%s' errata nel file '%s' alla riga %d"
 
-#: config.c:2440
+#: config.c:2441
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "nome sezione '%s' non valido"
 
-#: config.c:2472
+#: config.c:2473
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s ha più valori"
 
-#: config.c:2501
+#: config.c:2502
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "scrittura del nuovo file di configurazione %s non riuscita"
 
-#: config.c:2753 config.c:3077
+#: config.c:2754 config.c:3078
 #, c-format
 msgid "could not lock config file %s"
 msgstr "impossibile bloccare il file di configurazione %s"
 
-#: config.c:2764
+#: config.c:2765
 #, c-format
 msgid "opening %s"
 msgstr "apertura di %s in corso"
 
-#: config.c:2799 builtin/config.c:328
+#: config.c:2800 builtin/config.c:344
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "pattern non valido: %s"
 
-#: config.c:2824
+#: config.c:2825
 #, c-format
 msgid "invalid config file %s"
 msgstr "file di configurazione %s non valido"
 
-#: config.c:2837 config.c:3090
+#: config.c:2838 config.c:3091
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat di %s non riuscita"
 
-#: config.c:2848
+#: config.c:2849
 #, c-format
 msgid "unable to mmap '%s'"
 msgstr "impossibile eseguire mmap su '%s'"
 
-#: config.c:2857 config.c:3095
+#: config.c:2858 config.c:3096
 #, c-format
 msgid "chmod on %s failed"
 msgstr "esecuzione chmod su %s non riuscita"
 
-#: config.c:2942 config.c:3192
+#: config.c:2943 config.c:3193
 #, c-format
 msgid "could not write config file %s"
 msgstr "impossibile scrivere il file di configurazione %s"
 
-#: config.c:2976
+#: config.c:2977
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "impossibile impostare '%s' a '%s'"
 
-#: config.c:2978 builtin/remote.c:781
+#: config.c:2979 builtin/remote.c:655 builtin/remote.c:849 builtin/remote.c:857
 #, c-format
 msgid "could not unset '%s'"
 msgstr "impossibile eliminare l'impostazione di '%s'"
 
-#: config.c:3068
+#: config.c:3069
 #, c-format
 msgid "invalid section name: %s"
 msgstr "nome sezione non valido: %s"
 
-#: config.c:3235
+#: config.c:3236
 #, c-format
 msgid "missing value for '%s'"
 msgstr "valore mancante per '%s'"
@@ -2618,19 +2885,19 @@ msgstr "percorso strano '%s' bloccato"
 msgid "unable to fork"
 msgstr "impossibile eseguire fork"
 
-#: connected.c:89 builtin/fsck.c:208 builtin/prune.c:43
+#: connected.c:98 builtin/fsck.c:208 builtin/prune.c:43
 msgid "Checking connectivity"
 msgstr "Controllo connessione in corso"
 
-#: connected.c:101
+#: connected.c:110
 msgid "Could not run 'git rev-list'"
 msgstr "Impossibile eseguire 'git-rev-list'"
 
-#: connected.c:121
+#: connected.c:130
 msgid "failed write to rev-list"
 msgstr "scrittura nella rev-list non riuscita"
 
-#: connected.c:128
+#: connected.c:137
 msgid "failed to close rev-list's stdin"
 msgstr "chiusura standard input della rev-list non riuscita"
 
@@ -3493,62 +3760,62 @@ msgstr ""
 "potresti voler impostare la variabile %s ad almeno %d e riprovare ad "
 "eseguire il comando."
 
-#: dir.c:554
+#: dir.c:555
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
 msgstr ""
 "lo specificatore percorso '%s' non corrisponde ad alcun file noto a git"
 
-#: dir.c:664
+#: dir.c:695 dir.c:724 dir.c:737
 #, c-format
 msgid "unrecognized pattern: '%s'"
 msgstr "pattern non riconosciuto: '%s'"
 
-#: dir.c:682 dir.c:696
+#: dir.c:754 dir.c:768
 #, c-format
 msgid "unrecognized negative pattern: '%s'"
 msgstr "pattern negativo non riconosciuto: '%s'"
 
-#: dir.c:714
+#: dir.c:786
 #, c-format
 msgid "your sparse-checkout file may have issues: pattern '%s' is repeated"
 msgstr ""
-"il file sparse-checkout potrebbe avere dei problemi: il pattern '%s' è"
-" ripetuto"
+"il file sparse-checkout potrebbe avere dei problemi: il pattern '%s' è "
+"ripetuto"
 
-#: dir.c:724
+#: dir.c:796
 msgid "disabling cone pattern matching"
 msgstr "disabilito il pattern matching di tipo cone"
 
-#: dir.c:1101
+#: dir.c:1173
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "impossibile usare %s come file di esclusione"
 
-#: dir.c:2078
+#: dir.c:2144
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "impossibile aprire la directory '%s'"
 
-#: dir.c:2415
+#: dir.c:2479
 msgid "failed to get kernel name and information"
 msgstr "impossibile ottenere il nome e le informazioni sul kernel"
 
-#: dir.c:2539
+#: dir.c:2603
 msgid "untracked cache is disabled on this system or location"
 msgstr "la cache non tracciata è disabilitata su questo sistema o percorso"
 
-#: dir.c:3343
+#: dir.c:3407
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "file index corrotto nel repository %s"
 
-#: dir.c:3388 dir.c:3393
+#: dir.c:3452 dir.c:3457
 #, c-format
 msgid "could not create directories for %s"
 msgstr "impossibile creare le directory per %s"
 
-#: dir.c:3422
+#: dir.c:3486
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "impossibile migrare la directory git da '%s' a '%s'"
@@ -3797,7 +4064,7 @@ msgstr "errore durante l'elaborazione dei riferimenti desiderati: %d"
 msgid "no matching remote head"
 msgstr "nessun head remoto corrispondente"
 
-#: fetch-pack.c:1785 builtin/clone.c:688
+#: fetch-pack.c:1785 builtin/clone.c:689
 msgid "remote did not send all necessary objects"
 msgstr "il remoto non ha inviato tutti gli oggetti necessari"
 
@@ -3811,18 +4078,18 @@ msgstr "riferimento remoto non esistente: %s"
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Il server non consente richieste per l'oggetto non pubblicizzato %s"
 
-#: gpg-interface.c:223
+#: gpg-interface.c:408
+msgid "gpg failed to sign the data"
+msgstr "gpg non è riuscito a firmare i dati"
+
+#: gpg-interface.c:434
 msgid "could not create temporary file"
 msgstr "impossibile creare il file temporaneo"
 
-#: gpg-interface.c:226
+#: gpg-interface.c:437
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "scrittura della firma separata in '%s' non riuscita"
-
-#: gpg-interface.c:390
-msgid "gpg failed to sign the data"
-msgstr "gpg non è riuscito a firmare i dati"
 
 #: graph.c:98
 #, c-format
@@ -3837,18 +4104,18 @@ msgstr ""
 "il pattern fornito (con -f <file>) contiene un byte NULL. Ciò è supportato "
 "solo con -P usando PCRE v2"
 
-#: grep.c:2124
+#: grep.c:2128
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': impossibile leggere %s"
 
-#: grep.c:2141 setup.c:165 builtin/clone.c:411 builtin/diff.c:82
+#: grep.c:2145 setup.c:166 builtin/clone.c:411 builtin/diff.c:82
 #: builtin/rm.c:135
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "stat di '%s' non riuscito"
 
-#: grep.c:2152
+#: grep.c:2156
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': lettura troppo breve"
@@ -4066,7 +4333,7 @@ msgstr "nome ident vuoto (per <%s>) non consentito"
 msgid "name consists only of disallowed characters: %s"
 msgstr "il nome è composto solo da caratteri non consentiti: %s"
 
-#: ident.c:436 builtin/commit.c:631
+#: ident.c:436 builtin/commit.c:635
 #, c-format
 msgid "invalid date format: %s"
 msgstr "formato data non valido: %s"
@@ -4154,114 +4421,114 @@ msgid "failed to read the cache"
 msgstr "lettura della cache non riuscita"
 
 #: merge.c:107 rerere.c:720 builtin/am.c:1874 builtin/am.c:1908
-#: builtin/checkout.c:539 builtin/checkout.c:798 builtin/clone.c:809
+#: builtin/checkout.c:541 builtin/checkout.c:800 builtin/clone.c:810
 #: builtin/stash.c:264
 msgid "unable to write new index file"
 msgstr "impossibile scrivere il nuovo file index"
 
-#: merge-recursive.c:367
+#: merge-recursive.c:356
 msgid "(bad commit)\n"
 msgstr "(commit non valido)\n"
 
-#: merge-recursive.c:390
+#: merge-recursive.c:379
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr "add_cacheinfo non riuscito per il percorso '%s'; interrompo il merge."
 
-#: merge-recursive.c:399
+#: merge-recursive.c:388
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
 "aggiornamento add_cacheinfo non riuscito per il percorso '%s'; interrompo il "
 "merge."
 
-#: merge-recursive.c:885
+#: merge-recursive.c:874
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr "creazione del percorso '%s' non riuscita%s"
 
-#: merge-recursive.c:896
+#: merge-recursive.c:885
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr "Rimuovo %s per fare spazio alla sottodirectory\n"
 
-#: merge-recursive.c:910 merge-recursive.c:929
+#: merge-recursive.c:899 merge-recursive.c:918
 msgid ": perhaps a D/F conflict?"
 msgstr ": forse si tratta di un conflitto D/F?"
 
-#: merge-recursive.c:919
+#: merge-recursive.c:908
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr "mi rifiuto di perdere un file non tracciato in '%s'"
 
-#: merge-recursive.c:960 builtin/cat-file.c:41
+#: merge-recursive.c:949 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "impossibile leggere l'oggetto %s '%s'"
 
-#: merge-recursive.c:965
+#: merge-recursive.c:954
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "atteso blob per %s '%s'"
 
-#: merge-recursive.c:990
+#: merge-recursive.c:979
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr "apertura di '%s' non riuscita: %s"
 
-#: merge-recursive.c:1001
+#: merge-recursive.c:990
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr "creazione del collegamento simbolico '%s' non riuscita: %s"
 
-#: merge-recursive.c:1006
+#: merge-recursive.c:995
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "non so che fare con %06o %s '%s'"
 
-#: merge-recursive.c:1199
+#: merge-recursive.c:1191
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Merge del sottomodulo %s non riuscito (checkout non eseguito)"
 
-#: merge-recursive.c:1206
+#: merge-recursive.c:1198
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Merge del sottomodulo %s non riuscito (commit non presenti)"
 
-#: merge-recursive.c:1213
+#: merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 "Merge del sottomodulo %s non riuscito (i commit non seguono la base del "
 "merge)"
 
-#: merge-recursive.c:1221 merge-recursive.c:1233
+#: merge-recursive.c:1213 merge-recursive.c:1225
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr "Eseguo il fast forward del sottomodulo %s al seguente commit:"
 
-#: merge-recursive.c:1224 merge-recursive.c:1236
+#: merge-recursive.c:1216 merge-recursive.c:1228
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr "Eseguo il fast forward del sottomodulo %s"
 
-#: merge-recursive.c:1259
+#: merge-recursive.c:1251
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 "Merge del sottomodulo %s non riuscito (merge dopo i commit non trovato)"
 
-#: merge-recursive.c:1263
+#: merge-recursive.c:1255
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr "Merge del sottomodulo %s non riuscito (non fast forward)"
 
-#: merge-recursive.c:1264
+#: merge-recursive.c:1256
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr "Trovata possibile risoluzione merge per il sottomodulo:\n"
 
-#: merge-recursive.c:1267
+#: merge-recursive.c:1259
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4278,32 +4545,32 @@ msgstr ""
 "\n"
 "per accettare questo suggerimento.\n"
 
-#: merge-recursive.c:1276
+#: merge-recursive.c:1268
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr "Merge del sottomodulo %s non riuscito (più merge trovati)"
 
-#: merge-recursive.c:1349
+#: merge-recursive.c:1341
 msgid "Failed to execute internal merge"
 msgstr "Esecuzione del merge interno non riuscita"
 
-#: merge-recursive.c:1354
+#: merge-recursive.c:1346
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Impossibile aggiungere %s al database"
 
-#: merge-recursive.c:1386
+#: merge-recursive.c:1378
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Merge automatico di %s in corso"
 
-#: merge-recursive.c:1410
+#: merge-recursive.c:1402
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
 "Errore: mi rifiuto di perdere il file non tracciato %s; scrivo invece in %s."
 
-#: merge-recursive.c:1482
+#: merge-recursive.c:1474
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -4312,7 +4579,7 @@ msgstr ""
 "CONFLITTO (%s/eliminazione): %s eliminato in %s e %s in %s. Versione %s di "
 "%s lasciata nell'albero."
 
-#: merge-recursive.c:1487
+#: merge-recursive.c:1479
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -4321,7 +4588,7 @@ msgstr ""
 "CONFLITTO (%s/eliminazione): %s eliminato in %s e %s come %s in %s. Versione "
 "%s di %s lasciata nell'albero."
 
-#: merge-recursive.c:1494
+#: merge-recursive.c:1486
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -4330,7 +4597,7 @@ msgstr ""
 "CONFLITTO (%s/eliminazione): %s eliminato in %s e %s in %s. Versione %s di "
 "%s lasciata nell'albero in %s."
 
-#: merge-recursive.c:1499
+#: merge-recursive.c:1491
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -4339,38 +4606,38 @@ msgstr ""
 "CONFLITTO (%s/eliminazione): %s eliminato in %s e %s come %s in %s. Versione "
 "%s di %s lasciata nell'albero in %s."
 
-#: merge-recursive.c:1534
+#: merge-recursive.c:1526
 msgid "rename"
 msgstr "ridenominazione"
 
-#: merge-recursive.c:1534
+#: merge-recursive.c:1526
 msgid "renamed"
 msgstr "rinominato"
 
-#: merge-recursive.c:1614 merge-recursive.c:2530 merge-recursive.c:3175
+#: merge-recursive.c:1606 merge-recursive.c:2530 merge-recursive.c:3175
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Mi rifiuto di perdere un file sporco in %s"
 
-#: merge-recursive.c:1624
+#: merge-recursive.c:1616
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 "Mi rifiuto di perdere un file non tracciato in %s, benché sia d'ostacolo."
 
-#: merge-recursive.c:1682
+#: merge-recursive.c:1674
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 "CONFLITTO (ridenominazione/aggiunta): elemento ridenominato %s->%s in %s. %s "
 "aggiunto in %s"
 
-#: merge-recursive.c:1713
+#: merge-recursive.c:1705
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "%s è una directory in %s; la aggiungo come %s"
 
-#: merge-recursive.c:1718
+#: merge-recursive.c:1710
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr "Mi rifiuto di perdere un file non tracciato in %s; lo aggiungo come %s"
@@ -4475,7 +4742,7 @@ msgstr "aggiunta/aggiunta"
 msgid "Skipped %s (merged same as existing)"
 msgstr "Omesso %s (elemento sottoposto a merge uguale a quello esistente)"
 
-#: merge-recursive.c:3147 git-submodule.sh:993
+#: merge-recursive.c:3147 git-submodule.sh:1003
 msgid "submodule"
 msgstr "sottomodulo"
 
@@ -4594,7 +4861,7 @@ msgstr ""
 msgid "Could not parse object '%s'"
 msgstr "Impossibile analizzare l'oggetto '%s'"
 
-#: merge-recursive.c:3832 builtin/merge.c:694 builtin/merge.c:874
+#: merge-recursive.c:3832 builtin/merge.c:697 builtin/merge.c:877
 msgid "Unable to write index."
 msgstr "Impossibile scrivere l'indice."
 
@@ -4830,26 +5097,31 @@ msgstr "l'oggetto %s ha l'ID tipo sconosciuto %d"
 msgid "unable to parse object: %s"
 msgstr "impossibile analizzare l'oggetto: %s"
 
-#: object.c:266 object.c:277
+#: object.c:266 object.c:278
 #, c-format
 msgid "hash mismatch %s"
 msgstr "hash non corrispondente: %s"
 
-#: packfile.c:641
+#: packfile.c:629
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "offset collocato prima della fine del packfile (.idx corrotto?)"
 
-#: packfile.c:1888
+#: packfile.c:1899
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 "offset collocato prima dell'inizio dell'indice pack per %s (indice corrotto?)"
 
-#: packfile.c:1892
+#: packfile.c:1903
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 "offset collocato dopo la fine dell'indice pack per %s (indice troncato?)"
+
+#: pack-bitmap.c:800 pack-bitmap.c:806 builtin/pack-objects.c:2134
+#, c-format
+msgid "unable to get size of %s"
+msgstr "impossibile recuperare le dimensioni di %s"
 
 #: parse-options.c:38
 #, c-format
@@ -4882,36 +5154,36 @@ msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr ""
 "%s richiede un valore intero non negativo con un suffisso k/m/g facoltativo"
 
-#: parse-options.c:389
+#: parse-options.c:388
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "opzione ambigua: %s (potrebbe essere --%s%s o --%s%s)"
 
-#: parse-options.c:423 parse-options.c:431
+#: parse-options.c:422 parse-options.c:430
 #, c-format
-msgid "did you mean `--%s` (with two dashes ?)"
+msgid "did you mean `--%s` (with two dashes)?"
 msgstr "forse intendevi `--%s` (con due trattini)?"
 
-#: parse-options.c:860
+#: parse-options.c:859
 #, c-format
 msgid "unknown option `%s'"
 msgstr "opzione sconosciuta `%s'"
 
-#: parse-options.c:862
+#: parse-options.c:861
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "opzione `%c` sconosciuta"
 
-#: parse-options.c:864
+#: parse-options.c:863
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "opzione non ASCII sconosciuta presente nella stringa: `%s'"
 
-#: parse-options.c:888
+#: parse-options.c:887
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:907
+#: parse-options.c:906
 #, c-format
 msgid "usage: %s"
 msgstr "uso: %s"
@@ -4919,21 +5191,21 @@ msgstr "uso: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:913
+#: parse-options.c:912
 #, c-format
 msgid "   or: %s"
 msgstr "  oppure: %s"
 
-#: parse-options.c:916
+#: parse-options.c:915
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:955
+#: parse-options.c:954
 msgid "-NUM"
 msgstr "-NUM"
 
-#: parse-options.c:969
+#: parse-options.c:968
 #, c-format
 msgid "alias of --%s"
 msgstr "alias di --%s"
@@ -5022,26 +5294,26 @@ msgstr "%s: 'literal' e 'glob' non sono compatibili"
 
 #: pathspec.c:442
 #, c-format
-msgid "%s: '%s' is outside repository"
-msgstr "%s: '%s' è al di fuori del repository"
+msgid "%s: '%s' is outside repository at '%s'"
+msgstr "%s: '%s' è al di fuori del repository in '%s'"
 
-#: pathspec.c:516
+#: pathspec.c:517
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr "'%s' (opzione mnemonica: '%c')"
 
-#: pathspec.c:526
+#: pathspec.c:527
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr "%s: magic specificatore percorso non supportato da questo comando: %s"
 
-#: pathspec.c:593
+#: pathspec.c:594
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr ""
 "lo specificatore percorso '%s' si trova oltre un collegamento simbolico"
 
-#: pathspec.c:638
+#: pathspec.c:639
 #, c-format
 msgid "line is badly quoted: %s"
 msgstr "la riga non è ben racchiusa tra virgolette: %s"
@@ -5129,7 +5401,7 @@ msgstr "impossibile avviare `log`"
 msgid "could not read `log` output"
 msgstr "impossibile leggere l'output di `log`"
 
-#: range-diff.c:96 sequencer.c:5163
+#: range-diff.c:96 sequencer.c:5020
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "impossibile analizzare il commit '%s'"
@@ -5184,16 +5456,16 @@ msgstr "impossibile aggiungere '%s' all'indice"
 msgid "unable to stat '%s'"
 msgstr "impossibile eseguire stat su '%s'"
 
-#: read-cache.c:1325
+#: read-cache.c:1330
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' compare sia come file sia come directory"
 
-#: read-cache.c:1531
+#: read-cache.c:1536
 msgid "Refresh index"
 msgstr "Aggiornamento indice"
 
-#: read-cache.c:1646
+#: read-cache.c:1651
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -5202,7 +5474,7 @@ msgstr ""
 "index.version impostato, ma il valore non è valido.\n"
 "Uso la versione %i"
 
-#: read-cache.c:1656
+#: read-cache.c:1661
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -5211,143 +5483,154 @@ msgstr ""
 "GIT_INDEX_VERSION impostato, ma il valore non è valido.\n"
 "Uso la versione %i"
 
-#: read-cache.c:1712
+#: read-cache.c:1717
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "firma non valida: 0x%08x"
 
-#: read-cache.c:1715
+#: read-cache.c:1720
 #, c-format
 msgid "bad index version %d"
 msgstr "versione indice non valida: %d"
 
-#: read-cache.c:1724
+#: read-cache.c:1729
 msgid "bad index file sha1 signature"
 msgstr "firma SHA1 file indice non valida"
 
-#: read-cache.c:1754
+#: read-cache.c:1759
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "l'indice usa l'estensione %.4s che non comprendiamo"
 
-#: read-cache.c:1756
+#: read-cache.c:1761
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "estensione %.4s ignorata"
 
-#: read-cache.c:1793
+#: read-cache.c:1798
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "formato voce indice sconosciuto: 0x%08x"
 
-#: read-cache.c:1809
+#: read-cache.c:1814
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "campo nome malformato nell'indice, vicino al percorso '%s'"
 
-#: read-cache.c:1866
+#: read-cache.c:1871
 msgid "unordered stage entries in index"
 msgstr "voci stage non ordinate nell'indice"
 
-#: read-cache.c:1869
+#: read-cache.c:1874
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "voci stage multiple per il file sottoposto a merge '%s'"
 
-#: read-cache.c:1872
+#: read-cache.c:1877
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "voci stage non ordinate per '%s'"
 
-#: read-cache.c:1978 read-cache.c:2266 rerere.c:565 rerere.c:599 rerere.c:1111
-#: builtin/add.c:499 builtin/check-ignore.c:178 builtin/checkout.c:470
-#: builtin/checkout.c:654 builtin/clean.c:967 builtin/commit.c:367
-#: builtin/diff-tree.c:120 builtin/grep.c:499 builtin/mv.c:145
-#: builtin/reset.c:246 builtin/rm.c:271 builtin/submodule--helper.c:332
+#: read-cache.c:1983 read-cache.c:2271 rerere.c:565 rerere.c:599 rerere.c:1111
+#: submodule.c:1619 builtin/add.c:532 builtin/check-ignore.c:181
+#: builtin/checkout.c:470 builtin/checkout.c:656 builtin/clean.c:967
+#: builtin/commit.c:367 builtin/diff-tree.c:120 builtin/grep.c:485
+#: builtin/mv.c:145 builtin/reset.c:246 builtin/rm.c:271
+#: builtin/submodule--helper.c:332
 msgid "index file corrupt"
 msgstr "file indice corrotto"
 
-#: read-cache.c:2119
+#: read-cache.c:2124
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "impossibile creare il thread load_cache_entries: %s"
 
-#: read-cache.c:2132
+#: read-cache.c:2137
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "impossibile bloccare il thread load_cache_entries: %s"
 
-#: read-cache.c:2165
+#: read-cache.c:2170
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: apertura del file indice non riuscita"
 
-#: read-cache.c:2169
+#: read-cache.c:2174
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: impossibile eseguire stat sull'indice aperto"
 
-#: read-cache.c:2173
+#: read-cache.c:2178
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: file indice più piccolo della dimensione attesa"
 
-#: read-cache.c:2177
+#: read-cache.c:2182
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s: impossibile mappare il file indice"
 
-#: read-cache.c:2219
+#: read-cache.c:2224
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "impossibile creare il thread load_index_extensions: %s"
 
-#: read-cache.c:2246
+#: read-cache.c:2251
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "impossibile bloccare il thread load_index_extensions: %s"
 
-#: read-cache.c:2278
+#: read-cache.c:2283
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "impossibile aggiornare l'indice condiviso '%s'"
 
-#: read-cache.c:2325
+#: read-cache.c:2330
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "indice corrotto, atteso %s in %s, presente %s"
 
-#: read-cache.c:3021 strbuf.c:1145 wrapper.c:622 builtin/merge.c:1119
+#: read-cache.c:3026 strbuf.c:1160 wrapper.c:622 builtin/merge.c:1122
 #, c-format
 msgid "could not close '%s'"
 msgstr "impossibile chiudere '%s'"
 
-#: read-cache.c:3124 sequencer.c:2429 sequencer.c:4069
+#: read-cache.c:3129 sequencer.c:2343 sequencer.c:3959
 #, c-format
 msgid "could not stat '%s'"
 msgstr "impossibile eseguire lo stat di '%s'"
 
-#: read-cache.c:3137
+#: read-cache.c:3142
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "impossibile aprire la directory git: %s"
 
-#: read-cache.c:3149
+#: read-cache.c:3154
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "impossibile eseguire unlink: %s"
 
-#: read-cache.c:3174
+#: read-cache.c:3179
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "impossibile correggere i permessi di '%s'"
 
-#: read-cache.c:3323
+#: read-cache.c:3328
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: impossibile ripiegare sullo stadio 0"
 
-#: rebase-interactive.c:26
+#: rebase-interactive.c:11
+msgid ""
+"You can fix this with 'git rebase --edit-todo' and then run 'git rebase --"
+"continue'.\n"
+"Or you can abort the rebase with 'git rebase --abort'.\n"
+msgstr ""
+"Puoi correggere questa situazione con 'git rebase --edit-todo' e quindi "
+"eseguire 'git rebase --continue'.\n"
+"Oppure puoi interrompere il rebase con 'git rebase --abort'.\n"
+
+#: rebase-interactive.c:33
 #, c-format
 msgid ""
 "unrecognized setting %s for option rebase.missingCommitsCheck. Ignoring."
@@ -5355,7 +5638,7 @@ msgstr ""
 "impostazione %s non riconosciuta per l'opzione rebase.missingCommitsCheck. "
 "La ignoro."
 
-#: rebase-interactive.c:35
+#: rebase-interactive.c:42
 msgid ""
 "\n"
 "Commands:\n"
@@ -5400,14 +5683,14 @@ msgstr ""
 "Queste righe possono essere riordinate; saranno eseguite dalla prima "
 "all'ultima.\n"
 
-#: rebase-interactive.c:56
+#: rebase-interactive.c:63
 #, c-format
 msgid "Rebase %s onto %s (%d command)"
 msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Rebase di %s su %s (%d comando)"
 msgstr[1] "Rebase di %s su %s (%d comandi)"
 
-#: rebase-interactive.c:65 git-rebase--preserve-merges.sh:228
+#: rebase-interactive.c:72 git-rebase--preserve-merges.sh:228
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -5416,7 +5699,7 @@ msgstr ""
 "Non eliminare alcuna riga. Usa esplicitamente 'drop' per rimuovere un "
 "commit.\n"
 
-#: rebase-interactive.c:68 git-rebase--preserve-merges.sh:232
+#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:232
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -5424,7 +5707,7 @@ msgstr ""
 "\n"
 "Rimuovendo una riga da qui IL COMMIT CORRISPONDENTE ANDRÀ PERDUTO.\n"
 
-#: rebase-interactive.c:74 git-rebase--preserve-merges.sh:871
+#: rebase-interactive.c:81 git-rebase--preserve-merges.sh:871
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -5438,7 +5721,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:79 git-rebase--preserve-merges.sh:948
+#: rebase-interactive.c:86 git-rebase--preserve-merges.sh:948
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -5448,22 +5731,19 @@ msgstr ""
 "Ciò nonostante, se rimuovi tutto, il rebase sarà annullato.\n"
 "\n"
 
-#: rebase-interactive.c:85 git-rebase--preserve-merges.sh:955
-msgid "Note that empty commits are commented out"
-msgstr "Nota che i commit vuoti sono commentati"
-
-#: rebase-interactive.c:105 rerere.c:485 rerere.c:692 sequencer.c:3536
-#: sequencer.c:3562 sequencer.c:5263 builtin/fsck.c:346 builtin/rebase.c:254
+#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3444
+#: sequencer.c:3470 sequencer.c:5125 builtin/fsck.c:346 builtin/rebase.c:252
 #, c-format
 msgid "could not write '%s'"
 msgstr "impossibile scrivere '%s'"
 
-#: rebase-interactive.c:108
+#: rebase-interactive.c:116 builtin/rebase.c:184 builtin/rebase.c:210
+#: builtin/rebase.c:234
 #, c-format
-msgid "could not copy '%s' to '%s'."
-msgstr "impossibile copiare '%s' in '%s'."
+msgid "could not write '%s'."
+msgstr "impossibile scrivere '%s'."
 
-#: rebase-interactive.c:173
+#: rebase-interactive.c:193
 #, c-format
 msgid ""
 "Warning: some commits may have been dropped accidentally.\n"
@@ -5473,7 +5753,7 @@ msgstr ""
 "accidentalmente.\n"
 "Commit scartati (dal più al meno recente):\n"
 
-#: rebase-interactive.c:180
+#: rebase-interactive.c:200
 #, c-format
 msgid ""
 "To avoid this message, use \"drop\" to explicitly remove a commit.\n"
@@ -5490,6 +5770,13 @@ msgstr ""
 "degli avvisi.\n"
 "I comportamenti possibili sono ignore, warn, error.\n"
 "\n"
+
+#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2262
+#: builtin/rebase.c:170 builtin/rebase.c:195 builtin/rebase.c:221
+#: builtin/rebase.c:246
+#, c-format
+msgid "could not read '%s'."
+msgstr "impossibile leggere '%s'."
 
 #: refs.c:262
 #, c-format
@@ -5526,15 +5813,15 @@ msgstr "il riferimento '%s' esiste già"
 msgid "unexpected object ID when writing '%s'"
 msgstr "ID oggetto inatteso durante la scrittura di '%s'"
 
-#: refs.c:833 sequencer.c:405 sequencer.c:2793 sequencer.c:2997
-#: sequencer.c:3011 sequencer.c:3269 sequencer.c:5179 strbuf.c:1142
+#: refs.c:833 sequencer.c:407 sequencer.c:2701 sequencer.c:2905
+#: sequencer.c:2919 sequencer.c:3177 sequencer.c:5036 strbuf.c:1157
 #: wrapper.c:620
 #, c-format
 msgid "could not write to '%s'"
 msgstr "impossibile scrivere su '%s'"
 
-#: refs.c:860 strbuf.c:1140 wrapper.c:188 wrapper.c:358 builtin/am.c:714
-#: builtin/rebase.c:1031
+#: refs.c:860 strbuf.c:1155 wrapper.c:188 wrapper.c:358 builtin/am.c:714
+#: builtin/rebase.c:1029
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "impossibile aprire '%s' in scrittura"
@@ -5588,18 +5875,18 @@ msgstr "'%s' esiste già; impossibile creare '%s'"
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "impossibile gestire '%s' e '%s' contemporaneamente"
 
-#: refs/files-backend.c:1234
+#: refs/files-backend.c:1233
 #, c-format
 msgid "could not remove reference %s"
 msgstr "impossibile rimuovere il riferimento %s"
 
-#: refs/files-backend.c:1248 refs/packed-backend.c:1541
+#: refs/files-backend.c:1247 refs/packed-backend.c:1541
 #: refs/packed-backend.c:1551
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "impossibile eliminare il riferimento %s: %s"
 
-#: refs/files-backend.c:1251 refs/packed-backend.c:1554
+#: refs/files-backend.c:1250 refs/packed-backend.c:1554
 #, c-format
 msgid "could not delete references: %s"
 msgstr "impossibile eliminare i riferimenti: %s"
@@ -5866,45 +6153,45 @@ msgid "config remote shorthand cannot begin with '/': %s"
 msgstr ""
 "la forma breve della configurazione del remoto non può iniziare con '/': %s"
 
-#: remote.c:413
+#: remote.c:414
 msgid "more than one receivepack given, using the first"
 msgstr "è stata specificata più di una direttiva receivepack, uso la prima"
 
-#: remote.c:421
+#: remote.c:422
 msgid "more than one uploadpack given, using the first"
 msgstr "è stata specificata più di una direttiva uploadpack, uso la prima"
 
-#: remote.c:611
+#: remote.c:612
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Impossibile recuperare sia %s sia %s in %s"
 
-#: remote.c:615
+#: remote.c:616
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s solitamente traccia %s, non %s"
 
-#: remote.c:619
+#: remote.c:620
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s traccia sia %s sia %s"
 
-#: remote.c:687
+#: remote.c:688
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "la chiave '%s' del pattern non aveva un '*'"
 
-#: remote.c:697
+#: remote.c:698
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "il valore '%s' del pattern non ha un '*'"
 
-#: remote.c:1003
+#: remote.c:1004
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "nessuna corrispondenza per lo specificatore riferimento sorgente %s"
 
-#: remote.c:1008
+#: remote.c:1009
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr ""
@@ -5915,7 +6202,7 @@ msgstr ""
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1023
+#: remote.c:1024
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -5941,7 +6228,7 @@ msgstr ""
 "Nessuna delle due opzioni ha funzionato, quindi ci siamo arresi.\n"
 "Devi specificare un riferimento completamente qualificato."
 
-#: remote.c:1043
+#: remote.c:1044
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -5952,7 +6239,7 @@ msgstr ""
 "è un oggetto tag. Forse intendevi creare un nuovo\n"
 "branch eseguendo il push a '%s:refs/heads/%s'?"
 
-#: remote.c:1048
+#: remote.c:1049
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -5963,7 +6250,7 @@ msgstr ""
 "è un oggetto tag. Forse intendevi creare un nuovo\n"
 "branch eseguendo il push a '%s:refs/tags/%s'?"
 
-#: remote.c:1053
+#: remote.c:1054
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -5975,7 +6262,7 @@ msgstr ""
 "tag a un nuovo albero eseguendo il push a\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1058
+#: remote.c:1059
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -5987,121 +6274,121 @@ msgstr ""
 "tag a un nuovo blob eseguendo il push a\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1094
+#: remote.c:1095
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "%s non può essere risolto in un branch"
 
-#: remote.c:1105
+#: remote.c:1106
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "impossibile eliminare '%s': il riferimento remoto non esiste"
 
-#: remote.c:1117
+#: remote.c:1118
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr ""
 "sono state trovate più corrispondenze per lo specificatore riferimento "
 "destinazione %s"
 
-#: remote.c:1124
+#: remote.c:1125
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr ""
 "lo specificatore riferimento destinazione %s riceve dati da più di una "
 "sorgente"
 
-#: remote.c:1627 remote.c:1728
+#: remote.c:1628 remote.c:1729
 msgid "HEAD does not point to a branch"
 msgstr "HEAD non punta ad un branch"
 
-#: remote.c:1636
+#: remote.c:1637
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "branch '%s' non esistente"
 
-#: remote.c:1639
+#: remote.c:1640
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "nessun upstream configurato per il branch '%s'"
 
-#: remote.c:1645
+#: remote.c:1646
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr ""
 "branch upstream '%s' non memorizzato come branch che ne traccia uno remoto"
 
-#: remote.c:1660
+#: remote.c:1661
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr ""
 "la destinazione del push '%s' sul remoto '%s' non ha un branch locale che la "
 "traccia"
 
-#: remote.c:1672
+#: remote.c:1673
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "il branch '%s' non ha un remoto per il push"
 
-#: remote.c:1682
+#: remote.c:1683
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "gli specificatori riferimento per '%s' non includono '%s'"
 
-#: remote.c:1695
+#: remote.c:1696
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "il push non ha una destinazione (push.default è 'nothing')"
 
-#: remote.c:1717
+#: remote.c:1718
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "impossibile risolvere il push 'simple' a una singola destinazione"
 
-#: remote.c:1843
+#: remote.c:1844
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "impossibile trovare il riferimento remoto %s"
 
-#: remote.c:1856
+#: remote.c:1857
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ignoro localmente il riferimento strano '%s'"
 
-#: remote.c:2019
+#: remote.c:2020
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Il tuo branch è basato su '%s', ma l'upstream è scomparso.\n"
 
-#: remote.c:2023
+#: remote.c:2024
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (usa \"git branch --unset-upstream\" per correggere la situazione)\n"
 
-#: remote.c:2026
+#: remote.c:2027
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Il tuo branch è aggiornato rispetto a '%s'.\n"
 
-#: remote.c:2030
+#: remote.c:2031
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Il tuo branch e '%s' fanno riferimento a commit differenti.\n"
 
-#: remote.c:2033
+#: remote.c:2034
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (usa \"%s\" per visualizzare i dettagli)\n"
 
-#: remote.c:2037
+#: remote.c:2038
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Il tuo branch è avanti rispetto a '%s' di %d commit.\n"
 msgstr[1] "Il tuo branch è avanti rispetto a '%s' di %d commit.\n"
 
-#: remote.c:2043
+#: remote.c:2044
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (usa \"git push\" per pubblicare i tuoi commit locali)\n"
 
-#: remote.c:2046
+#: remote.c:2047
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -6113,11 +6400,11 @@ msgstr[1] ""
 "Il tuo branch, rispetto a '%s', è indietro di %d commit e ne posso eseguire "
 "il fast forward.\n"
 
-#: remote.c:2054
+#: remote.c:2055
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (usa \"git pull\" per aggiornare il tuo branch locale)\n"
 
-#: remote.c:2057
+#: remote.c:2058
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -6132,11 +6419,11 @@ msgstr[1] ""
 "Il tuo branch e '%s' sono diventati divergenti\n"
 "e hanno rispettivamente %d e %d commit differenti.\n"
 
-#: remote.c:2067
+#: remote.c:2068
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr "  (usa \"git pull\" per eseguire il merge del branch remoto nel tuo)\n"
 
-#: remote.c:2250
+#: remote.c:2251
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "impossibile analizzare il nome oggetto atteso '%s'"
@@ -6151,7 +6438,7 @@ msgstr "nome riferimento sostitutivo non valido: %s"
 msgid "duplicate replace ref: %s"
 msgstr "riferimento sostitutivo duplicato: %s"
 
-#: replace-object.c:73
+#: replace-object.c:82
 #, c-format
 msgid "replace depth too high for object %s"
 msgstr "profondità sostituzione troppo elevata per l'oggetto %s"
@@ -6214,8 +6501,8 @@ msgstr "impossibile eseguire l'unlink dell'oggetto smarrito '%s'"
 msgid "Recorded preimage for '%s'"
 msgstr "Salvata preimmagine di '%s'"
 
-#: rerere.c:881 submodule.c:2067 builtin/log.c:1871
-#: builtin/submodule--helper.c:1436 builtin/submodule--helper.c:1448
+#: rerere.c:881 submodule.c:2078 builtin/log.c:1871
+#: builtin/submodule--helper.c:1454 builtin/submodule--helper.c:1466
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "impossibile creare la directory '%s'"
@@ -6266,16 +6553,16 @@ msgstr "--first-parent non è compatibile con --bisect"
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L non supporta ancora formati diff oltre a -p e -s"
 
-#: run-command.c:762
+#: run-command.c:763
 msgid "open /dev/null failed"
 msgstr "apertura di /dev/null non riuscita"
 
-#: run-command.c:1268
+#: run-command.c:1269
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "impossibile creare il thread async: %s"
 
-#: run-command.c:1332
+#: run-command.c:1333
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
@@ -6324,39 +6611,39 @@ msgstr "il ricevente non supporta i push --atomic"
 msgid "the receiving end does not support push options"
 msgstr "il ricevente non supporta le opzioni push"
 
-#: sequencer.c:189
+#: sequencer.c:191
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "modalità pulizia messaggio commit non valida: '%s'"
 
-#: sequencer.c:294
+#: sequencer.c:296
 #, c-format
 msgid "could not delete '%s'"
 msgstr "impossibile eliminare '%s'"
 
-#: sequencer.c:313 builtin/rebase.c:781 builtin/rebase.c:1706 builtin/rm.c:369
+#: sequencer.c:315 builtin/rebase.c:785 builtin/rebase.c:1750 builtin/rm.c:369
 #, c-format
 msgid "could not remove '%s'"
 msgstr "impossibile rimuovere '%s'"
 
-#: sequencer.c:323
+#: sequencer.c:325
 msgid "revert"
 msgstr "revert"
 
-#: sequencer.c:325
+#: sequencer.c:327
 msgid "cherry-pick"
 msgstr "cherry-pick"
 
-#: sequencer.c:327
-msgid "rebase -i"
-msgstr "rebase -i"
-
 #: sequencer.c:329
+msgid "rebase"
+msgstr "rebase"
+
+#: sequencer.c:331
 #, c-format
 msgid "unknown action: %d"
 msgstr "azione sconosciuta: %d"
 
-#: sequencer.c:387
+#: sequencer.c:389
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -6364,7 +6651,7 @@ msgstr ""
 "dopo aver risolto i conflitti, contrassegna i percorsi corretti\n"
 "con 'git add <path>' o 'git rm <path>'"
 
-#: sequencer.c:390
+#: sequencer.c:392
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
@@ -6374,114 +6661,110 @@ msgstr ""
 "con 'git add <path>' o 'git rm <path>' ed esegui\n"
 "il commit del risultato con 'git commit'"
 
-#: sequencer.c:403 sequencer.c:2993
+#: sequencer.c:405 sequencer.c:2901
 #, c-format
 msgid "could not lock '%s'"
 msgstr "impossibile bloccare '%s'"
 
-#: sequencer.c:410
+#: sequencer.c:412
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "impossibile scrivere il carattere di fine riga in '%s'"
 
-#: sequencer.c:415 sequencer.c:2798 sequencer.c:2999 sequencer.c:3013
-#: sequencer.c:3277
+#: sequencer.c:417 sequencer.c:2706 sequencer.c:2907 sequencer.c:2921
+#: sequencer.c:3185
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "finalizzazione di '%s' non riuscita"
 
-#: sequencer.c:438 sequencer.c:1707 sequencer.c:2818 sequencer.c:3259
-#: sequencer.c:3368 builtin/am.c:244 builtin/commit.c:783 builtin/merge.c:1117
-#: builtin/rebase.c:589
+#: sequencer.c:440 sequencer.c:1613 sequencer.c:2726 sequencer.c:3167
+#: sequencer.c:3276 builtin/am.c:244 builtin/commit.c:787 builtin/merge.c:1120
+#: builtin/rebase.c:593
 #, c-format
 msgid "could not read '%s'"
 msgstr "impossibile leggere '%s'"
 
-#: sequencer.c:464
+#: sequencer.c:466
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "le tue modifiche locali sarebbero sovrascritte da %s."
 
-#: sequencer.c:468
+#: sequencer.c:470
 msgid "commit your changes or stash them to proceed."
 msgstr "esegui il commit delle modifiche o lo stash per procedere."
 
-#: sequencer.c:500
+#: sequencer.c:502
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: fast forward"
 
-#: sequencer.c:539 builtin/tag.c:565
+#: sequencer.c:541 builtin/tag.c:565
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Modalità pulizia non valida: %s"
 
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
-#. "rebase -i".
+#. "rebase".
 #.
-#: sequencer.c:633
+#: sequencer.c:635
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: impossibile scrivere il nuovo file indice"
 
-#: sequencer.c:650
+#: sequencer.c:652
 msgid "unable to update cache tree"
 msgstr "impossibile aggiornare l'albero cache"
 
-#: sequencer.c:664
+#: sequencer.c:666
 msgid "could not resolve HEAD commit"
 msgstr "impossibile risolvere il commit HEAD"
 
-#: sequencer.c:744
+#: sequencer.c:746
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "nessuna chiave presente in '%.*s'"
 
-#: sequencer.c:755
+#: sequencer.c:757
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "impossibile rimuovere gli apici dal valore di '%s'"
 
-#: sequencer.c:792 wrapper.c:190 wrapper.c:360 builtin/am.c:705
-#: builtin/am.c:797 builtin/merge.c:1114 builtin/rebase.c:1074
+#: sequencer.c:794 wrapper.c:190 wrapper.c:360 builtin/am.c:705
+#: builtin/am.c:797 builtin/merge.c:1117 builtin/rebase.c:1072
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "impossibile aprire '%s' in lettura"
 
-#: sequencer.c:802
+#: sequencer.c:804
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' già specificato"
 
-#: sequencer.c:807
+#: sequencer.c:809
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' già specificato"
 
-#: sequencer.c:812
+#: sequencer.c:814
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' già specificato"
 
-#: sequencer.c:816
+#: sequencer.c:818
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "variabile '%s' sconosciuta"
 
-#: sequencer.c:821
+#: sequencer.c:823
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "'GIT_AUTHOR_NAME' mancante"
 
-#: sequencer.c:823
+#: sequencer.c:825
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "'GIT_AUTHOR_EMAIL' mancante"
 
-#: sequencer.c:825
+#: sequencer.c:827
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "'GIT_AUTHOR_DATE' mancante"
 
-#: sequencer.c:902 sequencer.c:1427
-msgid "malformed ident line"
-msgstr "riga ident malformata"
-
-#: sequencer.c:925
+#: sequencer.c:876
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -6511,11 +6794,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1218
+#: sequencer.c:1148
 msgid "'prepare-commit-msg' hook failed"
 msgstr "hook 'prepare-commit-msg' non riuscito"
 
-#: sequencer.c:1224
+#: sequencer.c:1154
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -6542,7 +6825,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1237
+#: sequencer.c:1167
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -6568,333 +6851,328 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1279
+#: sequencer.c:1209
 msgid "couldn't look up newly created commit"
 msgstr "impossibile trovare il commit appena creato"
 
-#: sequencer.c:1281
+#: sequencer.c:1211
 msgid "could not parse newly created commit"
 msgstr "impossibile analizzare il commit appena creato"
 
-#: sequencer.c:1327
+#: sequencer.c:1257
 msgid "unable to resolve HEAD after creating commit"
 msgstr "impossibile risolvere HEAD dopo la creazione del commit"
 
-#: sequencer.c:1329
+#: sequencer.c:1259
 msgid "detached HEAD"
 msgstr "HEAD scollegato"
 
-#: sequencer.c:1333
+#: sequencer.c:1263
 msgid " (root-commit)"
 msgstr " (commit radice)"
 
-#: sequencer.c:1354
+#: sequencer.c:1284
 msgid "could not parse HEAD"
 msgstr "impossibile analizzare HEAD"
 
-#: sequencer.c:1356
+#: sequencer.c:1286
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "L'HEAD %s non è un commit!"
 
-#: sequencer.c:1360 sequencer.c:1458 builtin/commit.c:1569
+#: sequencer.c:1290 sequencer.c:1364 builtin/commit.c:1574
 msgid "could not parse HEAD commit"
 msgstr "impossibile analizzare il commit HEAD"
 
-#: sequencer.c:1411 sequencer.c:2055
+#: sequencer.c:1342 sequencer.c:1968
 msgid "unable to parse commit author"
 msgstr "impossibile analizzare l'autore del commit"
 
-#: sequencer.c:1431
-msgid "corrupted author without date information"
-msgstr "informazioni sull'autore corrotte (senza data)"
-
-#: sequencer.c:1447 builtin/am.c:1561 builtin/merge.c:684
+#: sequencer.c:1353 builtin/am.c:1561 builtin/merge.c:687
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree non è riuscito a scrivere un albero"
 
-#: sequencer.c:1480 sequencer.c:1550
+#: sequencer.c:1386 sequencer.c:1447
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "impossibile leggere il messaggio di commit da '%s'"
 
-#: sequencer.c:1516 builtin/am.c:1583 builtin/commit.c:1668 builtin/merge.c:883
-#: builtin/merge.c:908
+#: sequencer.c:1413 builtin/am.c:1583 builtin/commit.c:1673 builtin/merge.c:886
+#: builtin/merge.c:911
 msgid "failed to write commit object"
 msgstr "scrittura dell'oggetto del commit non riuscita"
 
-#: sequencer.c:1577
+#: sequencer.c:1474
 #, c-format
 msgid "could not parse commit %s"
 msgstr "impossibile analizzare il commit %s"
 
-#: sequencer.c:1582
+#: sequencer.c:1479
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "impossibile analizzare il commit genitore %s"
 
-#: sequencer.c:1656 sequencer.c:1767
+#: sequencer.c:1562 sequencer.c:1673
 #, c-format
 msgid "unknown command: %d"
 msgstr "comando sconosciuto: %d"
 
-#: sequencer.c:1714 sequencer.c:1739
+#: sequencer.c:1620 sequencer.c:1645
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Questa è una combinazione di %d commit."
 
-#: sequencer.c:1724
+#: sequencer.c:1630
 msgid "need a HEAD to fixup"
 msgstr "è necessaria un'HEAD per il fixup"
 
-#: sequencer.c:1726 sequencer.c:3304
+#: sequencer.c:1632 sequencer.c:3212
 msgid "could not read HEAD"
 msgstr "impossibile leggere l'HEAD"
 
-#: sequencer.c:1728
+#: sequencer.c:1634
 msgid "could not read HEAD's commit message"
 msgstr "impossibile leggere il messaggio di commit dell'HEAD"
 
-#: sequencer.c:1734
+#: sequencer.c:1640
 #, c-format
 msgid "cannot write '%s'"
 msgstr "impossibile scrivere '%s'"
 
-#: sequencer.c:1741 git-rebase--preserve-merges.sh:496
+#: sequencer.c:1647 git-rebase--preserve-merges.sh:496
 msgid "This is the 1st commit message:"
 msgstr "Questo è il primo messaggio di commit:"
 
-#: sequencer.c:1749
+#: sequencer.c:1655
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "impossibile leggere il messaggio di commit di %s"
 
-#: sequencer.c:1756
+#: sequencer.c:1662
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Questo è il messaggio di commit numero %d:"
 
-#: sequencer.c:1762
+#: sequencer.c:1668
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Il messaggio di commit numero %d sarà saltato:"
 
-#: sequencer.c:1850
+#: sequencer.c:1756
 msgid "your index file is unmerged."
 msgstr "il file indice non è stato sottoposto a merge."
 
-#: sequencer.c:1857
+#: sequencer.c:1763
 msgid "cannot fixup root commit"
 msgstr "impossibile eseguire il fixup sul commit radice"
 
-#: sequencer.c:1876
+#: sequencer.c:1782
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "il commit %s è un merge ma non è stata specificata l'opzione -m."
 
-#: sequencer.c:1884 sequencer.c:1892
+#: sequencer.c:1790 sequencer.c:1798
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "il commit %s non ha il genitore %d"
 
-#: sequencer.c:1898
+#: sequencer.c:1804
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "impossibile ottenere il messaggio di commit per %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1917
+#: sequencer.c:1823
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: impossibile analizzare il commit genitore %s"
 
-#: sequencer.c:1982
+#: sequencer.c:1888
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "impossibile ridenominare '%s' in '%s'"
 
-#: sequencer.c:2037
+#: sequencer.c:1943
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "non è stato possibile eseguire il revert di %s... %s"
 
-#: sequencer.c:2038
+#: sequencer.c:1944
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "non è stato possibile applicare %s... %s"
 
-#: sequencer.c:2105
+#: sequencer.c:1961
+#, c-format
+msgid "dropping %s %s -- patch contents already upstream\n"
+msgstr "scarto %s %s - i contenuti della patch sono già upstream\n"
+
+#: sequencer.c:2018
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: lettura dell'indice non riuscita"
 
-#: sequencer.c:2112
+#: sequencer.c:2025
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: aggiornamento dell'indice non riuscito"
 
-#: sequencer.c:2189
+#: sequencer.c:2102
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s non accetta argomenti: '%s'"
 
-#: sequencer.c:2198
+#: sequencer.c:2111
 #, c-format
 msgid "missing arguments for %s"
 msgstr "argomenti mancanti per %s"
 
-#: sequencer.c:2235
+#: sequencer.c:2142
 #, c-format
-msgid "could not parse '%.*s'"
-msgstr "impossibile analizzare '%.*s'"
+msgid "could not parse '%s'"
+msgstr "impossibile analizzare '%s'"
 
-#: sequencer.c:2289
+#: sequencer.c:2203
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "riga %d non valida: %.*s"
 
-#: sequencer.c:2300
+#: sequencer.c:2214
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "impossibile eseguire '%s' senza un commit precedente"
 
-#: sequencer.c:2348 builtin/rebase.c:172 builtin/rebase.c:197
-#: builtin/rebase.c:223 builtin/rebase.c:248
-#, c-format
-msgid "could not read '%s'."
-msgstr "impossibile leggere '%s'."
-
-#: sequencer.c:2384
+#: sequencer.c:2298
 msgid "cancelling a cherry picking in progress"
 msgstr "annullo un'operazione di cherry-pick in corso"
 
-#: sequencer.c:2391
+#: sequencer.c:2305
 msgid "cancelling a revert in progress"
 msgstr "annullo un'operazione di revert in corso"
 
-#: sequencer.c:2435
+#: sequencer.c:2349
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "correggi la situazione usando 'git rebase --edit-todo'."
 
-#: sequencer.c:2437
+#: sequencer.c:2351
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "foglio istruzioni inutilizzabile: '%s'"
 
-#: sequencer.c:2442
+#: sequencer.c:2356
 msgid "no commits parsed."
 msgstr "nessun commit analizzato."
 
-#: sequencer.c:2453
+#: sequencer.c:2367
 msgid "cannot cherry-pick during a revert."
 msgstr "impossibile eseguire un cherry-pick durante un revert."
 
-#: sequencer.c:2455
+#: sequencer.c:2369
 msgid "cannot revert during a cherry-pick."
 msgstr "impossibile eseguire un revert durante un cherry-pick."
 
-#: sequencer.c:2533
+#: sequencer.c:2447
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "valore non valido per %s: %s"
 
-#: sequencer.c:2630
+#: sequencer.c:2540
 msgid "unusable squash-onto"
 msgstr "squash-onto inutilizzabile"
 
-#: sequencer.c:2646
+#: sequencer.c:2556
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "foglio opzioni malformati: '%s'"
 
-#: sequencer.c:2736 sequencer.c:4463
+#: sequencer.c:2644 sequencer.c:4361
 msgid "empty commit set passed"
 msgstr "è stato passato un insieme di commit vuoto"
 
-#: sequencer.c:2752
+#: sequencer.c:2660
 msgid "revert is already in progress"
 msgstr "un'operazione di revert è già in corso"
 
-#: sequencer.c:2754
+#: sequencer.c:2662
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "prova \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2757
+#: sequencer.c:2665
 msgid "cherry-pick is already in progress"
 msgstr "un'operazione di cherry-pick è già in corso"
 
-#: sequencer.c:2759
+#: sequencer.c:2667
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "prova \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2773
+#: sequencer.c:2681
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "impossibile creare la directory sequencer '%s'"
 
-#: sequencer.c:2788
+#: sequencer.c:2696
 msgid "could not lock HEAD"
 msgstr "impossibile bloccare HEAD"
 
-#: sequencer.c:2848 sequencer.c:4209
+#: sequencer.c:2756 sequencer.c:4099
 msgid "no cherry-pick or revert in progress"
 msgstr "nessuna operazione di cherry-pick o revert in corso"
 
-#: sequencer.c:2850 sequencer.c:2861
+#: sequencer.c:2758 sequencer.c:2769
 msgid "cannot resolve HEAD"
 msgstr "impossibile risolvere HEAD"
 
-#: sequencer.c:2852 sequencer.c:2896
+#: sequencer.c:2760 sequencer.c:2804
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 "impossibile interrompere l'operazione da un branch che deve essere ancora "
 "creato"
 
-#: sequencer.c:2882 builtin/grep.c:736
+#: sequencer.c:2790 builtin/grep.c:724
 #, c-format
 msgid "cannot open '%s'"
 msgstr "impossibile aprire '%s'"
 
-#: sequencer.c:2884
+#: sequencer.c:2792
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "impossibile leggere '%s': %s"
 
-#: sequencer.c:2885
+#: sequencer.c:2793
 msgid "unexpected end of file"
 msgstr "fine del file inattesa"
 
-#: sequencer.c:2891
+#: sequencer.c:2799
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr ""
 "il file '%s' in cui è stato salvato l'HEAD prima del cherry pick è corrotto"
 
-#: sequencer.c:2902
+#: sequencer.c:2810
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Sembra che tu abbia spostato l'HEAD. Non eseguo il rewind, controlla l'HEAD!"
 
-#: sequencer.c:2943
+#: sequencer.c:2851
 msgid "no revert in progress"
 msgstr "nessun revert in corso"
 
-#: sequencer.c:2951
+#: sequencer.c:2859
 msgid "no cherry-pick in progress"
 msgstr "nessun cherry-pick in corso"
 
-#: sequencer.c:2961
+#: sequencer.c:2869
 msgid "failed to skip the commit"
 msgstr "salto del commit non riuscito"
 
-#: sequencer.c:2968
+#: sequencer.c:2876
 msgid "there is nothing to skip"
 msgstr "non c'è nulla da saltare"
 
-#: sequencer.c:2971
+#: sequencer.c:2879
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -6903,21 +7181,21 @@ msgstr ""
 "hai già eseguito il commit?\n"
 "prova \"git %s --continue\""
 
-#: sequencer.c:3095 sequencer.c:4121
+#: sequencer.c:3003 sequencer.c:4011
 #, c-format
 msgid "could not update %s"
 msgstr "impossibile aggiornare %s"
 
-#: sequencer.c:3134 sequencer.c:4101
+#: sequencer.c:3042 sequencer.c:3991
 msgid "cannot read HEAD"
 msgstr "impossibile leggere l'HEAD"
 
-#: sequencer.c:3151
+#: sequencer.c:3059
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "impossibile copiare '%s' in '%s'"
 
-#: sequencer.c:3159
+#: sequencer.c:3067
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -6936,22 +7214,22 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3169
+#: sequencer.c:3077
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Impossibile applicare %s... %.*s"
 
-#: sequencer.c:3176
+#: sequencer.c:3084
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Impossibile eseguire il merge di %.*s"
 
-#: sequencer.c:3190 sequencer.c:3194 builtin/difftool.c:641
+#: sequencer.c:3098 sequencer.c:3102 builtin/difftool.c:641
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "impossibile copiare '%s' in '%s'"
 
-#: sequencer.c:3221
+#: sequencer.c:3129
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -6966,11 +7244,11 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3227
+#: sequencer.c:3135
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "e sono state apportate modifiche all'indice e/o all'albero di lavoro\n"
 
-#: sequencer.c:3233
+#: sequencer.c:3141
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -6987,72 +7265,72 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3294
+#: sequencer.c:3202
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "nome etichetta illecito: '%.*s'"
 
-#: sequencer.c:3348
+#: sequencer.c:3256
 msgid "writing fake root commit"
 msgstr "scrittura commit radice falso in corso"
 
-#: sequencer.c:3353
+#: sequencer.c:3261
 msgid "writing squash-onto"
 msgstr "scrittura squash-onto in corso"
 
-#: sequencer.c:3391 builtin/rebase.c:876 builtin/rebase.c:882
+#: sequencer.c:3299 builtin/rebase.c:880 builtin/rebase.c:886
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "impossibile trovare l'albero di %s"
 
-#: sequencer.c:3436
+#: sequencer.c:3344
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "impossibile risolvere '%s'"
 
-#: sequencer.c:3467
+#: sequencer.c:3375
 msgid "cannot merge without a current revision"
 msgstr "impossibile eseguire il merge senza una revisione corrente"
 
-#: sequencer.c:3489
+#: sequencer.c:3397
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "impossibile analizzare '%.*s'"
 
-#: sequencer.c:3498
+#: sequencer.c:3406
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "non c'è nulla di cui eseguire il merge: '%.*s'"
 
-#: sequencer.c:3510
+#: sequencer.c:3418
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "il merge octopus non può essere eseguito su un [nuovo commit radice]"
 
-#: sequencer.c:3526
+#: sequencer.c:3434
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "impossibile ottenere il messaggio di commit per '%s'"
 
-#: sequencer.c:3688
+#: sequencer.c:3594
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "non è stato nemmeno possibile tentare di eseguire il merge di '%.*s'"
 
-#: sequencer.c:3704
+#: sequencer.c:3610
 msgid "merge: Unable to write new index file"
 msgstr "merge: impossibile scrivere il nuovo file indice"
 
-#: sequencer.c:3773 builtin/rebase.c:733
+#: sequencer.c:3679 builtin/rebase.c:737
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Stash automatico applicato.\n"
 
-#: sequencer.c:3785
+#: sequencer.c:3691
 #, c-format
 msgid "cannot store %s"
 msgstr "impossibile memorizzare %s"
 
-#: sequencer.c:3788 builtin/rebase.c:749 git-rebase--preserve-merges.sh:113
+#: sequencer.c:3694 builtin/rebase.c:753 git-rebase--preserve-merges.sh:113
 #, c-format
 msgid ""
 "Applying autostash resulted in conflicts.\n"
@@ -7063,31 +7341,26 @@ msgstr ""
 "Le tue modifiche sono al sicuro nello stash.\n"
 "Puoi eseguire \"git stash pop\" o \"git stash drop\" in qualunque momento.\n"
 
-#: sequencer.c:3849
-#, c-format
-msgid "could not checkout %s"
-msgstr "impossibile eseguire il checkout di %s"
-
-#: sequencer.c:3863
+#: sequencer.c:3755
 #, c-format
 msgid "%s: not a valid OID"
 msgstr "%s: non è un OID valido"
 
-#: sequencer.c:3868 git-rebase--preserve-merges.sh:779
+#: sequencer.c:3760 git-rebase--preserve-merges.sh:779
 msgid "could not detach HEAD"
 msgstr "impossibile scollegare l'HEAD"
 
-#: sequencer.c:3883
+#: sequencer.c:3775
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Fermato a HEAD\n"
 
-#: sequencer.c:3885
+#: sequencer.c:3777
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Fermato a %s\n"
 
-#: sequencer.c:3893
+#: sequencer.c:3785
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -7109,49 +7382,49 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:3979
+#: sequencer.c:3869
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Fermato a %s... %.*s\n"
 
-#: sequencer.c:4050
+#: sequencer.c:3940
 #, c-format
 msgid "unknown command %d"
 msgstr "comando %d sconosciuto"
 
-#: sequencer.c:4109
+#: sequencer.c:3999
 msgid "could not read orig-head"
 msgstr "impossibile leggere orig-head"
 
-#: sequencer.c:4114
+#: sequencer.c:4004
 msgid "could not read 'onto'"
 msgstr "impossibile leggere 'onto'"
 
-#: sequencer.c:4128
+#: sequencer.c:4018
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "impossibile aggiornare l'HEAD a %s"
 
-#: sequencer.c:4221
+#: sequencer.c:4111
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 "impossibile eseguire il rebase: ci sono delle modifiche non in staging."
 
-#: sequencer.c:4230
+#: sequencer.c:4120
 msgid "cannot amend non-existing commit"
 msgstr "impossibile modificare un commit inesistente"
 
-#: sequencer.c:4232
+#: sequencer.c:4122
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "file non valido: '%s'"
 
-#: sequencer.c:4234
+#: sequencer.c:4124
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "contenuti non validi: '%s'"
 
-#: sequencer.c:4237
+#: sequencer.c:4127
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -7162,69 +7435,59 @@ msgstr ""
 "di lavoro. Eseguine prima il commit e quindi esegui nuovamente 'git rebase\n"
 "--continue'."
 
-#: sequencer.c:4273 sequencer.c:4312
+#: sequencer.c:4163 sequencer.c:4202
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "impossibile scrivere il file: '%s'"
 
-#: sequencer.c:4327
+#: sequencer.c:4217
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "impossibile rimuovere CHERRY_PICK_HEAD"
 
-#: sequencer.c:4334
+#: sequencer.c:4224
 msgid "could not commit staged changes."
 msgstr "impossibile eseguire il commit delle modifiche in staging."
 
-#: sequencer.c:4440
+#: sequencer.c:4338
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: impossibile eseguire il cherry pick di un %s"
 
-#: sequencer.c:4444
+#: sequencer.c:4342
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: revisione non valida"
 
-#: sequencer.c:4479
+#: sequencer.c:4377
 msgid "can't revert as initial commit"
 msgstr "impossibile eseguire il revert come commit iniziale"
 
-#: sequencer.c:4952
+#: sequencer.c:4846
 msgid "make_script: unhandled options"
 msgstr "make_script: opzioni non gestite"
 
-#: sequencer.c:4955
+#: sequencer.c:4849
 msgid "make_script: error preparing revisions"
 msgstr "make_script: errore durante la preparazione delle revisioni"
 
-#: sequencer.c:5113
-msgid ""
-"You can fix this with 'git rebase --edit-todo' and then run 'git rebase --"
-"continue'.\n"
-"Or you can abort the rebase with 'git rebase --abort'.\n"
-msgstr ""
-"Puoi correggere questa situazione con 'git rebase --edit-todo' e quindi "
-"eseguire 'git rebase --continue'.\n"
-"Oppure puoi interrompere il rebase con 'git rebase --abort'.\n"
-
-#: sequencer.c:5226 sequencer.c:5243
+#: sequencer.c:5083 sequencer.c:5100
 msgid "nothing to do"
 msgstr "nulla da fare"
 
-#: sequencer.c:5257
+#: sequencer.c:5119
 msgid "could not skip unnecessary pick commands"
 msgstr "impossibile saltare i comandi pick non necessari"
 
-#: sequencer.c:5351
+#: sequencer.c:5213
 msgid "the script was already rearranged."
 msgstr "lo script è già stato riordinato."
 
 #: setup.c:124
 #, c-format
-msgid "'%s' is outside repository"
-msgstr "'%s' è al di fuori del repository"
+msgid "'%s' is outside repository at '%s'"
+msgstr "'%s' è al di fuori del repository in '%s'"
 
-#: setup.c:174
+#: setup.c:175
 #, c-format
 msgid ""
 "%s: no such path in the working tree.\n"
@@ -7234,7 +7497,7 @@ msgstr ""
 "Usa 'git <comando> -- <percorso>...' per specificare percorsi non esistenti "
 "localmente."
 
-#: setup.c:187
+#: setup.c:188
 #, c-format
 msgid ""
 "ambiguous argument '%s': unknown revision or path not in the working tree.\n"
@@ -7246,14 +7509,14 @@ msgstr ""
 "Usa '--' per separare i percorsi dalle revisioni, come segue:\n"
 "'git <comando> [<revisione>...] -- [<file>...]'"
 
-#: setup.c:236
+#: setup.c:254
 #, c-format
 msgid "option '%s' must come before non-option arguments"
 msgstr ""
 "l'opzione '%s' deve essere specificata prima degli argomenti che non "
 "costituiscono un'opzione"
 
-#: setup.c:255
+#: setup.c:273
 #, c-format
 msgid ""
 "ambiguous argument '%s': both revision and filename\n"
@@ -7264,93 +7527,93 @@ msgstr ""
 "Usa '--' per separare i percorsi dalle revisioni, come segue:\n"
 "'git <comando> [<revisione>...] -- [<file>...]'"
 
-#: setup.c:391
+#: setup.c:409
 msgid "unable to set up work tree using invalid config"
 msgstr ""
 "impossibile preparare l'albero di lavoro usando una configurazione non valida"
 
-#: setup.c:395
+#: setup.c:413
 msgid "this operation must be run in a work tree"
 msgstr "quest'operazione deve essere eseguita in un albero di lavoro"
 
-#: setup.c:541
+#: setup.c:559
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr "Attesa versione repository Git <= %d, trovata %d"
 
-#: setup.c:549
+#: setup.c:567
 msgid "unknown repository extensions found:"
 msgstr "trovate estensioni repository sconosciute:"
 
-#: setup.c:568
+#: setup.c:586
 #, c-format
 msgid "error opening '%s'"
 msgstr "errore durante l'apertura di '%s'"
 
-#: setup.c:570
+#: setup.c:588
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr "'%s' troppo grande per essere un file .git"
 
-#: setup.c:572
+#: setup.c:590
 #, c-format
 msgid "error reading %s"
 msgstr "errore durante la lettura di %s"
 
-#: setup.c:574
+#: setup.c:592
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr "formato file Git non valido: %s"
 
-#: setup.c:576
+#: setup.c:594
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr "nessun percorso presente nel file Git: %s"
 
-#: setup.c:578
+#: setup.c:596
 #, c-format
 msgid "not a git repository: %s"
 msgstr "%s non è un repository Git"
 
-#: setup.c:677
+#: setup.c:695
 #, c-format
 msgid "'$%s' too big"
 msgstr "'$%s' è troppo grande"
 
-#: setup.c:691
+#: setup.c:709
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr "'%s' non è un repository Git"
 
-#: setup.c:720 setup.c:722 setup.c:753
+#: setup.c:738 setup.c:740 setup.c:771
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr "impossibile modificare la directory corrente in '%s'"
 
-#: setup.c:725 setup.c:781 setup.c:791 setup.c:830 setup.c:838
+#: setup.c:743 setup.c:799 setup.c:809 setup.c:848 setup.c:856
 msgid "cannot come back to cwd"
 msgstr "impossibile tornare alla directory di lavoro corrente"
 
-#: setup.c:852
+#: setup.c:870
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "stat di '%*s%s%s' non riuscito"
 
-#: setup.c:1090
+#: setup.c:1108
 msgid "Unable to read current working directory"
 msgstr "Impossibile leggere la directory di lavoro corrente"
 
-#: setup.c:1099 setup.c:1105
+#: setup.c:1117 setup.c:1123
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "impossibile entrare in '%s'"
 
-#: setup.c:1110
+#: setup.c:1128
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr "%s non è un repository Git (né lo è alcuna delle directory genitrici)"
 
-#: setup.c:1116
+#: setup.c:1134
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -7360,7 +7623,7 @@ msgstr ""
 "Mi fermo al limite del filesystem (l'opzione GIT_DISCOVERY_ACROSS_FILESYSTEM "
 "non è impostata)."
 
-#: setup.c:1227
+#: setup.c:1245
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -7370,15 +7633,15 @@ msgstr ""
 "(0%.3o).\n"
 "Il proprietario dei file deve avere sempre i permessi di lettura e scrittura."
 
-#: setup.c:1271
+#: setup.c:1289
 msgid "open /dev/null or dup failed"
 msgstr "apertura di /dev/null o dup non riuscita"
 
-#: setup.c:1286
+#: setup.c:1304
 msgid "fork failed"
 msgstr "fork non riuscita"
 
-#: setup.c:1291
+#: setup.c:1309
 msgid "setsid failed"
 msgstr "setsid non riuscita"
 
@@ -7463,196 +7726,196 @@ msgstr "mmap non riuscita"
 msgid "object file %s is empty"
 msgstr "l'oggetto %s è vuoto"
 
-#: sha1-file.c:1252 sha1-file.c:2392
+#: sha1-file.c:1263 sha1-file.c:2443
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "oggetto sciolto '%s' corrotto"
 
-#: sha1-file.c:1254 sha1-file.c:2396
+#: sha1-file.c:1265 sha1-file.c:2447
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "dati inutilizzabili presenti alla fine dell'oggetto sciolto '%s'"
 
-#: sha1-file.c:1296
+#: sha1-file.c:1307
 msgid "invalid object type"
 msgstr "tipo oggetto non valido"
 
-#: sha1-file.c:1380
+#: sha1-file.c:1391
 #, c-format
 msgid "unable to unpack %s header with --allow-unknown-type"
 msgstr "impossibile decomprimere l'intestazione %s con --allow-unknown-type"
 
-#: sha1-file.c:1383
+#: sha1-file.c:1394
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "impossibile decomprimere l'intestazione %s"
 
-#: sha1-file.c:1389
+#: sha1-file.c:1400
 #, c-format
 msgid "unable to parse %s header with --allow-unknown-type"
 msgstr "impossibile analizzare l'intestazione %s con --allow-unknown-type"
 
-#: sha1-file.c:1392
+#: sha1-file.c:1403
 #, c-format
 msgid "unable to parse %s header"
 msgstr "impossibile analizzare l'intestazione %s"
 
-#: sha1-file.c:1584
+#: sha1-file.c:1629
 #, c-format
 msgid "failed to read object %s"
 msgstr "lettura dell'oggetto %s non riuscita"
 
-#: sha1-file.c:1588
+#: sha1-file.c:1633
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "%s sostitutivo non trovato per %s"
 
-#: sha1-file.c:1592
+#: sha1-file.c:1637
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "l'oggetto sciolto %s (salvato in %s) è corrotto"
 
-#: sha1-file.c:1596
+#: sha1-file.c:1641
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "l'oggetto archiviato %s (salvato in %s) è corrotto"
 
-#: sha1-file.c:1699
+#: sha1-file.c:1746
 #, c-format
 msgid "unable to write file %s"
 msgstr "impossibile scrivere il file %s"
 
-#: sha1-file.c:1706
+#: sha1-file.c:1753
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "impossibile impostare i permessi a '%s'"
 
-#: sha1-file.c:1713
+#: sha1-file.c:1760
 msgid "file write error"
 msgstr "errore di scrittura del file"
 
-#: sha1-file.c:1732
+#: sha1-file.c:1780
 msgid "error when closing loose object file"
 msgstr "errore durante la chiusura del file oggetto sciolto"
 
-#: sha1-file.c:1797
+#: sha1-file.c:1845
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "permessi non sufficienti per l'aggiunta di un oggetto al database repository "
 "%s"
 
-#: sha1-file.c:1799
+#: sha1-file.c:1847
 msgid "unable to create temporary file"
 msgstr "impossibile creare il file temporaneo"
 
-#: sha1-file.c:1823
+#: sha1-file.c:1871
 msgid "unable to write loose object file"
 msgstr "impossibile scrivere il file oggetto sciolto"
 
-#: sha1-file.c:1829
+#: sha1-file.c:1877
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "impossibile comprimere con deflate il nuovo oggetto %s (%d)"
 
-#: sha1-file.c:1833
+#: sha1-file.c:1881
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd non riuscita sull'oggetto %s (%d)"
 
-#: sha1-file.c:1837
+#: sha1-file.c:1885
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "sono confuso dall'origine dati oggetto non stabile per %s"
 
-#: sha1-file.c:1847 builtin/pack-objects.c:925
+#: sha1-file.c:1895 builtin/pack-objects.c:1054
 #, c-format
 msgid "failed utime() on %s"
 msgstr "utime() di %s non riuscita"
 
-#: sha1-file.c:1922
+#: sha1-file.c:1972
 #, c-format
 msgid "cannot read object for %s"
 msgstr "impossibile leggere l'oggetto per %s"
 
-#: sha1-file.c:1962
+#: sha1-file.c:2011
 msgid "corrupt commit"
 msgstr "commit corrotto"
 
-#: sha1-file.c:1970
+#: sha1-file.c:2019
 msgid "corrupt tag"
 msgstr "tag corrotto"
 
-#: sha1-file.c:2069
+#: sha1-file.c:2119
 #, c-format
 msgid "read error while indexing %s"
 msgstr "errore di lettura durante l'indicizzazione di %s"
 
-#: sha1-file.c:2072
+#: sha1-file.c:2122
 #, c-format
 msgid "short read while indexing %s"
 msgstr "lettura troppo breve durante l'indicizzazione di %s"
 
-#: sha1-file.c:2145 sha1-file.c:2154
+#: sha1-file.c:2195 sha1-file.c:2205
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: inserimento del record nel database non riuscito"
 
-#: sha1-file.c:2160
+#: sha1-file.c:2211
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: tipo di file non supportato"
 
-#: sha1-file.c:2184
+#: sha1-file.c:2235
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s non è un oggetto valido"
 
-#: sha1-file.c:2186
+#: sha1-file.c:2237
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s non è un oggetto '%s' valido"
 
-#: sha1-file.c:2213 builtin/index-pack.c:155
+#: sha1-file.c:2264 builtin/index-pack.c:155
 #, c-format
 msgid "unable to open %s"
 msgstr "impossibile aprire %s"
 
-#: sha1-file.c:2403 sha1-file.c:2455
+#: sha1-file.c:2454 sha1-file.c:2507
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "mancata corrispondenza per %s (atteso %s)"
 
-#: sha1-file.c:2427
+#: sha1-file.c:2478
 #, c-format
 msgid "unable to mmap %s"
 msgstr "impossibile eseguire mmap su %s"
 
-#: sha1-file.c:2432
+#: sha1-file.c:2483
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "impossibile decomprimere l'intestazione di %s"
 
-#: sha1-file.c:2438
+#: sha1-file.c:2489
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "impossibile analizzare l'intestazione di %s"
 
-#: sha1-file.c:2449
+#: sha1-file.c:2500
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "impossibile decomprimere i contenuti di %s"
 
-#: sha1-name.c:487
+#: sha1-name.c:486
 #, c-format
 msgid "short SHA1 %s is ambiguous"
 msgstr "lo SHA1 breve %s è ambiguo"
 
-#: sha1-name.c:498
+#: sha1-name.c:497
 msgid "The candidates are:"
 msgstr "I candidati sono:"
 
-#: sha1-name.c:797
+#: sha1-name.c:796
 msgid ""
 "Git normally never creates a ref that ends with 40 hex characters\n"
 "because it will be ignored when you just specify 40-hex. These refs\n"
@@ -7676,44 +7939,112 @@ msgstr ""
 "riferimenti ed eliminali se necessario. Disabilita questo\n"
 "messaggio eseguendo \"git config advice.objectNameWarning false\""
 
+#: sha1-name.c:916
+#, c-format
+msgid "log for '%.*s' only goes back to %s"
+msgstr "il log per '%.*s' è disponibile solo fino al %s"
+
+#: sha1-name.c:924
+#, c-format
+msgid "log for '%.*s' only has %d entries"
+msgstr "il log per '%.*s' ha solo %d voci"
+
+#: sha1-name.c:1689
+#, c-format
+msgid "path '%s' exists on disk, but not in '%.*s'"
+msgstr "il percorso '%s' esiste su disco, ma non in '%.*s'"
+
+#: sha1-name.c:1695
+#, c-format
+msgid ""
+"path '%s' exists, but not '%s'\n"
+"hint: Did you mean '%.*s:%s' aka '%.*s:./%s'?"
+msgstr ""
+"il percorso '%s' esiste, ma non '%s'\n"
+"suggerimento: forse intendevi '%.*s:%s' ossia '%.*s:./%s'?"
+
+#: sha1-name.c:1704
+#, c-format
+msgid "path '%s' does not exist in '%.*s'"
+msgstr "il percorso '%s' non esiste in '%.*s'"
+
+#: sha1-name.c:1732
+#, c-format
+msgid ""
+"path '%s' is in the index, but not at stage %d\n"
+"hint: Did you mean ':%d:%s'?"
+msgstr ""
+"il percorso '%s' è nell'indice, ma non nel passo %d\n"
+"suggerimento: Forse intendevi ':%d:%s'?"
+
+#: sha1-name.c:1748
+#, c-format
+msgid ""
+"path '%s' is in the index, but not '%s'\n"
+"hint: Did you mean ':%d:%s' aka ':%d:./%s'?"
+msgstr ""
+"il percorso '%s' è nell'indice, ma non '%s'\n"
+"suggerimento: Forse intendevi ':%d:%s' ossia ':%d:./%s'?"
+
+#: sha1-name.c:1756
+#, c-format
+msgid "path '%s' exists on disk, but not in the index"
+msgstr "il percorso '%s' esiste su disco, ma non nell'indice"
+
+#: sha1-name.c:1758
+#, c-format
+msgid "path '%s' does not exist (neither on disk nor in the index)"
+msgstr "il percorso '%s' non esiste (né su disco né nell'indice)"
+
+#: sha1-name.c:1771
+msgid "relative path syntax can't be used outside working tree"
+msgstr ""
+"la sintassi per i percorsi relativi non può essere usata al di fuori"
+" dell'albero di lavoro"
+
+#: sha1-name.c:1909
+#, c-format
+msgid "invalid object name '%.*s'."
+msgstr "nome oggetto non valido: '%.*s'."
+
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
-#: strbuf.c:822
+#: strbuf.c:837
 #, c-format
 msgid "%u.%2.2u GiB"
 msgstr "%u.%2.2u GiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte/second
-#: strbuf.c:824
+#: strbuf.c:839
 #, c-format
 msgid "%u.%2.2u GiB/s"
 msgstr "%u.%2.2u GiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte
-#: strbuf.c:832
+#: strbuf.c:847
 #, c-format
 msgid "%u.%2.2u MiB"
 msgstr "%u.%2.2u MiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte/second
-#: strbuf.c:834
+#: strbuf.c:849
 #, c-format
 msgid "%u.%2.2u MiB/s"
 msgstr "%u.%2.2u MiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte
-#: strbuf.c:841
+#: strbuf.c:856
 #, c-format
 msgid "%u.%2.2u KiB"
 msgstr "%u.%2.2u KiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte/second
-#: strbuf.c:843
+#: strbuf.c:858
 #, c-format
 msgid "%u.%2.2u KiB/s"
 msgstr "%u.%2.2u KiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 byte
-#: strbuf.c:849
+#: strbuf.c:864
 #, c-format
 msgid "%u byte"
 msgid_plural "%u bytes"
@@ -7721,14 +8052,14 @@ msgstr[0] "%u byte"
 msgstr[1] "%u byte"
 
 #. TRANSLATORS: IEC 80000-13:2008 byte/second
-#: strbuf.c:851
+#: strbuf.c:866
 #, c-format
 msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] "%u byte/s"
 msgstr[1] "%u byte/s"
 
-#: strbuf.c:1149
+#: strbuf.c:1164
 #, c-format
 msgid "could not edit '%s'"
 msgstr "impossibile modificare '%s'"
@@ -7763,59 +8094,132 @@ msgstr "nel sottomodulo non popolato '%s'"
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Lo specificatore percorso '%s' è nel sottomodulo '%.*s'"
 
+#: submodule.c:434
+#, c-format
+msgid "bad --ignore-submodules argument: %s"
+msgstr "argomento --ignore-submodules errato: %s"
+
+#: submodule.c:815
+#, c-format
+msgid ""
+"Submodule in commit %s at path: '%s' collides with a submodule named the "
+"same. Skipping it."
+msgstr ""
+"Il sottomodulo nel commit %s e nel percorso '%s' collide con un sottomodulo"
+" con lo stesso nome. Lo salto."
+
 #: submodule.c:910
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "la voce sottomodulo '%s' (%s) è un %s, non un commit"
 
-#: submodule.c:1147 builtin/branch.c:680 builtin/submodule--helper.c:2016
+#: submodule.c:995
+#, c-format
+msgid ""
+"Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
+"submodule %s"
+msgstr ""
+"Impossibile eseguire il comando 'git rev-list <commit> --not --remotes -n 1'"
+" nel sottomodulo %s"
+
+#: submodule.c:1118
+#, c-format
+msgid "process for submodule '%s' failed"
+msgstr "il processo per il sottomodulo '%s' non è uscito con successo"
+
+#: submodule.c:1147 builtin/branch.c:680 builtin/submodule--helper.c:2045
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Impossibile risolvere HEAD come riferimento valido."
 
-#: submodule.c:1481
+#: submodule.c:1158
 #, c-format
-msgid "Could not access submodule '%s'"
-msgstr "Impossibile accedere al sottomodulo '%s'"
+msgid "Pushing submodule '%s'\n"
+msgstr "Push del sottomodulo '%s' in corso\n"
 
-#: submodule.c:1651
+#: submodule.c:1161
+#, c-format
+msgid "Unable to push submodule '%s'\n"
+msgstr "Impossibile eseguire il push del sottomodulo '%s'\n"
+
+#: submodule.c:1453
+#, c-format
+msgid "Fetching submodule %s%s\n"
+msgstr "Recupero del sottomodulo %s%s in corso\n"
+
+#: submodule.c:1483
+#, c-format
+msgid "Could not access submodule '%s'\n"
+msgstr "Impossibile accedere al sottomodulo '%s'\n"
+
+#: submodule.c:1637
+#, c-format
+msgid ""
+"Errors during submodule fetch:\n"
+"%s"
+msgstr ""
+"Errore durante il recupero del sottomodulo:\n"
+"%s"
+
+#: submodule.c:1662
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' non riconosciuto come repository Git"
 
-#: submodule.c:1789
+#: submodule.c:1679
+#, c-format
+msgid "Could not run 'git status --porcelain=2' in submodule %s"
+msgstr "Impossibile eseguire 'git status --porcelain=2' nel sottomodulo %s"
+
+#: submodule.c:1720
+#, c-format
+msgid "'git status --porcelain=2' failed in submodule %s"
+msgstr ""
+"Esecuzione di 'git status --porcelain=2' non riuscita nel sottomodulo %s"
+
+#: submodule.c:1800
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "impossibile avviare 'git status' nel sottomodulo '%s'"
 
-#: submodule.c:1802
+#: submodule.c:1813
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "impossibile eseguire 'git status' nel sottomodulo '%s'"
 
-#: submodule.c:1817
+#: submodule.c:1828
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr ""
 "Impossibile annullare l'impostazione dell'opzione core.worktree nel "
 "sottomodulo '%s'"
 
-#: submodule.c:1907
+#: submodule.c:1855 submodule.c:2165
+#, c-format
+msgid "could not recurse into submodule '%s'"
+msgstr "impossibile eseguire l'azione ricorsivamente nel sottomodulo '%s'"
+
+#: submodule.c:1876
+msgid "could not reset submodule index"
+msgstr "impossibile ripristinare l'indice del sottomodulo"
+
+#: submodule.c:1918
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "il sottomodulo '%s' ha l'indice sporco"
 
-#: submodule.c:1959
+#: submodule.c:1970
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Impossibile aggiornare il sottomodulo '%s'."
 
-#: submodule.c:2027
+#: submodule.c:2038
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr ""
-"la directory Git del sottomodulo '%s' è all'interno della directory Git '%.*s'"
+"la directory Git del sottomodulo '%s' è all'interno della directory Git "
+"'%.*s'"
 
-#: submodule.c:2048
+#: submodule.c:2059
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -7823,17 +8227,17 @@ msgstr ""
 "relocate_gitdir non è supportata per il sottomodulo '%s' con più di un "
 "albero di lavoro"
 
-#: submodule.c:2060 submodule.c:2119
+#: submodule.c:2071 submodule.c:2130
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "impossibile ricercare il nome per il sottomodulo '%s'"
 
-#: submodule.c:2064
+#: submodule.c:2075
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "mi rifiuto di spostare '%s' in una directory Git esistente"
 
-#: submodule.c:2071
+#: submodule.c:2082
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -7844,16 +8248,11 @@ msgstr ""
 "'%s' a\n"
 "'%s'\n"
 
-#: submodule.c:2154
-#, c-format
-msgid "could not recurse into submodule '%s'"
-msgstr "impossibile eseguire l'azione ricorsivamente nel sottomodulo '%s'"
-
-#: submodule.c:2198
+#: submodule.c:2209
 msgid "could not start ls-files in .."
 msgstr "impossibile avviare ls-files in .."
 
-#: submodule.c:2237
+#: submodule.c:2248
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree ha restituito il valore di ritorno inatteso %d"
@@ -7879,7 +8278,7 @@ msgstr ""
 msgid "invalid value for %s"
 msgstr "valore non valido per %s"
 
-#: submodule-config.c:769
+#: submodule-config.c:765
 #, c-format
 msgid "Could not update .gitmodules entry %s"
 msgstr "Impossibile aggiornare la voce .gitmodules %s"
@@ -7895,7 +8294,7 @@ msgstr "esecuzione del comando finale '%s' non riuscita"
 msgid "unknown value '%s' for key '%s'"
 msgstr "valore '%s' sconosciuto per la chiave '%s'"
 
-#: trailer.c:539 trailer.c:544 builtin/remote.c:295
+#: trailer.c:539 trailer.c:544 builtin/remote.c:298 builtin/remote.c:323
 #, c-format
 msgid "more than one %s"
 msgstr "più di un %s"
@@ -8027,7 +8426,7 @@ msgstr "Interrompo l'operazione."
 msgid "failed to push all needed submodules"
 msgstr "push di tutti i sottomoduli richiesti non riuscito"
 
-#: transport.c:1345 transport-helper.c:656
+#: transport.c:1345 transport-helper.c:657
 msgid "operation not supported by protocol"
 msgstr "operazione non supportata dal protocollo"
 
@@ -8040,7 +8439,7 @@ msgstr "scrittura completa verso l'helper remoto non riuscita"
 msgid "unable to find remote helper for '%s'"
 msgstr "impossibile trovare l'helper remoto per '%s'"
 
-#: transport-helper.c:160 transport-helper.c:570
+#: transport-helper.c:160 transport-helper.c:571
 msgid "can't dup helper output fd"
 msgstr "impossibile duplicare il descrittore file dell'output helper"
 
@@ -8057,104 +8456,104 @@ msgstr ""
 msgid "this remote helper should implement refspec capability"
 msgstr "questo helper remoto dovrebbe implementare la capability refspec"
 
-#: transport-helper.c:284 transport-helper.c:424
+#: transport-helper.c:284 transport-helper.c:425
 #, c-format
 msgid "%s unexpectedly said: '%s'"
 msgstr "%s ha inviato un messaggio inatteso: '%s'"
 
-#: transport-helper.c:413
+#: transport-helper.c:414
 #, c-format
 msgid "%s also locked %s"
 msgstr "%s ha bloccato anche %s"
 
-#: transport-helper.c:492
+#: transport-helper.c:493
 msgid "couldn't run fast-import"
 msgstr "impossibile eseguire fast-import"
 
-#: transport-helper.c:515
+#: transport-helper.c:516
 msgid "error while running fast-import"
 msgstr "errore durante l'esecuzione di fast-import"
 
-#: transport-helper.c:544 transport-helper.c:1133
+#: transport-helper.c:545 transport-helper.c:1134
 #, c-format
 msgid "could not read ref %s"
 msgstr "impossibile leggere il riferimento %s"
 
-#: transport-helper.c:589
+#: transport-helper.c:590
 #, c-format
 msgid "unknown response to connect: %s"
 msgstr "risposta inattesa a connect: %s"
 
-#: transport-helper.c:611
+#: transport-helper.c:612
 msgid "setting remote service path not supported by protocol"
 msgstr ""
 "l'impostazione del percorso del servizio remoto non è supportata dal "
 "protocollo"
 
-#: transport-helper.c:613
+#: transport-helper.c:614
 msgid "invalid remote service path"
 msgstr "percorso servizio remoto non valido"
 
-#: transport-helper.c:659
+#: transport-helper.c:660
 #, c-format
 msgid "can't connect to subservice %s"
 msgstr "impossibile connettersi al sottoservizio %s"
 
-#: transport-helper.c:735
+#: transport-helper.c:736
 #, c-format
 msgid "expected ok/error, helper said '%s'"
 msgstr "attesi ok/error, l'helper ha inviato '%s'"
 
-#: transport-helper.c:788
+#: transport-helper.c:789
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "l'helper ha segnalato uno stato inatteso di %s"
 
-#: transport-helper.c:849
+#: transport-helper.c:850
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "l'helper %s non supporta dry-run"
 
-#: transport-helper.c:852
+#: transport-helper.c:853
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "l'helper %s non supporta --signed"
 
-#: transport-helper.c:855
+#: transport-helper.c:856
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "l'helper %s non supporta --signed=if-asked"
 
-#: transport-helper.c:860
+#: transport-helper.c:861
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "l'helper %s non supporta --atomic"
 
-#: transport-helper.c:866
+#: transport-helper.c:867
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "l'helper %s non supporta 'push-option'"
 
-#: transport-helper.c:964
+#: transport-helper.c:965
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr ""
 "l'helper remoto non supporta il push; è necessario uno specificatore "
 "riferimento"
 
-#: transport-helper.c:969
+#: transport-helper.c:970
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "l'helper %s non supporta 'force'"
 
-#: transport-helper.c:1016
+#: transport-helper.c:1017
 msgid "couldn't run fast-export"
 msgstr "impossibile eseguire fast-export"
 
-#: transport-helper.c:1021
+#: transport-helper.c:1022
 msgid "error while running fast-export"
 msgstr "errore durante l'esecuzione di fast-export"
 
-#: transport-helper.c:1046
+#: transport-helper.c:1047
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -8163,68 +8562,63 @@ msgstr ""
 "Nessun riferimento in comune e nessuno specificato; non eseguo nulla.\n"
 "Forse dovresti specificare un branch come 'master'.\n"
 
-#: transport-helper.c:1119
+#: transport-helper.c:1120
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "risposta malformata nell'elenco riferimenti: %s"
 
-#: transport-helper.c:1271
+#: transport-helper.c:1272
 #, c-format
 msgid "read(%s) failed"
 msgstr "read(%s) non riuscita"
 
-#: transport-helper.c:1298
+#: transport-helper.c:1299
 #, c-format
 msgid "write(%s) failed"
 msgstr "write(%s) non riuscita"
 
-#: transport-helper.c:1347
+#: transport-helper.c:1348
 #, c-format
 msgid "%s thread failed"
 msgstr "thread %s non riuscito"
 
-#: transport-helper.c:1351
+#: transport-helper.c:1352
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "join non riuscita per il thread %s: %s"
 
-#: transport-helper.c:1370 transport-helper.c:1374
+#: transport-helper.c:1371 transport-helper.c:1375
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "impossibile avviare il thread per la copia dei dati: %s"
 
-#: transport-helper.c:1411
+#: transport-helper.c:1412
 #, c-format
 msgid "%s process failed to wait"
 msgstr "wait non riuscita per il processo %s"
 
-#: transport-helper.c:1415
+#: transport-helper.c:1416
 #, c-format
 msgid "%s process failed"
 msgstr "processo %s non riuscito"
 
-#: transport-helper.c:1433 transport-helper.c:1442
+#: transport-helper.c:1434 transport-helper.c:1443
 msgid "can't start thread for copying data"
 msgstr "impossibile avviare il thread per la copia dei dati"
 
-#: tree-walk.c:33
+#: tree-walk.c:32
 msgid "too-short tree object"
 msgstr "oggetto albero troppo corto"
 
-#: tree-walk.c:39
+#: tree-walk.c:38
 msgid "malformed mode in tree entry"
 msgstr "modo malformato nella voce dell'albero"
 
-#: tree-walk.c:43
+#: tree-walk.c:42
 msgid "empty filename in tree entry"
 msgstr "nome file vuoto nella voce dell'albero"
 
-#: tree-walk.c:48
-#, c-format
-msgid "filename in tree entry contains backslash: '%s'"
-msgstr "il nome file nella voce albero contiene una barra rovesciata: '%s'"
-
-#: tree-walk.c:124
+#: tree-walk.c:117
 msgid "too-short tree file"
 msgstr "file alber troppo corto"
 
@@ -8488,7 +8882,7 @@ msgstr ""
 "su un filesystem non sensibile a tale differenza) e solo uno\n"
 "per gruppo in conflitto è nell'albero di lavoro:\n"
 
-#: unpack-trees.c:1441
+#: unpack-trees.c:1445
 msgid "Updating index flags"
 msgstr "Aggiornamento dei contrassegni indice in corso"
 
@@ -8521,35 +8915,35 @@ msgstr "numero di porta non valido"
 msgid "invalid '..' path segment"
 msgstr "parte percorso '..' non valida"
 
-#: worktree.c:258 builtin/am.c:2084
+#: worktree.c:259 builtin/am.c:2084
 #, c-format
 msgid "failed to read '%s'"
 msgstr "lettura di '%s' non riuscita"
 
-#: worktree.c:304
+#: worktree.c:305
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr ""
 "'%s' nell'albero di lavoro principale non è la directory del repository"
 
-#: worktree.c:315
+#: worktree.c:316
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr ""
 "il file '%s' non contiene il percorso assoluto alla posizione dell'albero di "
 "lavoro"
 
-#: worktree.c:327
+#: worktree.c:328
 #, c-format
 msgid "'%s' does not exist"
 msgstr "'%s' non esiste"
 
-#: worktree.c:333
+#: worktree.c:334
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "'%s' non è un file .git, codice d'errore %d"
 
-#: worktree.c:341
+#: worktree.c:342
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "'%s' non punta a '%s'"
@@ -9126,125 +9520,129 @@ msgstr "unlink di '%s' non riuscito"
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<opzioni>] [--] <specificatore percorso>..."
 
-#: builtin/add.c:87
+#: builtin/add.c:88
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "stato diff inatteso %c"
 
-#: builtin/add.c:92 builtin/commit.c:288
+#: builtin/add.c:93 builtin/commit.c:288
 msgid "updating files failed"
 msgstr "aggiornamento dei file non riuscito"
 
-#: builtin/add.c:102
+#: builtin/add.c:103
 #, c-format
 msgid "remove '%s'\n"
 msgstr "elimina '%s'\n"
 
-#: builtin/add.c:177
+#: builtin/add.c:178
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Modifiche non nell'area di staging dopo l'aggiornamento dell'indice:"
 
-#: builtin/add.c:252 builtin/rev-parse.c:899
+#: builtin/add.c:266 builtin/rev-parse.c:899
 msgid "Could not read the index"
 msgstr "Impossibile leggere l'indice"
 
-#: builtin/add.c:263
+#: builtin/add.c:277
 #, c-format
 msgid "Could not open '%s' for writing."
 msgstr "Impossibile aprire '%s' in scrittura."
 
-#: builtin/add.c:267
+#: builtin/add.c:281
 msgid "Could not write patch"
 msgstr "Impossibile scrivere la patch"
 
-#: builtin/add.c:270
+#: builtin/add.c:284
 msgid "editing patch failed"
 msgstr "modifica della patch non riuscita"
 
-#: builtin/add.c:273
+#: builtin/add.c:287
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Impossibile eseguire lo stat di '%s'"
 
-#: builtin/add.c:275
+#: builtin/add.c:289
 msgid "Empty patch. Aborted."
 msgstr "Patch vuota. Operazione interrotta."
 
-#: builtin/add.c:280
+#: builtin/add.c:294
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Impossibile applicare '%s'"
 
-#: builtin/add.c:288
+#: builtin/add.c:302
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "I seguenti percorsi sono ignorati da uno dei file .gitignore:\n"
 
-#: builtin/add.c:308 builtin/clean.c:910 builtin/fetch.c:163 builtin/mv.c:124
-#: builtin/prune-packed.c:56 builtin/pull.c:223 builtin/push.c:548
-#: builtin/remote.c:1344 builtin/rm.c:241 builtin/send-pack.c:165
+#: builtin/add.c:322 builtin/clean.c:910 builtin/fetch.c:163 builtin/mv.c:124
+#: builtin/prune-packed.c:56 builtin/pull.c:203 builtin/push.c:548
+#: builtin/remote.c:1421 builtin/rm.c:241 builtin/send-pack.c:165
 msgid "dry run"
 msgstr "test controllato"
 
-#: builtin/add.c:311
+#: builtin/add.c:325
 msgid "interactive picking"
 msgstr "scelta interattiva"
 
-#: builtin/add.c:312 builtin/checkout.c:1482 builtin/reset.c:307
+#: builtin/add.c:326 builtin/checkout.c:1511 builtin/reset.c:307
 msgid "select hunks interactively"
 msgstr "seleziona gli hunk in modalità interattiva"
 
-#: builtin/add.c:313
+#: builtin/add.c:327
 msgid "edit current diff and apply"
 msgstr "modifica il diff corrente e applicalo"
 
-#: builtin/add.c:314
+#: builtin/add.c:328
 msgid "allow adding otherwise ignored files"
 msgstr "consenti l'aggiunta di file altrimenti ignorati"
 
-#: builtin/add.c:315
+#: builtin/add.c:329
 msgid "update tracked files"
 msgstr "aggiorna i file tracciati"
 
-#: builtin/add.c:316
+#: builtin/add.c:330
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "rinormalizza i fine riga dei file tracciati (implica -u)"
 
-#: builtin/add.c:317
+#: builtin/add.c:331
 msgid "record only the fact that the path will be added later"
 msgstr "salva solo il fatto che il percorso sarà aggiunto successivamente"
 
-#: builtin/add.c:318
+#: builtin/add.c:332
 msgid "add changes from all tracked and untracked files"
 msgstr "aggiungi le modifiche da tutti i file tracciati e non"
 
-#: builtin/add.c:321
+#: builtin/add.c:335
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "ignora i percorsi eliminati nell'albero di lavoro (come --no-all)"
 
-#: builtin/add.c:323
+#: builtin/add.c:337
 msgid "don't add, only refresh the index"
 msgstr "non eseguire l'aggiunta, aggiorna solo l'indice"
 
-#: builtin/add.c:324
+#: builtin/add.c:338
 msgid "just skip files which cannot be added because of errors"
 msgstr ""
 "salta semplicemente i file che non possono essere aggiunti a causa di errori"
 
-#: builtin/add.c:325
+#: builtin/add.c:339
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
 "controlla se i file - anche quelli mancanti - sono ignorati durante il test "
 "controllato"
 
-#: builtin/add.c:327 builtin/update-index.c:1004
+#: builtin/add.c:341 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "esegui l'override del bit eseguibile dei file elencati"
 
-#: builtin/add.c:329
+#: builtin/add.c:343
 msgid "warn when adding an embedded repository"
 msgstr "emetti un avviso quando si aggiunge un repository incorporato"
 
-#: builtin/add.c:347
+#: builtin/add.c:345
+msgid "backend for `git stash -p`"
+msgstr "backend per `git stash -p`"
+
+#: builtin/add.c:363
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -9275,62 +9673,72 @@ msgstr ""
 "\n"
 "Vedi \"git help submodule\" per ulteriori informazioni."
 
-#: builtin/add.c:375
+#: builtin/add.c:391
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "aggiunta repository Git incorporato in corso: %s"
 
-#: builtin/add.c:393
-#, c-format
-msgid "Use -f if you really want to add them.\n"
-msgstr "Usa -f se vuoi davvero aggiungerli.\n"
+#: builtin/add.c:410
+msgid ""
+"Use -f if you really want to add them.\n"
+"Turn this message off by running\n"
+"\"git config advice.addIgnoredFile false\""
+msgstr ""
+"Usa -f se vuoi veramente aggiungerli.\n"
+"Per disabilitare questo messaggio, esegui\n"
+"\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:400
+#: builtin/add.c:419
 msgid "adding files failed"
 msgstr "aggiunta dei file non riuscita"
 
-#: builtin/add.c:428 builtin/commit.c:348
+#: builtin/add.c:447 builtin/commit.c:348
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr "--pathspec-from-file non è compatibile con --interactive/--patch"
 
-#: builtin/add.c:434
+#: builtin/add.c:464
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "--pathspec-from-file non è compatibile con --edit"
 
-#: builtin/add.c:446
+#: builtin/add.c:476
 msgid "-A and -u are mutually incompatible"
 msgstr "-A e -u non sono compatibili fra loro"
 
-#: builtin/add.c:449
+#: builtin/add.c:479
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr "L'opzione --ignore-missing può essere usata solo con --dry-run"
 
-#: builtin/add.c:453
+#: builtin/add.c:483
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "Il parametro --chmod '%s' deve essere -x o +x"
 
-#: builtin/add.c:471 builtin/checkout.c:1648 builtin/commit.c:354
+#: builtin/add.c:501 builtin/checkout.c:1675 builtin/commit.c:354
 #: builtin/reset.c:327
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr ""
-"--pathspec-from-file non è compatibile con gli argomenti specificatore"
-" percorso"
+"--pathspec-from-file non è compatibile con gli argomenti specificatore "
+"percorso"
 
-#: builtin/add.c:478 builtin/checkout.c:1660 builtin/commit.c:360
+#: builtin/add.c:508 builtin/checkout.c:1687 builtin/commit.c:360
 #: builtin/reset.c:333
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul richiede --pathspec-from-file"
 
-#: builtin/add.c:482
+#: builtin/add.c:512
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Non è stato specificato nulla, non è stato aggiunto nulla.\n"
 
-#: builtin/add.c:483
-#, c-format
-msgid "Maybe you wanted to say 'git add .'?\n"
-msgstr "Forse intendevi dire 'git add .'?\n"
+#: builtin/add.c:514
+msgid ""
+"Maybe you wanted to say 'git add .'?\n"
+"Turn this message off by running\n"
+"\"git config advice.addEmptyPathspec false\""
+msgstr ""
+"Forse volevi dire 'git add .'?\n"
+"Per disabilitare questo messaggio, esegui\n"
+"\"git config advice.addEmptyPathspec false\""
 
 #: builtin/am.c:347
 msgid "could not parse author script"
@@ -9475,7 +9883,7 @@ msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Applico? Sì [y]/No [n]/Modifica [e]/[V]isualizza patch/[A]ccetta tutto:"
 
-#: builtin/am.c:1695 builtin/commit.c:394
+#: builtin/am.c:1695 builtin/commit.c:398
 msgid "unable to write index file"
 msgstr "impossibile scrivere il file indice"
 
@@ -9615,9 +10023,9 @@ msgstr "rimuovi tutte le righe prima di una riga \"taglia qui\""
 msgid "pass it through git-apply"
 msgstr "passa l'argomento a git-apply"
 
-#: builtin/am.c:2203 builtin/commit.c:1386 builtin/fmt-merge-msg.c:673
-#: builtin/fmt-merge-msg.c:676 builtin/grep.c:883 builtin/merge.c:249
-#: builtin/pull.c:160 builtin/pull.c:219 builtin/rebase.c:1469
+#: builtin/am.c:2203 builtin/commit.c:1391 builtin/fmt-merge-msg.c:670
+#: builtin/fmt-merge-msg.c:673 builtin/grep.c:871 builtin/merge.c:250
+#: builtin/pull.c:140 builtin/pull.c:199 builtin/rebase.c:1505
 #: builtin/repack.c:315 builtin/repack.c:319 builtin/repack.c:321
 #: builtin/show-branch.c:650 builtin/show-ref.c:172 builtin/tag.c:403
 #: parse-options.h:154 parse-options.h:175 parse-options.h:316
@@ -9625,7 +10033,7 @@ msgid "n"
 msgstr "n"
 
 #: builtin/am.c:2209 builtin/branch.c:661 builtin/for-each-ref.c:38
-#: builtin/replace.c:555 builtin/tag.c:437 builtin/verify-tag.c:38
+#: builtin/replace.c:556 builtin/tag.c:437 builtin/verify-tag.c:38
 msgid "format"
 msgstr "formato"
 
@@ -9672,13 +10080,13 @@ msgstr "menti sulla data del commit"
 msgid "use current timestamp for author date"
 msgstr "usa il timestamp corrente come data autore"
 
-#: builtin/am.c:2241 builtin/commit-tree.c:120 builtin/commit.c:1507
-#: builtin/merge.c:286 builtin/pull.c:194 builtin/rebase.c:509
-#: builtin/rebase.c:1513 builtin/revert.c:117 builtin/tag.c:418
+#: builtin/am.c:2241 builtin/commit-tree.c:120 builtin/commit.c:1512
+#: builtin/merge.c:287 builtin/pull.c:174 builtin/rebase.c:517
+#: builtin/rebase.c:1556 builtin/revert.c:117 builtin/tag.c:418
 msgid "key-id"
 msgstr "ID chiave"
 
-#: builtin/am.c:2242 builtin/rebase.c:510 builtin/rebase.c:1514
+#: builtin/am.c:2242 builtin/rebase.c:518 builtin/rebase.c:1557
 msgid "GPG-sign commits"
 msgstr "firma i commit con GPG"
 
@@ -9896,7 +10304,7 @@ msgstr ""
 "Quindi devi specificare almeno una revisione %s ed una %s.\n"
 "Puoi usare \"git bisect %s\" e \"git bisect %s\" a questo scopo."
 
-#: builtin/bisect--helper.c:322
+#: builtin/bisect--helper.c:310
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "eseguo la bisezione solo con un commit %s"
@@ -9905,15 +10313,15 @@ msgstr "eseguo la bisezione solo con un commit %s"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:330
+#: builtin/bisect--helper.c:318
 msgid "Are you sure [Y/n]? "
 msgstr "Sei sicuro? [Y/n] "
 
-#: builtin/bisect--helper.c:377
+#: builtin/bisect--helper.c:379
 msgid "no terms defined"
 msgstr "nessun termine definito"
 
-#: builtin/bisect--helper.c:380
+#: builtin/bisect--helper.c:382
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -9922,7 +10330,7 @@ msgstr ""
 "I tuoi termini correnti sono %s per lo stato vecchio\n"
 "e %s per lo stato nuovo.\n"
 
-#: builtin/bisect--helper.c:390
+#: builtin/bisect--helper.c:392
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -9931,113 +10339,113 @@ msgstr ""
 "argomento %s non valido per 'git bisect terms'.\n"
 "Le opzioni supportate sono: --term-good|--term-old e --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:476
+#: builtin/bisect--helper.c:478
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "opzione non riconosciuta: '%s'"
 
-#: builtin/bisect--helper.c:480
+#: builtin/bisect--helper.c:482
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "sembra che '%s' non sia una revisione valida"
 
-#: builtin/bisect--helper.c:512
+#: builtin/bisect--helper.c:514
 msgid "bad HEAD - I need a HEAD"
 msgstr "HEAD non valida - ho bisogno di un'HEAD"
 
-#: builtin/bisect--helper.c:527
+#: builtin/bisect--helper.c:529
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
 "checkout di '%s' non riuscito. Prova con 'git bisect start <branch valido>'."
 
-#: builtin/bisect--helper.c:548
+#: builtin/bisect--helper.c:550
 msgid "won't bisect on cg-seek'ed tree"
 msgstr "non eseguirò la bisezione su un albero sottoposto a cg-seek"
 
-#: builtin/bisect--helper.c:551
+#: builtin/bisect--helper.c:553
 msgid "bad HEAD - strange symbolic ref"
 msgstr "head non valida - riferimento simbolico strano"
 
-#: builtin/bisect--helper.c:575
+#: builtin/bisect--helper.c:577
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "riferimento non valido: '%s'"
 
-#: builtin/bisect--helper.c:631
+#: builtin/bisect--helper.c:633
 msgid "perform 'git bisect next'"
 msgstr "esegui 'git bisect next'"
 
-#: builtin/bisect--helper.c:633
+#: builtin/bisect--helper.c:635
 msgid "write the terms to .git/BISECT_TERMS"
 msgstr "scrivi i termini in .git/BISECT_TERMS"
 
-#: builtin/bisect--helper.c:635
+#: builtin/bisect--helper.c:637
 msgid "cleanup the bisection state"
 msgstr "pulisci lo stato bisezione"
 
-#: builtin/bisect--helper.c:637
+#: builtin/bisect--helper.c:639
 msgid "check for expected revs"
 msgstr "controlla se le revisioni attese sono presenti"
 
-#: builtin/bisect--helper.c:639
+#: builtin/bisect--helper.c:641
 msgid "reset the bisection state"
 msgstr "reimposta lo stato della bisezione"
 
-#: builtin/bisect--helper.c:641
+#: builtin/bisect--helper.c:643
 msgid "write out the bisection state in BISECT_LOG"
 msgstr "scrivi lo stato della bisezione in BISECT_LOG"
 
-#: builtin/bisect--helper.c:643
+#: builtin/bisect--helper.c:645
 msgid "check and set terms in a bisection state"
 msgstr "controlla e imposta i termini in uno stato bisezione"
 
-#: builtin/bisect--helper.c:645
+#: builtin/bisect--helper.c:647
 msgid "check whether bad or good terms exist"
 msgstr ""
 "controlla se esistono termini per revisioni non funzionanti o funzionanti"
 
-#: builtin/bisect--helper.c:647
+#: builtin/bisect--helper.c:649
 msgid "print out the bisect terms"
 msgstr "stampa i termini della bisezione"
 
-#: builtin/bisect--helper.c:649
+#: builtin/bisect--helper.c:651
 msgid "start the bisect session"
 msgstr "inizia la sessione di bisezione"
 
-#: builtin/bisect--helper.c:651
+#: builtin/bisect--helper.c:653
 msgid "update BISECT_HEAD instead of checking out the current commit"
 msgstr "aggiorna BISECT_HEAD anziché eseguire il checkout del commit corrente"
 
-#: builtin/bisect--helper.c:653
+#: builtin/bisect--helper.c:655
 msgid "no log for BISECT_WRITE"
 msgstr "non registrare le operazioni eseguite per BISECT_WRITE"
 
-#: builtin/bisect--helper.c:670
+#: builtin/bisect--helper.c:673
 msgid "--write-terms requires two arguments"
 msgstr "--write-terms richiede due argomenti"
 
-#: builtin/bisect--helper.c:674
+#: builtin/bisect--helper.c:677
 msgid "--bisect-clean-state requires no arguments"
 msgstr "--bisect-clean-state non richiede argomenti"
 
-#: builtin/bisect--helper.c:681
+#: builtin/bisect--helper.c:684
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset richiede o nessun argomento o un commit"
 
-#: builtin/bisect--helper.c:685
+#: builtin/bisect--helper.c:688
 msgid "--bisect-write requires either 4 or 5 arguments"
 msgstr "--bisect-write richiede o quattro o cinque argomenti"
 
-#: builtin/bisect--helper.c:691
+#: builtin/bisect--helper.c:694
 msgid "--check-and-set-terms requires 3 arguments"
 msgstr "--check-and-set-terms richiede tre argomenti"
 
-#: builtin/bisect--helper.c:697
+#: builtin/bisect--helper.c:700
 msgid "--bisect-next-check requires 2 or 3 arguments"
 msgstr "--bisect-next-check richiede due o tre argomenti"
 
-#: builtin/bisect--helper.c:703
+#: builtin/bisect--helper.c:706
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms richiede zero o un argomento"
 
@@ -10448,7 +10856,7 @@ msgstr "imposta la modalità tracking (vedi git-pull(1))"
 msgid "do not use"
 msgstr "non usare"
 
-#: builtin/branch.c:626 builtin/rebase.c:505
+#: builtin/branch.c:626 builtin/rebase.c:513
 msgid "upstream"
 msgstr "upstream"
 
@@ -10560,7 +10968,7 @@ msgstr ""
 msgid "format to use for the output"
 msgstr "formato da usare per l'output"
 
-#: builtin/branch.c:684 builtin/clone.c:784
+#: builtin/branch.c:684 builtin/clone.c:785
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD non trovato fra i riferimenti/head!"
 
@@ -10672,20 +11080,20 @@ msgstr "git bundle list-heads <file> [<nome riferimento>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <file> [<nome riferimento>...]"
 
-#: builtin/bundle.c:66 builtin/pack-objects.c:3228
+#: builtin/bundle.c:66 builtin/pack-objects.c:3375
 msgid "do not show progress meter"
 msgstr "non visualizzare la barra di avanzamento"
 
-#: builtin/bundle.c:68 builtin/pack-objects.c:3230
+#: builtin/bundle.c:68 builtin/pack-objects.c:3377
 msgid "show progress meter"
 msgstr "visualizza la barra di avanzamento"
 
-#: builtin/bundle.c:70 builtin/pack-objects.c:3232
+#: builtin/bundle.c:70 builtin/pack-objects.c:3379
 msgid "show progress meter during object writing phase"
 msgstr ""
 "visualizza la barra di avanzamento durante la fase di scrittura oggetti"
 
-#: builtin/bundle.c:73 builtin/pack-objects.c:3235
+#: builtin/bundle.c:73 builtin/pack-objects.c:3382
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "simile a --all-progress quando è visualizzata la barra di avanzamento"
 
@@ -10706,12 +11114,12 @@ msgstr "%s è corretto\n"
 msgid "Need a repository to unbundle."
 msgstr "Per decomprimere un bundle è necessario un repository."
 
-#: builtin/bundle.c:168 builtin/remote.c:1609
+#: builtin/bundle.c:168 builtin/remote.c:1686
 msgid "be verbose; must be placed before a subcommand"
 msgstr ""
 "visualizza ulteriori dettagli; deve essere collocato prima di un sottocomando"
 
-#: builtin/bundle.c:190 builtin/remote.c:1640
+#: builtin/bundle.c:190 builtin/remote.c:1717
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Sottocomando sconosciuto: %s"
@@ -10764,7 +11172,7 @@ msgstr "esegui textconv sul contenuto dell'oggetto (per gli oggetti blob)"
 msgid "for blob objects, run filters on object's content"
 msgstr "esegui i filtri sul contenuto dell'oggetto (per gli oggetti blob)"
 
-#: builtin/cat-file.c:645 git-submodule.sh:992
+#: builtin/cat-file.c:645 git-submodule.sh:1002
 msgid "blob"
 msgstr "blob"
 
@@ -10828,8 +11236,8 @@ msgstr "leggi i nomi dei file dallo standard input"
 msgid "terminate input and output records by a NUL character"
 msgstr "termina i record di input e output con un carattere NUL"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1435 builtin/gc.c:537
-#: builtin/worktree.c:506
+#: builtin/check-ignore.c:21 builtin/checkout.c:1464 builtin/gc.c:537
+#: builtin/worktree.c:499
 msgid "suppress progress reporting"
 msgstr "non visualizzare l'avanzamento dell'operazione"
 
@@ -10841,27 +11249,27 @@ msgstr "visualizza i percorsi di input non corrispondenti"
 msgid "ignore index when checking"
 msgstr "ignora l'indice durante il controllo"
 
-#: builtin/check-ignore.c:160
+#: builtin/check-ignore.c:163
 msgid "cannot specify pathnames with --stdin"
 msgstr "impossibile specificare i nomi percorso con --stdin"
 
-#: builtin/check-ignore.c:163
+#: builtin/check-ignore.c:166
 msgid "-z only makes sense with --stdin"
 msgstr "-z ha senso solo con --stdin"
 
-#: builtin/check-ignore.c:165
+#: builtin/check-ignore.c:168
 msgid "no path specified"
 msgstr "nessun percorso specificato"
 
-#: builtin/check-ignore.c:169
+#: builtin/check-ignore.c:172
 msgid "--quiet is only valid with a single pathname"
 msgstr "--quiet è valido solo con un nome percorso singolo"
 
-#: builtin/check-ignore.c:171
+#: builtin/check-ignore.c:174
 msgid "cannot have both --quiet and --verbose"
 msgstr "non è possibile usare sia --quiet sia --verbose"
 
-#: builtin/check-ignore.c:174
+#: builtin/check-ignore.c:177
 msgid "--non-matching is only valid with --verbose"
 msgstr "--non-matching è valido solo con --verbose"
 
@@ -10919,9 +11327,9 @@ msgid "write the content to temporary files"
 msgstr "scrivi il contenuto in file temporanei"
 
 #: builtin/checkout-index.c:178 builtin/column.c:31
-#: builtin/submodule--helper.c:1385 builtin/submodule--helper.c:1388
-#: builtin/submodule--helper.c:1396 builtin/submodule--helper.c:1882
-#: builtin/worktree.c:679
+#: builtin/submodule--helper.c:1400 builtin/submodule--helper.c:1403
+#: builtin/submodule--helper.c:1411 builtin/submodule--helper.c:1909
+#: builtin/worktree.c:672
 msgid "string"
 msgstr "stringa"
 
@@ -11038,11 +11446,11 @@ msgstr "'%s' o '%s' non possono essere usati con %s"
 msgid "path '%s' is unmerged"
 msgstr "il percorso '%s' non è stato sottoposto a merge"
 
-#: builtin/checkout.c:682 builtin/sparse-checkout.c:82
+#: builtin/checkout.c:684 builtin/sparse-checkout.c:106
 msgid "you need to resolve your current index first"
 msgstr "prima devi risolvere l'indice corrente"
 
-#: builtin/checkout.c:732
+#: builtin/checkout.c:734
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -11051,50 +11459,50 @@ msgstr ""
 "impossibile continuare con modifiche in stage nei file seguenti:\n"
 "%s"
 
-#: builtin/checkout.c:835
+#: builtin/checkout.c:837
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Impossibile esaminare il registro dei riferimenti per '%s': %s\n"
 
-#: builtin/checkout.c:877
+#: builtin/checkout.c:879
 msgid "HEAD is now at"
 msgstr "HEAD si trova ora a"
 
-#: builtin/checkout.c:881 builtin/clone.c:716
+#: builtin/checkout.c:883 builtin/clone.c:717
 msgid "unable to update HEAD"
 msgstr "impossibile aggiornare HEAD"
 
-#: builtin/checkout.c:885
+#: builtin/checkout.c:887
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Ripristina il branch '%s'\n"
 
-#: builtin/checkout.c:888
+#: builtin/checkout.c:890
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Si è già su '%s'\n"
 
-#: builtin/checkout.c:892
+#: builtin/checkout.c:894
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Si è passati al branch '%s' e lo si è reimpostato\n"
 
-#: builtin/checkout.c:894 builtin/checkout.c:1291
+#: builtin/checkout.c:896 builtin/checkout.c:1320
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Si è passati a un nuovo branch '%s'\n"
 
-#: builtin/checkout.c:896
+#: builtin/checkout.c:898
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Si è passati al branch '%s'\n"
 
-#: builtin/checkout.c:947
+#: builtin/checkout.c:949
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ...e altri %d.\n"
 
-#: builtin/checkout.c:953
+#: builtin/checkout.c:955
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -11117,7 +11525,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:972
+#: builtin/checkout.c:974
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -11144,28 +11552,19 @@ msgstr[1] ""
 " git branch <nome del nuovo branch> %s\n"
 "\n"
 
-#: builtin/checkout.c:1007
+#: builtin/checkout.c:1009
 msgid "internal error in revision walk"
 msgstr "errore interno durante la visita delle revisioni"
 
-#: builtin/checkout.c:1011
+#: builtin/checkout.c:1013
 msgid "Previous HEAD position was"
 msgstr "La precedente posizione di HEAD era"
 
-#: builtin/checkout.c:1051 builtin/checkout.c:1286
+#: builtin/checkout.c:1053 builtin/checkout.c:1315
 msgid "You are on a branch yet to be born"
 msgstr "Sei su un branch che deve ancora essere creato"
 
-#: builtin/checkout.c:1178
-msgid "only one reference expected"
-msgstr "atteso solo un riferimento"
-
-#: builtin/checkout.c:1195
-#, c-format
-msgid "only one reference expected, %d given."
-msgstr "atteso solo un riferimento, %d specificati."
-
-#: builtin/checkout.c:1232
+#: builtin/checkout.c:1128
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -11174,235 +11573,8 @@ msgstr ""
 "'%s' potrebbe essere sia un file locale, sia un branch da tracciare.\n"
 "Usa -- (e facoltativamente --no-guess) per rimuovere l'ambiguità"
 
-#: builtin/checkout.c:1245 builtin/worktree.c:290 builtin/worktree.c:455
-#, c-format
-msgid "invalid reference: %s"
-msgstr "riferimento non valido: %s"
-
-#: builtin/checkout.c:1258 builtin/checkout.c:1622
-#, c-format
-msgid "reference is not a tree: %s"
-msgstr "il riferimento non è un albero: %s"
-
-#: builtin/checkout.c:1305
-#, c-format
-msgid "a branch is expected, got tag '%s'"
-msgstr "atteso branch, ricevuto tag '%s'"
-
-#: builtin/checkout.c:1307
-#, c-format
-msgid "a branch is expected, got remote branch '%s'"
-msgstr "atteso branch, ricevuto branch remoto '%s'"
-
-#: builtin/checkout.c:1308 builtin/checkout.c:1316
-#, c-format
-msgid "a branch is expected, got '%s'"
-msgstr "atteso branch, ricevuto '%s'"
-
-#: builtin/checkout.c:1311
-#, c-format
-msgid "a branch is expected, got commit '%s'"
-msgstr "atteso branch, ricevuto commit '%s'"
-
-#: builtin/checkout.c:1327
+#: builtin/checkout.c:1135
 msgid ""
-"cannot switch branch while merging\n"
-"Consider \"git merge --quit\" or \"git worktree add\"."
-msgstr ""
-"impossibile cambiare branch durante un merge\n"
-"Considera l'uso di \"git merge --quit\" o di \"git worktree add\"."
-
-#: builtin/checkout.c:1331
-msgid ""
-"cannot switch branch in the middle of an am session\n"
-"Consider \"git am --quit\" or \"git worktree add\"."
-msgstr ""
-"impossibile cambiare branch nel bel mezzo di una sessione am\n"
-"Considera l'uso di \"git am --quit\" o di \"git worktree add\"."
-
-#: builtin/checkout.c:1335
-msgid ""
-"cannot switch branch while rebasing\n"
-"Consider \"git rebase --quit\" or \"git worktree add\"."
-msgstr ""
-"impossibile cambiare branch durante un rebase\n"
-"Considera l'uso di \"git rebase --quit\" o di \"git worktree add\"."
-
-#: builtin/checkout.c:1339
-msgid ""
-"cannot switch branch while cherry-picking\n"
-"Consider \"git cherry-pick --quit\" or \"git worktree add\"."
-msgstr ""
-"impossibile cambiare branch durante un cherry-pick\n"
-"Considera l'uso di \"git cherry-pick --quit\" o di \"git worktree add\"."
-
-#: builtin/checkout.c:1343
-msgid ""
-"cannot switch branch while reverting\n"
-"Consider \"git revert --quit\" or \"git worktree add\"."
-msgstr ""
-"impossibile cambiare branch durante un revert\n"
-"Considera l'uso di \"git revert --quit\" o di \"git worktree add\"."
-
-#: builtin/checkout.c:1347
-msgid "you are switching branch while bisecting"
-msgstr "stai cambiando branch durante una bisezione"
-
-#: builtin/checkout.c:1354
-msgid "paths cannot be used with switching branches"
-msgstr "i percorsi non possono essere usati passando da un branch a un altro"
-
-#: builtin/checkout.c:1357 builtin/checkout.c:1361 builtin/checkout.c:1365
-#, c-format
-msgid "'%s' cannot be used with switching branches"
-msgstr "'%s' non può essere usato passando da un branch a un altro"
-
-#: builtin/checkout.c:1369 builtin/checkout.c:1372 builtin/checkout.c:1375
-#: builtin/checkout.c:1380 builtin/checkout.c:1385
-#, c-format
-msgid "'%s' cannot be used with '%s'"
-msgstr "'%s' non può essere usato con '%s'"
-
-#: builtin/checkout.c:1382
-#, c-format
-msgid "'%s' cannot take <start-point>"
-msgstr "'%s' non accetta l'argomento <punto di partenza>"
-
-#: builtin/checkout.c:1390
-#, c-format
-msgid "Cannot switch branch to a non-commit '%s'"
-msgstr "Impossibile cambiare branch per passare a '%s' che non è un commit"
-
-#: builtin/checkout.c:1397
-msgid "missing branch or commit argument"
-msgstr "argomento branch o commit mancante"
-
-#: builtin/checkout.c:1439 builtin/clone.c:91 builtin/commit-graph.c:52
-#: builtin/commit-graph.c:113 builtin/fetch.c:167 builtin/merge.c:285
-#: builtin/multi-pack-index.c:27 builtin/pull.c:138 builtin/push.c:563
-#: builtin/send-pack.c:174
-msgid "force progress reporting"
-msgstr "forza l'indicazione d'avanzamento dell'operazione"
-
-#: builtin/checkout.c:1440
-msgid "perform a 3-way merge with the new branch"
-msgstr "esegui un merge a tre vie con il nuovo branch"
-
-#: builtin/checkout.c:1441 builtin/log.c:1690 parse-options.h:322
-msgid "style"
-msgstr "stile"
-
-#: builtin/checkout.c:1442
-msgid "conflict style (merge or diff3)"
-msgstr "stile conflitti (merge o diff3)"
-
-#: builtin/checkout.c:1454 builtin/worktree.c:503
-msgid "detach HEAD at named commit"
-msgstr "scollega l'HEAD al commit specificato"
-
-#: builtin/checkout.c:1455
-msgid "set upstream info for new branch"
-msgstr "imposta le informazioni sull'upstream per il nuovo branch"
-
-#: builtin/checkout.c:1457
-msgid "force checkout (throw away local modifications)"
-msgstr "esegui forzatamente il checkout (scarta le modifiche locali)"
-
-#: builtin/checkout.c:1459
-msgid "new-branch"
-msgstr "nuovo branch"
-
-#: builtin/checkout.c:1459
-msgid "new unparented branch"
-msgstr "nuovo branch senza genitore"
-
-#: builtin/checkout.c:1461 builtin/merge.c:288
-msgid "update ignored files (default)"
-msgstr "aggiorna i file ignorati (impostazione predefinita)"
-
-#: builtin/checkout.c:1464
-msgid "do not check if another worktree is holding the given ref"
-msgstr ""
-"non controllare se un altro albero di lavoro contiene il riferimento "
-"specificato"
-
-#: builtin/checkout.c:1477
-msgid "checkout our version for unmerged files"
-msgstr ""
-"esegui il checkout della nostra versione per i file non sottoposti a merge"
-
-#: builtin/checkout.c:1480
-msgid "checkout their version for unmerged files"
-msgstr ""
-"esegui il checkout della loro versione per i file non sottoposti a merge"
-
-#: builtin/checkout.c:1484
-msgid "do not limit pathspecs to sparse entries only"
-msgstr "non limitare gli specificatori percorso solo alle voci sparse"
-
-#: builtin/checkout.c:1537
-msgid "-b, -B and --orphan are mutually exclusive"
-msgstr "le opzioni -b, -B e --orphan sono mutuamente esclusive"
-
-#: builtin/checkout.c:1540
-msgid "-p and --overlay are mutually exclusive"
-msgstr "le opzioni -p e --overlay sono mutualmente esclusive"
-
-#: builtin/checkout.c:1577
-msgid "--track needs a branch name"
-msgstr "--track richiede il nome di un branch"
-
-#: builtin/checkout.c:1582
-msgid "missing branch name; try -b"
-msgstr "nome del branch mancante; prova con -b"
-
-#: builtin/checkout.c:1615
-#, c-format
-msgid "could not resolve %s"
-msgstr "impossibile risolvere %s"
-
-#: builtin/checkout.c:1631
-msgid "invalid path specification"
-msgstr "specificatore percorso non valido"
-
-#: builtin/checkout.c:1638
-#, c-format
-msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
-msgstr ""
-"'%s' non è un commit e non si può creare un branch '%s' che parta da esso"
-
-#: builtin/checkout.c:1642
-#, c-format
-msgid "git checkout: --detach does not take a path argument '%s'"
-msgstr "git checkout: --detach non accetta un percorso '%s' come argomento"
-
-#: builtin/checkout.c:1651
-msgid "--pathspec-from-file is incompatible with --detach"
-msgstr "--pathspec-from-file non è compatibile con --detach"
-
-#: builtin/checkout.c:1654 builtin/reset.c:324
-msgid "--pathspec-from-file is incompatible with --patch"
-msgstr "--pathspec-from-file non è compatibile con --patch"
-
-#: builtin/checkout.c:1665
-msgid ""
-"git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
-"checking out of the index."
-msgstr ""
-"git checkout: --ours/--theirs, --force e --merge sono incompatibili quando\n"
-"si esegue il checkout dell'indice."
-
-#: builtin/checkout.c:1670
-msgid "you must specify path(s) to restore"
-msgstr "devi specificare il percorso/i percorsi da ripristinare"
-
-#: builtin/checkout.c:1689
-#, c-format
-msgid ""
-"'%s' matched more than one remote tracking branch.\n"
-"We found %d remotes with a reference that matched. So we fell back\n"
-"on trying to resolve the argument as a path, but failed there too!\n"
-"\n"
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
 "\n"
@@ -11412,11 +11584,6 @@ msgid ""
 "one remote, e.g. the 'origin' remote, consider setting\n"
 "checkout.defaultRemote=origin in your config."
 msgstr ""
-"'%s' corrisponde a più di un branch remoto.\n"
-"Abbiamo trovato %d remoti con un riferimento corrispondente, per cui\n"
-"abbiamo ripiegato tentando di risolvere l'argomento come percorso, ma\n"
-"non siamo riusciti nemmeno a portare a termine tale operazione!\n"
-"\n"
 "Se intendevi eseguire il checkout di un branch remoto, ad es. 'origin',\n"
 "puoi farlo usando la versione completamente qualificata del nome\n"
 "con l'opzione --track:\n"
@@ -11427,65 +11594,301 @@ msgstr ""
 "rispetto a un particolare remoto, ad es. 'origin', potresti voler\n"
 "impostare checkout.defaultRemote=origin nel tuo file di configurazione."
 
-#: builtin/checkout.c:1714 builtin/checkout.c:1716 builtin/checkout.c:1765
-#: builtin/checkout.c:1767 builtin/clone.c:121 builtin/remote.c:169
-#: builtin/remote.c:171 builtin/worktree.c:499 builtin/worktree.c:501
+#: builtin/checkout.c:1145
+#, c-format
+msgid "'%s' matched multiple (%d) remote tracking branches"
+msgstr "'%s' corrisponde a più (%d) branch che ne tracciano uno remoto"
+
+#: builtin/checkout.c:1211
+msgid "only one reference expected"
+msgstr "atteso solo un riferimento"
+
+#: builtin/checkout.c:1228
+#, c-format
+msgid "only one reference expected, %d given."
+msgstr "atteso solo un riferimento, %d specificati."
+
+#: builtin/checkout.c:1274 builtin/worktree.c:283 builtin/worktree.c:448
+#, c-format
+msgid "invalid reference: %s"
+msgstr "riferimento non valido: %s"
+
+#: builtin/checkout.c:1287 builtin/checkout.c:1649
+#, c-format
+msgid "reference is not a tree: %s"
+msgstr "il riferimento non è un albero: %s"
+
+#: builtin/checkout.c:1334
+#, c-format
+msgid "a branch is expected, got tag '%s'"
+msgstr "atteso branch, ricevuto tag '%s'"
+
+#: builtin/checkout.c:1336
+#, c-format
+msgid "a branch is expected, got remote branch '%s'"
+msgstr "atteso branch, ricevuto branch remoto '%s'"
+
+#: builtin/checkout.c:1337 builtin/checkout.c:1345
+#, c-format
+msgid "a branch is expected, got '%s'"
+msgstr "atteso branch, ricevuto '%s'"
+
+#: builtin/checkout.c:1340
+#, c-format
+msgid "a branch is expected, got commit '%s'"
+msgstr "atteso branch, ricevuto commit '%s'"
+
+#: builtin/checkout.c:1356
+msgid ""
+"cannot switch branch while merging\n"
+"Consider \"git merge --quit\" or \"git worktree add\"."
+msgstr ""
+"impossibile cambiare branch durante un merge\n"
+"Considera l'uso di \"git merge --quit\" o di \"git worktree add\"."
+
+#: builtin/checkout.c:1360
+msgid ""
+"cannot switch branch in the middle of an am session\n"
+"Consider \"git am --quit\" or \"git worktree add\"."
+msgstr ""
+"impossibile cambiare branch nel bel mezzo di una sessione am\n"
+"Considera l'uso di \"git am --quit\" o di \"git worktree add\"."
+
+#: builtin/checkout.c:1364
+msgid ""
+"cannot switch branch while rebasing\n"
+"Consider \"git rebase --quit\" or \"git worktree add\"."
+msgstr ""
+"impossibile cambiare branch durante un rebase\n"
+"Considera l'uso di \"git rebase --quit\" o di \"git worktree add\"."
+
+#: builtin/checkout.c:1368
+msgid ""
+"cannot switch branch while cherry-picking\n"
+"Consider \"git cherry-pick --quit\" or \"git worktree add\"."
+msgstr ""
+"impossibile cambiare branch durante un cherry-pick\n"
+"Considera l'uso di \"git cherry-pick --quit\" o di \"git worktree add\"."
+
+#: builtin/checkout.c:1372
+msgid ""
+"cannot switch branch while reverting\n"
+"Consider \"git revert --quit\" or \"git worktree add\"."
+msgstr ""
+"impossibile cambiare branch durante un revert\n"
+"Considera l'uso di \"git revert --quit\" o di \"git worktree add\"."
+
+#: builtin/checkout.c:1376
+msgid "you are switching branch while bisecting"
+msgstr "stai cambiando branch durante una bisezione"
+
+#: builtin/checkout.c:1383
+msgid "paths cannot be used with switching branches"
+msgstr "i percorsi non possono essere usati passando da un branch a un altro"
+
+#: builtin/checkout.c:1386 builtin/checkout.c:1390 builtin/checkout.c:1394
+#, c-format
+msgid "'%s' cannot be used with switching branches"
+msgstr "'%s' non può essere usato passando da un branch a un altro"
+
+#: builtin/checkout.c:1398 builtin/checkout.c:1401 builtin/checkout.c:1404
+#: builtin/checkout.c:1409 builtin/checkout.c:1414
+#, c-format
+msgid "'%s' cannot be used with '%s'"
+msgstr "'%s' non può essere usato con '%s'"
+
+#: builtin/checkout.c:1411
+#, c-format
+msgid "'%s' cannot take <start-point>"
+msgstr "'%s' non accetta l'argomento <punto di partenza>"
+
+#: builtin/checkout.c:1419
+#, c-format
+msgid "Cannot switch branch to a non-commit '%s'"
+msgstr "Impossibile cambiare branch per passare a '%s' che non è un commit"
+
+#: builtin/checkout.c:1426
+msgid "missing branch or commit argument"
+msgstr "argomento branch o commit mancante"
+
+#: builtin/checkout.c:1468 builtin/clone.c:91 builtin/commit-graph.c:72
+#: builtin/commit-graph.c:135 builtin/fetch.c:167 builtin/merge.c:286
+#: builtin/multi-pack-index.c:27 builtin/pull.c:118 builtin/push.c:563
+#: builtin/send-pack.c:174
+msgid "force progress reporting"
+msgstr "forza l'indicazione d'avanzamento dell'operazione"
+
+#: builtin/checkout.c:1469
+msgid "perform a 3-way merge with the new branch"
+msgstr "esegui un merge a tre vie con il nuovo branch"
+
+#: builtin/checkout.c:1470 builtin/log.c:1690 parse-options.h:322
+msgid "style"
+msgstr "stile"
+
+#: builtin/checkout.c:1471
+msgid "conflict style (merge or diff3)"
+msgstr "stile conflitti (merge o diff3)"
+
+#: builtin/checkout.c:1483 builtin/worktree.c:496
+msgid "detach HEAD at named commit"
+msgstr "scollega l'HEAD al commit specificato"
+
+#: builtin/checkout.c:1484
+msgid "set upstream info for new branch"
+msgstr "imposta le informazioni sull'upstream per il nuovo branch"
+
+#: builtin/checkout.c:1486
+msgid "force checkout (throw away local modifications)"
+msgstr "esegui forzatamente il checkout (scarta le modifiche locali)"
+
+#: builtin/checkout.c:1488
+msgid "new-branch"
+msgstr "nuovo branch"
+
+#: builtin/checkout.c:1488
+msgid "new unparented branch"
+msgstr "nuovo branch senza genitore"
+
+#: builtin/checkout.c:1490 builtin/merge.c:289
+msgid "update ignored files (default)"
+msgstr "aggiorna i file ignorati (impostazione predefinita)"
+
+#: builtin/checkout.c:1493
+msgid "do not check if another worktree is holding the given ref"
+msgstr ""
+"non controllare se un altro albero di lavoro contiene il riferimento "
+"specificato"
+
+#: builtin/checkout.c:1506
+msgid "checkout our version for unmerged files"
+msgstr ""
+"esegui il checkout della nostra versione per i file non sottoposti a merge"
+
+#: builtin/checkout.c:1509
+msgid "checkout their version for unmerged files"
+msgstr ""
+"esegui il checkout della loro versione per i file non sottoposti a merge"
+
+#: builtin/checkout.c:1513
+msgid "do not limit pathspecs to sparse entries only"
+msgstr "non limitare gli specificatori percorso solo alle voci sparse"
+
+#: builtin/checkout.c:1565
+msgid "-b, -B and --orphan are mutually exclusive"
+msgstr "le opzioni -b, -B e --orphan sono mutuamente esclusive"
+
+#: builtin/checkout.c:1568
+msgid "-p and --overlay are mutually exclusive"
+msgstr "le opzioni -p e --overlay sono mutualmente esclusive"
+
+#: builtin/checkout.c:1605
+msgid "--track needs a branch name"
+msgstr "--track richiede il nome di un branch"
+
+#: builtin/checkout.c:1610
+msgid "missing branch name; try -b"
+msgstr "nome del branch mancante; prova con -b"
+
+#: builtin/checkout.c:1642
+#, c-format
+msgid "could not resolve %s"
+msgstr "impossibile risolvere %s"
+
+#: builtin/checkout.c:1658
+msgid "invalid path specification"
+msgstr "specificatore percorso non valido"
+
+#: builtin/checkout.c:1665
+#, c-format
+msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
+msgstr ""
+"'%s' non è un commit e non si può creare un branch '%s' che parta da esso"
+
+#: builtin/checkout.c:1669
+#, c-format
+msgid "git checkout: --detach does not take a path argument '%s'"
+msgstr "git checkout: --detach non accetta un percorso '%s' come argomento"
+
+#: builtin/checkout.c:1678
+msgid "--pathspec-from-file is incompatible with --detach"
+msgstr "--pathspec-from-file non è compatibile con --detach"
+
+#: builtin/checkout.c:1681 builtin/reset.c:324
+msgid "--pathspec-from-file is incompatible with --patch"
+msgstr "--pathspec-from-file non è compatibile con --patch"
+
+#: builtin/checkout.c:1692
+msgid ""
+"git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
+"checking out of the index."
+msgstr ""
+"git checkout: --ours/--theirs, --force e --merge sono incompatibili quando\n"
+"si esegue il checkout dell'indice."
+
+#: builtin/checkout.c:1697
+msgid "you must specify path(s) to restore"
+msgstr "devi specificare il percorso/i percorsi da ripristinare"
+
+#: builtin/checkout.c:1723 builtin/checkout.c:1725 builtin/checkout.c:1774
+#: builtin/checkout.c:1776 builtin/clone.c:121 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/worktree.c:492 builtin/worktree.c:494
 msgid "branch"
 msgstr "branch"
 
-#: builtin/checkout.c:1715
+#: builtin/checkout.c:1724
 msgid "create and checkout a new branch"
 msgstr "crea un nuovo branch ed eseguine il checkout"
 
-#: builtin/checkout.c:1717
+#: builtin/checkout.c:1726
 msgid "create/reset and checkout a branch"
 msgstr "crea/reimposta un branch ed eseguine il checkout"
 
-#: builtin/checkout.c:1718
+#: builtin/checkout.c:1727
 msgid "create reflog for new branch"
 msgstr "crea il registro dei riferimenti per il nuovo branch"
 
-#: builtin/checkout.c:1720
+#: builtin/checkout.c:1729
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "prevedi 'git checkout <branch inesistente>' (impostazione predefinita)"
 
-#: builtin/checkout.c:1721
+#: builtin/checkout.c:1730
 msgid "use overlay mode (default)"
 msgstr "usa modalità overlay (impostazione predefinita)"
 
-#: builtin/checkout.c:1766
+#: builtin/checkout.c:1775
 msgid "create and switch to a new branch"
 msgstr "crea un nuovo branch e passa a quest'ultimo"
 
-#: builtin/checkout.c:1768
+#: builtin/checkout.c:1777
 msgid "create/reset and switch to a branch"
 msgstr "crea/reimposta un branch e passa a quest'ultimo"
 
-#: builtin/checkout.c:1770
+#: builtin/checkout.c:1779
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "prevedi 'git switch <branch inesistente>'"
 
-#: builtin/checkout.c:1772
+#: builtin/checkout.c:1781
 msgid "throw away local modifications"
 msgstr "scarta le modifiche locali"
 
-#: builtin/checkout.c:1804
+#: builtin/checkout.c:1813
 msgid "which tree-ish to checkout from"
 msgstr "albero da cui eseguire il checkout"
 
-#: builtin/checkout.c:1806
+#: builtin/checkout.c:1815
 msgid "restore the index"
 msgstr "ripristina l'indice"
 
-#: builtin/checkout.c:1808
+#: builtin/checkout.c:1817
 msgid "restore the working tree (default)"
 msgstr "ripristina l'albero di lavoro (impostazione predefinita)"
 
-#: builtin/checkout.c:1810
+#: builtin/checkout.c:1819
 msgid "ignore unmerged entries"
 msgstr "ignora voci non sottoposte a merge"
 
-#: builtin/checkout.c:1811
+#: builtin/checkout.c:1820
 msgid "use overlay mode"
 msgstr "usa modalità overlay"
 
@@ -11631,9 +12034,9 @@ msgstr "pulizia interattiva"
 msgid "remove whole directories"
 msgstr "rimuovi intere directory"
 
-#: builtin/clean.c:915 builtin/describe.c:548 builtin/describe.c:550
-#: builtin/grep.c:901 builtin/log.c:177 builtin/log.c:179
-#: builtin/ls-files.c:557 builtin/name-rev.c:464 builtin/name-rev.c:466
+#: builtin/clean.c:915 builtin/describe.c:562 builtin/describe.c:564
+#: builtin/grep.c:889 builtin/log.c:177 builtin/log.c:179
+#: builtin/ls-files.c:557 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "pattern"
@@ -11718,18 +12121,18 @@ msgstr "directory modelli"
 msgid "directory from which templates will be used"
 msgstr "directory da cui saranno recuperati i modelli"
 
-#: builtin/clone.c:114 builtin/clone.c:116 builtin/submodule--helper.c:1392
-#: builtin/submodule--helper.c:1885
+#: builtin/clone.c:114 builtin/clone.c:116 builtin/submodule--helper.c:1407
+#: builtin/submodule--helper.c:1912
 msgid "reference repository"
 msgstr "repository di riferimento"
 
-#: builtin/clone.c:118 builtin/submodule--helper.c:1394
-#: builtin/submodule--helper.c:1887
+#: builtin/clone.c:118 builtin/submodule--helper.c:1409
+#: builtin/submodule--helper.c:1914
 msgid "use --reference only while cloning"
 msgstr "usa --reference solo durante la clonazione"
 
 #: builtin/clone.c:119 builtin/column.c:27 builtin/merge-file.c:46
-#: builtin/pack-objects.c:3294 builtin/repack.c:327
+#: builtin/pack-objects.c:3441 builtin/repack.c:327
 msgid "name"
 msgstr "nome"
 
@@ -11745,8 +12148,8 @@ msgstr "esegui il checkout di <branch> anziché dell'HEAD del remoto"
 msgid "path to git-upload-pack on the remote"
 msgstr "percorso al comando remoto git-upload-pack"
 
-#: builtin/clone.c:125 builtin/fetch.c:168 builtin/grep.c:840
-#: builtin/pull.c:227
+#: builtin/clone.c:125 builtin/fetch.c:168 builtin/grep.c:828
+#: builtin/pull.c:207
 msgid "depth"
 msgstr "profondità"
 
@@ -11754,7 +12157,7 @@ msgstr "profondità"
 msgid "create a shallow clone of that depth"
 msgstr "crea un clone shallow con questa profondità"
 
-#: builtin/clone.c:127 builtin/fetch.c:170 builtin/pack-objects.c:3283
+#: builtin/clone.c:127 builtin/fetch.c:170 builtin/pack-objects.c:3430
 msgid "time"
 msgstr "tempo"
 
@@ -11763,7 +12166,7 @@ msgid "create a shallow clone since a specific time"
 msgstr "crea un clone shallow a partire dall'istante specificato"
 
 #: builtin/clone.c:129 builtin/fetch.c:172 builtin/fetch.c:195
-#: builtin/rebase.c:1445
+#: builtin/rebase.c:1480
 msgid "revision"
 msgstr "revisione"
 
@@ -11773,7 +12176,8 @@ msgstr ""
 "aumenta la profondità della cronologia del clone shallow fino alla revisione "
 "specificata esclusa"
 
-#: builtin/clone.c:132
+#: builtin/clone.c:132 builtin/submodule--helper.c:1419
+#: builtin/submodule--helper.c:1928
 msgid "clone only one branch, HEAD or --branch"
 msgstr "clona solo un branch, HEAD o quello specificato con --branch"
 
@@ -11811,12 +12215,12 @@ msgstr "specifica del server"
 msgid "option to transmit"
 msgstr "opzione da trasmettere"
 
-#: builtin/clone.c:143 builtin/fetch.c:191 builtin/pull.c:240
+#: builtin/clone.c:143 builtin/fetch.c:191 builtin/pull.c:220
 #: builtin/push.c:574
 msgid "use IPv4 addresses only"
 msgstr "usa solo indirizzi IPv4"
 
-#: builtin/clone.c:145 builtin/fetch.c:193 builtin/pull.c:243
+#: builtin/clone.c:145 builtin/fetch.c:193 builtin/pull.c:223
 #: builtin/push.c:576
 msgid "use IPv6 addresses only"
 msgstr "usa solo indirizzi IPv6"
@@ -11830,8 +12234,8 @@ msgstr ""
 #: builtin/clone.c:151
 msgid "initialize sparse-checkout file to include only files at root"
 msgstr ""
-"inizializza il file sparse-checkout per includere solo i file nel percorso"
-" radice"
+"inizializza il file sparse-checkout per includere solo i file nel percorso "
+"radice"
 
 #: builtin/clone.c:287
 msgid ""
@@ -11892,97 +12296,97 @@ msgstr ""
 msgid "Could not find remote branch %s to clone."
 msgstr "Impossibile trovare il branch remoto %s da clonare."
 
-#: builtin/clone.c:704
+#: builtin/clone.c:705
 #, c-format
 msgid "unable to update %s"
 msgstr "impossibile aggiornare %s"
 
-#: builtin/clone.c:752
+#: builtin/clone.c:753
 msgid "failed to initialize sparse-checkout"
 msgstr "inizializzazione del file sparse-checkout non riuscita"
 
-#: builtin/clone.c:775
+#: builtin/clone.c:776
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "l'HEAD remoto fa riferimento a un riferimento inesistente, impossibile "
 "eseguire il checkout.\n"
 
-#: builtin/clone.c:806
+#: builtin/clone.c:807
 msgid "unable to checkout working tree"
 msgstr "impossibile eseguire il checkout dell'albero di lavoro"
 
-#: builtin/clone.c:856
+#: builtin/clone.c:862
 msgid "unable to write parameters to config file"
 msgstr "impossibile scrivere i parametri nel file di configurazione"
 
-#: builtin/clone.c:919
+#: builtin/clone.c:925
 msgid "cannot repack to clean up"
 msgstr "impossibile eseguire il repack per pulire l'area di lavoro"
 
-#: builtin/clone.c:921
+#: builtin/clone.c:927
 msgid "cannot unlink temporary alternates file"
 msgstr "impossibile eseguire l'unlink del file alternates temporaneo"
 
-#: builtin/clone.c:959 builtin/receive-pack.c:1948
+#: builtin/clone.c:965 builtin/receive-pack.c:1950
 msgid "Too many arguments."
 msgstr "Troppi argomenti."
 
-#: builtin/clone.c:963
+#: builtin/clone.c:969
 msgid "You must specify a repository to clone."
 msgstr "Devi specificare un repository da clonare."
 
-#: builtin/clone.c:976
+#: builtin/clone.c:982
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "le opzioni --bare e --origin %s non sono compatibili."
 
-#: builtin/clone.c:979
+#: builtin/clone.c:985
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "le opzioni --bare e --separate-git-dir non sono compatibili."
 
-#: builtin/clone.c:992
+#: builtin/clone.c:998
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "il repository '%s' non esiste"
 
-#: builtin/clone.c:998 builtin/fetch.c:1787
+#: builtin/clone.c:1004 builtin/fetch.c:1796
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "la profondità %s non è un numero positivo"
 
-#: builtin/clone.c:1008
+#: builtin/clone.c:1014
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr ""
 "il percorso di destinazione '%s' esiste già e non è una directory vuota."
 
-#: builtin/clone.c:1018
+#: builtin/clone.c:1024
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "l'albero di lavoro '%s' esiste già."
 
-#: builtin/clone.c:1033 builtin/clone.c:1054 builtin/difftool.c:271
-#: builtin/log.c:1866 builtin/worktree.c:302 builtin/worktree.c:334
+#: builtin/clone.c:1039 builtin/clone.c:1060 builtin/difftool.c:271
+#: builtin/log.c:1866 builtin/worktree.c:295 builtin/worktree.c:327
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "impossibile creare le prime directory di '%s'"
 
-#: builtin/clone.c:1038
+#: builtin/clone.c:1044
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "impossibile creare la directory dell'albero di lavoro '%s'"
 
-#: builtin/clone.c:1058
+#: builtin/clone.c:1064
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Clone nel repository spoglio '%s' in corso...\n"
 
-#: builtin/clone.c:1060
+#: builtin/clone.c:1066
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Clone in '%s' in corso...\n"
 
-#: builtin/clone.c:1084
+#: builtin/clone.c:1090
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -11990,36 +12394,36 @@ msgstr ""
 "il clone --recursive non è compatibile né con --reference né con --reference-"
 "if-able"
 
-#: builtin/clone.c:1148
+#: builtin/clone.c:1154
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "L'opzione --depth è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1150
+#: builtin/clone.c:1156
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr "L'opzione --shallow-since è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1152
+#: builtin/clone.c:1158
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr "L'opzione --shallow-exclude è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1154
+#: builtin/clone.c:1160
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr "L'opzione --filter è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1157
+#: builtin/clone.c:1163
 msgid "source repository is shallow, ignoring --local"
 msgstr "il repository sorgente è shallow, ignoro l'opzione --local"
 
-#: builtin/clone.c:1162
+#: builtin/clone.c:1168
 msgid "--local is ignored"
 msgstr "l'opzione --local è ignorata"
 
-#: builtin/clone.c:1237 builtin/clone.c:1245
+#: builtin/clone.c:1243 builtin/clone.c:1251
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Il branch remoto %s non è stato trovato nell'upstream %s"
 
-#: builtin/clone.c:1248
+#: builtin/clone.c:1254
 msgid "You appear to have cloned an empty repository."
 msgstr "Sembra che tu abbia clonato un repository vuoto."
 
@@ -12096,13 +12500,13 @@ msgstr "genitore"
 msgid "id of a parent commit object"
 msgstr "ID di un oggetto commit genitore"
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1496 builtin/merge.c:270
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1469
+#: builtin/commit-tree.c:114 builtin/commit.c:1501 builtin/merge.c:271
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1472
 #: builtin/tag.c:412
 msgid "message"
 msgstr "messaggio"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1496
+#: builtin/commit-tree.c:115 builtin/commit.c:1501
 msgid "commit message"
 msgstr "messaggio di commit"
 
@@ -12110,8 +12514,8 @@ msgstr "messaggio di commit"
 msgid "read commit log message from file"
 msgstr "leggi il messaggio di log del commit da un file"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1508 builtin/merge.c:287
-#: builtin/pull.c:195 builtin/revert.c:118
+#: builtin/commit-tree.c:121 builtin/commit.c:1513 builtin/merge.c:288
+#: builtin/pull.c:175 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "firma il commit con GPG"
 
@@ -12200,53 +12604,53 @@ msgstr ""
 msgid "unable to create temporary index"
 msgstr "impossibile creare l'indice temporaneo"
 
-#: builtin/commit.c:382
+#: builtin/commit.c:385
 msgid "interactive add failed"
 msgstr "aggiunta interattiva non riuscita"
 
-#: builtin/commit.c:396
+#: builtin/commit.c:400
 msgid "unable to update temporary index"
 msgstr "impossibile aggiornare l'indice temporaneo"
 
-#: builtin/commit.c:398
+#: builtin/commit.c:402
 msgid "Failed to update main cache tree"
 msgstr "Impossibile aggiornare l'albero cache principale"
 
-#: builtin/commit.c:423 builtin/commit.c:446 builtin/commit.c:492
+#: builtin/commit.c:427 builtin/commit.c:450 builtin/commit.c:496
 msgid "unable to write new_index file"
 msgstr "impossibile scrivere il file new_index"
 
-#: builtin/commit.c:475
+#: builtin/commit.c:479
 msgid "cannot do a partial commit during a merge."
 msgstr "impossibile eseguire un commit parziale durante un merge."
 
-#: builtin/commit.c:477
+#: builtin/commit.c:481
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr "impossibile eseguire un commit parziale durante un cherry-pick."
 
-#: builtin/commit.c:485
+#: builtin/commit.c:489
 msgid "cannot read the index"
 msgstr "impossibile leggere l'indice"
 
-#: builtin/commit.c:504
+#: builtin/commit.c:508
 msgid "unable to write temporary index file"
 msgstr "impossibile scrivere il file indice temporaneo"
 
-#: builtin/commit.c:602
+#: builtin/commit.c:606
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "dal commit '%s' manca l'intestazione autore"
 
-#: builtin/commit.c:604
+#: builtin/commit.c:608
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "il commit '%s' ha una riga autore malformata"
 
-#: builtin/commit.c:623
+#: builtin/commit.c:627
 msgid "malformed --author parameter"
 msgstr "parametro --author malformato"
 
-#: builtin/commit.c:676
+#: builtin/commit.c:680
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -12254,38 +12658,38 @@ msgstr ""
 "impossibile selezionare un carattere commento non usato\n"
 "nel messaggio di commit corrente"
 
-#: builtin/commit.c:714 builtin/commit.c:747 builtin/commit.c:1092
+#: builtin/commit.c:718 builtin/commit.c:751 builtin/commit.c:1097
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "impossibile trovare il commit %s"
 
-#: builtin/commit.c:726 builtin/shortlog.c:319
+#: builtin/commit.c:730 builtin/shortlog.c:319
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(lettura del messaggio di log dallo standard input)\n"
 
-#: builtin/commit.c:728
+#: builtin/commit.c:732
 msgid "could not read log from standard input"
 msgstr "impossibile leggere il log dallo standard input"
 
-#: builtin/commit.c:732
+#: builtin/commit.c:736
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "impossibile leggere il file di log '%s'"
 
-#: builtin/commit.c:763 builtin/commit.c:779
+#: builtin/commit.c:767 builtin/commit.c:783
 msgid "could not read SQUASH_MSG"
 msgstr "impossibile leggere SQUASH_MSG"
 
-#: builtin/commit.c:770
+#: builtin/commit.c:774
 msgid "could not read MERGE_MSG"
 msgstr "impossibile leggere MERGE_MSG"
 
-#: builtin/commit.c:830
+#: builtin/commit.c:834
 msgid "could not write commit template"
 msgstr "impossibile scrivere il modello di commit"
 
-#: builtin/commit.c:849
+#: builtin/commit.c:853
 #, c-format
 msgid ""
 "\n"
@@ -12300,7 +12704,7 @@ msgstr ""
 "\t%s\n"
 "e riprova.\n"
 
-#: builtin/commit.c:854
+#: builtin/commit.c:858
 #, c-format
 msgid ""
 "\n"
@@ -12315,7 +12719,7 @@ msgstr ""
 "\t%s\n"
 "e riprova.\n"
 
-#: builtin/commit.c:867
+#: builtin/commit.c:871
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -12324,7 +12728,7 @@ msgstr ""
 "Immetti il messaggio di commit per le modifiche. Le righe che iniziano\n"
 "con '%c' saranno ignorate e un messaggio vuoto interromperà il commit.\n"
 
-#: builtin/commit.c:875
+#: builtin/commit.c:879
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -12335,144 +12739,144 @@ msgstr ""
 "con '%c' saranno mantenute; puoi rimuoverle autonomamente se lo desideri.\n"
 "Un messaggio vuoto interromperà il commit.\n"
 
-#: builtin/commit.c:892
+#: builtin/commit.c:896
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sAutore:           %.*s <%.*s>"
 
-#: builtin/commit.c:900
+#: builtin/commit.c:904
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sData:             %s"
 
-#: builtin/commit.c:907
+#: builtin/commit.c:911
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sEsecutore commit: %.*s <%.*s>"
 
-#: builtin/commit.c:925
+#: builtin/commit.c:929
 msgid "Cannot read index"
 msgstr "Impossibile leggere l'indice"
 
-#: builtin/commit.c:992
+#: builtin/commit.c:997
 msgid "Error building trees"
 msgstr "Errore durante la costruzione degli alberi"
 
-#: builtin/commit.c:1006 builtin/tag.c:275
+#: builtin/commit.c:1011 builtin/tag.c:275
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Fornisci il messaggio usando l'opzione -m o -F.\n"
 
-#: builtin/commit.c:1050
+#: builtin/commit.c:1055
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' non è nel formato 'Nome <e-mail>' e non corrisponde ad alcun "
 "autore esistente"
 
-#: builtin/commit.c:1064
+#: builtin/commit.c:1069
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Modo non valido ignorato: '%s'"
 
-#: builtin/commit.c:1082 builtin/commit.c:1322
+#: builtin/commit.c:1087 builtin/commit.c:1327
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Modo file non tracciati non valido: '%s'"
 
-#: builtin/commit.c:1122
+#: builtin/commit.c:1127
 msgid "--long and -z are incompatible"
 msgstr "--long e -z non sono compatibili"
 
-#: builtin/commit.c:1166
+#: builtin/commit.c:1171
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "L'uso di entrambe le opzioni --reset-author e --author non ha senso"
 
-#: builtin/commit.c:1175
+#: builtin/commit.c:1180
 msgid "You have nothing to amend."
 msgstr "Non c'è nulla da modificare."
 
-#: builtin/commit.c:1178
+#: builtin/commit.c:1183
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Sei nel bel mezzo di un merge - impossibile eseguire l'amend."
 
-#: builtin/commit.c:1180
+#: builtin/commit.c:1185
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "Sei nel bel mezzo di un cherry-pick - impossibile eseguire l'amend."
 
-#: builtin/commit.c:1183
+#: builtin/commit.c:1188
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Le opzioni --squash e --fixup non possono essere usate insieme"
 
-#: builtin/commit.c:1193
+#: builtin/commit.c:1198
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Solo una delle opzioni -c/-C/-F/--fixup può essere usata."
 
-#: builtin/commit.c:1195
+#: builtin/commit.c:1200
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "L'opzione -m non può essere combinata con -c/-C/-F."
 
-#: builtin/commit.c:1203
+#: builtin/commit.c:1208
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "L'opzione --reset-author può essere usata solo con -C, -c o --amend."
 
-#: builtin/commit.c:1220
+#: builtin/commit.c:1225
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Può essere usata solo una delle opzioni --include/--only/--all/--"
 "interactive/--patch."
 
-#: builtin/commit.c:1226
+#: builtin/commit.c:1231
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "i percorsi '%s ...' non hanno senso con -a"
 
-#: builtin/commit.c:1357 builtin/commit.c:1519
+#: builtin/commit.c:1362 builtin/commit.c:1524
 msgid "show status concisely"
 msgstr "visualizza concisamente lo stato"
 
-#: builtin/commit.c:1359 builtin/commit.c:1521
+#: builtin/commit.c:1364 builtin/commit.c:1526
 msgid "show branch information"
 msgstr "visualizza le informazioni sul branch"
 
-#: builtin/commit.c:1361
+#: builtin/commit.c:1366
 msgid "show stash information"
 msgstr "visualizza le informazioni sullo stash"
 
-#: builtin/commit.c:1363 builtin/commit.c:1523
+#: builtin/commit.c:1368 builtin/commit.c:1528
 msgid "compute full ahead/behind values"
 msgstr "calcola tutti i valori dopo/prima di"
 
-#: builtin/commit.c:1365
+#: builtin/commit.c:1370
 msgid "version"
 msgstr "versione"
 
-#: builtin/commit.c:1365 builtin/commit.c:1525 builtin/push.c:549
-#: builtin/worktree.c:650
+#: builtin/commit.c:1370 builtin/commit.c:1530 builtin/push.c:549
+#: builtin/worktree.c:643
 msgid "machine-readable output"
 msgstr "output leggibile da una macchina"
 
-#: builtin/commit.c:1368 builtin/commit.c:1527
+#: builtin/commit.c:1373 builtin/commit.c:1532
 msgid "show status in long format (default)"
 msgstr "visualizza lo stato in forma lunga (impostazione predefinita)"
 
-#: builtin/commit.c:1371 builtin/commit.c:1530
+#: builtin/commit.c:1376 builtin/commit.c:1535
 msgid "terminate entries with NUL"
 msgstr "termina le voci con NUL"
 
-#: builtin/commit.c:1373 builtin/commit.c:1377 builtin/commit.c:1533
+#: builtin/commit.c:1378 builtin/commit.c:1382 builtin/commit.c:1538
 #: builtin/fast-export.c:1153 builtin/fast-export.c:1156
-#: builtin/fast-export.c:1159 builtin/rebase.c:1525 parse-options.h:336
+#: builtin/fast-export.c:1159 builtin/rebase.c:1569 parse-options.h:336
 msgid "mode"
 msgstr "modo"
 
-#: builtin/commit.c:1374 builtin/commit.c:1533
+#: builtin/commit.c:1379 builtin/commit.c:1538
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "visualizza file non tracciati, modalità facoltative: all, normal, no. "
 "(Impostazione predefinita: all)"
 
-#: builtin/commit.c:1378
+#: builtin/commit.c:1383
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -12480,11 +12884,11 @@ msgstr ""
 "visualizza file ignorati, modalità facoltative: traditional, matching, no. "
 "(Impostazione predefinita: traditional)"
 
-#: builtin/commit.c:1380 parse-options.h:192
+#: builtin/commit.c:1385 parse-options.h:192
 msgid "when"
 msgstr "quando"
 
-#: builtin/commit.c:1381
+#: builtin/commit.c:1386
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -12492,175 +12896,175 @@ msgstr ""
 "ignora modifiche ai sottomoduli, opzione facoltativa \"quando\": all, dirty, "
 "untracked. (Impostazione predefinita: all)"
 
-#: builtin/commit.c:1383
+#: builtin/commit.c:1388
 msgid "list untracked files in columns"
 msgstr "elenca i file non tracciati in colonne"
 
-#: builtin/commit.c:1384
+#: builtin/commit.c:1389
 msgid "do not detect renames"
 msgstr "non rilevare le ridenominazioni"
 
-#: builtin/commit.c:1386
+#: builtin/commit.c:1391
 msgid "detect renames, optionally set similarity index"
 msgstr ""
 "rileva le ridenominazioni, imposta facoltativamente l'indice di similarità"
 
-#: builtin/commit.c:1406
+#: builtin/commit.c:1411
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Combinazione di argomenti sui file ignorati e non tracciati non supportata"
 
-#: builtin/commit.c:1489
+#: builtin/commit.c:1494
 msgid "suppress summary after successful commit"
 msgstr ""
 "ometti di visualizzare il riepilogo dopo un commit completato con successo"
 
-#: builtin/commit.c:1490
+#: builtin/commit.c:1495
 msgid "show diff in commit message template"
 msgstr "visualizza il diff nel modello del messaggio di commit"
 
-#: builtin/commit.c:1492
+#: builtin/commit.c:1497
 msgid "Commit message options"
 msgstr "Opzioni messaggio di commit"
 
-#: builtin/commit.c:1493 builtin/merge.c:274 builtin/tag.c:414
+#: builtin/commit.c:1498 builtin/merge.c:275 builtin/tag.c:414
 msgid "read message from file"
 msgstr "leggi il messaggio da un file"
 
-#: builtin/commit.c:1494
+#: builtin/commit.c:1499
 msgid "author"
 msgstr "autore"
 
-#: builtin/commit.c:1494
+#: builtin/commit.c:1499
 msgid "override author for commit"
 msgstr "sovrascrivi l'autore per il commit"
 
-#: builtin/commit.c:1495 builtin/gc.c:538
+#: builtin/commit.c:1500 builtin/gc.c:538
 msgid "date"
 msgstr "data"
 
-#: builtin/commit.c:1495
+#: builtin/commit.c:1500
 msgid "override date for commit"
 msgstr "sovrascrivi la data per il commit"
 
-#: builtin/commit.c:1497 builtin/commit.c:1498 builtin/commit.c:1499
-#: builtin/commit.c:1500 parse-options.h:328 ref-filter.h:92
+#: builtin/commit.c:1502 builtin/commit.c:1503 builtin/commit.c:1504
+#: builtin/commit.c:1505 parse-options.h:328 ref-filter.h:92
 msgid "commit"
 msgstr "commit"
 
-#: builtin/commit.c:1497
+#: builtin/commit.c:1502
 msgid "reuse and edit message from specified commit"
 msgstr "riusa il messaggio del commit specificato per poi modificarlo"
 
-#: builtin/commit.c:1498
+#: builtin/commit.c:1503
 msgid "reuse message from specified commit"
 msgstr "riusa il messaggio del commit specificato"
 
-#: builtin/commit.c:1499
+#: builtin/commit.c:1504
 msgid "use autosquash formatted message to fixup specified commit"
 msgstr ""
 "usa il messaggio in formato autosquash per correggere il commit specificato"
 
-#: builtin/commit.c:1500
+#: builtin/commit.c:1505
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "usa il messaggio in formato autosquash per eseguire lo squash del commit "
 "specificato"
 
-#: builtin/commit.c:1501
+#: builtin/commit.c:1506
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "il commit ora ha me come autore (opzione usata con -C/-c/--amend)"
 
-#: builtin/commit.c:1502 builtin/log.c:1634 builtin/merge.c:289
-#: builtin/pull.c:164 builtin/revert.c:110
+#: builtin/commit.c:1507 builtin/log.c:1634 builtin/merge.c:290
+#: builtin/pull.c:144 builtin/revert.c:110
 msgid "add Signed-off-by:"
 msgstr "aggiungi Signed-off-by:"
 
-#: builtin/commit.c:1503
+#: builtin/commit.c:1508
 msgid "use specified template file"
 msgstr "usa il file modello specificato"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1509
 msgid "force edit of commit"
 msgstr "forza la modifica del commit"
 
-#: builtin/commit.c:1506
+#: builtin/commit.c:1511
 msgid "include status in commit message template"
 msgstr "includi lo stato nel modello del messaggio di commit"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1516
 msgid "Commit contents options"
 msgstr "Opzioni contenuto commit"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1517
 msgid "commit all changed files"
 msgstr "esegui il commit di tutti i file modificati"
 
-#: builtin/commit.c:1513
+#: builtin/commit.c:1518
 msgid "add specified files to index for commit"
 msgstr "aggiungi i file specificati all'indice per il commit"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1519
 msgid "interactively add files"
 msgstr "aggiungi i file in modalità interattiva"
 
-#: builtin/commit.c:1515
+#: builtin/commit.c:1520
 msgid "interactively add changes"
 msgstr "aggiungi le modifiche in modalità interattiva"
 
-#: builtin/commit.c:1516
+#: builtin/commit.c:1521
 msgid "commit only specified files"
 msgstr "esegui il commit solo dei file specificati"
 
-#: builtin/commit.c:1517
+#: builtin/commit.c:1522
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "ignora gli hook pre-commit e commit-msg"
 
-#: builtin/commit.c:1518
+#: builtin/commit.c:1523
 msgid "show what would be committed"
 msgstr "visualizza gli elementi di cui sarebbe eseguito il commit"
 
-#: builtin/commit.c:1531
+#: builtin/commit.c:1536
 msgid "amend previous commit"
 msgstr "modifica il commit precedente"
 
-#: builtin/commit.c:1532
+#: builtin/commit.c:1537
 msgid "bypass post-rewrite hook"
 msgstr "ignora l'hook post-rewrite"
 
-#: builtin/commit.c:1539
+#: builtin/commit.c:1544
 msgid "ok to record an empty change"
 msgstr "accetta di registrare una modifica vuota"
 
-#: builtin/commit.c:1541
+#: builtin/commit.c:1546
 msgid "ok to record a change with an empty message"
 msgstr "accetta di registrare una modifica con un messaggio vuoto"
 
-#: builtin/commit.c:1614
+#: builtin/commit.c:1619
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "File MERGE_HEAD corrotto (%s)"
 
-#: builtin/commit.c:1621
+#: builtin/commit.c:1626
 msgid "could not read MERGE_MODE"
 msgstr "impossibile leggere MERGE_MODE"
 
-#: builtin/commit.c:1640
+#: builtin/commit.c:1645
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "impossibile leggere il messaggio di commit: %s"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1652
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Interrompo il commit a causa di un messaggio di commit vuoto.\n"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1657
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Interrompo il commit; non hai modificato il messaggio.\n"
 
-#: builtin/commit.c:1686
+#: builtin/commit.c:1691
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -12687,55 +13091,60 @@ msgstr ""
 "git commit-graph write [--object-dir <directory oggetti>] [--append|--split] "
 "[--reachable|--stdin-packs|--stdin-commits] [--[no-]progress] <opzioni split>"
 
-#: builtin/commit-graph.c:48 builtin/commit-graph.c:103
-#: builtin/commit-graph.c:187 builtin/fetch.c:179 builtin/log.c:1657
+#: builtin/commit-graph.c:52
+#, c-format
+msgid "could not find object directory matching %s"
+msgstr "impossibile trovare la directory oggetti corrispondente a %s"
+
+#: builtin/commit-graph.c:68 builtin/commit-graph.c:125
+#: builtin/commit-graph.c:210 builtin/fetch.c:179 builtin/log.c:1657
 msgid "dir"
 msgstr "directory"
 
-#: builtin/commit-graph.c:49 builtin/commit-graph.c:104
-#: builtin/commit-graph.c:188
+#: builtin/commit-graph.c:69 builtin/commit-graph.c:126
+#: builtin/commit-graph.c:211
 msgid "The object directory to store the graph"
 msgstr "La directory oggetti in cui memorizzare il grafo"
 
-#: builtin/commit-graph.c:51
+#: builtin/commit-graph.c:71
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr "se il grafo dei commit è diviso, verifica solo l'ultimo file"
 
-#: builtin/commit-graph.c:73 t/helper/test-read-graph.c:23
+#: builtin/commit-graph.c:94 t/helper/test-read-graph.c:23
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr "Impossibile aprire il grafo dei commit '%s'"
 
-#: builtin/commit-graph.c:106
+#: builtin/commit-graph.c:128
 msgid "start walk at all refs"
 msgstr "inizia la visita da tutti i riferimenti"
 
-#: builtin/commit-graph.c:108
+#: builtin/commit-graph.c:130
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr ""
 "esamina i pack-index elencati sullo standard input alla ricerca di commit"
 
-#: builtin/commit-graph.c:110
+#: builtin/commit-graph.c:132
 msgid "start walk at commits listed by stdin"
 msgstr "inizia la visita ai commit elencati sullo standard input"
 
-#: builtin/commit-graph.c:112
+#: builtin/commit-graph.c:134
 msgid "include all commits already in the commit-graph file"
 msgstr "includi tutti i commit già presenti nel file commit-graph"
 
-#: builtin/commit-graph.c:115
+#: builtin/commit-graph.c:137
 msgid "allow writing an incremental commit-graph file"
 msgstr "consenti la scrittura di un file grafo dei commit incrementale"
 
-#: builtin/commit-graph.c:117 builtin/commit-graph.c:121
+#: builtin/commit-graph.c:139 builtin/commit-graph.c:143
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr "numero massimo di commit in un grafo dei commit diviso non di base"
 
-#: builtin/commit-graph.c:119
+#: builtin/commit-graph.c:141
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr "rapporto massimo fra due livelli di un grafo dei commit diviso"
 
-#: builtin/commit-graph.c:137
+#: builtin/commit-graph.c:159
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr "usa al più un'opzione fra --reachable, --stdin-commits o --stdin-packs"
 
@@ -12743,212 +13152,218 @@ msgstr "usa al più un'opzione fra --reachable, --stdin-commits o --stdin-packs"
 msgid "git config [<options>]"
 msgstr "git config [<opzioni>]"
 
-#: builtin/config.c:103 builtin/env--helper.c:23
+#: builtin/config.c:104 builtin/env--helper.c:23
 #, c-format
 msgid "unrecognized --type argument, %s"
 msgstr "argomento --type non riconosciuto: %s"
 
-#: builtin/config.c:115
+#: builtin/config.c:116
 msgid "only one type at a time"
 msgstr "solo un tipo per volta"
 
-#: builtin/config.c:124
+#: builtin/config.c:125
 msgid "Config file location"
 msgstr "Percorso file di configurazione"
 
-#: builtin/config.c:125
+#: builtin/config.c:126
 msgid "use global config file"
 msgstr "usa il file di configurazione globale"
 
-#: builtin/config.c:126
+#: builtin/config.c:127
 msgid "use system config file"
 msgstr "usa il file di configurazione di sistema"
 
-#: builtin/config.c:127
+#: builtin/config.c:128
 msgid "use repository config file"
 msgstr "usa il file di configurazione del repository"
 
-#: builtin/config.c:128
+#: builtin/config.c:129
 msgid "use per-worktree config file"
 msgstr "usa il file di configurazione per albero di lavoro"
 
-#: builtin/config.c:129
+#: builtin/config.c:130
 msgid "use given config file"
 msgstr "usa il file di configurazione specificato"
 
-#: builtin/config.c:130
+#: builtin/config.c:131
 msgid "blob-id"
 msgstr "ID blob"
 
-#: builtin/config.c:130
+#: builtin/config.c:131
 msgid "read config from given blob object"
 msgstr "leggi la configurazione dall'oggetto blob specificato"
 
-#: builtin/config.c:131
+#: builtin/config.c:132
 msgid "Action"
 msgstr "Azione"
 
-#: builtin/config.c:132
+#: builtin/config.c:133
 msgid "get value: name [value-regex]"
 msgstr "ottieni valore: nome [espressione-regolare-valore]"
 
-#: builtin/config.c:133
+#: builtin/config.c:134
 msgid "get all values: key [value-regex]"
 msgstr "ottieni tutti i valori: chiave [espressione-regolare-valore]"
 
-#: builtin/config.c:134
+#: builtin/config.c:135
 msgid "get values for regexp: name-regex [value-regex]"
 msgstr ""
 "ottieni i valori in base a un'espressione regolare: espressione-regolare-"
 "nome [espressione-regolare-valore]"
 
-#: builtin/config.c:135
+#: builtin/config.c:136
 msgid "get value specific for the URL: section[.var] URL"
 msgstr "ottieni il valore specifico per l'URL: sezione[.variabile] URL"
 
-#: builtin/config.c:136
+#: builtin/config.c:137
 msgid "replace all matching variables: name value [value_regex]"
 msgstr ""
 "sostituisci tutte le variabili corrispondenti: nome-valore [espressione-"
 "regolare-valore]"
 
-#: builtin/config.c:137
+#: builtin/config.c:138
 msgid "add a new variable: name value"
 msgstr "aggiungi una nuova variabile: nome valore"
 
-#: builtin/config.c:138
+#: builtin/config.c:139
 msgid "remove a variable: name [value-regex]"
 msgstr "rimuovi una variabile: nome [espressione-regolare-valore]"
 
-#: builtin/config.c:139
+#: builtin/config.c:140
 msgid "remove all matches: name [value-regex]"
 msgstr "rimuovi tutte le corrispondenze: nome [espressione-regolare-valore]"
 
-#: builtin/config.c:140
+#: builtin/config.c:141
 msgid "rename section: old-name new-name"
 msgstr "rinomina sezione: vecchio-nome nuovo-nome"
 
-#: builtin/config.c:141
+#: builtin/config.c:142
 msgid "remove a section: name"
 msgstr "rimuovi una sezione: nome"
 
-#: builtin/config.c:142
+#: builtin/config.c:143
 msgid "list all"
 msgstr "elenca tutti"
 
-#: builtin/config.c:143
+#: builtin/config.c:144
 msgid "open an editor"
 msgstr "apri un editor"
 
-#: builtin/config.c:144
+#: builtin/config.c:145
 msgid "find the color configured: slot [default]"
 msgstr "trova il colore configurato: slot [valore-predefinito]"
 
-#: builtin/config.c:145
+#: builtin/config.c:146
 msgid "find the color setting: slot [stdout-is-tty]"
 msgstr "trova l'impostazione colore: slot [standard-output-è-una-tty]"
 
-#: builtin/config.c:146
+#: builtin/config.c:147
 msgid "Type"
 msgstr "Tipo"
 
-#: builtin/config.c:147 builtin/env--helper.c:38
+#: builtin/config.c:148 builtin/env--helper.c:38
 msgid "value is given this type"
 msgstr "al valore è assegnato questo tipo"
 
-#: builtin/config.c:148
+#: builtin/config.c:149
 msgid "value is \"true\" or \"false\""
 msgstr "il valore è \"true\" o \"false\""
 
-#: builtin/config.c:149
+#: builtin/config.c:150
 msgid "value is decimal number"
 msgstr "il valore è un numero decimale"
 
-#: builtin/config.c:150
+#: builtin/config.c:151
 msgid "value is --bool or --int"
 msgstr "il valore è --bool o --int"
 
-#: builtin/config.c:151
+#: builtin/config.c:152
 msgid "value is a path (file or directory name)"
 msgstr "il valore è un percorso (nome file o directory)"
 
-#: builtin/config.c:152
+#: builtin/config.c:153
 msgid "value is an expiry date"
 msgstr "il valore è una data di scadenza"
 
-#: builtin/config.c:153
+#: builtin/config.c:154
 msgid "Other"
 msgstr "Altro"
 
-#: builtin/config.c:154
+#: builtin/config.c:155
 msgid "terminate values with NUL byte"
 msgstr "termina i valori con un byte NUL"
 
-#: builtin/config.c:155
+#: builtin/config.c:156
 msgid "show variable names only"
 msgstr "visualizza solo i nomi delle variabili"
 
-#: builtin/config.c:156
+#: builtin/config.c:157
 msgid "respect include directives on lookup"
 msgstr ""
 "rispetta le directory di inclusione durante il recupero delle variabili"
 
-#: builtin/config.c:157
+#: builtin/config.c:158
 msgid "show origin of config (file, standard input, blob, command line)"
 msgstr ""
 "visualizza l'origine del file di configurazione (file, standard input, blob, "
 "riga di comando)"
 
-#: builtin/config.c:158 builtin/env--helper.c:40
+#: builtin/config.c:159
+msgid "show scope of config (worktree, local, global, system, command)"
+msgstr ""
+"visualizza l'ambito della configurazione (albero di lavoro, locale, globale,"
+" sistema, comando)"
+
+#: builtin/config.c:160 builtin/env--helper.c:40
 msgid "value"
 msgstr "valore"
 
-#: builtin/config.c:158
+#: builtin/config.c:160
 msgid "with --get, use default value when missing entry"
 msgstr "con --get, usa il valore predefinito se la voce è mancante"
 
-#: builtin/config.c:172
+#: builtin/config.c:174
 #, c-format
 msgid "wrong number of arguments, should be %d"
 msgstr "numero di argomenti errato, dovrebbero essere %d"
 
-#: builtin/config.c:174
+#: builtin/config.c:176
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
 msgstr "numero di argomenti errato, dovrebbero essere da %d a %d"
 
-#: builtin/config.c:308
+#: builtin/config.c:324
 #, c-format
 msgid "invalid key pattern: %s"
 msgstr "pattern chiave non valido: %s"
 
-#: builtin/config.c:344
+#: builtin/config.c:360
 #, c-format
 msgid "failed to format default config value: %s"
 msgstr "formattazione del valore configurazione predefinito non riuscita: %s"
 
-#: builtin/config.c:401
+#: builtin/config.c:417
 #, c-format
 msgid "cannot parse color '%s'"
 msgstr "impossibile analizzare il colore '%s'"
 
-#: builtin/config.c:443
+#: builtin/config.c:459
 msgid "unable to parse default color value"
 msgstr "impossibile analizzare il valore colore predefinito"
 
-#: builtin/config.c:496 builtin/config.c:742
+#: builtin/config.c:512 builtin/config.c:768
 msgid "not in a git directory"
 msgstr "non si è in una directory git"
 
-#: builtin/config.c:499
+#: builtin/config.c:515
 msgid "writing to stdin is not supported"
 msgstr "la scrittura su standard input non è supportata"
 
-#: builtin/config.c:502
+#: builtin/config.c:518
 msgid "writing config blobs is not supported"
 msgstr "la scrittura di blob di configurazione non è supportata"
 
-#: builtin/config.c:587
+#: builtin/config.c:603
 #, c-format
 msgid ""
 "# This is Git's per-user configuration file.\n"
@@ -12963,23 +13378,23 @@ msgstr ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 
-#: builtin/config.c:611
+#: builtin/config.c:627
 msgid "only one config file at a time"
 msgstr "solo un file di configurazione per volta"
 
-#: builtin/config.c:616
+#: builtin/config.c:632
 msgid "--local can only be used inside a git repository"
 msgstr "--local può essere usato solo in un repository Git"
 
-#: builtin/config.c:619
+#: builtin/config.c:635
 msgid "--blob can only be used inside a git repository"
 msgstr "--blob può essere usato solo in un repository Git"
 
-#: builtin/config.c:638
+#: builtin/config.c:655
 msgid "$HOME not set"
 msgstr "$HOME non impostata"
 
-#: builtin/config.c:658
+#: builtin/config.c:679
 msgid ""
 "--worktree cannot be used with multiple working trees unless the config\n"
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
@@ -12990,52 +13405,52 @@ msgstr ""
 "Leggi la sezione \"FILE DI CONFIGURAZIONE\" in \"git help worktree\" per\n"
 "i dettagli"
 
-#: builtin/config.c:688
+#: builtin/config.c:714
 msgid "--get-color and variable type are incoherent"
 msgstr "--get-color e il tipo della variabile non sono coerenti"
 
-#: builtin/config.c:693
+#: builtin/config.c:719
 msgid "only one action at a time"
 msgstr "solo un'azione per volta"
 
-#: builtin/config.c:706
+#: builtin/config.c:732
 msgid "--name-only is only applicable to --list or --get-regexp"
 msgstr "--name-only è applicabile solo a --list o --get-regexp"
 
-#: builtin/config.c:712
+#: builtin/config.c:738
 msgid ""
 "--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
 "list"
 msgstr ""
 "--show-origin è applicabile solo a --get, --get-all, --get-regexp e --list"
 
-#: builtin/config.c:718
+#: builtin/config.c:744
 msgid "--default is only applicable to --get"
 msgstr "--default è applicabile solo a --get"
 
-#: builtin/config.c:731
+#: builtin/config.c:757
 #, c-format
 msgid "unable to read config file '%s'"
 msgstr "impossibile leggere il file di configurazione '%s'"
 
-#: builtin/config.c:734
+#: builtin/config.c:760
 msgid "error processing config file(s)"
 msgstr "errore durante l'elaborazione del/dei file di configurazione"
 
-#: builtin/config.c:744
+#: builtin/config.c:770
 msgid "editing stdin is not supported"
 msgstr "la modifica dello standard input non è supportata"
 
-#: builtin/config.c:746
+#: builtin/config.c:772
 msgid "editing blobs is not supported"
 msgstr "la modifica dei blob non è supportata"
 
-#: builtin/config.c:760
+#: builtin/config.c:786
 #, c-format
 msgid "cannot create configuration file %s"
 msgstr "impossibile creare il file di configurazione %s"
 
-#: builtin/config.c:773
+#: builtin/config.c:799
 #, c-format
 msgid ""
 "cannot overwrite multiple values with a single value\n"
@@ -13044,7 +13459,7 @@ msgstr ""
 "impossibile sovrascrivere valori multipli con un singolo valore\n"
 "       Usa un'espressione regolare, --add o --replace-all per modificare %s."
 
-#: builtin/config.c:847 builtin/config.c:858
+#: builtin/config.c:873 builtin/config.c:884
 #, c-format
 msgid "no such section: %s"
 msgstr "sezione %s non esistente"
@@ -13104,12 +13519,12 @@ msgstr ""
 "Nessuna corrispondenza esatta sui riferimenti o sui tag, sto eseguendo una "
 "ricerca per descrivere il commit\n"
 
-#: builtin/describe.c:381
+#: builtin/describe.c:394
 #, c-format
 msgid "finished search at %s\n"
 msgstr "ricerca terminata in %s\n"
 
-#: builtin/describe.c:407
+#: builtin/describe.c:421
 #, c-format
 msgid ""
 "No annotated tags can describe '%s'.\n"
@@ -13118,7 +13533,7 @@ msgstr ""
 "Nessun tag annotato può descrivere '%s'.\n"
 "Ciò nonostante, c'erano dei tag non annotati: prova con --tags."
 
-#: builtin/describe.c:411
+#: builtin/describe.c:425
 #, c-format
 msgid ""
 "No tags can describe '%s'.\n"
@@ -13127,12 +13542,12 @@ msgstr ""
 "Nessun tag può descrivere '%s'.\n"
 "Prova con --always o crea dei tag."
 
-#: builtin/describe.c:441
+#: builtin/describe.c:455
 #, c-format
 msgid "traversed %lu commits\n"
 msgstr "ho attraversato %lu commit\n"
 
-#: builtin/describe.c:444
+#: builtin/describe.c:458
 #, c-format
 msgid ""
 "more than %i tags found; listed %i most recent\n"
@@ -13141,94 +13556,94 @@ msgstr ""
 "trovati più di %i tag; ho elencato i %i più recenti\n"
 "ho terminato la ricerca in %s\n"
 
-#: builtin/describe.c:512
+#: builtin/describe.c:526
 #, c-format
 msgid "describe %s\n"
 msgstr "descrivi %s\n"
 
-#: builtin/describe.c:515
+#: builtin/describe.c:529
 #, c-format
 msgid "Not a valid object name %s"
 msgstr "%s non è un nome oggetto valido"
 
-#: builtin/describe.c:523
+#: builtin/describe.c:537
 #, c-format
 msgid "%s is neither a commit nor blob"
 msgstr "%s non è né un commit né un blob"
 
-#: builtin/describe.c:537
+#: builtin/describe.c:551
 msgid "find the tag that comes after the commit"
 msgstr "trova il tag successivo al commit"
 
-#: builtin/describe.c:538
+#: builtin/describe.c:552
 msgid "debug search strategy on stderr"
 msgstr "esegui il debug della strategia di ricerca sullo standard error"
 
-#: builtin/describe.c:539
+#: builtin/describe.c:553
 msgid "use any ref"
 msgstr "usa qualunque riferimento"
 
-#: builtin/describe.c:540
+#: builtin/describe.c:554
 msgid "use any tag, even unannotated"
 msgstr "usa qualunque tag, anche quelli non annotati"
 
-#: builtin/describe.c:541
+#: builtin/describe.c:555
 msgid "always use long format"
 msgstr "usa sempre il formato lungo"
 
-#: builtin/describe.c:542
+#: builtin/describe.c:556
 msgid "only follow first parent"
 msgstr "segui solo il primo genitore"
 
-#: builtin/describe.c:545
+#: builtin/describe.c:559
 msgid "only output exact matches"
 msgstr "visualizza solo le corrispondenze esatte"
 
-#: builtin/describe.c:547
+#: builtin/describe.c:561
 msgid "consider <n> most recent tags (default: 10)"
 msgstr "considera gli <n> tag più recenti (impostazione predefinita: 10)"
 
-#: builtin/describe.c:549
+#: builtin/describe.c:563
 msgid "only consider tags matching <pattern>"
 msgstr "considera solo i tag corrispondenti al <pattern>"
 
-#: builtin/describe.c:551
+#: builtin/describe.c:565
 msgid "do not consider tags matching <pattern>"
 msgstr "non considerare i tag corrispondenti al <pattern>"
 
-#: builtin/describe.c:553 builtin/name-rev.c:473
+#: builtin/describe.c:567 builtin/name-rev.c:535
 msgid "show abbreviated commit object as fallback"
 msgstr "visualizza l'oggetto commit abbreviato come fallback"
 
-#: builtin/describe.c:554 builtin/describe.c:557
+#: builtin/describe.c:568 builtin/describe.c:571
 msgid "mark"
 msgstr "contrassegno"
 
-#: builtin/describe.c:555
+#: builtin/describe.c:569
 msgid "append <mark> on dirty working tree (default: \"-dirty\")"
 msgstr ""
 "aggiungi <contrassegno> all'albero di lavoro sporco (impostazione "
 "predefinita: \"-dirty\")"
 
-#: builtin/describe.c:558
+#: builtin/describe.c:572
 msgid "append <mark> on broken working tree (default: \"-broken\")"
 msgstr ""
 "aggiungi <contrassegno> all'albero di lavoro rotto (impostazione "
 "predefinita: \"-broken\")"
 
-#: builtin/describe.c:576
+#: builtin/describe.c:590
 msgid "--long is incompatible with --abbrev=0"
 msgstr "--long non è compatibile con --abbrev=0"
 
-#: builtin/describe.c:605
+#: builtin/describe.c:619
 msgid "No names found, cannot describe anything."
 msgstr "Nessun nome trovato, non è possibile descrivere nulla."
 
-#: builtin/describe.c:656
+#: builtin/describe.c:670
 msgid "--dirty is incompatible with commit-ishes"
 msgstr "--dirty non è compatibile con le espressioni commit"
 
-#: builtin/describe.c:658
+#: builtin/describe.c:672
 msgid "--broken is incompatible with commit-ishes"
 msgstr "--broken non è compatibile con le espressioni commit"
 
@@ -13414,7 +13829,7 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [opzioni-elenco-rev]"
 
-#: builtin/fast-export.c:852
+#: builtin/fast-export.c:853
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
 "Errore: Impossibile esportare i tag nidificati a meno che non sia "
@@ -13516,19 +13931,19 @@ msgstr "git fetch --all [<opzioni>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel non può essere negativo"
 
-#: builtin/fetch.c:139 builtin/pull.c:204
+#: builtin/fetch.c:139 builtin/pull.c:184
 msgid "fetch from all remotes"
 msgstr "esegui il fetch da tutti i remoti"
 
-#: builtin/fetch.c:141 builtin/pull.c:248
+#: builtin/fetch.c:141 builtin/pull.c:228
 msgid "set upstream for git pull/fetch"
 msgstr "imposta l'upstream per git pull/fetch"
 
-#: builtin/fetch.c:143 builtin/pull.c:207
+#: builtin/fetch.c:143 builtin/pull.c:187
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "aggiungi i dati a .git/FETCH_HEAD anziché sovrascriverli"
 
-#: builtin/fetch.c:145 builtin/pull.c:210
+#: builtin/fetch.c:145 builtin/pull.c:190
 msgid "path to upload pack on remote end"
 msgstr "percorso in cui caricare il pack sul remoto"
 
@@ -13540,7 +13955,7 @@ msgstr "forza la sovrascrittura del riferimento locale"
 msgid "fetch from multiple remotes"
 msgstr "esegui il fetch da più remoti"
 
-#: builtin/fetch.c:150 builtin/pull.c:214
+#: builtin/fetch.c:150 builtin/pull.c:194
 msgid "fetch all tags and associated objects"
 msgstr "esegui il fetch di tutti i tag e degli oggetti associati"
 
@@ -13552,7 +13967,7 @@ msgstr "non eseguire il fetch di alcun tag (--no-tags)"
 msgid "number of submodules fetched in parallel"
 msgstr "numero di sottomoduli recuperati in parallelo"
 
-#: builtin/fetch.c:156 builtin/pull.c:217
+#: builtin/fetch.c:156 builtin/pull.c:197
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "elimina i branch che ne tracciano uno remoto ma non più presenti sul remoto"
@@ -13563,7 +13978,7 @@ msgstr ""
 "elimina i tag locali non più presenti sul remoto e sovrascrivi i tag "
 "modificati"
 
-#: builtin/fetch.c:159 builtin/fetch.c:182 builtin/pull.c:141
+#: builtin/fetch.c:159 builtin/fetch.c:182 builtin/pull.c:121
 msgid "on-demand"
 msgstr "a richiesta"
 
@@ -13571,7 +13986,7 @@ msgstr "a richiesta"
 msgid "control recursive fetching of submodules"
 msgstr "controlla il recupero ricorsivo dei sottomoduli"
 
-#: builtin/fetch.c:164 builtin/pull.c:225
+#: builtin/fetch.c:164 builtin/pull.c:205
 msgid "keep downloaded pack"
 msgstr "mantieni il pack scaricato"
 
@@ -13579,7 +13994,7 @@ msgstr "mantieni il pack scaricato"
 msgid "allow updating of HEAD ref"
 msgstr "consenti l'aggiornamento del riferimento HEAD"
 
-#: builtin/fetch.c:169 builtin/fetch.c:175 builtin/pull.c:228
+#: builtin/fetch.c:169 builtin/fetch.c:175 builtin/pull.c:208
 msgid "deepen history of shallow clone"
 msgstr "aumenta la profondità della cronologia di un clone shallow"
 
@@ -13588,7 +14003,7 @@ msgid "deepen history of shallow repository based on time"
 msgstr ""
 "aumenta la profondità della cronologia di un clone shallow in base al tempo"
 
-#: builtin/fetch.c:177 builtin/pull.c:231
+#: builtin/fetch.c:177 builtin/pull.c:211
 msgid "convert to a complete repository"
 msgstr "converti in un repository completo"
 
@@ -13604,15 +14019,15 @@ msgstr ""
 "impostazione predefinita per il recupero ricorsivo dei sottomoduli (a "
 "priorità minore rispetto ai file di configurazione)"
 
-#: builtin/fetch.c:187 builtin/pull.c:234
+#: builtin/fetch.c:187 builtin/pull.c:214
 msgid "accept refs that update .git/shallow"
 msgstr "accetta i riferimenti che aggiornano .git/shallow"
 
-#: builtin/fetch.c:188 builtin/pull.c:236
+#: builtin/fetch.c:188 builtin/pull.c:216
 msgid "refmap"
 msgstr "mappa riferimenti"
 
-#: builtin/fetch.c:189 builtin/pull.c:237
+#: builtin/fetch.c:189 builtin/pull.c:217
 msgid "specify fetch refmap"
 msgstr "specifica la mappa dei riferimenti per il fetch"
 
@@ -13624,7 +14039,7 @@ msgstr "segnala che abbiamo solo oggetti raggiungibili da quest'oggetto"
 msgid "run 'gc --auto' after fetching"
 msgstr "esegui 'gc --auto' dopo il fetch"
 
-#: builtin/fetch.c:201 builtin/pull.c:246
+#: builtin/fetch.c:201 builtin/pull.c:226
 msgid "check for forced-updates on all updated branches"
 msgstr "controlla aggiornamenti forzati su tutti i branch aggiornati"
 
@@ -13714,22 +14129,22 @@ msgstr ""
 "aggiornamenti forzati. Puoi usare '--no-show-forced-updates' o eseguire\n"
 "'git config fetch.showForcedUpdates false' per omettere questo controllo.\n"
 
-#: builtin/fetch.c:911
+#: builtin/fetch.c:920
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s non ha inviato tutti gli oggetti necessari\n"
 
-#: builtin/fetch.c:932
+#: builtin/fetch.c:941
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr "%s rifiutato perché non è consentito aggiornare radici shallow"
 
-#: builtin/fetch.c:1017 builtin/fetch.c:1155
+#: builtin/fetch.c:1026 builtin/fetch.c:1164
 #, c-format
 msgid "From %.*s\n"
 msgstr "Da %.*s\n"
 
-#: builtin/fetch.c:1028
+#: builtin/fetch.c:1037
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -13739,58 +14154,58 @@ msgstr ""
 "eseguire\n"
 " 'git remote prune %s' per rimuovere ogni branch vecchio in conflitto"
 
-#: builtin/fetch.c:1125
+#: builtin/fetch.c:1134
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s diventerà pendente)"
 
-#: builtin/fetch.c:1126
+#: builtin/fetch.c:1135
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s è diventato pendente)"
 
-#: builtin/fetch.c:1158
+#: builtin/fetch.c:1167
 msgid "[deleted]"
 msgstr "[eliminato]"
 
-#: builtin/fetch.c:1159 builtin/remote.c:1035
+#: builtin/fetch.c:1168 builtin/remote.c:1112
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: builtin/fetch.c:1182
+#: builtin/fetch.c:1191
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr ""
 "Mi rifiuto di eseguire il fetch nel branch corrente %s di un repository non "
 "bare"
 
-#: builtin/fetch.c:1201
+#: builtin/fetch.c:1210
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "L'opzione \"%s\" con il valore \"%s\" non è valida per %s"
 
-#: builtin/fetch.c:1204
+#: builtin/fetch.c:1213
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "L'opzione \"%s\" è ignorata per %s\n"
 
-#: builtin/fetch.c:1412
+#: builtin/fetch.c:1421
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "rilevati branch multipli, stato incompatibile con --set-upstream"
 
-#: builtin/fetch.c:1427
+#: builtin/fetch.c:1436
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "non imposto l'upstream per un branch remoto che ne traccia uno remoto"
 
-#: builtin/fetch.c:1429
+#: builtin/fetch.c:1438
 msgid "not setting upstream for a remote tag"
 msgstr "non imposto l'upstream per un tag remoto"
 
-#: builtin/fetch.c:1431
+#: builtin/fetch.c:1440
 msgid "unknown branch type"
 msgstr "tipo branch sconosciuto"
 
-#: builtin/fetch.c:1433
+#: builtin/fetch.c:1442
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -13798,22 +14213,22 @@ msgstr ""
 "nessun branch sorgente trovato.\n"
 "devi specificare esattamente un branch con l'opzione --set-upstream."
 
-#: builtin/fetch.c:1559 builtin/fetch.c:1622
+#: builtin/fetch.c:1568 builtin/fetch.c:1631
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Recupero di %s in corso\n"
 
-#: builtin/fetch.c:1569 builtin/fetch.c:1624 builtin/remote.c:100
+#: builtin/fetch.c:1578 builtin/fetch.c:1633 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Impossibile recuperare %s"
 
-#: builtin/fetch.c:1581
+#: builtin/fetch.c:1590
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "impossibile recuperare '%s' (codice di uscita: %d)\n"
 
-#: builtin/fetch.c:1684
+#: builtin/fetch.c:1693
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -13821,45 +14236,45 @@ msgstr ""
 "Non è stato specificato alcun repository remoto. Specifica un URL o il\n"
 "nome di un remoto da cui dovranno essere recuperate le nuove revisioni."
 
-#: builtin/fetch.c:1721
+#: builtin/fetch.c:1730
 msgid "You need to specify a tag name."
 msgstr "Devi specificare il nome di un tag."
 
-#: builtin/fetch.c:1771
+#: builtin/fetch.c:1780
 msgid "Negative depth in --deepen is not supported"
 msgstr "Le profondità negative in --deepen non sono supportate"
 
-#: builtin/fetch.c:1773
+#: builtin/fetch.c:1782
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "le opzioni --deepen e --depth sono mutualmente esclusive"
 
-#: builtin/fetch.c:1778
+#: builtin/fetch.c:1787
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth e --unshallow non possono essere usati insieme."
 
-#: builtin/fetch.c:1780
+#: builtin/fetch.c:1789
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow su un repository completo non ha senso"
 
-#: builtin/fetch.c:1796
+#: builtin/fetch.c:1805
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all non richiede un repository come argomento"
 
-#: builtin/fetch.c:1798
+#: builtin/fetch.c:1807
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all non ha senso con degli specificatori riferimento"
 
-#: builtin/fetch.c:1807
+#: builtin/fetch.c:1816
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Remoto o gruppo remoti non esistente: %s"
 
-#: builtin/fetch.c:1814
+#: builtin/fetch.c:1823
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "Recuperare un gruppo e specificare gli specificatori riferimento non ha senso"
 
-#: builtin/fetch.c:1832
+#: builtin/fetch.c:1841
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -13873,23 +14288,23 @@ msgid ""
 msgstr ""
 "git fmt-merge-msg [-m <messaggio>] [--log[=<n>] | --no-log] [--file <file>]"
 
-#: builtin/fmt-merge-msg.c:674
+#: builtin/fmt-merge-msg.c:671
 msgid "populate log with at most <n> entries from shortlog"
 msgstr "popola il registro con al più <n> voci del registro breve"
 
-#: builtin/fmt-merge-msg.c:677
+#: builtin/fmt-merge-msg.c:674
 msgid "alias for --log (deprecated)"
 msgstr "alias di --log (deprecato)"
 
-#: builtin/fmt-merge-msg.c:680
+#: builtin/fmt-merge-msg.c:677
 msgid "text"
 msgstr "testo"
 
-#: builtin/fmt-merge-msg.c:681
+#: builtin/fmt-merge-msg.c:678
 msgid "use <text> as start of message"
 msgstr "usa <testo> come stringa iniziale del messaggio"
 
-#: builtin/fmt-merge-msg.c:682
+#: builtin/fmt-merge-msg.c:679
 msgid "file to read from"
 msgstr "file da cui leggere"
 
@@ -14100,7 +14515,7 @@ msgstr "Controllo directory oggetti in corso"
 msgid "Checking %s link"
 msgstr "Controllo collegamento %s"
 
-#: builtin/fsck.c:695 builtin/index-pack.c:842
+#: builtin/fsck.c:695 builtin/index-pack.c:843
 #, c-format
 msgid "invalid %s"
 msgstr "%s non valido"
@@ -14303,7 +14718,7 @@ msgstr ""
 "Ci sono troppi oggetti sparsi non raggiungibili; esegui 'git prune' per "
 "eliminarli."
 
-#: builtin/grep.c:29
+#: builtin/grep.c:30
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr ""
 "git grep [<opzioni>] [-e] <pattern> [<revisione>...] [[--] <percorso>...]"
@@ -14322,263 +14737,263 @@ msgstr "specificato numero non valido di thread (%d) per %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:287 builtin/index-pack.c:1534 builtin/index-pack.c:1727
-#: builtin/pack-objects.c:2708
+#: builtin/grep.c:287 builtin/index-pack.c:1538 builtin/index-pack.c:1731
+#: builtin/pack-objects.c:2854
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "non vi è supporto per i thread, ignoro %s"
 
-#: builtin/grep.c:467 builtin/grep.c:592 builtin/grep.c:635
+#: builtin/grep.c:453 builtin/grep.c:578 builtin/grep.c:618
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "impossibile leggere il tree (%s)"
 
-#: builtin/grep.c:650
+#: builtin/grep.c:633
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "impossibile eseguire grep su un oggetto di tipo %s"
 
-#: builtin/grep.c:716
+#: builtin/grep.c:704
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "switch '%c' richiede un valore numerico"
 
-#: builtin/grep.c:815
+#: builtin/grep.c:803
 msgid "search in index instead of in the work tree"
 msgstr "cerca nell'index anziché nell'albero di lavoro"
 
-#: builtin/grep.c:817
+#: builtin/grep.c:805
 msgid "find in contents not managed by git"
 msgstr "la ricerca nei contenuti non è gestita da Git"
 
-#: builtin/grep.c:819
+#: builtin/grep.c:807
 msgid "search in both tracked and untracked files"
 msgstr "cerca sia nei file tracciati sia in quelli non tracciati"
 
-#: builtin/grep.c:821
+#: builtin/grep.c:809
 msgid "ignore files specified via '.gitignore'"
 msgstr "ignora i file specificati in '.gitignore'"
 
-#: builtin/grep.c:823
+#: builtin/grep.c:811
 msgid "recursively search in each submodule"
 msgstr "cerca ricorsivamente in ogni sottomodulo"
 
-#: builtin/grep.c:826
+#: builtin/grep.c:814
 msgid "show non-matching lines"
 msgstr "visualizza le righe non corrispondenti"
 
-#: builtin/grep.c:828
+#: builtin/grep.c:816
 msgid "case insensitive matching"
 msgstr "ricerca corrispondenze senza differenze maiuscole/minuscole"
 
-#: builtin/grep.c:830
+#: builtin/grep.c:818
 msgid "match patterns only at word boundaries"
 msgstr "cerca corrispondenze ai pattern solo a inizio/fine parola"
 
-#: builtin/grep.c:832
+#: builtin/grep.c:820
 msgid "process binary files as text"
 msgstr "elabora i file binari come testuali"
 
-#: builtin/grep.c:834
+#: builtin/grep.c:822
 msgid "don't match patterns in binary files"
 msgstr "non cercare corrispondenze ai pattern nei file binari"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:825
 msgid "process binary files with textconv filters"
 msgstr "elabora i file binari con filtri di conversione in testo"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:827
 msgid "search in subdirectories (default)"
 msgstr "cerca nelle sottodirectory (impostazione predefinita)"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:829
 msgid "descend at most <depth> levels"
 msgstr "scendi al più di <profondità> livelli"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:833
 msgid "use extended POSIX regular expressions"
 msgstr "usa espressioni regolari POSIX estese"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:836
 msgid "use basic POSIX regular expressions (default)"
 msgstr "usa espressioni regolari POSIX di base (impostazione predefinita)"
 
-#: builtin/grep.c:851
+#: builtin/grep.c:839
 msgid "interpret patterns as fixed strings"
 msgstr "interpreta i pattern come stringhe fisse"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:842
 msgid "use Perl-compatible regular expressions"
 msgstr "usa espressioni regolari compatibili con Perl"
 
-#: builtin/grep.c:857
+#: builtin/grep.c:845
 msgid "show line numbers"
 msgstr "visualizza numeri di riga"
 
-#: builtin/grep.c:858
+#: builtin/grep.c:846
 msgid "show column number of first match"
 msgstr "visualizza il numero di colonna della prima corrispondenza"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:847
 msgid "don't show filenames"
 msgstr "non visualizzare i nomi file"
 
-#: builtin/grep.c:860
+#: builtin/grep.c:848
 msgid "show filenames"
 msgstr "visualizza i nomi file"
 
-#: builtin/grep.c:862
+#: builtin/grep.c:850
 msgid "show filenames relative to top directory"
 msgstr "visualizza i nomi file relativi alla directory di primo livello"
 
-#: builtin/grep.c:864
+#: builtin/grep.c:852
 msgid "show only filenames instead of matching lines"
 msgstr "visualizza solo i nomi file anziché le righe corrispondenti"
 
-#: builtin/grep.c:866
+#: builtin/grep.c:854
 msgid "synonym for --files-with-matches"
 msgstr "sinonimo di --files-with-matches"
 
-#: builtin/grep.c:869
+#: builtin/grep.c:857
 msgid "show only the names of files without match"
 msgstr "visualizza solo i nomi dei file non corrispondenti"
 
-#: builtin/grep.c:871
+#: builtin/grep.c:859
 msgid "print NUL after filenames"
 msgstr "stampa NUL dopo i nomi file"
 
-#: builtin/grep.c:874
+#: builtin/grep.c:862
 msgid "show only matching parts of a line"
 msgstr "visualizza solo le parti corrispondenti di una riga"
 
-#: builtin/grep.c:876
+#: builtin/grep.c:864
 msgid "show the number of matches instead of matching lines"
 msgstr "visualizza il numero di corrispondenze anziché le righe corrispondenti"
 
-#: builtin/grep.c:877
+#: builtin/grep.c:865
 msgid "highlight matches"
 msgstr "evidenzia corrispondenze"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:867
 msgid "print empty line between matches from different files"
 msgstr "stampa una riga vuota fra le corrispondenze in file differenti"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:869
 msgid "show filename only once above matches from same file"
 msgstr ""
 "visualizza il nome file solo una volta prima delle corrispondenze nello "
 "stesso file"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:872
 msgid "show <n> context lines before and after matches"
 msgstr "visualizza <n> righe di contesto prima e dopo le corrispondenze"
 
-#: builtin/grep.c:887
+#: builtin/grep.c:875
 msgid "show <n> context lines before matches"
 msgstr "visualizza <n> righe di contesto prima delle corrispondenze"
 
-#: builtin/grep.c:889
+#: builtin/grep.c:877
 msgid "show <n> context lines after matches"
 msgstr "visualizza <n> righe di contesto dopo le corrispondenze"
 
-#: builtin/grep.c:891
+#: builtin/grep.c:879
 msgid "use <n> worker threads"
 msgstr "usa <n> thread di lavoro"
 
-#: builtin/grep.c:892
+#: builtin/grep.c:880
 msgid "shortcut for -C NUM"
 msgstr "scorciatoia per -C NUM"
 
-#: builtin/grep.c:895
+#: builtin/grep.c:883
 msgid "show a line with the function name before matches"
 msgstr "visualizza una riga con il nome funzione prima delle corrispondenze"
 
-#: builtin/grep.c:897
+#: builtin/grep.c:885
 msgid "show the surrounding function"
 msgstr "visualizza la funzione circostante"
 
-#: builtin/grep.c:900
+#: builtin/grep.c:888
 msgid "read patterns from file"
 msgstr "leggi le corrispondenze da un file"
 
-#: builtin/grep.c:902
+#: builtin/grep.c:890
 msgid "match <pattern>"
 msgstr "cerca corrispondenze con <pattern>"
 
-#: builtin/grep.c:904
+#: builtin/grep.c:892
 msgid "combine patterns specified with -e"
 msgstr "combina i pattern specificati con -e"
 
-#: builtin/grep.c:916
+#: builtin/grep.c:904
 msgid "indicate hit with exit status without output"
 msgstr ""
 "segnala una corrispondenza con il codice di uscita senza emettere output"
 
-#: builtin/grep.c:918
+#: builtin/grep.c:906
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "visualizza solo le corrispondenze nei file in cui vi sono corrispondenze per "
 "tutti i pattern"
 
-#: builtin/grep.c:920
+#: builtin/grep.c:908
 msgid "show parse tree for grep expression"
 msgstr "visualizza l'albero di analisi per l'espressione grep"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:912
 msgid "pager"
 msgstr "pager"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:912
 msgid "show matching files in the pager"
 msgstr "visualizza i file corrispondenti nel pager"
 
-#: builtin/grep.c:928
+#: builtin/grep.c:916
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "consenti"
 
-#: builtin/grep.c:992
+#: builtin/grep.c:983
 msgid "no pattern given"
 msgstr "nessun pattern specificato"
 
-#: builtin/grep.c:1028
+#: builtin/grep.c:1019
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index o --untracked non possono essere usate con le revisioni"
 
-#: builtin/grep.c:1036
+#: builtin/grep.c:1027
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "impossibile risolvere la revisione %s"
 
-#: builtin/grep.c:1067
+#: builtin/grep.c:1057
+msgid "--untracked not supported with --recurse-submodules"
+msgstr "l'opzione --untracked non è supportata con --recurse-submodules"
+
+#: builtin/grep.c:1061
 msgid "invalid option combination, ignoring --threads"
 msgstr "combinazione di opzioni non valida, ignoro --threads"
 
-#: builtin/grep.c:1070 builtin/pack-objects.c:3400
+#: builtin/grep.c:1064 builtin/pack-objects.c:3547
 msgid "no threads support, ignoring --threads"
 msgstr "non vi è supporto per i thread, ignoro --threads"
 
-#: builtin/grep.c:1073 builtin/index-pack.c:1531 builtin/pack-objects.c:2705
+#: builtin/grep.c:1067 builtin/index-pack.c:1535 builtin/pack-objects.c:2851
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "specificato numero non valido di thread (%d)"
 
-#: builtin/grep.c:1096
+#: builtin/grep.c:1101
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "--open-files-in-pager funziona solo sull'albero di lavoro"
 
-#: builtin/grep.c:1119
-msgid "option not supported with --recurse-submodules"
-msgstr "opzione non supportata con --recurse-submodules"
-
-#: builtin/grep.c:1125
+#: builtin/grep.c:1127
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached o --untracked non possono essere usate con --no-index"
 
-#: builtin/grep.c:1131
+#: builtin/grep.c:1133
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr "--[no-]exclude-standard non può essere usata per i contenuti tracciati"
 
-#: builtin/grep.c:1139
+#: builtin/grep.c:1141
 msgid "both --cached and trees are given"
 msgstr "sono specificati sia --cached sia degli alberi"
 
@@ -14764,7 +15179,7 @@ msgstr "errore di lettura in input"
 msgid "used more bytes than were available"
 msgstr "usati più byte di quelli disponibili"
 
-#: builtin/index-pack.c:288 builtin/pack-objects.c:604
+#: builtin/index-pack.c:288 builtin/pack-objects.c:606
 msgid "pack too large for current definition of off_t"
 msgstr "pack troppo largo per la definizione corrente di off_t"
 
@@ -14824,191 +15239,191 @@ msgstr[1] "fine del file pack prematura, %<PRIuMAX> byte mancanti"
 msgid "serious inflate inconsistency"
 msgstr "inconsistenza grave di inflate"
 
-#: builtin/index-pack.c:735 builtin/index-pack.c:741 builtin/index-pack.c:764
-#: builtin/index-pack.c:803 builtin/index-pack.c:812
+#: builtin/index-pack.c:735 builtin/index-pack.c:741 builtin/index-pack.c:765
+#: builtin/index-pack.c:804 builtin/index-pack.c:813
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "TROVATA COLLISIONE SHA1 CON %s !"
 
-#: builtin/index-pack.c:738 builtin/pack-objects.c:157
-#: builtin/pack-objects.c:217 builtin/pack-objects.c:311
+#: builtin/index-pack.c:738 builtin/pack-objects.c:158
+#: builtin/pack-objects.c:218 builtin/pack-objects.c:313
 #, c-format
 msgid "unable to read %s"
 msgstr "impossibile leggere %s"
 
-#: builtin/index-pack.c:801
+#: builtin/index-pack.c:802
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "impossibile leggere le informazioni sull'oggetto esistente: %s"
 
-#: builtin/index-pack.c:809
+#: builtin/index-pack.c:810
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "non è possibile leggere l'oggetto %s esistente"
 
-#: builtin/index-pack.c:823
+#: builtin/index-pack.c:824
 #, c-format
 msgid "invalid blob object %s"
 msgstr "oggetto blob %s non valido"
 
-#: builtin/index-pack.c:826 builtin/index-pack.c:845
+#: builtin/index-pack.c:827 builtin/index-pack.c:846
 msgid "fsck error in packed object"
 msgstr "errore fsck nell'oggetto sottoposto a pack"
 
-#: builtin/index-pack.c:847
+#: builtin/index-pack.c:848
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Non tutti gli oggetti figlio di %s sono raggiungibili"
 
-#: builtin/index-pack.c:919 builtin/index-pack.c:950
+#: builtin/index-pack.c:920 builtin/index-pack.c:951
 msgid "failed to apply delta"
 msgstr "applicazione del delta non riuscita"
 
-#: builtin/index-pack.c:1118
+#: builtin/index-pack.c:1121
 msgid "Receiving objects"
 msgstr "Ricezione degli oggetti"
 
-#: builtin/index-pack.c:1118
+#: builtin/index-pack.c:1121
 msgid "Indexing objects"
 msgstr "Indicizzazione degli oggetti"
 
-#: builtin/index-pack.c:1152
+#: builtin/index-pack.c:1155
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "il pack è corrotto (SHA1 non corrisponde)"
 
-#: builtin/index-pack.c:1157
+#: builtin/index-pack.c:1160
 msgid "cannot fstat packfile"
 msgstr "impossibile eseguire fstat sul file pack"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1163
 msgid "pack has junk at the end"
 msgstr "il pack ha dati inutili alla fine"
 
-#: builtin/index-pack.c:1172
+#: builtin/index-pack.c:1175
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "confusione oltre ogni follia in parse_pack_objects()"
 
-#: builtin/index-pack.c:1195
+#: builtin/index-pack.c:1198
 msgid "Resolving deltas"
 msgstr "Risoluzione dei delta"
 
-#: builtin/index-pack.c:1205 builtin/pack-objects.c:2481
+#: builtin/index-pack.c:1208 builtin/pack-objects.c:2615
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "impossibile creare il thread: %s"
 
-#: builtin/index-pack.c:1246
+#: builtin/index-pack.c:1249
 msgid "confusion beyond insanity"
 msgstr "confusione oltre ogni follia"
 
-#: builtin/index-pack.c:1252
+#: builtin/index-pack.c:1255
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "completato con %d oggetto locale"
 msgstr[1] "completato con %d oggetti locali"
 
-#: builtin/index-pack.c:1264
+#: builtin/index-pack.c:1267
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Checksum in coda inatteso per %s (disco corrotto?)"
 
-#: builtin/index-pack.c:1268
+#: builtin/index-pack.c:1271
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "pack ha %d delta irrisolto"
 msgstr[1] "pack ha %d delta irrisolti"
 
-#: builtin/index-pack.c:1292
+#: builtin/index-pack.c:1295
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "impossibile eseguire deflate sull'oggetto aggiunto alla fine (%d)"
 
-#: builtin/index-pack.c:1388
+#: builtin/index-pack.c:1392
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "l'oggetto locale %s è corrotto"
 
-#: builtin/index-pack.c:1402
+#: builtin/index-pack.c:1406
 #, c-format
 msgid "packfile name '%s' does not end with '.pack'"
 msgstr "il nome del file pack '%s' non termina con '.pack'"
 
-#: builtin/index-pack.c:1427
+#: builtin/index-pack.c:1431
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "impossibile scrivere il file %s '%s'"
 
-#: builtin/index-pack.c:1435
+#: builtin/index-pack.c:1439
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "impossibile chiudere il file %s scritto '%s'"
 
-#: builtin/index-pack.c:1459
+#: builtin/index-pack.c:1463
 msgid "error while closing pack file"
 msgstr "errore nella chiusura del file pack"
 
-#: builtin/index-pack.c:1473
+#: builtin/index-pack.c:1477
 msgid "cannot store pack file"
 msgstr "impossibile archiviare il file pack"
 
-#: builtin/index-pack.c:1481
+#: builtin/index-pack.c:1485
 msgid "cannot store index file"
 msgstr "impossibile archiviare index file"
 
-#: builtin/index-pack.c:1525 builtin/pack-objects.c:2716
+#: builtin/index-pack.c:1529 builtin/pack-objects.c:2862
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "pack.indexversion=%<PRIu32> non valida"
 
-#: builtin/index-pack.c:1593
+#: builtin/index-pack.c:1597
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Impossibile aprire il file pack '%s' esistente"
 
-#: builtin/index-pack.c:1595
+#: builtin/index-pack.c:1599
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Impossibile aprire il file pack idx esistente per '%s'"
 
-#: builtin/index-pack.c:1643
+#: builtin/index-pack.c:1647
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "non delta: %d oggetto"
 msgstr[1] "non delta: %d oggetti"
 
-#: builtin/index-pack.c:1650
+#: builtin/index-pack.c:1654
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "lunghezza della catena = %d: %lu oggetto"
 msgstr[1] "lunghezza della catena = %d: %lu oggetti"
 
-#: builtin/index-pack.c:1689
+#: builtin/index-pack.c:1693
 msgid "Cannot come back to cwd"
 msgstr "impossibile tornare alla directory di lavoro corrente"
 
-#: builtin/index-pack.c:1738 builtin/index-pack.c:1741
-#: builtin/index-pack.c:1757 builtin/index-pack.c:1761
+#: builtin/index-pack.c:1742 builtin/index-pack.c:1745
+#: builtin/index-pack.c:1761 builtin/index-pack.c:1765
 #, c-format
 msgid "bad %s"
 msgstr "%s errato"
 
-#: builtin/index-pack.c:1777
+#: builtin/index-pack.c:1781
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin non può essere usato senza --stdin"
 
-#: builtin/index-pack.c:1779
+#: builtin/index-pack.c:1783
 msgid "--stdin requires a git repository"
 msgstr "--stdin richiede un repository Git"
 
-#: builtin/index-pack.c:1785
+#: builtin/index-pack.c:1789
 msgid "--verify with no packfile name given"
 msgstr "--verify senza un nome del file pack specificato"
 
-#: builtin/index-pack.c:1833 builtin/unpack-objects.c:581
+#: builtin/index-pack.c:1837 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "errore fsck negli oggetti sottoposti a pack"
 
@@ -15389,8 +15804,8 @@ msgstr "modo-lettera-da-descrizione"
 #: builtin/log.c:1652
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
-"genera parti di una lettera d'accompagnamento basandosi sulla descrizione di"
-" un branch"
+"genera parti di una lettera d'accompagnamento basandosi sulla descrizione di "
+"un branch"
 
 #: builtin/log.c:1654
 msgid "Use [<prefix>] instead of [PATCH]"
@@ -15735,7 +16150,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "non stampare l'URL del remoto"
 
-#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1518
+#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1561
 msgid "exec"
 msgstr "eseguibile"
 
@@ -15823,180 +16238,180 @@ msgstr "git merge --abort"
 msgid "git merge --continue"
 msgstr "git merge --continue"
 
-#: builtin/merge.c:118
+#: builtin/merge.c:119
 msgid "switch `m' requires a value"
 msgstr "lo switch 'm' richiede un valore"
 
-#: builtin/merge.c:141
+#: builtin/merge.c:142
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "l'opzione `%s' richiede un valore"
 
-#: builtin/merge.c:187
+#: builtin/merge.c:188
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Non è stato possibile trovare la strategia di merge '%s'.\n"
 
-#: builtin/merge.c:188
+#: builtin/merge.c:189
 #, c-format
 msgid "Available strategies are:"
 msgstr "Le strategie disponibili sono:"
 
-#: builtin/merge.c:193
+#: builtin/merge.c:194
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Le strategie personalizzate disponibili sono:"
 
-#: builtin/merge.c:244 builtin/pull.c:152
+#: builtin/merge.c:245 builtin/pull.c:132
 msgid "do not show a diffstat at the end of the merge"
 msgstr "non visualizzare un diffstat al termine del merge"
 
-#: builtin/merge.c:247 builtin/pull.c:155
+#: builtin/merge.c:248 builtin/pull.c:135
 msgid "show a diffstat at the end of the merge"
 msgstr "visualizza un diffstat al termine del merge"
 
-#: builtin/merge.c:248 builtin/pull.c:158
+#: builtin/merge.c:249 builtin/pull.c:138
 msgid "(synonym to --stat)"
 msgstr "(sinonimo di --stat)"
 
-#: builtin/merge.c:250 builtin/pull.c:161
+#: builtin/merge.c:251 builtin/pull.c:141
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "aggiungi (al più <n>) voci dal registro breve al messaggio di commit del "
 "merge"
 
-#: builtin/merge.c:253 builtin/pull.c:167
+#: builtin/merge.c:254 builtin/pull.c:147
 msgid "create a single commit instead of doing a merge"
 msgstr "crea un singolo commit anziché eseguire un merge"
 
-#: builtin/merge.c:255 builtin/pull.c:170
+#: builtin/merge.c:256 builtin/pull.c:150
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "esegui un commit se il merge ha successo (impostazione predefinita)"
 
-#: builtin/merge.c:257 builtin/pull.c:173
+#: builtin/merge.c:258 builtin/pull.c:153
 msgid "edit message before committing"
 msgstr "modifica il messaggio prima di eseguire il commit"
 
-#: builtin/merge.c:259
+#: builtin/merge.c:260
 msgid "allow fast-forward (default)"
 msgstr "consenti fast forward (impostazione predefinita)"
 
-#: builtin/merge.c:261 builtin/pull.c:180
+#: builtin/merge.c:262 builtin/pull.c:160
 msgid "abort if fast-forward is not possible"
 msgstr "interrompi se il fast forward non è possibile"
 
-#: builtin/merge.c:265 builtin/pull.c:183
+#: builtin/merge.c:266 builtin/pull.c:163
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "verifica che il commit specificato abbia una firma GPG valida"
 
-#: builtin/merge.c:266 builtin/notes.c:787 builtin/pull.c:187
-#: builtin/rebase.c:512 builtin/rebase.c:1531 builtin/revert.c:114
+#: builtin/merge.c:267 builtin/notes.c:787 builtin/pull.c:167
+#: builtin/rebase.c:520 builtin/rebase.c:1575 builtin/revert.c:114
 msgid "strategy"
 msgstr "strategia"
 
-#: builtin/merge.c:267 builtin/pull.c:188
+#: builtin/merge.c:268 builtin/pull.c:168
 msgid "merge strategy to use"
 msgstr "strategia di merge da usare"
 
-#: builtin/merge.c:268 builtin/pull.c:191
+#: builtin/merge.c:269 builtin/pull.c:171
 msgid "option=value"
 msgstr "opzione=valore"
 
-#: builtin/merge.c:269 builtin/pull.c:192
+#: builtin/merge.c:270 builtin/pull.c:172
 msgid "option for selected merge strategy"
 msgstr "opzione per la strategia di merge selezionata"
 
-#: builtin/merge.c:271
+#: builtin/merge.c:272
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "messaggio di commit del merge (per un merge non fast forward)"
 
-#: builtin/merge.c:278
+#: builtin/merge.c:279
 msgid "abort the current in-progress merge"
 msgstr "interrompi il merge attualmente in corso"
 
-#: builtin/merge.c:280
+#: builtin/merge.c:281
 msgid "--abort but leave index and working tree alone"
 msgstr "esegui --abort ma mantieni immutati l'indice e l'albero di lavoro"
 
-#: builtin/merge.c:282
+#: builtin/merge.c:283
 msgid "continue the current in-progress merge"
 msgstr "continua il merge attualmente in corso"
 
-#: builtin/merge.c:284 builtin/pull.c:199
+#: builtin/merge.c:285 builtin/pull.c:179
 msgid "allow merging unrelated histories"
 msgstr "consenti di unire cronologie non correlate"
 
-#: builtin/merge.c:290
+#: builtin/merge.c:291
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "ignora gli hook pre-merge-commit e commit-msg"
 
-#: builtin/merge.c:307
+#: builtin/merge.c:308
 msgid "could not run stash."
 msgstr "non è stato possibile eseguire stash."
 
-#: builtin/merge.c:312
+#: builtin/merge.c:313
 msgid "stash failed"
 msgstr "esecuzione di stash non riuscita"
 
-#: builtin/merge.c:317
+#: builtin/merge.c:318
 #, c-format
 msgid "not a valid object: %s"
 msgstr "non è un oggetto valido: %s"
 
-#: builtin/merge.c:339 builtin/merge.c:356
+#: builtin/merge.c:340 builtin/merge.c:357
 msgid "read-tree failed"
 msgstr "read-tree non riuscito"
 
-#: builtin/merge.c:386
+#: builtin/merge.c:387
 msgid " (nothing to squash)"
 msgstr " (nulla di cui eseguire lo squash)"
 
-#: builtin/merge.c:397
+#: builtin/merge.c:398
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Commit di squash -- non aggiorno HEAD\n"
 
-#: builtin/merge.c:447
+#: builtin/merge.c:448
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Nessun messaggio di merge -- HEAD non viene aggiornato\n"
 
-#: builtin/merge.c:498
+#: builtin/merge.c:499
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "'%s' non punta ad un commit"
 
-#: builtin/merge.c:585
+#: builtin/merge.c:586
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Stringa branch.%s.mergeoptions errata: %s"
 
-#: builtin/merge.c:705
+#: builtin/merge.c:708
 msgid "Not handling anything other than two heads merge."
 msgstr "Non gestisco nulla che non sia il merge di due head."
 
-#: builtin/merge.c:719
+#: builtin/merge.c:722
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Opzione sconosciuta per merge-recursive: -X%s"
 
-#: builtin/merge.c:734
+#: builtin/merge.c:737
 #, c-format
 msgid "unable to write %s"
 msgstr "impossibile scrivere %s"
 
-#: builtin/merge.c:786
+#: builtin/merge.c:789
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "Non è stato possibile leggere da '%s'"
 
-#: builtin/merge.c:795
+#: builtin/merge.c:798
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Non eseguo il commit del merge; usa 'git commit' per completare il merge.\n"
 
-#: builtin/merge.c:801
+#: builtin/merge.c:804
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -16007,11 +16422,11 @@ msgstr ""
 "aggiornato in un topic branch.\n"
 "\n"
 
-#: builtin/merge.c:806
+#: builtin/merge.c:809
 msgid "An empty message aborts the commit.\n"
 msgstr "Un messaggio vuoto interromperà il commit.\n"
 
-#: builtin/merge.c:809
+#: builtin/merge.c:812
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -16020,74 +16435,74 @@ msgstr ""
 "Le righe che iniziano con '%c' saranno ignorate e un messaggio vuoto\n"
 "interromperà il commit.\n"
 
-#: builtin/merge.c:862
+#: builtin/merge.c:865
 msgid "Empty commit message."
 msgstr "Messaggio di commit vuoto."
 
-#: builtin/merge.c:877
+#: builtin/merge.c:880
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Splendido.\n"
 
-#: builtin/merge.c:938
+#: builtin/merge.c:941
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Merge automatico fallito; risolvi i conflitti ed esegui il commit\n"
 "del risultato.\n"
 
-#: builtin/merge.c:977
+#: builtin/merge.c:980
 msgid "No current branch."
 msgstr "Nessun branch corrente."
 
-#: builtin/merge.c:979
+#: builtin/merge.c:982
 msgid "No remote for the current branch."
 msgstr "Nessun remote per il branch corrente."
 
-#: builtin/merge.c:981
+#: builtin/merge.c:984
 msgid "No default upstream defined for the current branch."
 msgstr "Nessun upstream di default definito per il branch corrente."
 
-#: builtin/merge.c:986
+#: builtin/merge.c:989
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Nessun branch che tracci un remoto per %s da %s"
 
-#: builtin/merge.c:1043
+#: builtin/merge.c:1046
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Valore errato '%s' nell'ambiente '%s'"
 
-#: builtin/merge.c:1146
+#: builtin/merge.c:1149
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "non è qualcosa di cui possiamo eseguire il merge in %s: %s"
 
-#: builtin/merge.c:1180
+#: builtin/merge.c:1183
 msgid "not something we can merge"
 msgstr "non è qualcosa di cui possiamo eseguire il merge"
 
-#: builtin/merge.c:1283
+#: builtin/merge.c:1286
 msgid "--abort expects no arguments"
 msgstr "--abort non richiede argomenti"
 
-#: builtin/merge.c:1287
+#: builtin/merge.c:1290
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Non c'è nessun merge da interrompere (MERGE_HEAD mancante)."
 
-#: builtin/merge.c:1296
+#: builtin/merge.c:1299
 msgid "--quit expects no arguments"
 msgstr "--quit non richiede argomenti"
 
-#: builtin/merge.c:1309
+#: builtin/merge.c:1312
 msgid "--continue expects no arguments"
 msgstr "--continue non richiede argomenti"
 
-#: builtin/merge.c:1313
+#: builtin/merge.c:1316
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Non c'è nessun merge in corso (MERGE_HEAD mancante)."
 
-#: builtin/merge.c:1329
+#: builtin/merge.c:1332
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -16095,7 +16510,7 @@ msgstr ""
 "Non hai concluso il merge (MERGE_HEAD esiste).\n"
 "Esegui il commit delle modifiche prima di eseguire il merge."
 
-#: builtin/merge.c:1336
+#: builtin/merge.c:1339
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -16103,96 +16518,96 @@ msgstr ""
 "Non hai concluso il cherry-pick (CHERRY_PICK_HEAD esiste).\n"
 "Esegui il commit delle modifiche prima di eseguire il merge."
 
-#: builtin/merge.c:1339
+#: builtin/merge.c:1342
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Il cherry-pick non è stato concluso (CHERRY_PICK_HEAD esiste)."
 
-#: builtin/merge.c:1353
+#: builtin/merge.c:1356
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Non è possibile combinare --squash con --no-ff."
 
-#: builtin/merge.c:1355
+#: builtin/merge.c:1358
 msgid "You cannot combine --squash with --commit."
 msgstr "Non è possibile combinare --squash con --commit."
 
-#: builtin/merge.c:1371
+#: builtin/merge.c:1374
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Nessun commit specificato e merge.defaultToUpstream non impostato."
 
-#: builtin/merge.c:1388
+#: builtin/merge.c:1391
 msgid "Squash commit into empty head not supported yet"
 msgstr "Lo squash di un commit in un'head vuota non è ancora supportato"
 
-#: builtin/merge.c:1390
+#: builtin/merge.c:1393
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Un commit non fast forward non ha senso in un'head vuota"
 
-#: builtin/merge.c:1395
+#: builtin/merge.c:1398
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - non è qualcosa per cui possiamo eseguire il merge"
 
-#: builtin/merge.c:1397
+#: builtin/merge.c:1400
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Si può eseguire solo il merge di uno e un solo commit in un'head vuota"
 
-#: builtin/merge.c:1476
+#: builtin/merge.c:1481
 msgid "refusing to merge unrelated histories"
 msgstr "mi rifiuto di eseguire il merge di cronologie non correlate"
 
-#: builtin/merge.c:1485
+#: builtin/merge.c:1490
 msgid "Already up to date."
 msgstr "Già aggiornato."
 
-#: builtin/merge.c:1495
+#: builtin/merge.c:1500
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Aggiornamento di %s..%s\n"
 
-#: builtin/merge.c:1537
+#: builtin/merge.c:1542
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Provo con un merge veramente banale dentro l'indice...\n"
 
-#: builtin/merge.c:1544
+#: builtin/merge.c:1549
 #, c-format
 msgid "Nope.\n"
 msgstr "No.\n"
 
-#: builtin/merge.c:1569
+#: builtin/merge.c:1574
 msgid "Already up to date. Yeeah!"
 msgstr "Già aggiornato. Oh sì!"
 
-#: builtin/merge.c:1575
+#: builtin/merge.c:1580
 msgid "Not possible to fast-forward, aborting."
 msgstr "Fast forward non possibile, interrompo l'operazione."
 
-#: builtin/merge.c:1598 builtin/merge.c:1663
+#: builtin/merge.c:1603 builtin/merge.c:1668
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Ripristino l'albero in uno stato pulito...\n"
 
-#: builtin/merge.c:1602
+#: builtin/merge.c:1607
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Tentativo con la strategia di merge %s...\n"
 
-#: builtin/merge.c:1654
+#: builtin/merge.c:1659
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Nessuna strategia di merge ha gestito il merge.\n"
 
-#: builtin/merge.c:1656
+#: builtin/merge.c:1661
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Merge con la strategia %s fallito.\n"
 
-#: builtin/merge.c:1665
+#: builtin/merge.c:1670
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
 msgstr "Uso %s per preparare una risoluzione manuale.\n"
 
-#: builtin/merge.c:1677
+#: builtin/merge.c:1682
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -16333,8 +16748,8 @@ msgid ""
 "git multi-pack-index [<options>] (write|verify|expire|repack --batch-"
 "size=<size>)"
 msgstr ""
-"git multi-pack-index [<opzioni>] (write|verify|expire|repack --batch-size=<"
-"dimensione>)"
+"git multi-pack-index [<opzioni>] (write|verify|expire|repack --batch-"
+"size=<dimensione>)"
 
 #: builtin/multi-pack-index.c:26
 msgid "object directory containing set of packfile and pack-index pairs"
@@ -16451,52 +16866,52 @@ msgstr "%s, sorgente=%s, destinazione=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Rinominazione di %s in %s in corso\n"
 
-#: builtin/mv.c:277 builtin/remote.c:716 builtin/repack.c:518
+#: builtin/mv.c:277 builtin/remote.c:781 builtin/repack.c:518
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "rinomina di '%s' non riuscita"
 
-#: builtin/name-rev.c:403
+#: builtin/name-rev.c:465
 msgid "git name-rev [<options>] <commit>..."
 msgstr "git name-rev [<opzioni>] <commit>..."
 
-#: builtin/name-rev.c:404
+#: builtin/name-rev.c:466
 msgid "git name-rev [<options>] --all"
 msgstr "git name-rev [<opzioni>] --all"
 
-#: builtin/name-rev.c:405
+#: builtin/name-rev.c:467
 msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [<opzioni>] --stdin"
 
-#: builtin/name-rev.c:462
+#: builtin/name-rev.c:524
 msgid "print only names (no SHA-1)"
 msgstr "stampa solo i nomi (non lo SHA-1)"
 
-#: builtin/name-rev.c:463
+#: builtin/name-rev.c:525
 msgid "only use tags to name the commits"
 msgstr "usa solo tag per denominare i commit"
 
-#: builtin/name-rev.c:465
+#: builtin/name-rev.c:527
 msgid "only use refs matching <pattern>"
 msgstr "usa solo i riferimenti corrispondenti a <pattern>"
 
-#: builtin/name-rev.c:467
+#: builtin/name-rev.c:529
 msgid "ignore refs matching <pattern>"
 msgstr "ignora i riferimenti corrispondenti a <pattern>"
 
-#: builtin/name-rev.c:469
+#: builtin/name-rev.c:531
 msgid "list all commits reachable from all refs"
 msgstr "elenca tutti i commit raggiungibili da tutti i riferimenti"
 
-#: builtin/name-rev.c:470
+#: builtin/name-rev.c:532
 msgid "read from stdin"
 msgstr "leggi dallo standard input"
 
-#: builtin/name-rev.c:471
+#: builtin/name-rev.c:533
 msgid "allow to print `undefined` names (default)"
 msgstr "consenti di stampare nomi `non definito` (impostazione predefinita)"
 
-#: builtin/name-rev.c:477
+#: builtin/name-rev.c:539
 msgid "dereference tags in the input (internal use)"
 msgstr "dereferenzia tag nell'input (uso interno)"
 
@@ -16916,7 +17331,7 @@ msgstr "riferimento note"
 msgid "use notes from <notes-ref>"
 msgstr "usa le note in <riferimento note>"
 
-#: builtin/notes.c:1034 builtin/stash.c:1607
+#: builtin/notes.c:1034 builtin/stash.c:1610
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "sottocomando sconosciuto: %s"
@@ -16935,129 +17350,106 @@ msgstr ""
 "git pack-objects [<opzioni>...] <nome base> [< <elenco riferimenti> | < "
 "<elenco oggetti>]"
 
-#: builtin/pack-objects.c:428
+#: builtin/pack-objects.c:430
 #, c-format
 msgid "bad packed object CRC for %s"
 msgstr "CRC oggetto sottoposto a pack %s errato"
 
-#: builtin/pack-objects.c:439
+#: builtin/pack-objects.c:441
 #, c-format
 msgid "corrupt packed object for %s"
 msgstr "oggetto sottoposto a pack %s corrotto"
 
-#: builtin/pack-objects.c:570
+#: builtin/pack-objects.c:572
 #, c-format
 msgid "recursive delta detected for object %s"
 msgstr "rilevato delta ricorsivo per l'oggetto %s"
 
-#: builtin/pack-objects.c:781
+#: builtin/pack-objects.c:783
 #, c-format
 msgid "ordered %u objects, expected %<PRIu32>"
 msgstr "%u oggetti ordinati, attesi %<PRIu32>"
 
-#: builtin/pack-objects.c:794
-#, c-format
-msgid "packfile is invalid: %s"
-msgstr "packfile non valido: %s"
-
-#: builtin/pack-objects.c:798
-#, c-format
-msgid "unable to open packfile for reuse: %s"
-msgstr "impossibile aprire il packfile per il suo riuso: %s"
-
-#: builtin/pack-objects.c:802
-msgid "unable to seek in reused packfile"
-msgstr "impossibile eseguire seek nel packfile riusato"
-
-#: builtin/pack-objects.c:813
-msgid "unable to read from reused packfile"
-msgstr "impossibile leggere dal packfile riusato"
-
-#: builtin/pack-objects.c:841
+#: builtin/pack-objects.c:972
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "disabilito la scrittura delle bitmap, i pack sono divisi a causa "
 "dell'impostazione pack.packSizeLimit"
 
-#: builtin/pack-objects.c:854
+#: builtin/pack-objects.c:985
 msgid "Writing objects"
 msgstr "Scrittura degli oggetti in corso"
 
-#: builtin/pack-objects.c:917 builtin/update-index.c:90
+#: builtin/pack-objects.c:1046 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "stat di %s non riuscito"
 
-#: builtin/pack-objects.c:970
+#: builtin/pack-objects.c:1099
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "scritti %<PRIu32> oggetti quando me ne attendevo %<PRIu32>"
 
-#: builtin/pack-objects.c:1164
+#: builtin/pack-objects.c:1297
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "disabilito la scrittura delle bitmap perché alcuni oggetti non saranno "
 "sottoposti a pack"
 
-#: builtin/pack-objects.c:1592
+#: builtin/pack-objects.c:1724
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "overflow dell'offset base del delta nel pack per %s"
 
-#: builtin/pack-objects.c:1601
+#: builtin/pack-objects.c:1733
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "offset base del delta fuori dall'intervallo consentito per %s"
 
-#: builtin/pack-objects.c:1870
+#: builtin/pack-objects.c:2004
 msgid "Counting objects"
 msgstr "Conteggio degli oggetti in corso"
 
-#: builtin/pack-objects.c:2000
-#, c-format
-msgid "unable to get size of %s"
-msgstr "impossibile recuperare le dimensioni di %s"
-
-#: builtin/pack-objects.c:2015
+#: builtin/pack-objects.c:2149
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "impossibile analizzare l'intestazione oggetto di %s"
 
-#: builtin/pack-objects.c:2085 builtin/pack-objects.c:2101
-#: builtin/pack-objects.c:2111
+#: builtin/pack-objects.c:2219 builtin/pack-objects.c:2235
+#: builtin/pack-objects.c:2245
 #, c-format
 msgid "object %s cannot be read"
 msgstr "impossibile leggere l'oggetto %s"
 
-#: builtin/pack-objects.c:2088 builtin/pack-objects.c:2115
+#: builtin/pack-objects.c:2222 builtin/pack-objects.c:2249
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr ""
 "oggetto %s: lunghezza oggetto inconsistente (%<PRIuMAX> contro %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2125
+#: builtin/pack-objects.c:2259
 msgid "suboptimal pack - out of memory"
 msgstr "pack subottimo - memoria esaurita"
 
-#: builtin/pack-objects.c:2440
+#: builtin/pack-objects.c:2574
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Compressione delta in corso, uso fino a %d thread"
 
-#: builtin/pack-objects.c:2572
+#: builtin/pack-objects.c:2713
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "impossibile eseguire il pack degli oggetti raggiungibili dal tag %s"
 
-#: builtin/pack-objects.c:2659
+#: builtin/pack-objects.c:2801
 msgid "Compressing objects"
 msgstr "Compressione oggetti in corso"
 
-#: builtin/pack-objects.c:2665
+#: builtin/pack-objects.c:2807
 msgid "inconsistency with delta count"
 msgstr "inconsistenza con il numero dei delta"
 
-#: builtin/pack-objects.c:2742
+#: builtin/pack-objects.c:2888
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -17066,7 +17458,7 @@ msgstr ""
 "atteso ID oggetto arco, ricevuti dati errati:\n"
 " %s"
 
-#: builtin/pack-objects.c:2748
+#: builtin/pack-objects.c:2894
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -17075,239 +17467,241 @@ msgstr ""
 "atteso ID oggetto, ricevuti dati errati:\n"
 " %s"
 
-#: builtin/pack-objects.c:2846
+#: builtin/pack-objects.c:2992
 msgid "invalid value for --missing"
 msgstr "valore non valido per --missing"
 
-#: builtin/pack-objects.c:2905 builtin/pack-objects.c:3013
+#: builtin/pack-objects.c:3051 builtin/pack-objects.c:3159
 msgid "cannot open pack index"
 msgstr "impossibile aprire l'indice pack"
 
-#: builtin/pack-objects.c:2936
+#: builtin/pack-objects.c:3082
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "impossibile esaminare l'oggetto sciolto %s"
 
-#: builtin/pack-objects.c:3021
+#: builtin/pack-objects.c:3167
 msgid "unable to force loose object"
 msgstr "impossibile forzare l'oggetto sciolto"
 
-#: builtin/pack-objects.c:3113
+#: builtin/pack-objects.c:3260
 #, c-format
 msgid "not a rev '%s'"
 msgstr "'%s' non è una revisione"
 
-#: builtin/pack-objects.c:3116
+#: builtin/pack-objects.c:3263
 #, c-format
 msgid "bad revision '%s'"
 msgstr "revisione '%s' errata"
 
-#: builtin/pack-objects.c:3141
+#: builtin/pack-objects.c:3288
 msgid "unable to add recent objects"
 msgstr "impossibile aggiungere gli oggetti recenti"
 
-#: builtin/pack-objects.c:3194
+#: builtin/pack-objects.c:3341
 #, c-format
 msgid "unsupported index version %s"
 msgstr "versione %s di index non supportata"
 
-#: builtin/pack-objects.c:3198
+#: builtin/pack-objects.c:3345
 #, c-format
 msgid "bad index version '%s'"
 msgstr "versione '%s' di index errata"
 
-#: builtin/pack-objects.c:3236
+#: builtin/pack-objects.c:3383
 msgid "<version>[,<offset>]"
 msgstr "<versione>[,<offset>]"
 
-#: builtin/pack-objects.c:3237
+#: builtin/pack-objects.c:3384
 msgid "write the pack index file in the specified idx format version"
 msgstr "scrivi il file indice pack usando la versione formato idx specificata"
 
-#: builtin/pack-objects.c:3240
+#: builtin/pack-objects.c:3387
 msgid "maximum size of each output pack file"
 msgstr "dimensione massima di ogni file pack in output"
 
-#: builtin/pack-objects.c:3242
+#: builtin/pack-objects.c:3389
 msgid "ignore borrowed objects from alternate object store"
 msgstr "ignora gli oggetti presi in prestito dallo store oggetti alternativo"
 
-#: builtin/pack-objects.c:3244
+#: builtin/pack-objects.c:3391
 msgid "ignore packed objects"
 msgstr "ignora gli oggetti sottoposti a pack"
 
-#: builtin/pack-objects.c:3246
+#: builtin/pack-objects.c:3393
 msgid "limit pack window by objects"
 msgstr "limita la finestra di pack al numero di oggetti specificato"
 
-#: builtin/pack-objects.c:3248
+#: builtin/pack-objects.c:3395
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 "limita la finestra di pack alla memoria specificata in aggiunta al limite "
 "sugli oggetti"
 
-#: builtin/pack-objects.c:3250
+#: builtin/pack-objects.c:3397
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr "lunghezza massima della catena di delta consentita nel pack risultante"
 
-#: builtin/pack-objects.c:3252
+#: builtin/pack-objects.c:3399
 msgid "reuse existing deltas"
 msgstr "riusa i delta esistenti"
 
-#: builtin/pack-objects.c:3254
+#: builtin/pack-objects.c:3401
 msgid "reuse existing objects"
 msgstr "riusa gli oggetti esistenti"
 
-#: builtin/pack-objects.c:3256
+#: builtin/pack-objects.c:3403
 msgid "use OFS_DELTA objects"
 msgstr "usa oggetti OFS_DELTA"
 
-#: builtin/pack-objects.c:3258
+#: builtin/pack-objects.c:3405
 msgid "use threads when searching for best delta matches"
 msgstr ""
 "usa più thread durante la ricerca delle migliori corrispondenze per i delta"
 
-#: builtin/pack-objects.c:3260
+#: builtin/pack-objects.c:3407
 msgid "do not create an empty pack output"
 msgstr "non creare un output pack vuoto"
 
-#: builtin/pack-objects.c:3262
+#: builtin/pack-objects.c:3409
 msgid "read revision arguments from standard input"
 msgstr "leggi gli argomenti revisione dallo standard input"
 
-#: builtin/pack-objects.c:3264
+#: builtin/pack-objects.c:3411
 msgid "limit the objects to those that are not yet packed"
 msgstr "limita gli oggetti a quelli non ancora sottoposti a pack"
 
-#: builtin/pack-objects.c:3267
+#: builtin/pack-objects.c:3414
 msgid "include objects reachable from any reference"
 msgstr "includi gli oggetti raggiungibili da qualunque riferimento"
 
-#: builtin/pack-objects.c:3270
+#: builtin/pack-objects.c:3417
 msgid "include objects referred by reflog entries"
 msgstr "includi gli oggetti referenziati da voci del log riferimenti"
 
-#: builtin/pack-objects.c:3273
+#: builtin/pack-objects.c:3420
 msgid "include objects referred to by the index"
 msgstr "includi gli oggetti referenziati dall'indice"
 
-#: builtin/pack-objects.c:3276
+#: builtin/pack-objects.c:3423
 msgid "output pack to stdout"
 msgstr "invia il pack in output sullo standard output"
 
-#: builtin/pack-objects.c:3278
+#: builtin/pack-objects.c:3425
 msgid "include tag objects that refer to objects to be packed"
 msgstr ""
 "includi gli oggetti tag che fanno riferimento agli oggetti da sottoporre a "
 "pack"
 
-#: builtin/pack-objects.c:3280
+#: builtin/pack-objects.c:3427
 msgid "keep unreachable objects"
 msgstr "mantieni gli oggetti non raggiungibili"
 
-#: builtin/pack-objects.c:3282
+#: builtin/pack-objects.c:3429
 msgid "pack loose unreachable objects"
 msgstr "esegui il pack degli oggetti non raggiungibili sciolti"
 
-#: builtin/pack-objects.c:3284
+#: builtin/pack-objects.c:3431
 msgid "unpack unreachable objects newer than <time>"
 msgstr "decomprimi gli oggetti non raggiungibili più recenti di <tempo>"
 
-#: builtin/pack-objects.c:3287
+#: builtin/pack-objects.c:3434
 msgid "use the sparse reachability algorithm"
 msgstr "usa l'algoritmo di raggiungibilità sparse"
 
-#: builtin/pack-objects.c:3289
+#: builtin/pack-objects.c:3436
 msgid "create thin packs"
 msgstr "crea pack thin"
 
-#: builtin/pack-objects.c:3291
+#: builtin/pack-objects.c:3438
 msgid "create packs suitable for shallow fetches"
 msgstr "crea pack adatti per fetch shallow"
 
-#: builtin/pack-objects.c:3293
+#: builtin/pack-objects.c:3440
 msgid "ignore packs that have companion .keep file"
 msgstr "ignora i pack che hanno un file .keep che li accompagna"
 
-#: builtin/pack-objects.c:3295
+#: builtin/pack-objects.c:3442
 msgid "ignore this pack"
 msgstr "ignora questo pack"
 
-#: builtin/pack-objects.c:3297
+#: builtin/pack-objects.c:3444
 msgid "pack compression level"
 msgstr "livello compressione pack"
 
-#: builtin/pack-objects.c:3299
+#: builtin/pack-objects.c:3446
 msgid "do not hide commits by grafts"
 msgstr "non nascondere i commit innestati"
 
-#: builtin/pack-objects.c:3301
+#: builtin/pack-objects.c:3448
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "usa un indice bitmap se disponibile per velocizzare il conteggio degli "
 "oggetti"
 
-#: builtin/pack-objects.c:3303
+#: builtin/pack-objects.c:3450
 msgid "write a bitmap index together with the pack index"
 msgstr "scrivi un indice bitmap insieme all'indice pack"
 
-#: builtin/pack-objects.c:3307
+#: builtin/pack-objects.c:3454
 msgid "write a bitmap index if possible"
 msgstr "scrivi un indice bitmap se possibile"
 
-#: builtin/pack-objects.c:3311
+#: builtin/pack-objects.c:3458
 msgid "handling for missing objects"
 msgstr "azione da eseguire sugli oggetti mancanti"
 
-#: builtin/pack-objects.c:3314
+#: builtin/pack-objects.c:3461
 msgid "do not pack objects in promisor packfiles"
 msgstr "non eseguire il pack degli oggetti nei file pack promettenti"
 
-#: builtin/pack-objects.c:3316
+#: builtin/pack-objects.c:3463
 msgid "respect islands during delta compression"
 msgstr "rispetta le isole durante la compressione delta"
 
-#: builtin/pack-objects.c:3345
+#: builtin/pack-objects.c:3492
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "la profondità della catena dei delta (%d) è troppo elevata, forzo %d"
 
-#: builtin/pack-objects.c:3350
+#: builtin/pack-objects.c:3497
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "il valore pack.deltaCacheLimit è troppo elevato, forzo %d"
 
-#: builtin/pack-objects.c:3404
+#: builtin/pack-objects.c:3551
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size non può essere usato per generare un pack da trasferire"
 
-#: builtin/pack-objects.c:3406
+#: builtin/pack-objects.c:3553
 msgid "minimum pack size limit is 1 MiB"
 msgstr "il limite minimo delle dimensioni dei pack è 1 MiB"
 
-#: builtin/pack-objects.c:3411
+#: builtin/pack-objects.c:3558
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin non può essere usato per generare un pack indicizzabile"
 
-#: builtin/pack-objects.c:3414
+#: builtin/pack-objects.c:3561
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable e --unpack-unreachable non sono compatibili"
 
-#: builtin/pack-objects.c:3420
+#: builtin/pack-objects.c:3567
 msgid "cannot use --filter without --stdout"
 msgstr "impossibile usare --filter senza --stdout"
 
-#: builtin/pack-objects.c:3481
+#: builtin/pack-objects.c:3627
 msgid "Enumerating objects"
 msgstr "Enumerazione degli oggetti in corso"
 
-#: builtin/pack-objects.c:3511
+#: builtin/pack-objects.c:3657
 #, c-format
-msgid "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>)"
+msgid ""
+"Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
+"reused %<PRIu32>"
 msgstr ""
-"%<PRIu32> oggetti totali (%<PRIu32> delta), %<PRIu32> riutilizzati "
-"(%<PRIu32> delta)"
+"%<PRIu32> oggetti totali (%<PRIu32> delta), %<PRIu32> riutilizzati (%<PRIu32>"
+" delta), %<PRIu32> riutilizzati nel file pack"
 
 #: builtin/pack-refs.c:8
 msgid "git pack-refs [<options>]"
@@ -17350,53 +17744,53 @@ msgid "cannot prune in a precious-objects repo"
 msgstr ""
 "impossibile eseguire l'eliminazione in un repository 'oggetti preziosi'"
 
-#: builtin/pull.c:66 builtin/pull.c:68
+#: builtin/pull.c:45 builtin/pull.c:47
 #, c-format
 msgid "Invalid value for %s: %s"
 msgstr "Valore non valido per %s: %s"
 
-#: builtin/pull.c:88
+#: builtin/pull.c:67
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<opzioni>] [<repository> [<specificatore riferimento>...]]"
 
-#: builtin/pull.c:142
+#: builtin/pull.c:122
 msgid "control for recursive fetching of submodules"
 msgstr "controlla il recupero ricorsivo dei sottomoduli"
 
-#: builtin/pull.c:146
+#: builtin/pull.c:126
 msgid "Options related to merging"
 msgstr "Opzioni relative al merge"
 
-#: builtin/pull.c:149
+#: builtin/pull.c:129
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "incorpora le modifiche eseguendo un rebase anziché un merge"
 
-#: builtin/pull.c:177 builtin/rebase.c:467 builtin/revert.c:126
+#: builtin/pull.c:157 builtin/rebase.c:471 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "consenti fast forward"
 
-#: builtin/pull.c:186
+#: builtin/pull.c:166
 msgid "automatically stash/stash pop before and after rebase"
 msgstr "esegui stash/stash pop automaticamente prima e dopo il rebase"
 
-#: builtin/pull.c:202
+#: builtin/pull.c:182
 msgid "Options related to fetching"
 msgstr "Opzioni relative al fetch"
 
-#: builtin/pull.c:212
+#: builtin/pull.c:192
 msgid "force overwrite of local branch"
 msgstr "forza la sovrascrittura del branch locale"
 
-#: builtin/pull.c:220
+#: builtin/pull.c:200
 msgid "number of submodules pulled in parallel"
 msgstr "numero di sottomoduli recuperati in parallelo"
 
-#: builtin/pull.c:320
+#: builtin/pull.c:300
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "Valore non valido per pull.ff: %s"
 
-#: builtin/pull.c:437
+#: builtin/pull.c:426
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -17404,14 +17798,14 @@ msgstr ""
 "Non ci sono candidati in base ai quali eseguire il rebase fra i riferimenti "
 "appena recuperati."
 
-#: builtin/pull.c:439
+#: builtin/pull.c:428
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Non ci sono candidati in base ai quali eseguire il merge fra i riferimenti "
 "appena recuperati."
 
-#: builtin/pull.c:440
+#: builtin/pull.c:429
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -17419,7 +17813,7 @@ msgstr ""
 "In generale, questo significa che hai fornito uno specificatore\n"
 "riferimento che non aveva corrispondenze nel remoto."
 
-#: builtin/pull.c:443
+#: builtin/pull.c:432
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -17431,44 +17825,44 @@ msgstr ""
 "configurato come predefinito per il branch corrente, devi\n"
 "specificare un branch sulla riga di comando."
 
-#: builtin/pull.c:448 builtin/rebase.c:1375 git-parse-remote.sh:73
+#: builtin/pull.c:437 builtin/rebase.c:1409 git-parse-remote.sh:73
 msgid "You are not currently on a branch."
 msgstr "Attualmente non sei su un branch."
 
-#: builtin/pull.c:450 builtin/pull.c:465 git-parse-remote.sh:79
+#: builtin/pull.c:439 builtin/pull.c:454 git-parse-remote.sh:79
 msgid "Please specify which branch you want to rebase against."
 msgstr "Specifica il branch in base a cui vuoi effettuare il rebase."
 
-#: builtin/pull.c:452 builtin/pull.c:467 git-parse-remote.sh:82
+#: builtin/pull.c:441 builtin/pull.c:456 git-parse-remote.sh:82
 msgid "Please specify which branch you want to merge with."
 msgstr "Specifica il branch in base a cui vuoi effettuare il merge."
 
-#: builtin/pull.c:453 builtin/pull.c:468
+#: builtin/pull.c:442 builtin/pull.c:457
 msgid "See git-pull(1) for details."
 msgstr "Vedi git-pull(1) per ulteriori dettagli."
 
-#: builtin/pull.c:455 builtin/pull.c:461 builtin/pull.c:470
-#: builtin/rebase.c:1381 git-parse-remote.sh:64
+#: builtin/pull.c:444 builtin/pull.c:450 builtin/pull.c:459
+#: builtin/rebase.c:1415 git-parse-remote.sh:64
 msgid "<remote>"
 msgstr "<remoto>"
 
-#: builtin/pull.c:455 builtin/pull.c:470 builtin/pull.c:475
+#: builtin/pull.c:444 builtin/pull.c:459 builtin/pull.c:464
 #: git-parse-remote.sh:65
 msgid "<branch>"
 msgstr "<branch>"
 
-#: builtin/pull.c:463 builtin/rebase.c:1373 git-parse-remote.sh:75
+#: builtin/pull.c:452 builtin/rebase.c:1407 git-parse-remote.sh:75
 msgid "There is no tracking information for the current branch."
 msgstr "Non ci sono informazioni di tracciamento per il branch corrente."
 
-#: builtin/pull.c:472 git-parse-remote.sh:95
+#: builtin/pull.c:461 git-parse-remote.sh:95
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
 "Se vuoi impostare le informazioni di tracciamento per questo branch puoi "
 "farlo con:"
 
-#: builtin/pull.c:477
+#: builtin/pull.c:466
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -17478,32 +17872,32 @@ msgstr ""
 "il merge con il riferimento '%s' del remoto, ma un tale\n"
 "riferimento non è stato recuperato."
 
-#: builtin/pull.c:587
+#: builtin/pull.c:576
 #, c-format
 msgid "unable to access commit %s"
 msgstr "impossibile accedere al commit %s"
 
-#: builtin/pull.c:867
+#: builtin/pull.c:857
 msgid "ignoring --verify-signatures for rebase"
 msgstr "ignoro --verify-signature per il rebase"
 
-#: builtin/pull.c:922
+#: builtin/pull.c:912
 msgid "--[no-]autostash option is only valid with --rebase."
 msgstr "l'opzione --[no-]autostash option è valida solo con --rebase."
 
-#: builtin/pull.c:930
+#: builtin/pull.c:920
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Aggiorno un branch non nato con le modifiche aggiunte all'indice."
 
-#: builtin/pull.c:934
+#: builtin/pull.c:924
 msgid "pull with rebase"
 msgstr "pull con rebase"
 
-#: builtin/pull.c:935
+#: builtin/pull.c:925
 msgid "please commit or stash them."
 msgstr "eseguine il commit o lo stash."
 
-#: builtin/pull.c:960
+#: builtin/pull.c:950
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -17515,7 +17909,7 @@ msgstr ""
 "Eseguo il fast forward dell'albero\n"
 "di lavoro dal commit %s."
 
-#: builtin/pull.c:966
+#: builtin/pull.c:956
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -17534,15 +17928,15 @@ msgstr ""
 "$ git reset --hard\n"
 "per eseguire il ripristino."
 
-#: builtin/pull.c:981
+#: builtin/pull.c:971
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Impossibile eseguire il merge di più branch in un head vuoto."
 
-#: builtin/pull.c:985
+#: builtin/pull.c:975
 msgid "Cannot rebase onto multiple branches."
 msgstr "Impossibile eseguire il rebase su più branch."
 
-#: builtin/pull.c:992
+#: builtin/pull.c:982
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "impossibile eseguire il rebase se ci sono delle modifiche registrate "
@@ -17995,217 +18389,208 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:177 builtin/rebase.c:201 builtin/rebase.c:228
+#: builtin/rebase.c:175 builtin/rebase.c:199 builtin/rebase.c:226
 #, c-format
 msgid "unusable todo list: '%s'"
 msgstr "elenco todo inutilizzabile: '%s'"
 
-#: builtin/rebase.c:186 builtin/rebase.c:212 builtin/rebase.c:236
-#, c-format
-msgid "could not write '%s'."
-msgstr "impossibile scrivere '%s'."
-
-#: builtin/rebase.c:271
-msgid "no HEAD?"
-msgstr "nessun'HEAD?"
-
-#: builtin/rebase.c:298
+#: builtin/rebase.c:292
 #, c-format
 msgid "could not create temporary %s"
 msgstr "impossibile creare un %s temporaneo"
 
-#: builtin/rebase.c:304
+#: builtin/rebase.c:298
 msgid "could not mark as interactive"
 msgstr "impossibile contrassegnare come interattivo"
 
-#: builtin/rebase.c:362
+#: builtin/rebase.c:352
 msgid "could not generate todo list"
 msgstr "impossibile generare l'elenco todo"
 
-#: builtin/rebase.c:402
+#: builtin/rebase.c:391
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr ""
 "le opzioni --upstream o --onto richiedono che sia fornito un commit di base"
 
-#: builtin/rebase.c:457
+#: builtin/rebase.c:461
 msgid "git rebase--interactive [<options>]"
 msgstr "git rebase --interactive [<opzioni>]"
 
-#: builtin/rebase.c:469
-msgid "keep empty commits"
-msgstr "mantieni i commit vuoti"
+#: builtin/rebase.c:474 builtin/rebase.c:1550
+msgid "(DEPRECATED) keep empty commits"
+msgstr "(DEPRECATO) mantieni i commit vuoti"
 
-#: builtin/rebase.c:471 builtin/revert.c:128
+#: builtin/rebase.c:478 builtin/revert.c:128
 msgid "allow commits with empty messages"
 msgstr "consenti commit con messaggi vuoti"
 
-#: builtin/rebase.c:472
+#: builtin/rebase.c:480
 msgid "rebase merge commits"
 msgstr "esegui il rebase dei commit di merge"
 
-#: builtin/rebase.c:474
+#: builtin/rebase.c:482
 msgid "keep original branch points of cousins"
 msgstr "mantieni i punti di branch originali dei cugini"
 
-#: builtin/rebase.c:476
+#: builtin/rebase.c:484
 msgid "move commits that begin with squash!/fixup!"
 msgstr "sposta i commit che iniziano con squash!/fixup!"
 
-#: builtin/rebase.c:477
+#: builtin/rebase.c:485
 msgid "sign commits"
 msgstr "firma i commit"
 
-#: builtin/rebase.c:479 builtin/rebase.c:1455
+#: builtin/rebase.c:487 builtin/rebase.c:1490
 msgid "display a diffstat of what changed upstream"
 msgstr "visualizza un diffstat delle modifiche upstream"
 
-#: builtin/rebase.c:481
+#: builtin/rebase.c:489
 msgid "continue rebase"
 msgstr "continua il rebase"
 
-#: builtin/rebase.c:483
+#: builtin/rebase.c:491
 msgid "skip commit"
 msgstr "salta il commit"
 
-#: builtin/rebase.c:484
+#: builtin/rebase.c:492
 msgid "edit the todo list"
 msgstr "modifica l'elenco todo"
 
-#: builtin/rebase.c:486
+#: builtin/rebase.c:494
 msgid "show the current patch"
 msgstr "visualizza la patch corrente"
 
-#: builtin/rebase.c:489
+#: builtin/rebase.c:497
 msgid "shorten commit ids in the todo list"
 msgstr "abbrevia gli ID dei commit nell'elenco todo"
 
-#: builtin/rebase.c:491
+#: builtin/rebase.c:499
 msgid "expand commit ids in the todo list"
 msgstr "espandi gli ID dei commit nell'elenco todo"
 
-#: builtin/rebase.c:493
+#: builtin/rebase.c:501
 msgid "check the todo list"
 msgstr "controlla l'elenco todo"
 
-#: builtin/rebase.c:495
+#: builtin/rebase.c:503
 msgid "rearrange fixup/squash lines"
 msgstr "ridisponi le righe fixup/squash"
 
-#: builtin/rebase.c:497
+#: builtin/rebase.c:505
 msgid "insert exec commands in todo list"
 msgstr "inserisci i comandi exec nell'elenco todo"
 
-#: builtin/rebase.c:498
+#: builtin/rebase.c:506
 msgid "onto"
 msgstr "su"
 
-#: builtin/rebase.c:501
+#: builtin/rebase.c:509
 msgid "restrict-revision"
 msgstr "revisioni-limite"
 
-#: builtin/rebase.c:501
+#: builtin/rebase.c:509
 msgid "restrict revision"
 msgstr "limita la revisione"
 
-#: builtin/rebase.c:503
+#: builtin/rebase.c:511
 msgid "squash-onto"
 msgstr "squash-su"
 
-#: builtin/rebase.c:504
+#: builtin/rebase.c:512
 msgid "squash onto"
 msgstr "esegui lo squash su"
 
-#: builtin/rebase.c:506
+#: builtin/rebase.c:514
 msgid "the upstream commit"
 msgstr "il commit upstream"
 
-#: builtin/rebase.c:508
+#: builtin/rebase.c:516
 msgid "head-name"
 msgstr "nome head"
 
-#: builtin/rebase.c:508
+#: builtin/rebase.c:516
 msgid "head name"
 msgstr "nome head"
 
-#: builtin/rebase.c:513
+#: builtin/rebase.c:521
 msgid "rebase strategy"
 msgstr "strategia di rebase"
 
-#: builtin/rebase.c:514
+#: builtin/rebase.c:522
 msgid "strategy-opts"
 msgstr "opzioni strategia"
 
-#: builtin/rebase.c:515
+#: builtin/rebase.c:523
 msgid "strategy options"
 msgstr "opzioni strategia"
 
-#: builtin/rebase.c:516
+#: builtin/rebase.c:524
 msgid "switch-to"
 msgstr "passa a"
 
-#: builtin/rebase.c:517
+#: builtin/rebase.c:525
 msgid "the branch or commit to checkout"
 msgstr "il branch o il commit di cui eseguire il checkout"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:526
 msgid "onto-name"
 msgstr "nome"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:526
 msgid "onto name"
 msgstr "sul nome"
 
-#: builtin/rebase.c:519
+#: builtin/rebase.c:527
 msgid "cmd"
 msgstr "comando"
 
-#: builtin/rebase.c:519
+#: builtin/rebase.c:527
 msgid "the command to run"
 msgstr "il comando da eseguire"
 
-#: builtin/rebase.c:522 builtin/rebase.c:1540
+#: builtin/rebase.c:530 builtin/rebase.c:1584
 msgid "automatically re-schedule any `exec` that fails"
 msgstr "schedula nuovamente le operazioni `exec` non riuscite automaticamente"
 
-#: builtin/rebase.c:540
+#: builtin/rebase.c:546
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
 msgstr "--[no-]rebase-cousins non ha effetto senza --rebase-merges"
 
-#: builtin/rebase.c:556
+#: builtin/rebase.c:562
 #, c-format
 msgid "%s requires an interactive rebase"
 msgstr "%s richiede un rebase interattivo"
 
-#: builtin/rebase.c:608
+#: builtin/rebase.c:612
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "impossibile ottenere 'onto': '%s'"
 
-#: builtin/rebase.c:623
+#: builtin/rebase.c:627
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "orig-head non valida: '%s'"
 
-#: builtin/rebase.c:648
+#: builtin/rebase.c:652
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "ignoro il valore non valido per allow_rerere_autoupdate: '%s'"
 
-#: builtin/rebase.c:724
+#: builtin/rebase.c:728
 #, c-format
 msgid "Could not read '%s'"
 msgstr "Impossibile leggere '%s'"
 
-#: builtin/rebase.c:742
+#: builtin/rebase.c:746
 #, c-format
 msgid "Cannot store %s"
 msgstr "Impossibile memorizzare %s"
 
-#: builtin/rebase.c:849
+#: builtin/rebase.c:853
 msgid "could not determine HEAD revision"
 msgstr "impossibile determinare la revisione HEAD"
 
-#: builtin/rebase.c:972 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:976 git-rebase--preserve-merges.sh:81
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -18221,7 +18606,7 @@ msgstr ""
 "Per interrompere l'operazione e tornare allo stato precedente\n"
 "il \"git rebase\", esegui \"git rebase --abort\"."
 
-#: builtin/rebase.c:1060
+#: builtin/rebase.c:1058
 #, c-format
 msgid ""
 "\n"
@@ -18240,7 +18625,16 @@ msgstr ""
 "\n"
 "Di conseguenza, Git non può eseguirne il rebase."
 
-#: builtin/rebase.c:1367
+#: builtin/rebase.c:1383
+#, c-format
+msgid ""
+"unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
+"\"."
+msgstr ""
+"tipo vuoto '%s' non riconosciuto; i valori validi sono \"drop\", \"keep\" e"
+" \"ask\"."
+
+#: builtin/rebase.c:1401
 #, c-format
 msgid ""
 "%s\n"
@@ -18257,7 +18651,7 @@ msgstr ""
 "    git rebase '<branch>'\n"
 "\n"
 
-#: builtin/rebase.c:1383
+#: builtin/rebase.c:1417
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -18271,149 +18665,143 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<branch> %s\n"
 "\n"
 
-#: builtin/rebase.c:1413
+#: builtin/rebase.c:1447
 msgid "exec commands cannot contain newlines"
 msgstr "i comandi exec non possono contenere caratteri di fine riga"
 
-#: builtin/rebase.c:1417
+#: builtin/rebase.c:1451
 msgid "empty exec command"
 msgstr "comando exec vuoto"
 
-#: builtin/rebase.c:1446
+#: builtin/rebase.c:1481
 msgid "rebase onto given branch instead of upstream"
 msgstr "esegui il rebase sul branch specificato anziché su quello upstream"
 
-#: builtin/rebase.c:1448
+#: builtin/rebase.c:1483
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "usa la base del merge dell'upstream e del branch come base corrente"
 
-#: builtin/rebase.c:1450
+#: builtin/rebase.c:1485
 msgid "allow pre-rebase hook to run"
 msgstr "consenti l'esecuzione dell'hook pre-rebase"
 
-#: builtin/rebase.c:1452
+#: builtin/rebase.c:1487
 msgid "be quiet. implies --no-stat"
 msgstr "sii silenzioso. implica --no-stat"
 
-#: builtin/rebase.c:1458
+#: builtin/rebase.c:1493
 msgid "do not show diffstat of what changed upstream"
 msgstr "non visualizzare un diffstat delle modifiche upstream"
 
-#: builtin/rebase.c:1461
+#: builtin/rebase.c:1496
 msgid "add a Signed-off-by: line to each commit"
 msgstr "aggiungi una riga Signed-off-by: a ogni commit"
 
-#: builtin/rebase.c:1464
-msgid "make committer date match author date"
-msgstr ""
-"fai corrispondere la data della persona che ha eseguito il commit alla data"
-" autore"
+#: builtin/rebase.c:1498 builtin/rebase.c:1502 builtin/rebase.c:1504
+msgid "passed to 'git am'"
+msgstr "passato a 'git am'"
 
-#: builtin/rebase.c:1466
-msgid "ignore author date and use current date"
-msgstr "ignora la data autore e usa la data corrente"
-
-#: builtin/rebase.c:1468
-msgid "synonym of --reset-author-date"
-msgstr "sinonimo di --reset-author-date"
-
-#: builtin/rebase.c:1470 builtin/rebase.c:1474
+#: builtin/rebase.c:1506 builtin/rebase.c:1508
 msgid "passed to 'git apply'"
 msgstr "passato a 'git apply'"
 
-#: builtin/rebase.c:1472
-msgid "ignore changes in whitespace"
-msgstr "ignora modifiche agli spazi bianchi"
-
-#: builtin/rebase.c:1476 builtin/rebase.c:1479
+#: builtin/rebase.c:1510 builtin/rebase.c:1513
 msgid "cherry-pick all commits, even if unchanged"
 msgstr "esegui il cherry-pick di tutti i commit, anche se non modificati"
 
-#: builtin/rebase.c:1481
+#: builtin/rebase.c:1515
 msgid "continue"
 msgstr "continua"
 
-#: builtin/rebase.c:1484
+#: builtin/rebase.c:1518
 msgid "skip current patch and continue"
 msgstr "salta la patch corrente e continua"
 
-#: builtin/rebase.c:1486
+#: builtin/rebase.c:1520
 msgid "abort and check out the original branch"
 msgstr "interrompi ed esegui il checkout del branch originario"
 
-#: builtin/rebase.c:1489
+#: builtin/rebase.c:1523
 msgid "abort but keep HEAD where it is"
 msgstr "interrompi ma mantieni l'HEAD dov'è"
 
-#: builtin/rebase.c:1490
+#: builtin/rebase.c:1524
 msgid "edit the todo list during an interactive rebase"
 msgstr "modifica l'elenco todo durante un rebase interattivo"
 
-#: builtin/rebase.c:1493
+#: builtin/rebase.c:1527
 msgid "show the patch file being applied or merged"
 msgstr ""
 "visualizza il file patch che sta per essere applicato o sottoposto a merge"
 
-#: builtin/rebase.c:1496
+#: builtin/rebase.c:1530
+msgid "use apply strategies to rebase"
+msgstr "usa le strategie di apply per eseguire il rebase"
+
+#: builtin/rebase.c:1534
 msgid "use merging strategies to rebase"
 msgstr "usa le strategie di merge per eseguire il rebase"
 
-#: builtin/rebase.c:1500
+#: builtin/rebase.c:1538
 msgid "let the user edit the list of commits to rebase"
 msgstr ""
 "consenti all'utente di modificare l'elenco dei commit di cui eseguire il "
 "rebase"
 
-#: builtin/rebase.c:1504
+#: builtin/rebase.c:1542
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(DEPRECATO) prova a ricreare i merge anziché ignorarli"
 
-#: builtin/rebase.c:1509
-msgid "preserve empty commits during rebase"
-msgstr "mantieni i commit vuoti durante il rebase"
+#: builtin/rebase.c:1546
+msgid "{drop,keep,ask}"
+msgstr "{drop,keep,ask}"
 
-#: builtin/rebase.c:1511
+#: builtin/rebase.c:1547
+msgid "how to handle commits that become empty"
+msgstr "come gestire i commit che diventano vuoti"
+
+#: builtin/rebase.c:1554
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "sposta i commit che iniziano con squash!/fixup! in -i"
 
-#: builtin/rebase.c:1517
+#: builtin/rebase.c:1560
 msgid "automatically stash/stash pop before and after"
 msgstr "esegui stash/stash pop automaticamente prima e dopo"
 
-#: builtin/rebase.c:1519
+#: builtin/rebase.c:1562
 msgid "add exec lines after each commit of the editable list"
 msgstr "aggiungi righe exec dopo ogni commit della lista modificabile"
 
-#: builtin/rebase.c:1523
+#: builtin/rebase.c:1566
 msgid "allow rebasing commits with empty messages"
 msgstr "consenti il rebase di commit con messaggi vuoti"
 
-#: builtin/rebase.c:1526
+#: builtin/rebase.c:1570
 msgid "try to rebase merges instead of skipping them"
 msgstr "prova ad eseguire il rebase dei merge anziché saltarli"
 
-#: builtin/rebase.c:1529
+#: builtin/rebase.c:1573
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr ""
 "usa 'merge-base --fork-point' per ridefinire più precisamente l'upstream"
 
-#: builtin/rebase.c:1531
+#: builtin/rebase.c:1575
 msgid "use the given merge strategy"
 msgstr "usa la strategia di merge specificata"
 
-#: builtin/rebase.c:1533 builtin/revert.c:115
+#: builtin/rebase.c:1577 builtin/revert.c:115
 msgid "option"
 msgstr "opzione"
 
-#: builtin/rebase.c:1534
+#: builtin/rebase.c:1578
 msgid "pass the argument through to the merge strategy"
 msgstr "passa l'argomento alla strategia di merge"
 
-#: builtin/rebase.c:1537
+#: builtin/rebase.c:1581
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "esegui il rebase di tutti i commit raggiungibili fino a quelli radice"
 
-#: builtin/rebase.c:1554
+#: builtin/rebase.c:1598
 msgid ""
 "the rebase.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -18421,37 +18809,37 @@ msgstr ""
 "il supporto per rebase.useBuiltin è stato rimosso!\n"
 "Vedi la voce relativa in 'git help config' per i dettagli."
 
-#: builtin/rebase.c:1560
+#: builtin/rebase.c:1604
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "Sembra che 'git am' sia in corso. Impossibile eseguire il rebase."
 
-#: builtin/rebase.c:1601
+#: builtin/rebase.c:1645
 msgid ""
 "git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
 msgstr "git rebase --preserve-merges è deprecato. Usa --rebase-merges."
 
-#: builtin/rebase.c:1606
+#: builtin/rebase.c:1650
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "impossibile combinare '--keep-base' con '--onto'"
 
-#: builtin/rebase.c:1608
+#: builtin/rebase.c:1652
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "impossibile combinare '--keep-base' con '--root'"
 
-#: builtin/rebase.c:1612
+#: builtin/rebase.c:1656
 msgid "No rebase in progress?"
 msgstr "Nessun rebase in corso?"
 
-#: builtin/rebase.c:1616
+#: builtin/rebase.c:1660
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "L'azione --edit-todo può essere usata solo durante un rebase interattivo."
 
-#: builtin/rebase.c:1639
+#: builtin/rebase.c:1683
 msgid "Cannot read HEAD"
 msgstr "Impossibile leggere l'HEAD"
 
-#: builtin/rebase.c:1651
+#: builtin/rebase.c:1695
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -18460,16 +18848,16 @@ msgstr ""
 "quindi contrassegnarli come risolti usando\n"
 "git add"
 
-#: builtin/rebase.c:1670
+#: builtin/rebase.c:1714
 msgid "could not discard worktree changes"
 msgstr "impossibile scartare le modifiche all'albero di lavoro"
 
-#: builtin/rebase.c:1689
+#: builtin/rebase.c:1733
 #, c-format
 msgid "could not move back to %s"
 msgstr "impossibile ritornare a %s"
 
-#: builtin/rebase.c:1734
+#: builtin/rebase.c:1778
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -18490,169 +18878,169 @@ msgstr ""
 "ed eseguimi di nuovo. Mi fermo nel caso in cui tu abbia ancora\n"
 "salvato qualcosa di importante lì.\n"
 
-#: builtin/rebase.c:1757
+#: builtin/rebase.c:1806
 msgid "switch `C' expects a numerical value"
 msgstr "l'opzione `C` richiede un valore numerico"
 
-#: builtin/rebase.c:1798
+#: builtin/rebase.c:1847
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Modo sconosciuto: %s"
 
-#: builtin/rebase.c:1820
+#: builtin/rebase.c:1869
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy richiede --merge o --interactive"
 
-#: builtin/rebase.c:1860
+#: builtin/rebase.c:1899
+msgid "cannot combine apply options with merge options"
+msgstr "non è possibile combinare le opzioni apply con quelle merge"
+
+#: builtin/rebase.c:1912
+#, c-format
+msgid "Unknown rebase backend: %s"
+msgstr "Backend di rebase sconosciuto: %s"
+
+#: builtin/rebase.c:1937
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec richiede --exec o --interactive"
 
-#: builtin/rebase.c:1872
-msgid "cannot combine am options with either interactive or merge options"
-msgstr "non è possibile combinare le opzioni am con quelle interactive o merge"
-
-#: builtin/rebase.c:1891
+#: builtin/rebase.c:1957
 msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
 msgstr "impossibile combinare '--preserve-merges' con '--rebase-merges'"
 
-#: builtin/rebase.c:1895
+#: builtin/rebase.c:1961
 msgid ""
 "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
 "errore: impossibile combinare '--preserve-merges' con '--reschedule-failed-"
 "exec'"
 
-#: builtin/rebase.c:1919
+#: builtin/rebase.c:1985
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "upstream non valido: '%s'"
 
-#: builtin/rebase.c:1925
+#: builtin/rebase.c:1991
 msgid "Could not create new root commit"
 msgstr "Impossibile creare il nuovo commit radice"
 
-#: builtin/rebase.c:1951
+#: builtin/rebase.c:2017
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr ""
 "'%s': è necessario specificare esattamente una base per il merge con il "
 "branch"
 
-#: builtin/rebase.c:1954
+#: builtin/rebase.c:2020
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': è necessario specificare esattamente una base per il merge"
 
-#: builtin/rebase.c:1962
+#: builtin/rebase.c:2028
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' non punta a un commit valido"
 
-#: builtin/rebase.c:1987
+#: builtin/rebase.c:2054
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
 msgstr "errore fatale: branch/commit '%s' inesistente"
 
-#: builtin/rebase.c:1995 builtin/submodule--helper.c:40
-#: builtin/submodule--helper.c:1961
+#: builtin/rebase.c:2062 builtin/submodule--helper.c:40
+#: builtin/submodule--helper.c:1990
 #, c-format
 msgid "No such ref: %s"
 msgstr "Riferimento non esistente: %s"
 
-#: builtin/rebase.c:2006
+#: builtin/rebase.c:2073
 msgid "Could not resolve HEAD to a revision"
 msgstr "Impossibile risolvere HEAD come revisione"
 
-#: builtin/rebase.c:2044
+#: builtin/rebase.c:2111
 msgid "Cannot autostash"
 msgstr "Impossibile eseguire lo stash automatico"
 
-#: builtin/rebase.c:2047
+#: builtin/rebase.c:2114
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Risposta stash non attesa: '%s'"
 
-#: builtin/rebase.c:2053
+#: builtin/rebase.c:2120
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Impossibile creare la directory '%s'"
 
-#: builtin/rebase.c:2056
+#: builtin/rebase.c:2123
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Stash automatico creato: %s\n"
 
-#: builtin/rebase.c:2059
+#: builtin/rebase.c:2126
 msgid "could not reset --hard"
 msgstr "impossibile eseguire reset --hard"
 
-#: builtin/rebase.c:2068
+#: builtin/rebase.c:2135
 msgid "Please commit or stash them."
 msgstr "Eseguine il commit o lo stash."
 
-#: builtin/rebase.c:2095
-#, c-format
-msgid "could not parse '%s'"
-msgstr "impossibile analizzare '%s'"
-
-#: builtin/rebase.c:2108
+#: builtin/rebase.c:2169
 #, c-format
 msgid "could not switch to %s"
 msgstr "impossibile passare a %s"
 
-#: builtin/rebase.c:2119
+#: builtin/rebase.c:2180
 msgid "HEAD is up to date."
 msgstr "HEAD è aggiornato."
 
-#: builtin/rebase.c:2121
+#: builtin/rebase.c:2182
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Il branch corrente %s è aggiornato.\n"
 
-#: builtin/rebase.c:2129
+#: builtin/rebase.c:2190
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD è aggiornato, forzo il rebase."
 
-#: builtin/rebase.c:2131
+#: builtin/rebase.c:2192
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Il branch corrente %s è aggiornato, forzo il rebase.\n"
 
-#: builtin/rebase.c:2139
+#: builtin/rebase.c:2200
 msgid "The pre-rebase hook refused to rebase."
 msgstr "L'hook pre-rebase ha rifiutato di consentire il rebase."
 
-#: builtin/rebase.c:2146
+#: builtin/rebase.c:2207
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Modifiche a %s:\n"
 
-#: builtin/rebase.c:2149
+#: builtin/rebase.c:2210
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Modifiche da %s a %s:\n"
 
-#: builtin/rebase.c:2174
+#: builtin/rebase.c:2235
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Per prima cosa, ripristino l'head per riapplicare le tue modifiche su di "
 "esso...\n"
 
-#: builtin/rebase.c:2183
+#: builtin/rebase.c:2244
 msgid "Could not detach HEAD"
 msgstr "Impossibile scollegare l'HEAD"
 
-#: builtin/rebase.c:2192
+#: builtin/rebase.c:2253
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Fast forward da %s a %s eseguito.\n"
 
-#: builtin/receive-pack.c:32
+#: builtin/receive-pack.c:33
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <directory Git>"
 
-#: builtin/receive-pack.c:830
+#: builtin/receive-pack.c:821
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -18685,7 +19073,7 @@ msgstr ""
 "il comportamento predefinito, imposta la variabile di\n"
 "configurazione 'receive.denyCurrentBranch' a 'refuse'."
 
-#: builtin/receive-pack.c:850
+#: builtin/receive-pack.c:841
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -18708,11 +19096,11 @@ msgstr ""
 "Per non visualizzare più questo messaggio, puoi impostarla a\n"
 "'refuse'."
 
-#: builtin/receive-pack.c:1936
+#: builtin/receive-pack.c:1938
 msgid "quiet"
 msgstr "non visualizzare messaggi"
 
-#: builtin/receive-pack.c:1950
+#: builtin/receive-pack.c:1952
 msgid "You must specify a directory."
 msgstr "Devi specificare una directory."
 
@@ -18738,49 +19126,49 @@ msgstr ""
 msgid "git reflog exists <ref>"
 msgstr "git reflog exists <riferimento>"
 
-#: builtin/reflog.c:567 builtin/reflog.c:572
+#: builtin/reflog.c:568 builtin/reflog.c:573
 #, c-format
 msgid "'%s' is not a valid timestamp"
 msgstr "'%s' non è un timestamp valido"
 
-#: builtin/reflog.c:605
+#: builtin/reflog.c:606
 #, c-format
 msgid "Marking reachable objects..."
 msgstr "Contrassegno gli oggetti raggiungibili..."
 
-#: builtin/reflog.c:643
+#: builtin/reflog.c:644
 #, c-format
 msgid "%s points nowhere!"
 msgstr "%s non punta a niente!"
 
-#: builtin/reflog.c:695
+#: builtin/reflog.c:696
 msgid "no reflog specified to delete"
 msgstr "nessun registro riferimenti da eliminare specificato"
 
-#: builtin/reflog.c:704
+#: builtin/reflog.c:705
 #, c-format
 msgid "not a reflog: %s"
 msgstr "non è un registro riferimenti: %s"
 
-#: builtin/reflog.c:709
+#: builtin/reflog.c:710
 #, c-format
 msgid "no reflog for '%s'"
 msgstr "log riferimenti non esistente per '%s'"
 
-#: builtin/reflog.c:755
+#: builtin/reflog.c:756
 #, c-format
 msgid "invalid ref format: %s"
 msgstr "formato riferimento non valido: %s"
 
-#: builtin/reflog.c:764
+#: builtin/reflog.c:765
 msgid "git reflog [ show | expire | delete | exists ]"
 msgstr "git reflog [ show | expire | delete | exists ]"
 
-#: builtin/remote.c:16
+#: builtin/remote.c:17
 msgid "git remote [-v | --verbose]"
 msgstr "git remote [-v | --verbose]"
 
-#: builtin/remote.c:17
+#: builtin/remote.c:18
 msgid ""
 "git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--"
 "mirror=<fetch|push>] <name> <url>"
@@ -18788,82 +19176,82 @@ msgstr ""
 "git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--"
 "mirror=<fetch|push>] <nome> <URL>"
 
-#: builtin/remote.c:18 builtin/remote.c:38
+#: builtin/remote.c:19 builtin/remote.c:39
 msgid "git remote rename <old> <new>"
 msgstr "git remote rename <vecchio> <nuovo>"
 
-#: builtin/remote.c:19 builtin/remote.c:43
+#: builtin/remote.c:20 builtin/remote.c:44
 msgid "git remote remove <name>"
 msgstr "git remote remove <nome>"
 
-#: builtin/remote.c:20 builtin/remote.c:48
+#: builtin/remote.c:21 builtin/remote.c:49
 msgid "git remote set-head <name> (-a | --auto | -d | --delete | <branch>)"
 msgstr "git remote set-head <nome> (-a | --auto | -d | --delete | <branch>)"
 
-#: builtin/remote.c:21
+#: builtin/remote.c:22
 msgid "git remote [-v | --verbose] show [-n] <name>"
 msgstr "git remote [-v | --verbose] show [-n] <nome>"
 
-#: builtin/remote.c:22
+#: builtin/remote.c:23
 msgid "git remote prune [-n | --dry-run] <name>"
 msgstr "git remote prune [-n | --dry-run] <nome>"
 
-#: builtin/remote.c:23
+#: builtin/remote.c:24
 msgid ""
 "git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]"
 msgstr ""
 "git remote [-v | --verbose] update [-p | --prune] [(<gruppo> | <remoto>)...]"
 
-#: builtin/remote.c:24
+#: builtin/remote.c:25
 msgid "git remote set-branches [--add] <name> <branch>..."
 msgstr "git remote set-branches [--add] <nome> <branch>..."
 
-#: builtin/remote.c:25 builtin/remote.c:74
+#: builtin/remote.c:26 builtin/remote.c:75
 msgid "git remote get-url [--push] [--all] <name>"
 msgstr "git remote get-url [--push] [--all] <nome>"
 
-#: builtin/remote.c:26 builtin/remote.c:79
+#: builtin/remote.c:27 builtin/remote.c:80
 msgid "git remote set-url [--push] <name> <newurl> [<oldurl>]"
 msgstr "git remote set-url [--push] <nome> <nuovo URL> [<vecchio URL>]"
 
-#: builtin/remote.c:27 builtin/remote.c:80
+#: builtin/remote.c:28 builtin/remote.c:81
 msgid "git remote set-url --add <name> <newurl>"
 msgstr "git remote set-url --add <nome> <nuovo URL>"
 
-#: builtin/remote.c:28 builtin/remote.c:81
+#: builtin/remote.c:29 builtin/remote.c:82
 msgid "git remote set-url --delete <name> <url>"
 msgstr "git remote set-url --delete <nome> <URL>"
 
-#: builtin/remote.c:33
+#: builtin/remote.c:34
 msgid "git remote add [<options>] <name> <url>"
 msgstr "git remote add [<opzioni>] <nome> <URL>"
 
-#: builtin/remote.c:53
+#: builtin/remote.c:54
 msgid "git remote set-branches <name> <branch>..."
 msgstr "git remote set-branches <nome> <branch>..."
 
-#: builtin/remote.c:54
+#: builtin/remote.c:55
 msgid "git remote set-branches --add <name> <branch>..."
 msgstr "git remote set-branches --add <nome> <branch>..."
 
-#: builtin/remote.c:59
+#: builtin/remote.c:60
 msgid "git remote show [<options>] <name>"
 msgstr "git remote show [<opzioni>] <nome>"
 
-#: builtin/remote.c:64
+#: builtin/remote.c:65
 msgid "git remote prune [<options>] <name>"
 msgstr "git remote prune [<opzioni>] <nome>"
 
-#: builtin/remote.c:69
+#: builtin/remote.c:70
 msgid "git remote update [<options>] [<group> | <remote>]..."
 msgstr "git remote update [<opzioni>] [<gruppo> | <remoto>]..."
 
-#: builtin/remote.c:98
+#: builtin/remote.c:99
 #, c-format
 msgid "Updating %s"
 msgstr "Aggiornamento di %s"
 
-#: builtin/remote.c:130
+#: builtin/remote.c:131
 msgid ""
 "--mirror is dangerous and deprecated; please\n"
 "\t use --mirror=fetch or --mirror=push instead"
@@ -18871,88 +19259,104 @@ msgstr ""
 "--mirror è pericoloso e deprecato; per favore\n"
 "\t usa invece --mirror-fetch o --mirror-push"
 
-#: builtin/remote.c:147
+#: builtin/remote.c:148
 #, c-format
 msgid "unknown mirror argument: %s"
 msgstr "argomento di mirror sconosciuto: %s"
 
-#: builtin/remote.c:163
+#: builtin/remote.c:164
 msgid "fetch the remote branches"
 msgstr "recupera i branch remoti"
 
-#: builtin/remote.c:165
+#: builtin/remote.c:166
 msgid "import all tags and associated objects when fetching"
 msgstr "importa tutti i tag e gli oggetti associati durante il recupero"
 
-#: builtin/remote.c:168
+#: builtin/remote.c:169
 msgid "or do not fetch any tag at all (--no-tags)"
 msgstr "o non recuperare alcun tag (--no-tags)"
 
-#: builtin/remote.c:170
+#: builtin/remote.c:171
 msgid "branch(es) to track"
 msgstr "branch da tracciare"
 
-#: builtin/remote.c:171
+#: builtin/remote.c:172
 msgid "master branch"
 msgstr "branch master"
 
-#: builtin/remote.c:173
+#: builtin/remote.c:174
 msgid "set up remote as a mirror to push to or fetch from"
 msgstr ""
 "imposta il remoto come mirror su cui eseguire push o da cui recuperare dati"
 
-#: builtin/remote.c:185
+#: builtin/remote.c:186
 msgid "specifying a master branch makes no sense with --mirror"
 msgstr "specificare un branch master con --mirror non ha senso"
 
-#: builtin/remote.c:187
+#: builtin/remote.c:188
 msgid "specifying branches to track makes sense only with fetch mirrors"
 msgstr ""
 "specificare i branch da tracciare ha senso solo con i mirror da cui "
 "recuperare dati"
 
-#: builtin/remote.c:194 builtin/remote.c:636
+#: builtin/remote.c:195 builtin/remote.c:696
 #, c-format
 msgid "remote %s already exists."
 msgstr "il remoto %s esiste già."
 
-#: builtin/remote.c:198 builtin/remote.c:640
+#: builtin/remote.c:199 builtin/remote.c:700
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' non è un nome di remoto valido"
 
-#: builtin/remote.c:238
+#: builtin/remote.c:239
 #, c-format
 msgid "Could not setup master '%s'"
 msgstr "Impossibile configurare il master '%s'"
 
-#: builtin/remote.c:344
+#: builtin/remote.c:354
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr ""
 "Impossibile ottenere la mappa di recupero per lo specificatore riferimento %s"
 
-#: builtin/remote.c:443 builtin/remote.c:451
+#: builtin/remote.c:453 builtin/remote.c:461
 msgid "(matching)"
 msgstr "(corrispondente)"
 
-#: builtin/remote.c:455
+#: builtin/remote.c:465
 msgid "(delete)"
 msgstr "(elimina)"
 
-#: builtin/remote.c:629 builtin/remote.c:764 builtin/remote.c:863
+#: builtin/remote.c:653
+#, c-format
+msgid "could not set '%s'"
+msgstr "impossibile impostare '%s'"
+
+#: builtin/remote.c:658
+#, c-format
+msgid ""
+"The %s configuration remote.pushDefault in:\n"
+"\t%s:%d\n"
+"now names the non-existent remote '%s'"
+msgstr ""
+"La configurazione remote.pushDefault %s in:\n"
+"\t%s:%d\n"
+"ora dà il nome al remoto inesistente '%s'"
+
+#: builtin/remote.c:689 builtin/remote.c:832 builtin/remote.c:940
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Remoto non esistente: '%s'"
 
-#: builtin/remote.c:646
+#: builtin/remote.c:706
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr ""
 "Non è stato possibile ridenominare la sezione di configurazione da '%s' in "
 "'%s'"
 
-#: builtin/remote.c:666
+#: builtin/remote.c:726
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -18963,17 +19367,17 @@ msgstr ""
 "\t%s\n"
 "\tAggiorna la configurazione manualmente se necessario."
 
-#: builtin/remote.c:701
+#: builtin/remote.c:766
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "eliminazione di '%s' non riuscita"
 
-#: builtin/remote.c:735
+#: builtin/remote.c:800
 #, c-format
 msgid "creating '%s' failed"
 msgstr "creazione di '%s' non riuscita"
 
-#: builtin/remote.c:801
+#: builtin/remote.c:876
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -18989,120 +19393,120 @@ msgstr[1] ""
 "eliminati;\n"
 "per eliminarli, usa:"
 
-#: builtin/remote.c:815
+#: builtin/remote.c:890
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Impossibile rimuovere la sezione di configurazione '%s'"
 
-#: builtin/remote.c:916
+#: builtin/remote.c:993
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " nuovo (il prossimo fetch lo salverà in remotes/%s)"
 
-#: builtin/remote.c:919
+#: builtin/remote.c:996
 msgid " tracked"
 msgstr " tracciato"
 
-#: builtin/remote.c:921
+#: builtin/remote.c:998
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " vecchio (usa 'git remote prune' per rimuoverlo)"
 
-#: builtin/remote.c:923
+#: builtin/remote.c:1000
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:964
+#: builtin/remote.c:1041
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr ""
 "valore branch.%s.merge non valido; impossibile eseguire il rebase su più di "
 "un branch"
 
-#: builtin/remote.c:973
+#: builtin/remote.c:1050
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "rebase interattivo sul remoto %s"
 
-#: builtin/remote.c:975
+#: builtin/remote.c:1052
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "rebase interattivo (con merge) sul remoto %s"
 
-#: builtin/remote.c:978
+#: builtin/remote.c:1055
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "rebase sul remoto %s"
 
-#: builtin/remote.c:982
+#: builtin/remote.c:1059
 #, c-format
 msgid " merges with remote %s"
 msgstr " merge con il remote %s"
 
-#: builtin/remote.c:985
+#: builtin/remote.c:1062
 #, c-format
 msgid "merges with remote %s"
 msgstr "merge con il remote %s"
 
-#: builtin/remote.c:988
+#: builtin/remote.c:1065
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    e con il remoto %s\n"
 
-#: builtin/remote.c:1031
+#: builtin/remote.c:1108
 msgid "create"
 msgstr "crea"
 
-#: builtin/remote.c:1034
+#: builtin/remote.c:1111
 msgid "delete"
 msgstr "elimina"
 
-#: builtin/remote.c:1038
+#: builtin/remote.c:1115
 msgid "up to date"
 msgstr "aggiornato"
 
-#: builtin/remote.c:1041
+#: builtin/remote.c:1118
 msgid "fast-forwardable"
 msgstr "fast forward possibile"
 
-#: builtin/remote.c:1044
+#: builtin/remote.c:1121
 msgid "local out of date"
 msgstr "locale non aggiornato"
 
-#: builtin/remote.c:1051
+#: builtin/remote.c:1128
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s esegue un aggiornamento forzato su %-*s (%s)"
 
-#: builtin/remote.c:1054
+#: builtin/remote.c:1131
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s esegue il push su %-*s (%s)"
 
-#: builtin/remote.c:1058
+#: builtin/remote.c:1135
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s esegue un aggiornamento forzato su %s"
 
-#: builtin/remote.c:1061
+#: builtin/remote.c:1138
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s esegue il push su %s"
 
-#: builtin/remote.c:1129
+#: builtin/remote.c:1206
 msgid "do not query remotes"
 msgstr "non interrogare i remoti"
 
-#: builtin/remote.c:1156
+#: builtin/remote.c:1233
 #, c-format
 msgid "* remote %s"
 msgstr "* remoto %s"
 
-#: builtin/remote.c:1157
+#: builtin/remote.c:1234
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL recupero: %s"
 
-#: builtin/remote.c:1158 builtin/remote.c:1174 builtin/remote.c:1313
+#: builtin/remote.c:1235 builtin/remote.c:1251 builtin/remote.c:1390
 msgid "(no URL)"
 msgstr "(nessun URL)"
 
@@ -19110,177 +19514,177 @@ msgstr "(nessun URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1172 builtin/remote.c:1174
+#: builtin/remote.c:1249 builtin/remote.c:1251
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "      URL push: %s"
 
-#: builtin/remote.c:1176 builtin/remote.c:1178 builtin/remote.c:1180
+#: builtin/remote.c:1253 builtin/remote.c:1255 builtin/remote.c:1257
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  branch HEAD: %s"
 
-#: builtin/remote.c:1176
+#: builtin/remote.c:1253
 msgid "(not queried)"
 msgstr "(non interrogato)"
 
-#: builtin/remote.c:1178
+#: builtin/remote.c:1255
 msgid "(unknown)"
 msgstr "(sconosciuto)"
 
-#: builtin/remote.c:1182
+#: builtin/remote.c:1259
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr ""
 "  branch HEAD (l'HEAD remoto è ambiguo, potrebbe essere uno dei seguenti):\n"
 
-#: builtin/remote.c:1194
+#: builtin/remote.c:1271
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Branch remoto:%s"
 msgstr[1] "  Branch remoti:%s"
 
-#: builtin/remote.c:1197 builtin/remote.c:1223
+#: builtin/remote.c:1274 builtin/remote.c:1300
 msgid " (status not queried)"
 msgstr " (stato non richiesto)"
 
-#: builtin/remote.c:1206
+#: builtin/remote.c:1283
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Branch locale configurato per 'git pull':"
 msgstr[1] "  Branch locali configurati per 'git pull':"
 
-#: builtin/remote.c:1214
+#: builtin/remote.c:1291
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  I riferimenti locali saranno copiati da 'git push'"
 
-#: builtin/remote.c:1220
+#: builtin/remote.c:1297
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Ref locale configurato per 'git push'%s:"
 msgstr[1] "  Ref locali configurati per 'git push'%s:"
 
-#: builtin/remote.c:1241
+#: builtin/remote.c:1318
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "imposta refs/remotes/<nome>/HEAD in base al remoto"
 
-#: builtin/remote.c:1243
+#: builtin/remote.c:1320
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "elimina refs/remotes/<nome>/HEAD"
 
-#: builtin/remote.c:1258
+#: builtin/remote.c:1335
 msgid "Cannot determine remote HEAD"
 msgstr "Impossibile determinare l'HEAD remoto"
 
-#: builtin/remote.c:1260
+#: builtin/remote.c:1337
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr "Branch HEAD remoti multipli. Scegline uno esplicitamente con:"
 
-#: builtin/remote.c:1270
+#: builtin/remote.c:1347
 #, c-format
 msgid "Could not delete %s"
 msgstr "Non è stato possibile eliminare %s"
 
-#: builtin/remote.c:1278
+#: builtin/remote.c:1355
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "Non è un ref valido: %s"
 
-#: builtin/remote.c:1280
+#: builtin/remote.c:1357
 #, c-format
 msgid "Could not setup %s"
 msgstr "Non è stato possibile configurare %s"
 
-#: builtin/remote.c:1298
+#: builtin/remote.c:1375
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s diventerà pendente!"
 
-#: builtin/remote.c:1299
+#: builtin/remote.c:1376
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s è diventato pendente!"
 
-#: builtin/remote.c:1309
+#: builtin/remote.c:1386
 #, c-format
 msgid "Pruning %s"
 msgstr "Eliminazione di %s in corso"
 
-#: builtin/remote.c:1310
+#: builtin/remote.c:1387
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1326
+#: builtin/remote.c:1403
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [sarebbe eliminato] %s"
 
-#: builtin/remote.c:1329
+#: builtin/remote.c:1406
 #, c-format
 msgid " * [pruned] %s"
 msgstr " * [eliminato] %s"
 
-#: builtin/remote.c:1374
+#: builtin/remote.c:1451
 msgid "prune remotes after fetching"
 msgstr "elimina remoti dopo il fetch"
 
-#: builtin/remote.c:1437 builtin/remote.c:1491 builtin/remote.c:1559
+#: builtin/remote.c:1514 builtin/remote.c:1568 builtin/remote.c:1636
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Remote '%s' non esistente"
 
-#: builtin/remote.c:1453
+#: builtin/remote.c:1530
 msgid "add branch"
 msgstr "aggiungi branch"
 
-#: builtin/remote.c:1460
+#: builtin/remote.c:1537
 msgid "no remote specified"
 msgstr "nessun remote specificato"
 
-#: builtin/remote.c:1477
+#: builtin/remote.c:1554
 msgid "query push URLs rather than fetch URLs"
 msgstr "interroga gli URL per il push anziché gli URL per il fetch"
 
-#: builtin/remote.c:1479
+#: builtin/remote.c:1556
 msgid "return all URLs"
 msgstr "restituisci tutti gli URL"
 
-#: builtin/remote.c:1507
+#: builtin/remote.c:1584
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "nessun URL configurato per il remoto '%s'"
 
-#: builtin/remote.c:1533
+#: builtin/remote.c:1610
 msgid "manipulate push URLs"
 msgstr "manipola gli URL per il push"
 
-#: builtin/remote.c:1535
+#: builtin/remote.c:1612
 msgid "add URL"
 msgstr "aggiungi URL"
 
-#: builtin/remote.c:1537
+#: builtin/remote.c:1614
 msgid "delete URLs"
 msgstr "elimina URL"
 
-#: builtin/remote.c:1544
+#: builtin/remote.c:1621
 msgid "--add --delete doesn't make sense"
 msgstr "--add --delete non ha senso"
 
-#: builtin/remote.c:1583
+#: builtin/remote.c:1660
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "Pattern URL vecchio non valido: %s"
 
-#: builtin/remote.c:1591
+#: builtin/remote.c:1668
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Nessuna URL trovata: %s"
 
-#: builtin/remote.c:1593
+#: builtin/remote.c:1670
 msgid "Will not delete all non-push URLs"
 msgstr "Non eliminerò tutti gli URL non push"
 
@@ -19536,8 +19940,8 @@ msgstr "impossibile eseguire fstat su %s"
 msgid "unable to write object to database"
 msgstr "impossibile scrivere l'oggetto nel database"
 
-#: builtin/replace.c:322 builtin/replace.c:378 builtin/replace.c:423
-#: builtin/replace.c:453
+#: builtin/replace.c:322 builtin/replace.c:378 builtin/replace.c:424
+#: builtin/replace.c:454
 #, c-format
 msgid "not a valid object name: '%s'"
 msgstr "nome oggetto non valido: '%s'"
@@ -19561,17 +19965,17 @@ msgstr "il nuovo oggetto è lo stesso di quello vecchio: '%s'"
 msgid "could not parse %s as a commit"
 msgstr "impossibile analizzare %s come commit"
 
-#: builtin/replace.c:415
+#: builtin/replace.c:416
 #, c-format
 msgid "bad mergetag in commit '%s'"
 msgstr "tag merge non valido nel commit '%s'"
 
-#: builtin/replace.c:417
+#: builtin/replace.c:418
 #, c-format
 msgid "malformed mergetag in commit '%s'"
 msgstr "tag merge malformato nel commit '%s'"
 
-#: builtin/replace.c:429
+#: builtin/replace.c:430
 #, c-format
 msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
@@ -19580,31 +19984,31 @@ msgstr ""
 "il commit originario '%s' contiene il tag merge '%s' che è stato scartato; "
 "usa --edit anziché --graft"
 
-#: builtin/replace.c:468
+#: builtin/replace.c:469
 #, c-format
 msgid "the original commit '%s' has a gpg signature"
 msgstr "il commit originario '%s' ha una firma GPG"
 
-#: builtin/replace.c:469
+#: builtin/replace.c:470
 msgid "the signature will be removed in the replacement commit!"
 msgstr "la firma sarà rimossa nel commit sostitutivo!"
 
-#: builtin/replace.c:479
+#: builtin/replace.c:480
 #, c-format
 msgid "could not write replacement commit for: '%s'"
 msgstr "impossibile scrivere il commit sostitutivo per '%s'"
 
-#: builtin/replace.c:487
+#: builtin/replace.c:488
 #, c-format
 msgid "graft for '%s' unnecessary"
 msgstr "graft per '%s' non necessario"
 
-#: builtin/replace.c:491
+#: builtin/replace.c:492
 #, c-format
 msgid "new commit is the same as the old one: '%s'"
 msgstr "il nuovo commit è lo stesso di quello vecchio: '%s'"
 
-#: builtin/replace.c:526
+#: builtin/replace.c:527
 #, c-format
 msgid ""
 "could not convert the following graft(s):\n"
@@ -19613,71 +20017,71 @@ msgstr ""
 "impossibile convertire i seguenti graft:\n"
 "%s"
 
-#: builtin/replace.c:547
+#: builtin/replace.c:548
 msgid "list replace refs"
 msgstr "elenca i riferimenti sostitutivi"
 
-#: builtin/replace.c:548
+#: builtin/replace.c:549
 msgid "delete replace refs"
 msgstr "elimina i riferimenti sostitutivi"
 
-#: builtin/replace.c:549
+#: builtin/replace.c:550
 msgid "edit existing object"
 msgstr "modifica l'oggetto esistente"
 
-#: builtin/replace.c:550
+#: builtin/replace.c:551
 msgid "change a commit's parents"
 msgstr "cambia i genitori di un commit"
 
-#: builtin/replace.c:551
+#: builtin/replace.c:552
 msgid "convert existing graft file"
 msgstr "converti un file graft esistente"
 
-#: builtin/replace.c:552
+#: builtin/replace.c:553
 msgid "replace the ref if it exists"
 msgstr "sostituisci il riferimento se esiste"
 
-#: builtin/replace.c:554
+#: builtin/replace.c:555
 msgid "do not pretty-print contents for --edit"
 msgstr "non stampare i contenuti in un formato leggibile (per --edit)"
 
-#: builtin/replace.c:555
+#: builtin/replace.c:556
 msgid "use this format"
 msgstr "usa questo formato"
 
-#: builtin/replace.c:568
+#: builtin/replace.c:569
 msgid "--format cannot be used when not listing"
 msgstr "--format non può essere usato quando non si elencano voci"
 
-#: builtin/replace.c:576
+#: builtin/replace.c:577
 msgid "-f only makes sense when writing a replacement"
 msgstr "-f ha senso solo se si sta scrivendo un oggetto sostitutivo"
 
-#: builtin/replace.c:580
+#: builtin/replace.c:581
 msgid "--raw only makes sense with --edit"
 msgstr "--raw ha senso solo con --edit"
 
-#: builtin/replace.c:586
+#: builtin/replace.c:587
 msgid "-d needs at least one argument"
 msgstr "-d richiede almeno un argomento"
 
-#: builtin/replace.c:592
+#: builtin/replace.c:593
 msgid "bad number of arguments"
 msgstr "numero di argomenti errato"
 
-#: builtin/replace.c:598
+#: builtin/replace.c:599
 msgid "-e needs exactly one argument"
 msgstr "-e richiede esattamente un argomento"
 
-#: builtin/replace.c:604
+#: builtin/replace.c:605
 msgid "-g needs at least one argument"
 msgstr "-g richiede almeno un argomento"
 
-#: builtin/replace.c:610
+#: builtin/replace.c:611
 msgid "--convert-graft-file takes no argument"
 msgstr "--convert-graft-file non richiede argomenti"
 
-#: builtin/replace.c:616
+#: builtin/replace.c:617
 msgid "only one pattern can be given with -l"
 msgstr "con -l può essere specificato solo un pattern"
 
@@ -19713,8 +20117,8 @@ msgstr "git reset [-q] [<espressione albero>] [--] <specificatore percorso>..."
 msgid ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 msgstr ""
-"git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<espressione"
-" albero>]"
+"git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<espressione "
+"albero>]"
 
 #: builtin/reset.c:35
 msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
@@ -19849,21 +20253,21 @@ msgstr "Impossibile ripristinare il file indice alla revisione '%s'."
 msgid "Could not write new index file."
 msgstr "Impossibile scrivere il nuovo file indice."
 
-#: builtin/rev-list.c:411
+#: builtin/rev-list.c:499
 msgid "cannot combine --exclude-promisor-objects and --missing"
 msgstr "impossibile combinare --exclude-promisor-objects e --missing"
 
-#: builtin/rev-list.c:472
+#: builtin/rev-list.c:560
 msgid "object filtering requires --objects"
 msgstr "il filtraggio oggetti richiede --objects"
 
-#: builtin/rev-list.c:522
+#: builtin/rev-list.c:610
 msgid "rev-list does not support display of notes"
 msgstr "rev-list non supporta la visualizzazione delle note"
 
-#: builtin/rev-list.c:525
-msgid "cannot combine --use-bitmap-index with object filtering"
-msgstr "impossibile combinare --use-bitmap-index con il filtraggio oggetti"
+#: builtin/rev-list.c:615
+msgid "marked counting is incompatible with --objects"
+msgstr "il conteggio contrassegnato non è compatibile con --objects"
 
 #: builtin/rev-parse.c:408
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
@@ -20318,54 +20722,72 @@ msgstr ""
 "visualizza i riferimenti dati sullo standard input che non sono nel "
 "repository locale"
 
-#: builtin/sparse-checkout.c:20
-msgid "git sparse-checkout (init|list|set|disable) <options>"
-msgstr "git sparse-checkout (init|list|set|disable) <opzioni>"
+#: builtin/sparse-checkout.c:21
+msgid "git sparse-checkout (init|list|set|add|disable) <options>"
+msgstr "git sparse-checkout (init|list|set|add|disable) <opzioni>"
 
-#: builtin/sparse-checkout.c:61
+#: builtin/sparse-checkout.c:64
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
-"questo albero di lavoro non è sparse (il file sparse-checkout potrebbe non"
-" esistere)"
+"questo albero di lavoro non è sparse (il file sparse-checkout potrebbe non "
+"esistere)"
 
-#: builtin/sparse-checkout.c:220
+#: builtin/sparse-checkout.c:225
+msgid "failed to create directory for sparse-checkout file"
+msgstr "creazione della directory per il file sparse-checkout non riuscita"
+
+#: builtin/sparse-checkout.c:266
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "impostazione dell'opzione extensions.worktreeConfig non riuscita"
 
-#: builtin/sparse-checkout.c:237
+#: builtin/sparse-checkout.c:283
 msgid "git sparse-checkout init [--cone]"
 msgstr "git sparse-checkout init [--cone]"
 
-#: builtin/sparse-checkout.c:256
+#: builtin/sparse-checkout.c:302
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "inizializza il checkout sparse in modalità cone"
 
-#: builtin/sparse-checkout.c:262
+#: builtin/sparse-checkout.c:308
 msgid "initialize sparse-checkout"
 msgstr "inizializza sparse-checkout"
 
-#: builtin/sparse-checkout.c:295
+#: builtin/sparse-checkout.c:341
 #, c-format
 msgid "failed to open '%s'"
 msgstr "apertura di '%s' non riuscita"
 
-#: builtin/sparse-checkout.c:361
-msgid "git sparse-checkout set (--stdin | <patterns>)"
-msgstr "git sparse-checkout set (--stdin | <pattern>)"
+#: builtin/sparse-checkout.c:398
+#, c-format
+msgid "could not normalize path %s"
+msgstr "impossibile normalizzare il percorso '%s'"
 
-#: builtin/sparse-checkout.c:378
+#: builtin/sparse-checkout.c:410
+msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
+msgstr "git sparse-checkout (set|add) (--stdin | <pattern>)"
+
+#: builtin/sparse-checkout.c:435
+#, c-format
+msgid "unable to unquote C-style string '%s'"
+msgstr "impossibile rimuovere le virgolette dalla stringa in stile C '%s'"
+
+#: builtin/sparse-checkout.c:489 builtin/sparse-checkout.c:513
+msgid "unable to load existing sparse-checkout patterns"
+msgstr "impossibile caricare i pattern sparse-checkout esistenti"
+
+#: builtin/sparse-checkout.c:558
 msgid "read patterns from standard in"
 msgstr "leggi i pattern dallo standard input"
 
-#: builtin/sparse-checkout.c:384
+#: builtin/sparse-checkout.c:564
 msgid "set sparse-checkout patterns"
 msgstr "imposta i pattern sparse-checkout"
 
-#: builtin/sparse-checkout.c:447
+#: builtin/sparse-checkout.c:581
 msgid "disable sparse-checkout"
 msgstr "disabilita sparse-checkout"
 
-#: builtin/sparse-checkout.c:459
+#: builtin/sparse-checkout.c:593
 msgid "error while refreshing working directory"
 msgstr "errore durante l'aggiornamento della directory di lavoro"
 
@@ -20509,7 +20931,7 @@ msgstr "Nome del branch non specificato"
 msgid "Cannot update %s with %s"
 msgstr "Impossibile aggiornare %s con %s"
 
-#: builtin/stash.c:813 builtin/stash.c:1470 builtin/stash.c:1506
+#: builtin/stash.c:813 builtin/stash.c:1473 builtin/stash.c:1509
 msgid "stash message"
 msgstr "messaggio di stash"
 
@@ -20517,82 +20939,82 @@ msgstr "messaggio di stash"
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" richiede un argomento <commit>"
 
-#: builtin/stash.c:1045 git-legacy-stash.sh:218
+#: builtin/stash.c:1048 git-legacy-stash.sh:218
 msgid "No changes selected"
 msgstr "Nessuna modifica selezionata"
 
-#: builtin/stash.c:1145 git-legacy-stash.sh:150
+#: builtin/stash.c:1148 git-legacy-stash.sh:150
 msgid "You do not have the initial commit yet"
 msgstr "Non hai ancora un commit iniziale"
 
-#: builtin/stash.c:1172 git-legacy-stash.sh:165
+#: builtin/stash.c:1175 git-legacy-stash.sh:165
 msgid "Cannot save the current index state"
 msgstr "Impossibile salvare lo stato corrente di index"
 
-#: builtin/stash.c:1181 git-legacy-stash.sh:180
+#: builtin/stash.c:1184 git-legacy-stash.sh:180
 msgid "Cannot save the untracked files"
 msgstr "Impossibile salvare i file non tracciati"
 
-#: builtin/stash.c:1192 builtin/stash.c:1201 git-legacy-stash.sh:201
+#: builtin/stash.c:1195 builtin/stash.c:1204 git-legacy-stash.sh:201
 #: git-legacy-stash.sh:214
 msgid "Cannot save the current worktree state"
 msgstr "Impossibile salvare lo stato corrente dell'albero di lavoro"
 
-#: builtin/stash.c:1229 git-legacy-stash.sh:234
+#: builtin/stash.c:1232 git-legacy-stash.sh:234
 msgid "Cannot record working tree state"
 msgstr "Impossibile registrare lo stato dell'albero di lavoro"
 
-#: builtin/stash.c:1278 git-legacy-stash.sh:338
+#: builtin/stash.c:1281 git-legacy-stash.sh:338
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Impossibile usare --patch e --include-untracked o --all allo stesso tempo"
 
-#: builtin/stash.c:1294
+#: builtin/stash.c:1297
 msgid "Did you forget to 'git add'?"
 msgstr "Ti sei scordato di eseguire 'git add'?"
 
-#: builtin/stash.c:1309 git-legacy-stash.sh:346
+#: builtin/stash.c:1312 git-legacy-stash.sh:346
 msgid "No local changes to save"
 msgstr "Nessuna modifica locale da salvare"
 
-#: builtin/stash.c:1316 git-legacy-stash.sh:351
+#: builtin/stash.c:1319 git-legacy-stash.sh:351
 msgid "Cannot initialize stash"
 msgstr "Impossibile inizializzare stash"
 
-#: builtin/stash.c:1331 git-legacy-stash.sh:355
+#: builtin/stash.c:1334 git-legacy-stash.sh:355
 msgid "Cannot save the current status"
 msgstr "Impossibile salvare lo stato attuale"
 
-#: builtin/stash.c:1336
+#: builtin/stash.c:1339
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Directory di lavoro e stato indice salvati: %s"
 
-#: builtin/stash.c:1426 git-legacy-stash.sh:385
+#: builtin/stash.c:1429 git-legacy-stash.sh:385
 msgid "Cannot remove worktree changes"
 msgstr "Impossibile rimuovere le modifiche all'albero di lavoro"
 
-#: builtin/stash.c:1461 builtin/stash.c:1497
+#: builtin/stash.c:1464 builtin/stash.c:1500
 msgid "keep index"
 msgstr "mantieni l'indice"
 
-#: builtin/stash.c:1463 builtin/stash.c:1499
+#: builtin/stash.c:1466 builtin/stash.c:1502
 msgid "stash in patch mode"
 msgstr "esegui lo stash in modalità patch"
 
-#: builtin/stash.c:1464 builtin/stash.c:1500
+#: builtin/stash.c:1467 builtin/stash.c:1503
 msgid "quiet mode"
 msgstr "modalità silenziosa"
 
-#: builtin/stash.c:1466 builtin/stash.c:1502
+#: builtin/stash.c:1469 builtin/stash.c:1505
 msgid "include untracked files in stash"
 msgstr "includi i file non tracciati nello stash"
 
-#: builtin/stash.c:1468 builtin/stash.c:1504
+#: builtin/stash.c:1471 builtin/stash.c:1507
 msgid "include ignore files"
 msgstr "includi i file ignorati"
 
-#: builtin/stash.c:1564
+#: builtin/stash.c:1567
 #, c-format
 msgid "could not exec %s"
 msgstr "impossibile eseguire %s"
@@ -20613,7 +21035,7 @@ msgstr "salta e rimuovi tutte le righe che iniziano con un carattere commento"
 msgid "prepend comment character and space to each line"
 msgstr "anteponi il carattere commento e uno spazio a ogni riga"
 
-#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:1970
+#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:1999
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Atteso nome riferimento completo, ricevuto %s"
@@ -20627,7 +21049,7 @@ msgstr "submodule--helper print-default-remote non richiede argomenti"
 msgid "cannot strip one component off url '%s'"
 msgstr "impossibile rimuovere un componente dall'URL '%s'"
 
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1380
+#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1395
 msgid "alternative anchor for relative paths"
 msgstr "ancoraggio alternativo per i percorsi relativi"
 
@@ -20670,7 +21092,7 @@ msgstr ""
 msgid "Suppress output of entering each submodule command"
 msgstr "Non visualizzare l'output dei comandi eseguiti in ogni sottomodulo"
 
-#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:1053
+#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:1063
 msgid "Recurse into nested submodules"
 msgstr "Esegui ricorsivamente sui sottomoduli innestati"
 
@@ -20717,26 +21139,26 @@ msgstr "Non visualizzare l'output dell'inizializzazione del sottomodulo"
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<opzioni>] [<percorso>]"
 
-#: builtin/submodule--helper.c:787 builtin/submodule--helper.c:914
+#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "mapping sottomodulo per il percorso '%s' non trovato in .gitmodules"
 
-#: builtin/submodule--helper.c:827
+#: builtin/submodule--helper.c:837
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "impossibile risolvere il riferimento HEAD nel sottomodulo '%s'"
 
-#: builtin/submodule--helper.c:854 builtin/submodule--helper.c:1023
+#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1033
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "ricorsione nel sottomodulo '%s' non riuscita"
 
-#: builtin/submodule--helper.c:878 builtin/submodule--helper.c:1189
+#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1199
 msgid "Suppress submodule status output"
 msgstr "Non visualizzare l'output dello stato del sottomodulo"
 
-#: builtin/submodule--helper.c:879
+#: builtin/submodule--helper.c:889
 msgid ""
 "Use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -20744,49 +21166,49 @@ msgstr ""
 "Usa il commit salvato nell'indice anziché quello salvato nell'HEAD del "
 "sottomodulo"
 
-#: builtin/submodule--helper.c:880
+#: builtin/submodule--helper.c:890
 msgid "recurse into nested submodules"
 msgstr "esegui ricorsivamente sui sottomoduli innestati"
 
-#: builtin/submodule--helper.c:885
+#: builtin/submodule--helper.c:895
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr ""
 "git submodule status [--quiet] [--cached] [--recursive] [<percorso>...]"
 
-#: builtin/submodule--helper.c:909
+#: builtin/submodule--helper.c:919
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <percorso>"
 
-#: builtin/submodule--helper.c:973
+#: builtin/submodule--helper.c:983
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Sincronizzazione URL sottomodulo per '%s' in corso\n"
 
-#: builtin/submodule--helper.c:979
+#: builtin/submodule--helper.c:989
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "registrazione dell'URL per il percorso sottomodulo '%s' non riuscita"
 
-#: builtin/submodule--helper.c:993
+#: builtin/submodule--helper.c:1003
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "recupero del remoto predefinito per il sottomodulo '%s' non riuscito"
 
-#: builtin/submodule--helper.c:1004
+#: builtin/submodule--helper.c:1014
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "aggiornamento del remoto per il sottomodulo '%s' non riuscito"
 
-#: builtin/submodule--helper.c:1051
+#: builtin/submodule--helper.c:1061
 msgid "Suppress output of synchronizing submodule url"
 msgstr ""
 "Non visualizzare l'output della sincronizzazione dell'URL del sottomodulo"
 
-#: builtin/submodule--helper.c:1058
+#: builtin/submodule--helper.c:1068
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<percorso>]"
 
-#: builtin/submodule--helper.c:1112
+#: builtin/submodule--helper.c:1122
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -20795,7 +21217,7 @@ msgstr ""
 "L'albero di lavoro del sottomodulo ('%s') contiene una directory .git (usa "
 "'rm -rf' se vuoi veramente rimuoverla, inclusa l'intera sua cronologia)"
 
-#: builtin/submodule--helper.c:1124
+#: builtin/submodule--helper.c:1134
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -20804,47 +21226,47 @@ msgstr ""
 "L'albero di lavoro del sottomodulo ('%s') contiene modifiche locali; usa '-"
 "f' per scartarle"
 
-#: builtin/submodule--helper.c:1132
+#: builtin/submodule--helper.c:1142
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Directory '%s' ripulita\n"
 
-#: builtin/submodule--helper.c:1134
+#: builtin/submodule--helper.c:1144
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Impossibile rimuovere l'albero di lavoro del sottomodulo '%s'\n"
 
-#: builtin/submodule--helper.c:1145
+#: builtin/submodule--helper.c:1155
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "impossibile creare la directory vuota del sottomodulo %s"
 
-#: builtin/submodule--helper.c:1161
+#: builtin/submodule--helper.c:1171
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Rimossa registrazione sottomodulo '%s' (%s) per il percorso '%s'\n"
 
-#: builtin/submodule--helper.c:1190
+#: builtin/submodule--helper.c:1200
 msgid "Remove submodule working trees even if they contain local changes"
 msgstr ""
 "Rimuovi gli alberi di lavoro dei sottomoduli anche se contengono modifiche "
 "locali"
 
-#: builtin/submodule--helper.c:1191
+#: builtin/submodule--helper.c:1201
 msgid "Unregister all submodules"
 msgstr "Annulla la registrazione di tutti i sottomoduli"
 
-#: builtin/submodule--helper.c:1196
+#: builtin/submodule--helper.c:1206
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<percorso>...]]"
 
-#: builtin/submodule--helper.c:1210
+#: builtin/submodule--helper.c:1220
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Usa '--all' se vuoi veramente deinizializzare tutti i sottomoduli"
 
-#: builtin/submodule--helper.c:1275
+#: builtin/submodule--helper.c:1289
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -20853,163 +21275,164 @@ msgid ""
 msgstr ""
 "Un alternato calcolato a partire dall'alternato di un progetto di livello\n"
 "superiore non è valido.\n"
-"Per consentire a Git di eseguire il clone senza alternati in tal caso,"
-" imposta\n"
-"submodule.alternateErrorStrategy a 'info' o, equivalentemente, esegui il"
-" clone\n"
+"Per consentire a Git di eseguire il clone senza alternati in tal caso, "
+"imposta\n"
+"submodule.alternateErrorStrategy a 'info' o, equivalentemente, esegui il "
+"clone\n"
 "con l'opzione '--reference-if-able' anziché '--reference'."
 
-#: builtin/submodule--helper.c:1314 builtin/submodule--helper.c:1317
+#: builtin/submodule--helper.c:1328 builtin/submodule--helper.c:1331
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "non è possibile aggiungere un alternato per il sottomodulo '%s': %s"
 
-#: builtin/submodule--helper.c:1353
+#: builtin/submodule--helper.c:1367
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Valore '%s' per submodule.alternateErrorStrategy non riconosciuto"
 
-#: builtin/submodule--helper.c:1360
+#: builtin/submodule--helper.c:1374
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Valore '%s' per submodule.alternateLocation non riconosciuto"
 
-#: builtin/submodule--helper.c:1383
+#: builtin/submodule--helper.c:1398
 msgid "where the new submodule will be cloned to"
 msgstr "percorso in cui sarà clonato il nuovo sottomodulo"
 
-#: builtin/submodule--helper.c:1386
+#: builtin/submodule--helper.c:1401
 msgid "name of the new submodule"
 msgstr "nome del nuovo sottomodulo"
 
-#: builtin/submodule--helper.c:1389
+#: builtin/submodule--helper.c:1404
 msgid "url where to clone the submodule from"
 msgstr "URL da cui clonare il sottomodulo"
 
-#: builtin/submodule--helper.c:1397
+#: builtin/submodule--helper.c:1412
 msgid "depth for shallow clones"
 msgstr "profondità per i cloni shallow"
 
-#: builtin/submodule--helper.c:1400 builtin/submodule--helper.c:1897
+#: builtin/submodule--helper.c:1415 builtin/submodule--helper.c:1924
 msgid "force cloning progress"
 msgstr "forza l'indicazione d'avanzamento della clonazione"
 
-#: builtin/submodule--helper.c:1402 builtin/submodule--helper.c:1899
+#: builtin/submodule--helper.c:1417 builtin/submodule--helper.c:1926
 msgid "disallow cloning into non-empty directory"
 msgstr "disabilita il clone in una directory non vuota"
 
-#: builtin/submodule--helper.c:1407
+#: builtin/submodule--helper.c:1424
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
-"<repository>] [--name <name>] [--depth <depth>] --url <url> --path <path>"
+"<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
+"<url> --path <path>"
 msgstr ""
-"git submodule--helper clone [--prefix=<percorso>] [--quiet] [--reference "
-"<repository>] [--name <nome>] [--depth <profondità>] --url <URL> --path "
-"<percorso>"
+"git submodule--helper clone [--prefix=<percorso>] [--quiet] [--reference <"
+"repository>] [--name <nome>] [--depth <profondità>] [--single-branch] --url <"
+"URL> --path <percorso>"
 
-#: builtin/submodule--helper.c:1431
+#: builtin/submodule--helper.c:1449
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "mi rifiuto di creare/usare '%s' nella directory Git di un altro sottomodulo"
 
-#: builtin/submodule--helper.c:1442
+#: builtin/submodule--helper.c:1460
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "clone di '%s' nel percorso del sottomodulo ('%s') non riuscito"
 
-#: builtin/submodule--helper.c:1446
+#: builtin/submodule--helper.c:1464
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "directory non vuota: '%s'"
 
-#: builtin/submodule--helper.c:1458
+#: builtin/submodule--helper.c:1476
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "impossibile recuperare la directory del sottomodulo per '%s'"
 
-#: builtin/submodule--helper.c:1494
+#: builtin/submodule--helper.c:1512
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr ""
 "Modalità aggiornamento '%s' non valida per il percorso del sottomodulo ('%s')"
 
-#: builtin/submodule--helper.c:1498
+#: builtin/submodule--helper.c:1516
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "È stata configurata una modalità aggiornamento '%s' non valida per il "
 "percorso del sottomodulo ('%s')"
 
-#: builtin/submodule--helper.c:1594
+#: builtin/submodule--helper.c:1617
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Percorso del sottomodulo ('%s') non inizializzato"
 
-#: builtin/submodule--helper.c:1598
+#: builtin/submodule--helper.c:1621
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Potresti voler usare 'update --init'."
 
-#: builtin/submodule--helper.c:1628
+#: builtin/submodule--helper.c:1651
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Ignoro il sottomodulo %s non sottoposto a merge"
 
-#: builtin/submodule--helper.c:1657
+#: builtin/submodule--helper.c:1680
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Ignoro il sottomodulo '%s'"
 
-#: builtin/submodule--helper.c:1803
+#: builtin/submodule--helper.c:1830
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Clone di '%s' non riuscito. Nuovo tentativo programmato"
 
-#: builtin/submodule--helper.c:1814
+#: builtin/submodule--helper.c:1841
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr ""
 "Clone di '%s' non riuscito per la seconda volta, interrompo l'operazione"
 
-#: builtin/submodule--helper.c:1876 builtin/submodule--helper.c:2120
+#: builtin/submodule--helper.c:1903 builtin/submodule--helper.c:2149
 msgid "path into the working tree"
 msgstr "percorso nell'albero di lavoro"
 
-#: builtin/submodule--helper.c:1879
+#: builtin/submodule--helper.c:1906
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr ""
 "percorso nell'albero di lavoro attraverso i confini dei sottomoduli innestati"
 
-#: builtin/submodule--helper.c:1883
+#: builtin/submodule--helper.c:1910
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout o none"
 
-#: builtin/submodule--helper.c:1889
+#: builtin/submodule--helper.c:1916
 msgid "Create a shallow clone truncated to the specified number of revisions"
 msgstr "Crea un clone shallow limitato al numero di revisioni specificato"
 
-#: builtin/submodule--helper.c:1892
+#: builtin/submodule--helper.c:1919
 msgid "parallel jobs"
 msgstr "processi da eseguire in parallelo"
 
-#: builtin/submodule--helper.c:1894
+#: builtin/submodule--helper.c:1921
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "determina se il clone iniziale sarà shallow come raccomandato"
 
-#: builtin/submodule--helper.c:1895
+#: builtin/submodule--helper.c:1922
 msgid "don't print cloning progress"
 msgstr "non stampare l'indicazione di avanzamento della clonazione"
 
-#: builtin/submodule--helper.c:1904
+#: builtin/submodule--helper.c:1933
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr ""
 "git submodule--helper update-clone [--prefix=<percorso>] [<percorso>...]"
 
-#: builtin/submodule--helper.c:1917
+#: builtin/submodule--helper.c:1946
 msgid "bad value for update parameter"
 msgstr "valore parametro aggiornamento errato"
 
-#: builtin/submodule--helper.c:1965
+#: builtin/submodule--helper.c:1994
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -21018,50 +21441,50 @@ msgstr ""
 "Il branch del sottomodulo (%s) è configurato in modo da ereditare il branch "
 "dal progetto al livello superiore, ma questo non è su alcun branch"
 
-#: builtin/submodule--helper.c:2088
+#: builtin/submodule--helper.c:2117
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "impossibile recuperare un handle repository per il sottomodulo '%s'"
 
-#: builtin/submodule--helper.c:2121
+#: builtin/submodule--helper.c:2150
 msgid "recurse into submodules"
 msgstr "esegui ricorsivamente sui sottomoduli"
 
-#: builtin/submodule--helper.c:2127
+#: builtin/submodule--helper.c:2156
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<opzioni>] [<percorso>...]"
 
-#: builtin/submodule--helper.c:2183
+#: builtin/submodule--helper.c:2212
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "controlla se è sicuro scrivere sul file .gitmodules"
 
-#: builtin/submodule--helper.c:2186
+#: builtin/submodule--helper.c:2215
 msgid "unset the config in the .gitmodules file"
 msgstr "rimuovi la configurazione nel file .gitmodules"
 
-#: builtin/submodule--helper.c:2191
+#: builtin/submodule--helper.c:2220
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <nome> [<valore>]"
 
-#: builtin/submodule--helper.c:2192
+#: builtin/submodule--helper.c:2221
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <nome>"
 
-#: builtin/submodule--helper.c:2193
+#: builtin/submodule--helper.c:2222
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2212 git-submodule.sh:173
+#: builtin/submodule--helper.c:2241 git-submodule.sh:174
 #, sh-format
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "assicurati che il file .gitmodules sia nell'albero di lavoro"
 
-#: builtin/submodule--helper.c:2262 git.c:433 git.c:684
+#: builtin/submodule--helper.c:2291 git.c:433 git.c:684
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s non supporta --super-prefix"
 
-#: builtin/submodule--helper.c:2268
+#: builtin/submodule--helper.c:2297
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' non è un sottocomando submodule--helper valido"
@@ -21319,7 +21742,7 @@ msgstr "il tag '%s' esiste già"
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Tag '%s' aggiornato (era %s)\n"
 
-#: builtin/unpack-objects.c:501
+#: builtin/unpack-objects.c:502
 msgid "Unpacking objects"
 msgstr "Decompressione degli oggetti in corso"
 
@@ -21716,7 +22139,7 @@ msgstr "git worktree remove [<opzioni>] <albero di lavoro>"
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <percorso>"
 
-#: builtin/worktree.c:60 builtin/worktree.c:898
+#: builtin/worktree.c:60 builtin/worktree.c:891
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "eliminazione di '%s' non riuscita"
@@ -21768,12 +22191,12 @@ msgstr "fai scadere gli alberi di lavoro più vecchi di <tempo>"
 msgid "'%s' already exists"
 msgstr "'%s' esiste già"
 
-#: builtin/worktree.c:251
+#: builtin/worktree.c:244
 #, c-format
 msgid "unable to re-add worktree '%s'"
 msgstr "impossibile aggiungere nuovamente l'albero di lavoro '%s'"
 
-#: builtin/worktree.c:256
+#: builtin/worktree.c:249
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
@@ -21783,7 +22206,7 @@ msgstr ""
 "usa 'add -f -f' per eseguire l'override, o 'unlock' e 'prune' o 'remove' per "
 "rimuoverlo"
 
-#: builtin/worktree.c:258
+#: builtin/worktree.c:251
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
@@ -21792,129 +22215,129 @@ msgstr ""
 "'%s' è un albero di lavoro mancante ma già registrato;\n"
 "usa 'add -f' per eseguire l'override, o 'prune' o 'remove' per rimuoverlo"
 
-#: builtin/worktree.c:308
+#: builtin/worktree.c:301
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr "impossibile creare la directory di '%s'"
 
-#: builtin/worktree.c:439 builtin/worktree.c:445
+#: builtin/worktree.c:432 builtin/worktree.c:438
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Preparazione dell'albero di lavoro in corso (nuovo branch '%s')"
 
-#: builtin/worktree.c:441
+#: builtin/worktree.c:434
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr ""
 "Preparazione dell'albero di lavoro in corso (reimposto il branch '%s'; era a "
 "%s)"
 
-#: builtin/worktree.c:450
+#: builtin/worktree.c:443
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Preparazione dell'albero di lavoro in corso (checkout di '%s')"
 
-#: builtin/worktree.c:456
+#: builtin/worktree.c:449
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Preparazione dell'albero di lavoro in corso (HEAD scollegato %s)"
 
-#: builtin/worktree.c:497
+#: builtin/worktree.c:490
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 "esegui il checkout di <branch> anche se tale operazione è stata eseguita in "
 "un altro albero di lavoro"
 
-#: builtin/worktree.c:500
+#: builtin/worktree.c:493
 msgid "create a new branch"
 msgstr "crea un nuovo branch"
 
-#: builtin/worktree.c:502
+#: builtin/worktree.c:495
 msgid "create or reset a branch"
 msgstr "crea o reimposta un branch"
 
-#: builtin/worktree.c:504
+#: builtin/worktree.c:497
 msgid "populate the new working tree"
 msgstr "popola il nuovo albero di lavoro"
 
-#: builtin/worktree.c:505
+#: builtin/worktree.c:498
 msgid "keep the new working tree locked"
 msgstr "mantieni bloccato il nuovo albero di lavoro"
 
-#: builtin/worktree.c:508
+#: builtin/worktree.c:501
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "imposta la modalità tracking (vedi git-branch(1))"
 
-#: builtin/worktree.c:511
+#: builtin/worktree.c:504
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 "tenta di cercare una corrispondenza fra il nome del nuovo branch e un branch "
 "remoto da tracciare"
 
-#: builtin/worktree.c:519
+#: builtin/worktree.c:512
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "le opzioni -b, -B e --detach sono mutualmente esclusive"
 
-#: builtin/worktree.c:580
+#: builtin/worktree.c:573
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr ""
 "l'opzione --[no-]track può essere usata solo se viene creato un nuovo branch"
 
-#: builtin/worktree.c:680
+#: builtin/worktree.c:673
 msgid "reason for locking"
 msgstr "motivo di blocco"
 
-#: builtin/worktree.c:692 builtin/worktree.c:725 builtin/worktree.c:799
-#: builtin/worktree.c:926
+#: builtin/worktree.c:685 builtin/worktree.c:718 builtin/worktree.c:792
+#: builtin/worktree.c:919
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' non è un albero di lavoro"
 
-#: builtin/worktree.c:694 builtin/worktree.c:727
+#: builtin/worktree.c:687 builtin/worktree.c:720
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Non è possibile bloccare o sbloccare l'albero di lavoro principale"
 
-#: builtin/worktree.c:699
+#: builtin/worktree.c:692
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "'%s' è già bloccato per questo motivo: %s"
 
-#: builtin/worktree.c:701
+#: builtin/worktree.c:694
 #, c-format
 msgid "'%s' is already locked"
 msgstr "'%s' è già bloccato"
 
-#: builtin/worktree.c:729
+#: builtin/worktree.c:722
 #, c-format
 msgid "'%s' is not locked"
 msgstr "'%s' non è bloccato"
 
-#: builtin/worktree.c:770
+#: builtin/worktree.c:763
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "gli alberi di lavoro contenenti sottomoduli non possono essere spostati o "
 "rimossi"
 
-#: builtin/worktree.c:778
+#: builtin/worktree.c:771
 msgid "force move even if worktree is dirty or locked"
 msgstr "forza lo spostamento anche se l'albero di lavoro è sporco o bloccato"
 
-#: builtin/worktree.c:801 builtin/worktree.c:928
+#: builtin/worktree.c:794 builtin/worktree.c:921
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' è un albero di lavoro principale"
 
-#: builtin/worktree.c:806
+#: builtin/worktree.c:799
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "impossibile determinare il nome destinazione da '%s'"
 
-#: builtin/worktree.c:812
+#: builtin/worktree.c:805
 #, c-format
 msgid "target '%s' already exists"
 msgstr "la destinazione '%s' esiste già"
 
-#: builtin/worktree.c:820
+#: builtin/worktree.c:813
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -21924,7 +22347,7 @@ msgstr ""
 "usa 'move -f -f' per eseguirne l'override o sbloccalo prima di eseguire "
 "l'operazione"
 
-#: builtin/worktree.c:822
+#: builtin/worktree.c:815
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -21933,37 +22356,37 @@ msgstr ""
 "usa 'move -f -f' per eseguirne l'override o sbloccalo prima di eseguire "
 "l'operazione"
 
-#: builtin/worktree.c:825
+#: builtin/worktree.c:818
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "validazione non riuscita, impossibile spostare l'albero di lavoro: %s"
 
-#: builtin/worktree.c:830
+#: builtin/worktree.c:823
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "spostamento di '%s' in '%s' non riuscito"
 
-#: builtin/worktree.c:878
+#: builtin/worktree.c:871
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "esecuzione di 'git status' su '%s' non riuscita"
 
-#: builtin/worktree.c:882
+#: builtin/worktree.c:875
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' contiene file modificati o non tracciati, usa --force per eliminarlo"
 
-#: builtin/worktree.c:887
+#: builtin/worktree.c:880
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "esecuzione di 'git status' su '%s' non riuscita, codice %d"
 
-#: builtin/worktree.c:910
+#: builtin/worktree.c:903
 msgid "force removal even if worktree is dirty or locked"
 msgstr "forza la rimozione anche se l'albero di lavoro è sporco o bloccato"
 
-#: builtin/worktree.c:933
+#: builtin/worktree.c:926
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -21973,7 +22396,7 @@ msgstr ""
 "usa 'remove -f -f' per eseguirne l'override o sbloccalo prima di eseguire "
 "l'operazione"
 
-#: builtin/worktree.c:935
+#: builtin/worktree.c:928
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -21982,7 +22405,7 @@ msgstr ""
 "usa 'remove -f -f' per eseguirne l'override o sbloccalo prima di eseguire "
 "l'operazione"
 
-#: builtin/worktree.c:938
+#: builtin/worktree.c:931
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "validazione non riuscita, impossibile rimuovere l'albero di lavoro: %s"
@@ -22324,7 +22747,7 @@ msgstr ""
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "errore protocollo: atteso SHA/riferimento, ricevuto '%s'"
 
-#: remote-curl.c:1147 remote-curl.c:1261
+#: remote-curl.c:1147 remote-curl.c:1262
 #, c-format
 msgid "http transport does not support %s"
 msgstr "il trasporto HTTP non supporta %s"
@@ -22333,19 +22756,19 @@ msgstr "il trasporto HTTP non supporta %s"
 msgid "git-http-push failed"
 msgstr "git-http-push non riuscito"
 
-#: remote-curl.c:1367
+#: remote-curl.c:1368
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: uso: git remote-curl <remoto> [<URL>]"
 
-#: remote-curl.c:1399
+#: remote-curl.c:1400
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: errore durante la lettura del flusso dei comandi da Git"
 
-#: remote-curl.c:1406
+#: remote-curl.c:1407
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: tentato un fetch senza un repository locale"
 
-#: remote-curl.c:1446
+#: remote-curl.c:1447
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: ricevuto comando sconosciuto '%s' da Git"
@@ -22390,8 +22813,8 @@ msgstr "leggi gli specificatori percorso da un file"
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
-"con --pathspec-from-file gli elementi specificatori percorso sono separati da"
-" un carattere NUL"
+"con --pathspec-from-file gli elementi specificatori percorso sono separati "
+"da un carattere NUL"
 
 #: ref-filter.h:101
 msgid "key"
@@ -23296,61 +23719,50 @@ msgstr "${REV}: non è stato possibile rimuovere la voce di stash"
 msgid "(To restore them type \"git stash apply\")"
 msgstr "(Per ripristinarli digita \"git stash apply\")"
 
-#: git-submodule.sh:202
+#: git-submodule.sh:203
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
 "Il percorso relativo può essere usato solo dal primo livello dell'albero di "
 "lavoro"
 
-#: git-submodule.sh:212
+#: git-submodule.sh:213
 #, sh-format
 msgid "repo URL: '$repo' must be absolute or begin with ./|../"
 msgstr "URL repository:: '$repo' deve essere assoluto o iniziare con ./|../"
 
-#: git-submodule.sh:231
+#: git-submodule.sh:232
 #, sh-format
 msgid "'$sm_path' already exists in the index"
 msgstr "'$sm_path' esiste già nell'indice"
 
-#: git-submodule.sh:234
+#: git-submodule.sh:235
 #, sh-format
 msgid "'$sm_path' already exists in the index and is not a submodule"
 msgstr "'$sm_path' esiste già nell'indice e non è un sottomodulo"
 
-#: git-submodule.sh:241
+#: git-submodule.sh:242
 #, sh-format
 msgid "'$sm_path' does not have a commit checked out"
 msgstr "'$sm_path' non ha un commit di cui è stato eseguito il checkout"
 
-#: git-submodule.sh:247
-#, sh-format
-msgid ""
-"The following path is ignored by one of your .gitignore files:\n"
-"$sm_path\n"
-"Use -f if you really want to add it."
-msgstr ""
-"Il seguente percorso è ignorato da uno dei tuoi file .gitignore:\n"
-"$sm_path\n"
-"Usa -f se vuoi davvero aggiungerlo."
-
-#: git-submodule.sh:270
+#: git-submodule.sh:273
 #, sh-format
 msgid "Adding existing repo at '$sm_path' to the index"
 msgstr "Aggiunta del repository esistente in '$sm_path' all'indice"
 
-#: git-submodule.sh:272
+#: git-submodule.sh:275
 #, sh-format
 msgid "'$sm_path' already exists and is not a valid git repo"
 msgstr "'$sm_path' esiste già e non è un repository Git valido"
 
-#: git-submodule.sh:280
+#: git-submodule.sh:283
 #, sh-format
 msgid "A git directory for '$sm_name' is found locally with remote(s):"
 msgstr ""
 "È stata trovata localmente una directory Git per '$sm_name' con i seguenti "
 "remoti:"
 
-#: git-submodule.sh:282
+#: git-submodule.sh:285
 #, sh-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -23367,39 +23779,39 @@ msgstr ""
 "altro\n"
 "nome con l'opzione '--name'."
 
-#: git-submodule.sh:288
+#: git-submodule.sh:291
 #, sh-format
 msgid "Reactivating local git directory for submodule '$sm_name'."
 msgstr "Riattivo la directory Git locale per il sottomodulo '$sm_name'."
 
-#: git-submodule.sh:300
+#: git-submodule.sh:303
 #, sh-format
 msgid "Unable to checkout submodule '$sm_path'"
 msgstr "Impossibile eseguire il checkout del sottomodulo '$sm_path'"
 
-#: git-submodule.sh:305
+#: git-submodule.sh:308
 #, sh-format
 msgid "Failed to add submodule '$sm_path'"
 msgstr "Aggiunta del sottomodulo '$sm_path' non riuscita"
 
-#: git-submodule.sh:314
+#: git-submodule.sh:317
 #, sh-format
 msgid "Failed to register submodule '$sm_path'"
 msgstr "Registrazione del sottomodulo '$sm_path' non riuscita"
 
-#: git-submodule.sh:580
+#: git-submodule.sh:590
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr ""
 "Impossibile trovare la revisione corrente nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:590
+#: git-submodule.sh:600
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "Impossibile eseguire il fetch nel percorso del sottomodulo '$sm_path'"
 
-#: git-submodule.sh:595
+#: git-submodule.sh:605
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -23408,7 +23820,7 @@ msgstr ""
 "Impossibile trovare la revisione corrente per ${remote_name}/${branch} nel "
 "percorso del sottomodulo '$sm_path'"
 
-#: git-submodule.sh:613
+#: git-submodule.sh:623
 #, sh-format
 msgid ""
 "Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
@@ -23417,7 +23829,7 @@ msgstr ""
 "Impossibile eseguire il fetch nel percorso del sottomodulo '$displaypath'; "
 "provo a recuperare direttamente $sha1:"
 
-#: git-submodule.sh:619
+#: git-submodule.sh:629
 #, sh-format
 msgid ""
 "Fetched in submodule path '$displaypath', but it did not contain $sha1. "
@@ -23426,79 +23838,79 @@ msgstr ""
 "Fetch eseguito nel percorso del sottomodulo '$displaypath', ma non conteneva "
 "$sha1. Fetch diretto di tale commit non riuscito."
 
-#: git-submodule.sh:626
+#: git-submodule.sh:636
 #, sh-format
 msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
 msgstr ""
 "Impossibile eseguire il checkout di '$sha1' nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:627
+#: git-submodule.sh:637
 #, sh-format
 msgid "Submodule path '$displaypath': checked out '$sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': eseguito checkout di '$sha1'"
 
-#: git-submodule.sh:631
+#: git-submodule.sh:641
 #, sh-format
 msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
 msgstr ""
 "Impossibile eseguire il rebase di '$sha1' nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:632
+#: git-submodule.sh:642
 #, sh-format
 msgid "Submodule path '$displaypath': rebased into '$sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': eseguito rebase su '$sha1'"
 
-#: git-submodule.sh:637
+#: git-submodule.sh:647
 #, sh-format
 msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
 msgstr ""
 "Impossibile eseguire il merge di '$sha1' nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:638
+#: git-submodule.sh:648
 #, sh-format
 msgid "Submodule path '$displaypath': merged in '$sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': eseguito merge in '$sha1'"
 
-#: git-submodule.sh:643
+#: git-submodule.sh:653
 #, sh-format
 msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
 msgstr ""
 "Esecuzione di '$command $sha1' non riuscita nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:644
+#: git-submodule.sh:654
 #, sh-format
 msgid "Submodule path '$displaypath': '$command $sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': '$command $sha1'"
 
-#: git-submodule.sh:675
+#: git-submodule.sh:685
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr "Ricorsione nel percorso del sottomodulo '$displaypath' non riuscita"
 
-#: git-submodule.sh:886
+#: git-submodule.sh:896
 msgid "The --cached option cannot be used with the --files option"
 msgstr "L'opzione --cached non può essere usata con l'opzione --files"
 
-#: git-submodule.sh:938
+#: git-submodule.sh:948
 #, sh-format
 msgid "unexpected mode $mod_dst"
 msgstr "modalità $mod_dst inattesa"
 
-#: git-submodule.sh:958
+#: git-submodule.sh:968
 #, sh-format
 msgid "  Warn: $display_name doesn't contain commit $sha1_src"
 msgstr "  Attenzione: $display_name non contiene il commit $sha1_src"
 
-#: git-submodule.sh:961
+#: git-submodule.sh:971
 #, sh-format
 msgid "  Warn: $display_name doesn't contain commit $sha1_dst"
 msgstr "  Attenzione: $display_name non contiene il commit $sha1_dst"
 
-#: git-submodule.sh:964
+#: git-submodule.sh:974
 #, sh-format
 msgid "  Warn: $display_name doesn't contain commits $sha1_src and $sha1_dst"
 msgstr ""
@@ -23824,6 +24236,10 @@ msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
 msgstr[0] "Rebase di $shortrevisions su $shortonto ($todocount comando)"
 msgstr[1] "Rebase di $shortrevisions su $shortonto ($todocount comandi)"
 
+#: git-rebase--preserve-merges.sh:955
+msgid "Note that empty commits are commented out"
+msgstr "Nota che i commit vuoti sono commentati"
+
 #: git-rebase--preserve-merges.sh:997 git-rebase--preserve-merges.sh:1002
 msgid "Could not init rewritten commits"
 msgstr "Impossibile inizializzare i commit riscritti"
@@ -24123,131 +24539,10 @@ msgstr ""
 msgid "The selected hunks do not apply to the index!\n"
 msgstr "Gli hunk selezionati non si applicano senza problemi all'indice!\n"
 
-#: git-add--interactive.perl:1343
-msgid "Apply them to the worktree anyway? "
-msgstr "Vuoi comunque applicarli all'albero di lavoro? "
-
-#: git-add--interactive.perl:1346
-msgid "Nothing was applied.\n"
-msgstr "Non è stato applicato nulla.\n"
-
 #: git-add--interactive.perl:1357
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "ignoro ciò che non è stato sottoposto a merge: %s\n"
-
-#: git-add--interactive.perl:1428
-#, perl-format
-msgid "Stage mode change [y,n,q,a,d%s,?]? "
-msgstr "Modifica modo stage [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1429
-#, perl-format
-msgid "Stage deletion [y,n,q,a,d%s,?]? "
-msgstr "Eliminazione stage [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1430
-#, perl-format
-msgid "Stage this hunk [y,n,q,a,d%s,?]? "
-msgstr "Eseguire lo stage di quest'hunk [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1433
-#, perl-format
-msgid "Stash mode change [y,n,q,a,d%s,?]? "
-msgstr "Modifica modo stash [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1434
-#, perl-format
-msgid "Stash deletion [y,n,q,a,d%s,?]? "
-msgstr "Eliminazione stash [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1435
-#, perl-format
-msgid "Stash this hunk [y,n,q,a,d%s,?]? "
-msgstr "Eseguire lo stash di quest'hunk [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1438
-#, perl-format
-msgid "Unstage mode change [y,n,q,a,d%s,?]? "
-msgstr "Rimozione modifica modo dall'area di staging [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1439
-#, perl-format
-msgid "Unstage deletion [y,n,q,a,d%s,?]? "
-msgstr "Rimozione eliminazione dall'area di staging [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1440
-#, perl-format
-msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
-msgstr "Rimuovere quest'hunk dall'area di staging [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1443
-#, perl-format
-msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
-msgstr "Applicare la modifica modo all'indice [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1444
-#, perl-format
-msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
-msgstr "Applicare l'eliminazione all'indice [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1445
-#, perl-format
-msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
-msgstr "Applicare quest'hunk all'indice [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1448 git-add--interactive.perl:1463
-#, perl-format
-msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
-msgstr "Scartare le modifiche modo dall'albero di lavoro [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1449 git-add--interactive.perl:1464
-#, perl-format
-msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
-msgstr "Scartare l'eliminazione dall'albero di lavoro [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1450 git-add--interactive.perl:1465
-#, perl-format
-msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
-msgstr "Scartare quest'hunk dall'albero di lavoro [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1453
-#, perl-format
-msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
-"Scartare la modifica modo dall'indice e dall'albero di lavoro [y,n,q,a,d"
-"%s,?]? "
-
-#: git-add--interactive.perl:1454
-#, perl-format
-msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
-"Scartare l'eliminazione dall'indice e dall'albero di lavoro [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1455
-#, perl-format
-msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
-"Scartare quest'hunk dall'indice e dall'albero di lavoro [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1458
-#, perl-format
-msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
-"Applicare la modifica modo all'indice e all'albero di lavoro [y,n,q,a,d"
-"%s,?]? "
-
-#: git-add--interactive.perl:1459
-#, perl-format
-msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
-"Applicare l'eliminazione all'indice e all'albero di lavoro [y,n,q,a,d%s,?]? "
-
-#: git-add--interactive.perl:1460
-#, perl-format
-msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
-"Applicare quest'hunk all'indice e all'albero di lavoro [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1468
 #, perl-format
@@ -24729,6 +25024,118 @@ msgstr "Salto %s con il suffisso di backup '%s'.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Inviare %s? [y|N]: "
+
+#, c-format
+#~ msgid "Stage mode change [y,n,a,q,d%s,?]? "
+#~ msgstr "Modifica modo stage [y,n,a,q,d%s,?]? "
+
+#, c-format
+#~ msgid "Stage deletion [y,n,a,q,d%s,?]? "
+#~ msgstr "Eliminazione stage [y,n,a,q,d%s,?]? "
+
+#, c-format
+#~ msgid "Stage this hunk [y,n,a,q,d%s,?]? "
+#~ msgstr "Eseguire lo stage di quest'hunk [y,n,a,q,d%s,?]? "
+
+#~ msgid ""
+#~ "If the patch applies cleanly, the edited hunk will immediately be\n"
+#~ "marked for staging.\n"
+#~ msgstr ""
+#~ "Se la patch viene applicata senza problemi, l'hunk modificato sarà\n"
+#~ "contrassegnato immediatamente per l'aggiunta all'area di staging.\n"
+
+#~ msgid ""
+#~ "y - stage this hunk\n"
+#~ "n - do not stage this hunk\n"
+#~ "q - quit; do not stage this hunk or any of the remaining ones\n"
+#~ "a - stage this and all the remaining hunks\n"
+#~ "d - do not stage this hunk nor any of the remaining hunks\n"
+#~ msgstr ""
+#~ "y - aggiungi quest'hunk all'area di staging\n"
+#~ "n - non aggiungere quest'hunk all'area di staging\n"
+#~ "q - esci; non aggiungere né quest'hunk né quelli rimanenti all'area di "
+#~ "staging\n"
+#~ "a - aggiungi quest'hunk e tutti quelli successivi nel file all'area di "
+#~ "staging\n"
+#~ "d - non aggiungere né quest'hunk né quelli successivi nel file all'area "
+#~ "di staging\n"
+
+#, c-format
+#~ msgid "could not copy '%s' to '%s'."
+#~ msgstr "impossibile copiare '%s' in '%s'."
+
+#~ msgid "malformed ident line"
+#~ msgstr "riga ident malformata"
+
+#~ msgid "corrupted author without date information"
+#~ msgstr "informazioni sull'autore corrotte (senza data)"
+
+#, c-format
+#~ msgid "could not parse '%.*s'"
+#~ msgstr "impossibile analizzare '%.*s'"
+
+#, c-format
+#~ msgid "could not checkout %s"
+#~ msgstr "impossibile eseguire il checkout di %s"
+
+#, c-format
+#~ msgid "filename in tree entry contains backslash: '%s'"
+#~ msgstr "il nome file nella voce albero contiene una barra rovesciata: '%s'"
+
+#, c-format
+#~ msgid "Use -f if you really want to add them.\n"
+#~ msgstr "Usa -f se vuoi davvero aggiungerli.\n"
+
+#, c-format
+#~ msgid "Maybe you wanted to say 'git add .'?\n"
+#~ msgstr "Forse intendevi dire 'git add .'?\n"
+
+#, c-format
+#~ msgid "packfile is invalid: %s"
+#~ msgstr "packfile non valido: %s"
+
+#, c-format
+#~ msgid "unable to open packfile for reuse: %s"
+#~ msgstr "impossibile aprire il packfile per il suo riuso: %s"
+
+#~ msgid "unable to seek in reused packfile"
+#~ msgstr "impossibile eseguire seek nel packfile riusato"
+
+#~ msgid "unable to read from reused packfile"
+#~ msgstr "impossibile leggere dal packfile riusato"
+
+#~ msgid "no HEAD?"
+#~ msgstr "nessun'HEAD?"
+
+#~ msgid "make committer date match author date"
+#~ msgstr ""
+#~ "fai corrispondere la data della persona che ha eseguito il commit alla "
+#~ "data autore"
+
+#~ msgid "ignore author date and use current date"
+#~ msgstr "ignora la data autore e usa la data corrente"
+
+#~ msgid "synonym of --reset-author-date"
+#~ msgstr "sinonimo di --reset-author-date"
+
+#~ msgid "ignore changes in whitespace"
+#~ msgstr "ignora modifiche agli spazi bianchi"
+
+#~ msgid "preserve empty commits during rebase"
+#~ msgstr "mantieni i commit vuoti durante il rebase"
+
+#~ msgid "cannot combine --use-bitmap-index with object filtering"
+#~ msgstr "impossibile combinare --use-bitmap-index con il filtraggio oggetti"
+
+#, sh-format
+#~ msgid ""
+#~ "The following path is ignored by one of your .gitignore files:\n"
+#~ "$sm_path\n"
+#~ "Use -f if you really want to add it."
+#~ msgstr ""
+#~ "Il seguente percorso è ignorato da uno dei tuoi file .gitignore:\n"
+#~ "$sm_path\n"
+#~ "Usa -f se vuoi davvero aggiungerlo."
 
 #, c-format
 #~ msgid "unable to get tree for %s"


### PR DESCRIPTION
This PR updates the Italian translation for Git 2.26.0, round 1.