### PR TITLE
l10n: it.po: update the Italian translation for Git 2.26.0 round 2

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2020-03-06 14:25+0800\n"
-"PO-Revision-Date: 2020-03-07 09:36+0100\n"
+"POT-Creation-Date: 2020-03-11 15:26+0800\n"
+"PO-Revision-Date: 2020-03-12 07:52+0100\n"
 "Last-Translator: Alessandro Menti <alessandro.menti@alessandromenti.it>\n"
 "Language-Team: Italian <>\n"
 "Language: it\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Lokalize 19.12.2\n"
+"X-Generator: Lokalize 19.12.3\n"
 
 #: add-interactive.c:368
 #, c-format
@@ -221,8 +221,8 @@ msgstr "nell'area di staging"
 msgid "unstaged"
 msgstr "rimosso dall'area di staging"
 
-#: add-interactive.c:1136 apply.c:4967 apply.c:4970 builtin/am.c:2197
-#: builtin/am.c:2200 builtin/clone.c:123 builtin/fetch.c:144
+#: add-interactive.c:1136 apply.c:4967 apply.c:4970 builtin/am.c:2251
+#: builtin/am.c:2254 builtin/clone.c:123 builtin/fetch.c:144
 #: builtin/merge.c:274 builtin/pull.c:189 builtin/submodule--helper.c:409
 #: builtin/submodule--helper.c:1394 builtin/submodule--helper.c:1397
 #: builtin/submodule--helper.c:1902 builtin/submodule--helper.c:1905
@@ -259,8 +259,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "staging."
 msgstr ""
-"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
-" contrassegnato immediatamente per l'aggiunta all'area di staging."
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà "
+"contrassegnato immediatamente per l'aggiunta all'area di staging."
 
 #: add-patch.c:40
 msgid ""
@@ -299,8 +299,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
 msgstr ""
-"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
-" contrassegnato immediatamente per lo stash."
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà "
+"contrassegnato immediatamente per lo stash."
 
 #: add-patch.c:61
 msgid ""
@@ -336,8 +336,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
 msgstr ""
-"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
-" contrassegnato immediatamente per la rimozione dall'area di staging."
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà "
+"contrassegnato immediatamente per la rimozione dall'area di staging."
 
 #: add-patch.c:84
 msgid ""
@@ -376,8 +376,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "applying."
 msgstr ""
-"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
-" contrassegnato immediatamente per l'applicazione."
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà "
+"contrassegnato immediatamente per l'applicazione."
 
 #: add-patch.c:106
 msgid ""
@@ -416,8 +416,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "discarding."
 msgstr ""
-"Se la patch viene applicata senza problemi, l'hunk modificato sarà"
-" contrassegnato immediatamente per la rimozione."
+"Se la patch viene applicata senza problemi, l'hunk modificato sarà "
+"contrassegnato immediatamente per la rimozione."
 
 #: add-patch.c:128 add-patch.c:193
 msgid ""
@@ -1343,7 +1343,7 @@ msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d riga applicata dopo la correzione di errori di spazi bianchi."
 msgstr[1] "%d righe applicate dopo la correzione di errori di spazi bianchi."
 
-#: apply.c:4940 builtin/add.c:612 builtin/mv.c:301 builtin/rm.c:390
+#: apply.c:4940 builtin/add.c:612 builtin/mv.c:301 builtin/rm.c:406
 msgid "Unable to write new index file"
 msgstr "Impossibile scrivere il nuovo file index"
 
@@ -1355,7 +1355,7 @@ msgstr "non applicare le modifiche corrispondenti al percorso specificato"
 msgid "apply changes matching the given path"
 msgstr "applica le modifiche corrispondenti al percorso specificato"
 
-#: apply.c:4973 builtin/am.c:2206
+#: apply.c:4973 builtin/am.c:2260
 msgid "num"
 msgstr "num"
 
@@ -1422,7 +1422,7 @@ msgstr "i percorsi sono separati con un carattere NUL"
 msgid "ensure at least <n> lines of context match"
 msgstr "assicura che almeno <n> righe di contesto corrispondano"
 
-#: apply.c:5008 builtin/am.c:2185 builtin/interpret-trailers.c:98
+#: apply.c:5008 builtin/am.c:2239 builtin/interpret-trailers.c:98
 #: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
 #: builtin/pack-objects.c:3457 builtin/rebase.c:1508
 msgid "action"
@@ -1469,7 +1469,7 @@ msgid "do not trust the line counts in the hunk headers"
 msgstr ""
 "non fare affidamento sul numero di righe nelle intestazioni dei frammenti"
 
-#: apply.c:5032 builtin/am.c:2194
+#: apply.c:5032 builtin/am.c:2248
 msgid "root"
 msgstr "radice"
 
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <repository> [--exec <comando>] --list"
 
-#: archive.c:372 builtin/add.c:181 builtin/add.c:588 builtin/rm.c:299
+#: archive.c:372 builtin/add.c:181 builtin/add.c:588 builtin/rm.c:315
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "lo specificatore percorso '%s' non corrisponde ad alcun file"
@@ -2073,8 +2073,8 @@ msgstr "comando index-pack morto"
 msgid "invalid color value: %.*s"
 msgstr "valore colore non valido: %.*s"
 
-#: commit.c:51 sequencer.c:2719 builtin/am.c:354 builtin/am.c:398
-#: builtin/am.c:1366 builtin/am.c:2009 builtin/replace.c:457
+#: commit.c:51 sequencer.c:2719 builtin/am.c:359 builtin/am.c:403
+#: builtin/am.c:1371 builtin/am.c:2014 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "impossibile analizzare %s"
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "could not find commit %s"
 msgstr "impossibile trovare il commit %s"
 
-#: commit-graph.c:852 builtin/am.c:1287
+#: commit-graph.c:852 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "impossibile analizzare il commit %s"
@@ -3223,7 +3223,7 @@ msgid "invalid --stat value: %s"
 msgstr "valore non valido per --stat: %s"
 
 #: diff.c:4681 diff.c:4686 diff.c:4691 diff.c:4696 diff.c:5209
-#: parse-options.c:199 parse-options.c:203
+#: parse-options.c:197 parse-options.c:201
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s richiede un valore numerico"
@@ -4420,9 +4420,9 @@ msgstr "Impossibile creare '%s.lock': %s"
 msgid "failed to read the cache"
 msgstr "lettura della cache non riuscita"
 
-#: merge.c:107 rerere.c:720 builtin/am.c:1874 builtin/am.c:1908
+#: merge.c:107 rerere.c:720 builtin/am.c:1879 builtin/am.c:1913
 #: builtin/checkout.c:541 builtin/checkout.c:800 builtin/clone.c:810
-#: builtin/stash.c:264
+#: builtin/stash.c:265
 msgid "unable to write new index file"
 msgstr "impossibile scrivere il nuovo file index"
 
@@ -4614,35 +4614,35 @@ msgstr "ridenominazione"
 msgid "renamed"
 msgstr "rinominato"
 
-#: merge-recursive.c:1606 merge-recursive.c:2530 merge-recursive.c:3175
+#: merge-recursive.c:1577 merge-recursive.c:2472 merge-recursive.c:3117
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Mi rifiuto di perdere un file sporco in %s"
 
-#: merge-recursive.c:1616
+#: merge-recursive.c:1587
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 "Mi rifiuto di perdere un file non tracciato in %s, benché sia d'ostacolo."
 
-#: merge-recursive.c:1674
+#: merge-recursive.c:1645
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 "CONFLITTO (ridenominazione/aggiunta): elemento ridenominato %s->%s in %s. %s "
 "aggiunto in %s"
 
-#: merge-recursive.c:1705
+#: merge-recursive.c:1676
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "%s è una directory in %s; la aggiungo come %s"
 
-#: merge-recursive.c:1710
+#: merge-recursive.c:1681
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr "Mi rifiuto di perdere un file non tracciato in %s; lo aggiungo come %s"
 
-#: merge-recursive.c:1737
+#: merge-recursive.c:1708
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -4651,18 +4651,18 @@ msgstr ""
 "CONFLITTO (ridenominazione/ridenominazione): file ridenominato \"%s\"->\"%s"
 "\" nel branch \"%s\", ridenominato \"%s\"->\"%s\" in \"%s\"%s"
 
-#: merge-recursive.c:1742
+#: merge-recursive.c:1713
 msgid " (left unresolved)"
 msgstr " (lasciato irrisolto)"
 
-#: merge-recursive.c:1851
+#: merge-recursive.c:1793
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "CONFLITTO (ridenominazione/ridenominazione): file ridenominato %s->%s in %s. "
 "Ridenominato %s->%s in %s"
 
-#: merge-recursive.c:2114
+#: merge-recursive.c:2056
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -4673,7 +4673,7 @@ msgstr ""
 "perché la directory %s è stata ridenominata in più directory diverse e "
 "nessuna directory di destinazione contiene la maggior parte dei file."
 
-#: merge-recursive.c:2146
+#: merge-recursive.c:2088
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4683,7 +4683,7 @@ msgstr ""
 "%s è d'ostacolo alle seguenti ridenominazioni directory che spostano in tale "
 "posizione i seguenti percorsi: %s."
 
-#: merge-recursive.c:2156
+#: merge-recursive.c:2098
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4693,7 +4693,7 @@ msgstr ""
 "un percorso in %s; delle ridenominazioni directory implicite hanno tentato "
 "di spostare in tale posizione i seguenti percorsi: %s"
 
-#: merge-recursive.c:2248
+#: merge-recursive.c:2190
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
@@ -4702,7 +4702,7 @@ msgstr ""
 "CONFLITTO (ridenominazione/ridenominazione): directory ridenominata %s->%s "
 "in %s. Directory ridenominata %s->%s in %s"
 
-#: merge-recursive.c:2493
+#: merge-recursive.c:2435
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4711,52 +4711,52 @@ msgstr ""
 "ATTENZIONE: evito di applicare la ridenominazione %s -> %s a %s perché %s "
 "stesso è stato ridenominato."
 
-#: merge-recursive.c:3019
+#: merge-recursive.c:2961
 #, c-format
 msgid "cannot read object %s"
 msgstr "impossibile leggere l'oggetto %s"
 
-#: merge-recursive.c:3022
+#: merge-recursive.c:2964
 #, c-format
 msgid "object %s is not a blob"
 msgstr "l'oggetto %s non è un blob"
 
-#: merge-recursive.c:3086
+#: merge-recursive.c:3028
 msgid "modify"
 msgstr "modifica"
 
-#: merge-recursive.c:3086
+#: merge-recursive.c:3028
 msgid "modified"
 msgstr "modificato"
 
-#: merge-recursive.c:3098
+#: merge-recursive.c:3040
 msgid "content"
 msgstr "contenuto"
 
-#: merge-recursive.c:3102
+#: merge-recursive.c:3044
 msgid "add/add"
 msgstr "aggiunta/aggiunta"
 
-#: merge-recursive.c:3125
+#: merge-recursive.c:3067
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "Omesso %s (elemento sottoposto a merge uguale a quello esistente)"
 
-#: merge-recursive.c:3147 git-submodule.sh:1003
+#: merge-recursive.c:3089 git-submodule.sh:1003
 msgid "submodule"
 msgstr "sottomodulo"
 
-#: merge-recursive.c:3148
+#: merge-recursive.c:3090
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "CONFLITTO (%s): conflitto di merge in %s"
 
-#: merge-recursive.c:3178
+#: merge-recursive.c:3120
 #, c-format
 msgid "Adding as %s instead"
 msgstr "Lo aggiungo come %s"
 
-#: merge-recursive.c:3261
+#: merge-recursive.c:3203
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4765,7 +4765,7 @@ msgstr ""
 "Percorso aggiornato: %s aggiunto in %s in una directory ridenominata in %s; "
 "lo sposto in %s."
 
-#: merge-recursive.c:3264
+#: merge-recursive.c:3206
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4774,7 +4774,7 @@ msgstr ""
 "CONFLITTO (posizione file): %s aggiunto in %s in una directory ridenominata "
 "in %s, il che suggerisce che forse dovrebbe essere spostato in %s."
 
-#: merge-recursive.c:3268
+#: merge-recursive.c:3210
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4783,7 +4783,7 @@ msgstr ""
 "Percorso aggiornato: %s ridenominato in %s in %s in una directory "
 "ridenominata in %s; lo sposto in %s."
 
-#: merge-recursive.c:3271
+#: merge-recursive.c:3213
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4793,61 +4793,61 @@ msgstr ""
 "ridenominata in %s, il che suggerisce che forse dovrebbe essere spostato in "
 "%s."
 
-#: merge-recursive.c:3385
+#: merge-recursive.c:3327
 #, c-format
 msgid "Removing %s"
 msgstr "Rimozione di %s"
 
-#: merge-recursive.c:3408
+#: merge-recursive.c:3350
 msgid "file/directory"
 msgstr "file/directory"
 
-#: merge-recursive.c:3413
+#: merge-recursive.c:3355
 msgid "directory/file"
 msgstr "directory/file"
 
-#: merge-recursive.c:3420
+#: merge-recursive.c:3362
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 "CONFLITTO (%s): una directory denominata %s esiste già in %s. Aggiungo %s "
 "come %s"
 
-#: merge-recursive.c:3429
+#: merge-recursive.c:3371
 #, c-format
 msgid "Adding %s"
 msgstr "Aggiunta %s"
 
-#: merge-recursive.c:3438
+#: merge-recursive.c:3380
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr "CONFLITTO (aggiungi/aggiungi): conflitto di merge in %s"
 
-#: merge-recursive.c:3482
+#: merge-recursive.c:3424
 msgid "Already up to date!"
 msgstr "Già aggiornato!"
 
-#: merge-recursive.c:3491
+#: merge-recursive.c:3433
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "merge degli alberi %s e %s non riuscito"
 
-#: merge-recursive.c:3595
+#: merge-recursive.c:3537
 msgid "Merging:"
 msgstr "Merge in corso:"
 
-#: merge-recursive.c:3608
+#: merge-recursive.c:3550
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "trovato %u antenato comune:"
 msgstr[1] "trovati %u antenati comuni:"
 
-#: merge-recursive.c:3658
+#: merge-recursive.c:3600
 msgid "merge returned no commit"
 msgstr "il merge non ha restituito alcun commit"
 
-#: merge-recursive.c:3717
+#: merge-recursive.c:3659
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -4856,12 +4856,12 @@ msgstr ""
 "Le tue modifiche locali ai seguenti file sarebbero sovrascritte dal merge:\n"
 "  %s"
 
-#: merge-recursive.c:3814
+#: merge-recursive.c:3756
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Impossibile analizzare l'oggetto '%s'"
 
-#: merge-recursive.c:3832 builtin/merge.c:697 builtin/merge.c:877
+#: merge-recursive.c:3774 builtin/merge.c:697 builtin/merge.c:877
 msgid "Unable to write index."
 msgstr "Impossibile scrivere l'indice."
 
@@ -5138,7 +5138,7 @@ msgstr "%s non è compatibile con %s"
 msgid "%s : incompatible with something else"
 msgstr "%s non è compatibile con qualcos'altro"
 
-#: parse-options.c:92 parse-options.c:96 parse-options.c:319
+#: parse-options.c:92 parse-options.c:96 parse-options.c:317
 #, c-format
 msgid "%s takes no value"
 msgstr "%s non richiede un valore"
@@ -5148,42 +5148,42 @@ msgstr "%s non richiede un valore"
 msgid "%s isn't available"
 msgstr "%s non è disponibile"
 
-#: parse-options.c:219
+#: parse-options.c:217
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr ""
 "%s richiede un valore intero non negativo con un suffisso k/m/g facoltativo"
 
-#: parse-options.c:388
+#: parse-options.c:386
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "opzione ambigua: %s (potrebbe essere --%s%s o --%s%s)"
 
-#: parse-options.c:422 parse-options.c:430
+#: parse-options.c:420 parse-options.c:428
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "forse intendevi `--%s` (con due trattini)?"
 
-#: parse-options.c:859
+#: parse-options.c:857
 #, c-format
 msgid "unknown option `%s'"
 msgstr "opzione sconosciuta `%s'"
 
-#: parse-options.c:861
+#: parse-options.c:859
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "opzione `%c` sconosciuta"
 
-#: parse-options.c:863
+#: parse-options.c:861
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "opzione non ASCII sconosciuta presente nella stringa: `%s'"
 
-#: parse-options.c:887
+#: parse-options.c:885
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:906
+#: parse-options.c:904
 #, c-format
 msgid "usage: %s"
 msgstr "uso: %s"
@@ -5191,21 +5191,21 @@ msgstr "uso: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:912
+#: parse-options.c:910
 #, c-format
 msgid "   or: %s"
 msgstr "  oppure: %s"
 
-#: parse-options.c:915
+#: parse-options.c:913
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:954
+#: parse-options.c:952
 msgid "-NUM"
 msgstr "-NUM"
 
-#: parse-options.c:968
+#: parse-options.c:966
 #, c-format
 msgid "alias of --%s"
 msgstr "alias di --%s"
@@ -5535,7 +5535,7 @@ msgstr "voci stage non ordinate per '%s'"
 #: submodule.c:1619 builtin/add.c:532 builtin/check-ignore.c:181
 #: builtin/checkout.c:470 builtin/checkout.c:656 builtin/clean.c:967
 #: builtin/commit.c:367 builtin/diff-tree.c:120 builtin/grep.c:485
-#: builtin/mv.c:145 builtin/reset.c:246 builtin/rm.c:271
+#: builtin/mv.c:145 builtin/reset.c:246 builtin/rm.c:290
 #: builtin/submodule--helper.c:332
 msgid "index file corrupt"
 msgstr "file indice corrotto"
@@ -5820,7 +5820,7 @@ msgstr "ID oggetto inatteso durante la scrittura di '%s'"
 msgid "could not write to '%s'"
 msgstr "impossibile scrivere su '%s'"
 
-#: refs.c:860 strbuf.c:1155 wrapper.c:188 wrapper.c:358 builtin/am.c:714
+#: refs.c:860 strbuf.c:1155 wrapper.c:188 wrapper.c:358 builtin/am.c:719
 #: builtin/rebase.c:1029
 #, c-format
 msgid "could not open '%s' for writing"
@@ -6621,7 +6621,7 @@ msgstr "modalità pulizia messaggio commit non valida: '%s'"
 msgid "could not delete '%s'"
 msgstr "impossibile eliminare '%s'"
 
-#: sequencer.c:315 builtin/rebase.c:785 builtin/rebase.c:1750 builtin/rm.c:369
+#: sequencer.c:315 builtin/rebase.c:785 builtin/rebase.c:1750 builtin/rm.c:385
 #, c-format
 msgid "could not remove '%s'"
 msgstr "impossibile rimuovere '%s'"
@@ -6678,7 +6678,7 @@ msgid "failed to finalize '%s'"
 msgstr "finalizzazione di '%s' non riuscita"
 
 #: sequencer.c:440 sequencer.c:1613 sequencer.c:2726 sequencer.c:3167
-#: sequencer.c:3276 builtin/am.c:244 builtin/commit.c:787 builtin/merge.c:1120
+#: sequencer.c:3276 builtin/am.c:249 builtin/commit.c:787 builtin/merge.c:1120
 #: builtin/rebase.c:593
 #, c-format
 msgid "could not read '%s'"
@@ -6729,8 +6729,8 @@ msgstr "nessuna chiave presente in '%.*s'"
 msgid "unable to dequote value of '%s'"
 msgstr "impossibile rimuovere gli apici dal valore di '%s'"
 
-#: sequencer.c:794 wrapper.c:190 wrapper.c:360 builtin/am.c:705
-#: builtin/am.c:797 builtin/merge.c:1117 builtin/rebase.c:1072
+#: sequencer.c:794 wrapper.c:190 wrapper.c:360 builtin/am.c:710
+#: builtin/am.c:802 builtin/merge.c:1117 builtin/rebase.c:1072
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "impossibile aprire '%s' in lettura"
@@ -6888,7 +6888,7 @@ msgstr "impossibile analizzare il commit HEAD"
 msgid "unable to parse commit author"
 msgstr "impossibile analizzare l'autore del commit"
 
-#: sequencer.c:1353 builtin/am.c:1561 builtin/merge.c:687
+#: sequencer.c:1353 builtin/am.c:1566 builtin/merge.c:687
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree non è riuscito a scrivere un albero"
 
@@ -6897,7 +6897,7 @@ msgstr "git write-tree non è riuscito a scrivere un albero"
 msgid "unable to read commit message from '%s'"
 msgstr "impossibile leggere il messaggio di commit da '%s'"
 
-#: sequencer.c:1413 builtin/am.c:1583 builtin/commit.c:1673 builtin/merge.c:886
+#: sequencer.c:1413 builtin/am.c:1588 builtin/commit.c:1673 builtin/merge.c:886
 #: builtin/merge.c:911
 msgid "failed to write commit object"
 msgstr "scrittura dell'oggetto del commit non riuscita"
@@ -7999,8 +7999,8 @@ msgstr "il percorso '%s' non esiste (né su disco né nell'indice)"
 #: sha1-name.c:1771
 msgid "relative path syntax can't be used outside working tree"
 msgstr ""
-"la sintassi per i percorsi relativi non può essere usata al di fuori"
-" dell'albero di lavoro"
+"la sintassi per i percorsi relativi non può essere usata al di fuori "
+"dell'albero di lavoro"
 
 #: sha1-name.c:1909
 #, c-format
@@ -8105,8 +8105,8 @@ msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
 "same. Skipping it."
 msgstr ""
-"Il sottomodulo nel commit %s e nel percorso '%s' collide con un sottomodulo"
-" con lo stesso nome. Lo salto."
+"Il sottomodulo nel commit %s e nel percorso '%s' collide con un sottomodulo "
+"con lo stesso nome. Lo salto."
 
 #: submodule.c:910
 #, c-format
@@ -8119,8 +8119,8 @@ msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
 "submodule %s"
 msgstr ""
-"Impossibile eseguire il comando 'git rev-list <commit> --not --remotes -n 1'"
-" nel sottomodulo %s"
+"Impossibile eseguire il comando 'git rev-list <commit> --not --remotes -n 1' "
+"nel sottomodulo %s"
 
 #: submodule.c:1118
 #, c-format
@@ -8915,7 +8915,11 @@ msgstr "numero di porta non valido"
 msgid "invalid '..' path segment"
 msgstr "parte percorso '..' non valida"
 
-#: worktree.c:259 builtin/am.c:2084
+#: walker.c:170
+msgid "Fetching objects"
+msgstr "Recupero oggetti in corso"
+
+#: worktree.c:259 builtin/am.c:2099
 #, c-format
 msgid "failed to read '%s'"
 msgstr "lettura di '%s' non riuscita"
@@ -9575,7 +9579,7 @@ msgstr "I seguenti percorsi sono ignorati da uno dei file .gitignore:\n"
 
 #: builtin/add.c:322 builtin/clean.c:910 builtin/fetch.c:163 builtin/mv.c:124
 #: builtin/prune-packed.c:56 builtin/pull.c:203 builtin/push.c:548
-#: builtin/remote.c:1421 builtin/rm.c:241 builtin/send-pack.c:165
+#: builtin/remote.c:1421 builtin/rm.c:242 builtin/send-pack.c:165
 msgid "dry run"
 msgstr "test controllato"
 
@@ -9714,14 +9718,14 @@ msgid "--chmod param '%s' must be either -x or +x"
 msgstr "Il parametro --chmod '%s' deve essere -x o +x"
 
 #: builtin/add.c:501 builtin/checkout.c:1675 builtin/commit.c:354
-#: builtin/reset.c:327
+#: builtin/reset.c:327 builtin/rm.c:272 builtin/stash.c:1509
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr ""
 "--pathspec-from-file non è compatibile con gli argomenti specificatore "
 "percorso"
 
 #: builtin/add.c:508 builtin/checkout.c:1687 builtin/commit.c:360
-#: builtin/reset.c:333
+#: builtin/reset.c:333 builtin/rm.c:278 builtin/stash.c:1515
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul richiede --pathspec-from-file"
 
@@ -9740,111 +9744,111 @@ msgstr ""
 "Per disabilitare questo messaggio, esegui\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:347
+#: builtin/am.c:352
 msgid "could not parse author script"
 msgstr "impossibile analizzare lo script author"
 
-#: builtin/am.c:431
+#: builtin/am.c:436
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' è stato eliminato dall'hook applypatch-msg"
 
-#: builtin/am.c:473
+#: builtin/am.c:478
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Riga di input malformata: '%s'."
 
-#: builtin/am.c:511
+#: builtin/am.c:516
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Copia delle note da '%s' a '%s' non riuscita"
 
-#: builtin/am.c:537
+#: builtin/am.c:542
 msgid "fseek failed"
 msgstr "fseek non riuscita"
 
-#: builtin/am.c:725
+#: builtin/am.c:730
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "impossibile analizzare la patch '%s'"
 
-#: builtin/am.c:790
+#: builtin/am.c:795
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Può essere applicata solo una serie di patch StGIT per volta"
 
-#: builtin/am.c:838
+#: builtin/am.c:843
 msgid "invalid timestamp"
 msgstr "timestamp non valido"
 
-#: builtin/am.c:843 builtin/am.c:855
+#: builtin/am.c:848 builtin/am.c:860
 msgid "invalid Date line"
 msgstr "riga Date non valida"
 
-#: builtin/am.c:850
+#: builtin/am.c:855
 msgid "invalid timezone offset"
 msgstr "offset fuso orario non valido"
 
-#: builtin/am.c:943
+#: builtin/am.c:948
 msgid "Patch format detection failed."
 msgstr "Rilevamento del formato della patch non riuscito."
 
-#: builtin/am.c:948 builtin/clone.c:409
+#: builtin/am.c:953 builtin/clone.c:409
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "creazione della directory '%s' non riuscita"
 
-#: builtin/am.c:953
+#: builtin/am.c:958
 msgid "Failed to split patches."
 msgstr "Divisione delle patch non riuscita."
 
-#: builtin/am.c:1084
+#: builtin/am.c:1089
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "Una volta risolto questo problema, esegui \"%s --continue\"."
 
-#: builtin/am.c:1085
+#: builtin/am.c:1090
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr "Se preferisci saltare questa patch, esegui invece \"%s --skip\"."
 
-#: builtin/am.c:1086
+#: builtin/am.c:1091
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Per ripristinare il branch originario e terminare il patching, esegui \"%s --"
 "abort\"."
 
-#: builtin/am.c:1169
+#: builtin/am.c:1174
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch inviata con format=flowed; gli spazi al termine delle righe potrebbero "
 "essere andati perduti."
 
-#: builtin/am.c:1197
+#: builtin/am.c:1202
 msgid "Patch is empty."
 msgstr "La patch è vuota."
 
-#: builtin/am.c:1262
+#: builtin/am.c:1267
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "riga autore mancante nel commit %s"
 
-#: builtin/am.c:1265
+#: builtin/am.c:1270
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "riga ident non valida: %.*s"
 
-#: builtin/am.c:1484
+#: builtin/am.c:1489
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Dal repository mancano i blob necessari per ripiegare sul merge a tre vie."
 
-#: builtin/am.c:1486
+#: builtin/am.c:1491
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Utilizzo le informazioni dell'indice per ricostruire un albero di base..."
 
-#: builtin/am.c:1505
+#: builtin/am.c:1510
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -9852,24 +9856,24 @@ msgstr ""
 "Hai modificato manualmente la patch?\n"
 "Non può essere applicata ai blob registrati nel suo indice."
 
-#: builtin/am.c:1511
+#: builtin/am.c:1516
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Ripiego sul patching della base e sul merge a tre vie..."
 
-#: builtin/am.c:1537
+#: builtin/am.c:1542
 msgid "Failed to merge in the changes."
 msgstr "Merge delle modifiche non riuscito."
 
-#: builtin/am.c:1569
+#: builtin/am.c:1574
 msgid "applying to an empty history"
 msgstr "applicazione a una cronologia vuota"
 
-#: builtin/am.c:1616 builtin/am.c:1620
+#: builtin/am.c:1621 builtin/am.c:1625
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "impossibile riprendere l'attività: %s non esiste."
 
-#: builtin/am.c:1638
+#: builtin/am.c:1643
 msgid "Commit Body is:"
 msgstr "Il corpo del commit è:"
 
@@ -9877,41 +9881,41 @@ msgstr "Il corpo del commit è:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1648
+#: builtin/am.c:1653
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Applico? Sì [y]/No [n]/Modifica [e]/[V]isualizza patch/[A]ccetta tutto:"
 
-#: builtin/am.c:1695 builtin/commit.c:398
+#: builtin/am.c:1700 builtin/commit.c:398
 msgid "unable to write index file"
 msgstr "impossibile scrivere il file indice"
 
-#: builtin/am.c:1699
+#: builtin/am.c:1704
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Indice sporco: impossibile applicare le patch (elemento sporco: %s)"
 
-#: builtin/am.c:1739 builtin/am.c:1807
+#: builtin/am.c:1744 builtin/am.c:1812
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Applicazione in corso: %.*s"
 
-#: builtin/am.c:1756
+#: builtin/am.c:1761
 msgid "No changes -- Patch already applied."
 msgstr "Nessuna modifica -- patch già applicata."
 
-#: builtin/am.c:1762
+#: builtin/am.c:1767
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Patch non riuscita a %s %.*s"
 
-#: builtin/am.c:1766
-msgid "Use 'git am --show-current-patch' to see the failed patch"
+#: builtin/am.c:1771
+msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
-"Usa 'git am --show-current-patch' per visualizzare la patch non riuscita"
+"Usa 'git am --show-current-patch=diff' per visualizzare la patch non riuscita"
 
-#: builtin/am.c:1810
+#: builtin/am.c:1815
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -9921,7 +9925,7 @@ msgstr ""
 "Se non rimane nulla da aggiungere all'area di staging, forse qualcos'altro\n"
 "ha già introdotto le stesse modifiche; potresti voler saltare questa patch."
 
-#: builtin/am.c:1817
+#: builtin/am.c:1822
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -9934,17 +9938,17 @@ msgstr ""
 "Potresti eseguire `git rm` su un file per accettarne la risoluzione "
 "\"eliminato da loro\"."
 
-#: builtin/am.c:1924 builtin/am.c:1928 builtin/am.c:1940 builtin/reset.c:346
+#: builtin/am.c:1929 builtin/am.c:1933 builtin/am.c:1945 builtin/reset.c:346
 #: builtin/reset.c:354
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Impossibile analizzare l'oggetto '%s'."
 
-#: builtin/am.c:1976
+#: builtin/am.c:1981
 msgid "failed to clean index"
 msgstr "pulizia dell'indice non riuscita"
 
-#: builtin/am.c:2020
+#: builtin/am.c:2025
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -9953,77 +9957,87 @@ msgstr ""
 "'am'.\n"
 "Non ritorno indietro a ORIG_HEAD"
 
-#: builtin/am.c:2117
+#: builtin/am.c:2132
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Valore non valido per --patch-format: %s"
 
-#: builtin/am.c:2153
+#: builtin/am.c:2172
+#, c-format
+msgid "Invalid value for --show-current-patch: %s"
+msgstr "Valore non valido per --show-current-patch: %s"
+
+#: builtin/am.c:2176
+#, c-format
+msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
+msgstr "--show-current-patch=%s non è compatibile con --show-current-patch=%s"
+
+#: builtin/am.c:2207
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<opzioni>] [(<mbox> | <Maildir>)...]"
 
-#: builtin/am.c:2154
+#: builtin/am.c:2208
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<opzioni>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2160
+#: builtin/am.c:2214
 msgid "run interactively"
 msgstr "esegui in modalità interattiva"
 
-#: builtin/am.c:2162
+#: builtin/am.c:2216
 msgid "historical option -- no-op"
 msgstr "opzione storica -- non esegue nulla"
 
-#: builtin/am.c:2164
+#: builtin/am.c:2218
 msgid "allow fall back on 3way merging if needed"
 msgstr "consenti il ripiego sul merge a tre vie se necessario"
 
-#: builtin/am.c:2165 builtin/init-db.c:494 builtin/prune-packed.c:58
-#: builtin/repack.c:304 builtin/stash.c:811
+#: builtin/am.c:2219 builtin/init-db.c:494 builtin/prune-packed.c:58
+#: builtin/repack.c:304 builtin/stash.c:812
 msgid "be quiet"
 msgstr "non visualizzare messaggi"
 
-#: builtin/am.c:2167
+#: builtin/am.c:2221
 msgid "add a Signed-off-by line to the commit message"
 msgstr "aggiungi una riga Signed-off-by al messaggio di commit"
 
-#: builtin/am.c:2170
+#: builtin/am.c:2224
 msgid "recode into utf8 (default)"
 msgstr "converti codifica in UTF-8 (impostazione predefinita)"
 
-#: builtin/am.c:2172
+#: builtin/am.c:2226
 msgid "pass -k flag to git-mailinfo"
 msgstr "fornisci l'argomento -k a git-mailinfo"
 
-#: builtin/am.c:2174
+#: builtin/am.c:2228
 msgid "pass -b flag to git-mailinfo"
 msgstr "fornisci l'argomento -b a git-mailinfo"
 
-#: builtin/am.c:2176
+#: builtin/am.c:2230
 msgid "pass -m flag to git-mailinfo"
 msgstr "fornisci l'argomento -m a git-mailinfo"
 
-#: builtin/am.c:2178
+#: builtin/am.c:2232
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "fornisci a git-mailsplit l'argomento --keep-cr per il formato mbox"
 
-#: builtin/am.c:2181
+#: builtin/am.c:2235
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "non fornire l'argomento --keep-cr a git-mailsplit indipendentemente dal "
 "valore di am.keepcr"
 
-#: builtin/am.c:2184
+#: builtin/am.c:2238
 msgid "strip everything before a scissors line"
 msgstr "rimuovi tutte le righe prima di una riga \"taglia qui\""
 
-#: builtin/am.c:2186 builtin/am.c:2189 builtin/am.c:2192 builtin/am.c:2195
-#: builtin/am.c:2198 builtin/am.c:2201 builtin/am.c:2204 builtin/am.c:2207
-#: builtin/am.c:2213
+#: builtin/am.c:2240 builtin/am.c:2243 builtin/am.c:2246 builtin/am.c:2249
+#: builtin/am.c:2252 builtin/am.c:2255 builtin/am.c:2258 builtin/am.c:2261
+#: builtin/am.c:2267
 msgid "pass it through git-apply"
 msgstr "passa l'argomento a git-apply"
 
-#: builtin/am.c:2203 builtin/commit.c:1391 builtin/fmt-merge-msg.c:670
+#: builtin/am.c:2257 builtin/commit.c:1391 builtin/fmt-merge-msg.c:670
 #: builtin/fmt-merge-msg.c:673 builtin/grep.c:871 builtin/merge.c:250
 #: builtin/pull.c:140 builtin/pull.c:199 builtin/rebase.c:1505
 #: builtin/repack.c:315 builtin/repack.c:319 builtin/repack.c:321
@@ -10032,69 +10046,69 @@ msgstr "passa l'argomento a git-apply"
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2209 builtin/branch.c:661 builtin/for-each-ref.c:38
+#: builtin/am.c:2263 builtin/branch.c:661 builtin/for-each-ref.c:38
 #: builtin/replace.c:556 builtin/tag.c:437 builtin/verify-tag.c:38
 msgid "format"
 msgstr "formato"
 
-#: builtin/am.c:2210
+#: builtin/am.c:2264
 msgid "format the patch(es) are in"
 msgstr "il formato delle patch"
 
-#: builtin/am.c:2216
+#: builtin/am.c:2270
 msgid "override error message when patch failure occurs"
 msgstr ""
 "esegui l'override del messaggio d'errore quando si verifica un errore legato "
 "alle patch"
 
-#: builtin/am.c:2218
+#: builtin/am.c:2272
 msgid "continue applying patches after resolving a conflict"
 msgstr ""
 "continua l'applicazione delle patch dopo la risoluzione di un conflitto"
 
-#: builtin/am.c:2221
+#: builtin/am.c:2275
 msgid "synonyms for --continue"
 msgstr "sinonimi di --continue"
 
-#: builtin/am.c:2224
+#: builtin/am.c:2278
 msgid "skip the current patch"
 msgstr "salta la patch corrente"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2281
 msgid "restore the original branch and abort the patching operation."
 msgstr "ripristina il branch originario e interrompi l'operazione di patching."
 
-#: builtin/am.c:2230
+#: builtin/am.c:2284
 msgid "abort the patching operation but keep HEAD where it is."
 msgstr "interrompi l'operazione di patching ma mantieni HEAD dov'è."
 
-#: builtin/am.c:2233
-msgid "show the patch being applied."
-msgstr "visualizza la patch in fase di applicazione."
+#: builtin/am.c:2288
+msgid "show the patch being applied"
+msgstr "visualizza la patch in fase di applicazione"
 
-#: builtin/am.c:2237
+#: builtin/am.c:2293
 msgid "lie about committer date"
 msgstr "menti sulla data del commit"
 
-#: builtin/am.c:2239
+#: builtin/am.c:2295
 msgid "use current timestamp for author date"
 msgstr "usa il timestamp corrente come data autore"
 
-#: builtin/am.c:2241 builtin/commit-tree.c:120 builtin/commit.c:1512
+#: builtin/am.c:2297 builtin/commit-tree.c:120 builtin/commit.c:1512
 #: builtin/merge.c:287 builtin/pull.c:174 builtin/rebase.c:517
 #: builtin/rebase.c:1556 builtin/revert.c:117 builtin/tag.c:418
 msgid "key-id"
 msgstr "ID chiave"
 
-#: builtin/am.c:2242 builtin/rebase.c:518 builtin/rebase.c:1557
+#: builtin/am.c:2298 builtin/rebase.c:518 builtin/rebase.c:1557
 msgid "GPG-sign commits"
 msgstr "firma i commit con GPG"
 
-#: builtin/am.c:2245
+#: builtin/am.c:2301
 msgid "(internal use for git-rebase)"
 msgstr "(a uso interno per git-rebase)"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2319
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10102,18 +10116,18 @@ msgstr ""
 "L'opzione -b/--binary non esegue nulla da molto tempo e\n"
 "sarà rimossa. Non usarla più."
 
-#: builtin/am.c:2270
+#: builtin/am.c:2326
 msgid "failed to read the index"
 msgstr "lettura dell'indice non riuscita"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2341
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
 "la directory di rebase precedente %s esiste ancora ma è stata specificata "
 "un'mbox."
 
-#: builtin/am.c:2309
+#: builtin/am.c:2365
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10122,11 +10136,11 @@ msgstr ""
 "Trovata directory smarrita %s.\n"
 "Usa \"git am --abort\" per eliminarla."
 
-#: builtin/am.c:2315
+#: builtin/am.c:2371
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Operazione di risoluzione non in corso, non riprendiamo."
 
-#: builtin/am.c:2325
+#: builtin/am.c:2381
 msgid "interactive mode requires patches on the command line"
 msgstr ""
 "la modalità interattiva richiede che le patch siano fornite sulla riga di "
@@ -11814,7 +11828,7 @@ msgstr "git checkout: --detach non accetta un percorso '%s' come argomento"
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file non è compatibile con --detach"
 
-#: builtin/checkout.c:1681 builtin/reset.c:324
+#: builtin/checkout.c:1681 builtin/reset.c:324 builtin/stash.c:1506
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file non è compatibile con --patch"
 
@@ -12501,7 +12515,7 @@ msgid "id of a parent commit object"
 msgstr "ID di un oggetto commit genitore"
 
 #: builtin/commit-tree.c:114 builtin/commit.c:1501 builtin/merge.c:271
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1472
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1477
 #: builtin/tag.c:412
 msgid "message"
 msgstr "messaggio"
@@ -13311,8 +13325,8 @@ msgstr ""
 #: builtin/config.c:159
 msgid "show scope of config (worktree, local, global, system, command)"
 msgstr ""
-"visualizza l'ambito della configurazione (albero di lavoro, locale, globale,"
-" sistema, comando)"
+"visualizza l'ambito della configurazione (albero di lavoro, locale, globale, "
+"sistema, comando)"
 
 #: builtin/config.c:160 builtin/env--helper.c:40
 msgid "value"
@@ -17331,7 +17345,7 @@ msgstr "riferimento note"
 msgid "use notes from <notes-ref>"
 msgstr "usa le note in <riferimento note>"
 
-#: builtin/notes.c:1034 builtin/stash.c:1610
+#: builtin/notes.c:1034 builtin/stash.c:1643
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "sottocomando sconosciuto: %s"
@@ -17700,8 +17714,8 @@ msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
 "reused %<PRIu32>"
 msgstr ""
-"%<PRIu32> oggetti totali (%<PRIu32> delta), %<PRIu32> riutilizzati (%<PRIu32>"
-" delta), %<PRIu32> riutilizzati nel file pack"
+"%<PRIu32> oggetti totali (%<PRIu32> delta), %<PRIu32> riutilizzati "
+"(%<PRIu32> delta), %<PRIu32> riutilizzati nel file pack"
 
 #: builtin/pack-refs.c:8
 msgid "git pack-refs [<options>]"
@@ -18631,8 +18645,8 @@ msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
 "\"."
 msgstr ""
-"tipo vuoto '%s' non riconosciuto; i valori validi sono \"drop\", \"keep\" e"
-" \"ask\"."
+"tipo vuoto '%s' non riconosciuto; i valori validi sono \"drop\", \"keep\" e "
+"\"ask\"."
 
 #: builtin/rebase.c:1401
 #, c-format
@@ -18751,10 +18765,6 @@ msgstr ""
 #: builtin/rebase.c:1542
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(DEPRECATO) prova a ricreare i merge anziché ignorarli"
-
-#: builtin/rebase.c:1546
-msgid "{drop,keep,ask}"
-msgstr "{drop,keep,ask}"
 
 #: builtin/rebase.c:1547
 msgid "how to handle commits that become empty"
@@ -20168,8 +20178,8 @@ msgstr "HEAD ora si trova a %s"
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Impossibile eseguire un %s reset nel corso di un merge."
 
-#: builtin/reset.c:294 builtin/stash.c:519 builtin/stash.c:594
-#: builtin/stash.c:618
+#: builtin/reset.c:294 builtin/stash.c:520 builtin/stash.c:595
+#: builtin/stash.c:619
 msgid "be quiet, only report errors"
 msgstr "non visualizzare messaggi, segnala solo gli errori"
 
@@ -20434,40 +20444,45 @@ msgid_plural "the following files have local modifications:"
 msgstr[0] "il seguente file ha delle modifiche locali:"
 msgstr[1] "i seguenti file hanno delle modifiche locali:"
 
-#: builtin/rm.c:242
+#: builtin/rm.c:243
 msgid "do not list removed files"
 msgstr "non elencare i file rimossi"
 
-#: builtin/rm.c:243
+#: builtin/rm.c:244
 msgid "only remove from the index"
 msgstr "rimuovi solo dall'indice"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "override the up-to-date check"
 msgstr "ignora il controllo sullo stato di aggiornamento"
 
-#: builtin/rm.c:245
+#: builtin/rm.c:246
 msgid "allow recursive removal"
 msgstr "consenti rimozioni ricorsive"
 
-#: builtin/rm.c:247
+#: builtin/rm.c:248
 msgid "exit with a zero status even if nothing matched"
 msgstr ""
 "esci con codice d'uscita zero anche nel caso in cui non vi siano "
 "corrispondenze"
 
-#: builtin/rm.c:289
+#: builtin/rm.c:282
+msgid "No pathspec was given. Which files should I remove?"
+msgstr ""
+"Non è stato fornito uno specificatore percorso. Quali file devo rimuovere?"
+
+#: builtin/rm.c:305
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "esegui lo stage delle modifiche a .gitmodules o eseguine lo stash per "
 "procedere"
 
-#: builtin/rm.c:307
+#: builtin/rm.c:323
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "non rimuovo '%s' ricorsivamente senza -r"
 
-#: builtin/rm.c:346
+#: builtin/rm.c:362
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: non è possibile eliminare %s"
@@ -20791,15 +20806,15 @@ msgstr "disabilita sparse-checkout"
 msgid "error while refreshing working directory"
 msgstr "errore durante l'aggiornamento della directory di lavoro"
 
-#: builtin/stash.c:22 builtin/stash.c:37
+#: builtin/stash.c:22 builtin/stash.c:38
 msgid "git stash list [<options>]"
 msgstr "git stash list [<opzioni>]"
 
-#: builtin/stash.c:23 builtin/stash.c:42
+#: builtin/stash.c:23 builtin/stash.c:43
 msgid "git stash show [<options>] [<stash>]"
 msgstr "git stash show [<opzioni>] [<stash>]"
 
-#: builtin/stash.c:24 builtin/stash.c:47
+#: builtin/stash.c:24 builtin/stash.c:48
 msgid "git stash drop [-q|--quiet] [<stash>]"
 msgstr "git stash drop [-q|--quiet] [<stash>]"
 
@@ -20807,15 +20822,47 @@ msgstr "git stash drop [-q|--quiet] [<stash>]"
 msgid "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
 msgstr "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
 
-#: builtin/stash.c:26 builtin/stash.c:62
+#: builtin/stash.c:26 builtin/stash.c:63
 msgid "git stash branch <branchname> [<stash>]"
 msgstr "git stash branch <nome branch> [<stash>]"
 
-#: builtin/stash.c:27 builtin/stash.c:67
+#: builtin/stash.c:27 builtin/stash.c:68
 msgid "git stash clear"
 msgstr "git stash clear"
 
-#: builtin/stash.c:28 builtin/stash.c:77
+#: builtin/stash.c:28
+msgid ""
+"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
+"          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"          [--] [<pathspec>...]]"
+msgstr ""
+"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [-m|--message <messaggio>]\n"
+"          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"          [--] [<specificatore percorso>...]]"
+
+#: builtin/stash.c:32 builtin/stash.c:85
+msgid ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [<message>]"
+msgstr ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [<messaggio>]"
+
+#: builtin/stash.c:53
+msgid "git stash pop [--index] [-q|--quiet] [<stash>]"
+msgstr "git stash pop [--index] [-q|--quiet] [<stash>]"
+
+#: builtin/stash.c:58
+msgid "git stash apply [--index] [-q|--quiet] [<stash>]"
+msgstr "git stash apply [--index] [-q|--quiet] [<stash>]"
+
+#: builtin/stash.c:73
+msgid "git stash store [-m|--message <message>] [-q|--quiet] <commit>"
+msgstr "git stash store [-m|--message <messaggio>] [-q|--quiet] <commit>"
+
+#: builtin/stash.c:78
 msgid ""
 "git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
@@ -20825,196 +20872,176 @@ msgstr ""
 "          [-u|--include-untracked] [-a|--all] [-m|--message <messaggio>]\n"
 "          [--] [<specificatore percorso>...]]"
 
-#: builtin/stash.c:31 builtin/stash.c:84
-msgid ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [<message>]"
-msgstr ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [<messaggio>]"
-
-#: builtin/stash.c:52
-msgid "git stash pop [--index] [-q|--quiet] [<stash>]"
-msgstr "git stash pop [--index] [-q|--quiet] [<stash>]"
-
-#: builtin/stash.c:57
-msgid "git stash apply [--index] [-q|--quiet] [<stash>]"
-msgstr "git stash apply [--index] [-q|--quiet] [<stash>]"
-
-#: builtin/stash.c:72
-msgid "git stash store [-m|--message <message>] [-q|--quiet] <commit>"
-msgstr "git stash store [-m|--message <messaggio>] [-q|--quiet] <commit>"
-
-#: builtin/stash.c:127
+#: builtin/stash.c:128
 #, c-format
 msgid "'%s' is not a stash-like commit"
 msgstr "'%s' non è un commit simile a uno stash"
 
-#: builtin/stash.c:147
+#: builtin/stash.c:148
 #, c-format
 msgid "Too many revisions specified:%s"
 msgstr "Troppe revisioni specificate:%s"
 
-#: builtin/stash.c:161 git-legacy-stash.sh:549
+#: builtin/stash.c:162 git-legacy-stash.sh:549
 msgid "No stash entries found."
 msgstr "Nessuna voce di stash trovata."
 
-#: builtin/stash.c:175
+#: builtin/stash.c:176
 #, c-format
 msgid "%s is not a valid reference"
 msgstr "%s non è un riferimento valido"
 
-#: builtin/stash.c:224 git-legacy-stash.sh:75
+#: builtin/stash.c:225 git-legacy-stash.sh:75
 msgid "git stash clear with parameters is unimplemented"
 msgstr "git stash clear con parametri non è implementato"
 
-#: builtin/stash.c:403
+#: builtin/stash.c:404
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "impossibile applicare uno stash nel mezzo di un merge"
 
-#: builtin/stash.c:414
+#: builtin/stash.c:415
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "impossibile generare il diff %s^!"
 
-#: builtin/stash.c:421
+#: builtin/stash.c:422
 msgid "conflicts in index.Try without --index."
 msgstr "ci sono conflitti nell'indice. Prova senza --index."
 
-#: builtin/stash.c:427
+#: builtin/stash.c:428
 msgid "could not save index tree"
 msgstr "impossibile salvare l'albero indice"
 
-#: builtin/stash.c:436
+#: builtin/stash.c:437
 msgid "could not restore untracked files from stash"
 msgstr "non è stato possibile ripristinare i file non tracciati dallo stash"
 
-#: builtin/stash.c:450
+#: builtin/stash.c:451
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Merge di %s con %s in corso"
 
-#: builtin/stash.c:460 git-legacy-stash.sh:681
+#: builtin/stash.c:461 git-legacy-stash.sh:681
 msgid "Index was not unstashed."
 msgstr "L'indice non è stato rimosso dallo stash."
 
-#: builtin/stash.c:521 builtin/stash.c:620
+#: builtin/stash.c:522 builtin/stash.c:621
 msgid "attempt to recreate the index"
 msgstr "tenta di ricreare l'indice"
 
-#: builtin/stash.c:554
+#: builtin/stash.c:555
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Ho scartato %s (%s)"
 
-#: builtin/stash.c:557
+#: builtin/stash.c:558
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Impossibile scartare la voce di stash"
 
-#: builtin/stash.c:582
+#: builtin/stash.c:583
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' non è un riferimento stash"
 
-#: builtin/stash.c:632 git-legacy-stash.sh:695
+#: builtin/stash.c:633 git-legacy-stash.sh:695
 msgid "The stash entry is kept in case you need it again."
 msgstr ""
 "La voce di stash è mantenuta nel caso in cui tu ne abbia nuovamente bisogno."
 
-#: builtin/stash.c:655 git-legacy-stash.sh:713
+#: builtin/stash.c:656 git-legacy-stash.sh:713
 msgid "No branch name specified"
 msgstr "Nome del branch non specificato"
 
-#: builtin/stash.c:795 builtin/stash.c:832
+#: builtin/stash.c:796 builtin/stash.c:833
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Impossibile aggiornare %s con %s"
 
-#: builtin/stash.c:813 builtin/stash.c:1473 builtin/stash.c:1509
+#: builtin/stash.c:814 builtin/stash.c:1478 builtin/stash.c:1543
 msgid "stash message"
 msgstr "messaggio di stash"
 
-#: builtin/stash.c:823
+#: builtin/stash.c:824
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" richiede un argomento <commit>"
 
-#: builtin/stash.c:1048 git-legacy-stash.sh:218
+#: builtin/stash.c:1049 git-legacy-stash.sh:218
 msgid "No changes selected"
 msgstr "Nessuna modifica selezionata"
 
-#: builtin/stash.c:1148 git-legacy-stash.sh:150
+#: builtin/stash.c:1149 git-legacy-stash.sh:150
 msgid "You do not have the initial commit yet"
 msgstr "Non hai ancora un commit iniziale"
 
-#: builtin/stash.c:1175 git-legacy-stash.sh:165
+#: builtin/stash.c:1176 git-legacy-stash.sh:165
 msgid "Cannot save the current index state"
 msgstr "Impossibile salvare lo stato corrente di index"
 
-#: builtin/stash.c:1184 git-legacy-stash.sh:180
+#: builtin/stash.c:1185 git-legacy-stash.sh:180
 msgid "Cannot save the untracked files"
 msgstr "Impossibile salvare i file non tracciati"
 
-#: builtin/stash.c:1195 builtin/stash.c:1204 git-legacy-stash.sh:201
+#: builtin/stash.c:1196 builtin/stash.c:1205 git-legacy-stash.sh:201
 #: git-legacy-stash.sh:214
 msgid "Cannot save the current worktree state"
 msgstr "Impossibile salvare lo stato corrente dell'albero di lavoro"
 
-#: builtin/stash.c:1232 git-legacy-stash.sh:234
+#: builtin/stash.c:1233 git-legacy-stash.sh:234
 msgid "Cannot record working tree state"
 msgstr "Impossibile registrare lo stato dell'albero di lavoro"
 
-#: builtin/stash.c:1281 git-legacy-stash.sh:338
+#: builtin/stash.c:1282 git-legacy-stash.sh:338
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Impossibile usare --patch e --include-untracked o --all allo stesso tempo"
 
-#: builtin/stash.c:1297
+#: builtin/stash.c:1298
 msgid "Did you forget to 'git add'?"
 msgstr "Ti sei scordato di eseguire 'git add'?"
 
-#: builtin/stash.c:1312 git-legacy-stash.sh:346
+#: builtin/stash.c:1313 git-legacy-stash.sh:346
 msgid "No local changes to save"
 msgstr "Nessuna modifica locale da salvare"
 
-#: builtin/stash.c:1319 git-legacy-stash.sh:351
+#: builtin/stash.c:1320 git-legacy-stash.sh:351
 msgid "Cannot initialize stash"
 msgstr "Impossibile inizializzare stash"
 
-#: builtin/stash.c:1334 git-legacy-stash.sh:355
+#: builtin/stash.c:1335 git-legacy-stash.sh:355
 msgid "Cannot save the current status"
 msgstr "Impossibile salvare lo stato attuale"
 
-#: builtin/stash.c:1339
+#: builtin/stash.c:1340
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Directory di lavoro e stato indice salvati: %s"
 
-#: builtin/stash.c:1429 git-legacy-stash.sh:385
+#: builtin/stash.c:1430 git-legacy-stash.sh:385
 msgid "Cannot remove worktree changes"
 msgstr "Impossibile rimuovere le modifiche all'albero di lavoro"
 
-#: builtin/stash.c:1464 builtin/stash.c:1500
+#: builtin/stash.c:1469 builtin/stash.c:1534
 msgid "keep index"
 msgstr "mantieni l'indice"
 
-#: builtin/stash.c:1466 builtin/stash.c:1502
+#: builtin/stash.c:1471 builtin/stash.c:1536
 msgid "stash in patch mode"
 msgstr "esegui lo stash in modalità patch"
 
-#: builtin/stash.c:1467 builtin/stash.c:1503
+#: builtin/stash.c:1472 builtin/stash.c:1537
 msgid "quiet mode"
 msgstr "modalità silenziosa"
 
-#: builtin/stash.c:1469 builtin/stash.c:1505
+#: builtin/stash.c:1474 builtin/stash.c:1539
 msgid "include untracked files in stash"
 msgstr "includi i file non tracciati nello stash"
 
-#: builtin/stash.c:1471 builtin/stash.c:1507
+#: builtin/stash.c:1476 builtin/stash.c:1541
 msgid "include ignore files"
 msgstr "includi i file ignorati"
 
-#: builtin/stash.c:1567
+#: builtin/stash.c:1600
 #, c-format
 msgid "could not exec %s"
 msgstr "impossibile eseguire %s"
@@ -21326,9 +21353,9 @@ msgid ""
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
 "<url> --path <path>"
 msgstr ""
-"git submodule--helper clone [--prefix=<percorso>] [--quiet] [--reference <"
-"repository>] [--name <nome>] [--depth <profondità>] [--single-branch] --url <"
-"URL> --path <percorso>"
+"git submodule--helper clone [--prefix=<percorso>] [--quiet] [--reference "
+"<repository>] [--name <nome>] [--depth <profondità>] [--single-branch] --url "
+"<URL> --path <percorso>"
 
 #: builtin/submodule--helper.c:1449
 #, c-format
@@ -22732,43 +22759,43 @@ msgstr "impossibile eseguire il deflate della richiesta; errore fine zlib %d"
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "il trasporto http stupido non supporta le funzionalità shallow"
 
-#: remote-curl.c:1037
+#: remote-curl.c:1038
 msgid "fetch failed."
 msgstr "recupero non riuscito."
 
-#: remote-curl.c:1085
+#: remote-curl.c:1086
 msgid "cannot fetch by sha1 over smart http"
 msgstr ""
 "impossibile recuperare i dati in base allo SHA1 con il trasporto HTTP "
 "intelligente"
 
-#: remote-curl.c:1129 remote-curl.c:1135
+#: remote-curl.c:1130 remote-curl.c:1136
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "errore protocollo: atteso SHA/riferimento, ricevuto '%s'"
 
-#: remote-curl.c:1147 remote-curl.c:1262
+#: remote-curl.c:1148 remote-curl.c:1263
 #, c-format
 msgid "http transport does not support %s"
 msgstr "il trasporto HTTP non supporta %s"
 
-#: remote-curl.c:1183
+#: remote-curl.c:1184
 msgid "git-http-push failed"
 msgstr "git-http-push non riuscito"
 
-#: remote-curl.c:1368
+#: remote-curl.c:1369
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: uso: git remote-curl <remoto> [<URL>]"
 
-#: remote-curl.c:1400
+#: remote-curl.c:1401
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: errore durante la lettura del flusso dei comandi da Git"
 
-#: remote-curl.c:1407
+#: remote-curl.c:1408
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: tentato un fetch senza un repository locale"
 
-#: remote-curl.c:1447
+#: remote-curl.c:1448
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: ricevuto comando sconosciuto '%s' da Git"
@@ -25024,6 +25051,9 @@ msgstr "Salto %s con il suffisso di backup '%s'.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Inviare %s? [y|N]: "
+
+#~ msgid "{drop,keep,ask}"
+#~ msgstr "{drop,keep,ask}"
 
 #, c-format
 #~ msgid "Stage mode change [y,n,a,q,d%s,?]? "


### PR DESCRIPTION
This PR updates the Italian translation for Git 2.26.0, round 2.