### PR TITLE
l10n: it.po: update the Italian translation for Git 2.29.0 round 1

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2020-07-10 09:53+0800\n"
-"PO-Revision-Date: 2020-07-11 15:31+0200\n"
+"POT-Creation-Date: 2020-10-06 09:14+0800\n"
+"PO-Revision-Date: 2020-10-07 21:44+0200\n"
 "Last-Translator: Alessandro Menti <alessandro.menti@alessandromenti.it>\n"
 "Language-Team: Italian <>\n"
 "Language: it\n"
@@ -20,16 +20,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Lokalize 20.04.2\n"
+"X-Generator: Lokalize 20.08.1\n"
 
 #: add-interactive.c:368
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Eh (%s)?"
 
-#: add-interactive.c:521 add-interactive.c:822 reset.c:65 sequencer.c:3142
-#: sequencer.c:3581 sequencer.c:3723 builtin/rebase.c:1518
-#: builtin/rebase.c:1919
+#: add-interactive.c:521 add-interactive.c:822 reset.c:65 sequencer.c:3250
+#: sequencer.c:3698 sequencer.c:3840 builtin/rebase.c:1526
+#: builtin/rebase.c:1944
 msgid "could not read index"
 msgstr "impossibile leggere l'indice"
 
@@ -57,7 +57,7 @@ msgstr "Aggiorna"
 msgid "could not stage '%s'"
 msgstr "impossibile aggiungere '%s' all'area di staging"
 
-#: add-interactive.c:695 add-interactive.c:884 reset.c:89 sequencer.c:3336
+#: add-interactive.c:695 add-interactive.c:884 reset.c:89 sequencer.c:3444
 msgid "could not write index"
 msgstr "impossibile scrivere l'indice"
 
@@ -73,7 +73,7 @@ msgstr[1] "aggiornati %d percorsi\n"
 msgid "note: %s is untracked now.\n"
 msgstr "nota: %s ora non è tracciato.\n"
 
-#: add-interactive.c:721 apply.c:4110 builtin/checkout.c:294
+#: add-interactive.c:721 apply.c:4127 builtin/checkout.c:295
 #: builtin/reset.c:145
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
@@ -115,21 +115,21 @@ msgstr[1] "aggiunti %d percorsi\n"
 msgid "ignoring unmerged: %s"
 msgstr "ignoro ciò che non è stato sottoposto a merge: %s"
 
-#: add-interactive.c:929 add-patch.c:1691 git-add--interactive.perl:1368
+#: add-interactive.c:929 add-patch.c:1738 git-add--interactive.perl:1371
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Sono stati modificati solo file binari.\n"
 
-#: add-interactive.c:931 add-patch.c:1689 git-add--interactive.perl:1370
+#: add-interactive.c:931 add-patch.c:1736 git-add--interactive.perl:1373
 #, c-format
 msgid "No changes.\n"
 msgstr "Nessuna modifica.\n"
 
-#: add-interactive.c:935 git-add--interactive.perl:1378
+#: add-interactive.c:935 git-add--interactive.perl:1381
 msgid "Patch update"
 msgstr "Aggiornamento patch"
 
-#: add-interactive.c:974 git-add--interactive.perl:1771
+#: add-interactive.c:974 git-add--interactive.perl:1794
 msgid "Review diff"
 msgstr "Rivedi diff"
 
@@ -204,11 +204,11 @@ msgstr "seleziona un elemento numerato"
 msgid "(empty) select nothing"
 msgstr "(vuoto) non selezionare nulla"
 
-#: add-interactive.c:1083 builtin/clean.c:816 git-add--interactive.perl:1868
+#: add-interactive.c:1083 builtin/clean.c:816 git-add--interactive.perl:1891
 msgid "*** Commands ***"
 msgstr "*** Comandi ***"
 
-#: add-interactive.c:1084 builtin/clean.c:817 git-add--interactive.perl:1865
+#: add-interactive.c:1084 builtin/clean.c:817 git-add--interactive.perl:1888
 msgid "What now"
 msgstr "Cosa faccio ora"
 
@@ -220,12 +220,12 @@ msgstr "nell'area di staging"
 msgid "unstaged"
 msgstr "rimosso dall'area di staging"
 
-#: add-interactive.c:1136 apply.c:4967 apply.c:4970 builtin/am.c:2250
-#: builtin/am.c:2253 builtin/clone.c:123 builtin/fetch.c:145
-#: builtin/merge.c:276 builtin/pull.c:190 builtin/submodule--helper.c:409
-#: builtin/submodule--helper.c:1394 builtin/submodule--helper.c:1397
-#: builtin/submodule--helper.c:1902 builtin/submodule--helper.c:1905
-#: builtin/submodule--helper.c:2148 bugreport.c:135
+#: add-interactive.c:1136 apply.c:4984 apply.c:4987 builtin/am.c:2270
+#: builtin/am.c:2273 builtin/bugreport.c:133 builtin/clone.c:123
+#: builtin/fetch.c:147 builtin/merge.c:275 builtin/pull.c:190
+#: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1818
+#: builtin/submodule--helper.c:1821 builtin/submodule--helper.c:2326
+#: builtin/submodule--helper.c:2329 builtin/submodule--helper.c:2572
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "percorso"
@@ -234,27 +234,27 @@ msgstr "percorso"
 msgid "could not refresh index"
 msgstr "impossibile aggiornare l'indice"
 
-#: add-interactive.c:1157 builtin/clean.c:781 git-add--interactive.perl:1782
+#: add-interactive.c:1157 builtin/clean.c:781 git-add--interactive.perl:1805
 #, c-format
 msgid "Bye.\n"
 msgstr "Ciao.\n"
 
-#: add-patch.c:34 git-add--interactive.perl:1430
+#: add-patch.c:34 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
 msgstr "Modifica modo stage [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:35 git-add--interactive.perl:1431
+#: add-patch.c:35 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
 msgstr "Eliminazione stage [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:36 git-add--interactive.perl:1432
+#: add-patch.c:36 git-add--interactive.perl:1435
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
 msgstr "Aggiunta stage [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:37 git-add--interactive.perl:1433
+#: add-patch.c:37 git-add--interactive.perl:1436
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Eseguire lo stage di quest'hunk [y,n,q,a,d%s,?]? "
@@ -284,22 +284,22 @@ msgstr ""
 "d - non aggiungere né quest'hunk né quelli successivi nel file all'area di "
 "staging\n"
 
-#: add-patch.c:56 git-add--interactive.perl:1436
+#: add-patch.c:56 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
 msgstr "Modifica modo stash [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:57 git-add--interactive.perl:1437
+#: add-patch.c:57 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
 msgstr "Eliminazione stash [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:58 git-add--interactive.perl:1438
+#: add-patch.c:58 git-add--interactive.perl:1441
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
 msgstr "Aggiunta stash [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:59 git-add--interactive.perl:1439
+#: add-patch.c:59 git-add--interactive.perl:1442
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
 msgstr "Eseguire lo stash di quest'hunk [y,n,q,a,d%s,?]? "
@@ -326,22 +326,22 @@ msgstr ""
 "a - esegui lo stash di quest'hunk e di tutti quelli successivi nel file\n"
 "d - non eseguire lo stash né di quest'hunk né di quelli successivi nel file\n"
 
-#: add-patch.c:80 git-add--interactive.perl:1442
+#: add-patch.c:80 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
 msgstr "Rimozione modifica modo dall'area di staging [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:81 git-add--interactive.perl:1443
+#: add-patch.c:81 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
 msgstr "Rimozione eliminazione dall'area di staging [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:82 git-add--interactive.perl:1444
+#: add-patch.c:82 git-add--interactive.perl:1447
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
 msgstr "Rimozione aggiunta dall'area di staging [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:83 git-add--interactive.perl:1445
+#: add-patch.c:83 git-add--interactive.perl:1448
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Rimuovere quest'hunk dall'area di staging [y,n,q,a,d%s,?]? "
@@ -371,22 +371,22 @@ msgstr ""
 "d - non rimuovere né quest'hunk né quelli successivi nel file dall'area di "
 "staging\n"
 
-#: add-patch.c:103 git-add--interactive.perl:1448
+#: add-patch.c:103 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
 msgstr "Applicare la modifica modo all'indice [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:104 git-add--interactive.perl:1449
+#: add-patch.c:104 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
 msgstr "Applicare l'eliminazione all'indice [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:105 git-add--interactive.perl:1450
+#: add-patch.c:105 git-add--interactive.perl:1453
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
 msgstr "Applicare l'aggiunta all'indice [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:106 git-add--interactive.perl:1451
+#: add-patch.c:106 git-add--interactive.perl:1454
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
 msgstr "Applicare quest'hunk all'indice [y,n,q,a,d%s,?]? "
@@ -413,26 +413,26 @@ msgstr ""
 "a - applica quest'hunk e tutti quelli successivi nel file\n"
 "d - non applicare né quest'hunk né quelli successivi nel file\n"
 
-#: add-patch.c:126 git-add--interactive.perl:1454
-#: git-add--interactive.perl:1472
+#: add-patch.c:126 git-add--interactive.perl:1457
+#: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
 msgstr "Scartare le modifiche modo dall'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:127 git-add--interactive.perl:1455
-#: git-add--interactive.perl:1473
+#: add-patch.c:127 git-add--interactive.perl:1458
+#: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
 msgstr "Scartare l'eliminazione dall'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:128 git-add--interactive.perl:1456
-#: git-add--interactive.perl:1474
+#: add-patch.c:128 git-add--interactive.perl:1459
+#: git-add--interactive.perl:1477
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
 msgstr "Scartare l'aggiunta dall'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:129 git-add--interactive.perl:1457
-#: git-add--interactive.perl:1475
+#: add-patch.c:129 git-add--interactive.perl:1460
+#: git-add--interactive.perl:1478
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr "Scartare quest'hunk dall'albero di lavoro [y,n,q,a,d%s,?]? "
@@ -459,26 +459,26 @@ msgstr ""
 "a - rimuovi quest'hunk e tutti quelli successivi nel file\n"
 "d - non rimuovere né quest'hunk né quelli successivi nel file\n"
 
-#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1460
+#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Scartare la modifica modo dall'indice e dall'albero di lavoro [y,n,q,a,d"
 "%s,?]? "
 
-#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1461
+#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Scartare l'eliminazione dall'indice e dall'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1462
+#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1465
 #, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Scartare l'aggiunta dall'indice e dall'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1463
+#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1466
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
@@ -498,26 +498,26 @@ msgstr ""
 "a - rimuovi quest'hunk e tutti quelli successivi nel file\n"
 "d - non rimuovere né quest'hunk né quelli successivi nel file\n"
 
-#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1466
+#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Applicare la modifica modo all'indice e all'albero di lavoro [y,n,q,a,d"
 "%s,?]? "
 
-#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1467
+#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Applicare l'eliminazione all'indice e all'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1468
+#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1471
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Applicare l'aggiunta all'indice e all'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1469
+#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1472
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
@@ -551,34 +551,34 @@ msgstr ""
 "a - applica quest'hunk e tutti quelli successivi nel file\n"
 "d - non applicare né quest'hunk né quelli successivi nel file\n"
 
-#: add-patch.c:328
+#: add-patch.c:342
 #, c-format
 msgid "could not parse hunk header '%.*s'"
 msgstr "impossibile analizzare l'header hunk '%.*s'"
 
-#: add-patch.c:347 add-patch.c:351
+#: add-patch.c:361 add-patch.c:365
 #, c-format
 msgid "could not parse colored hunk header '%.*s'"
 msgstr "impossibile analizzare l'header hunk colorato '%.*s'"
 
-#: add-patch.c:405
+#: add-patch.c:419
 msgid "could not parse diff"
 msgstr "impossibile analizzare il diff"
 
-#: add-patch.c:424
+#: add-patch.c:438
 msgid "could not parse colored diff"
 msgstr "impossibile analizzare il diff colorato"
 
-#: add-patch.c:438
+#: add-patch.c:452
 #, c-format
 msgid "failed to run '%s'"
 msgstr "esecuzione di '%s' non riuscita"
 
-#: add-patch.c:602
+#: add-patch.c:611
 msgid "mismatched output from interactive.diffFilter"
 msgstr "output di interactive.diffFilter non corrispondente"
 
-#: add-patch.c:603
+#: add-patch.c:612
 msgid ""
 "Your filter must maintain a one-to-one correspondence\n"
 "between its input and output lines."
@@ -586,7 +586,7 @@ msgstr ""
 "Il filtro deve mantenere una corrispondenza uno a uno\n"
 "fra le righe di input e di output."
 
-#: add-patch.c:776
+#: add-patch.c:785
 #, c-format
 msgid ""
 "expected context line #%d in\n"
@@ -595,7 +595,7 @@ msgstr ""
 "attesa riga contesto %d in\n"
 "%.*s"
 
-#: add-patch.c:791
+#: add-patch.c:800
 #, c-format
 msgid ""
 "hunks do not overlap:\n"
@@ -608,13 +608,13 @@ msgstr ""
 "\tnon termina con:\n"
 "%.*s"
 
-#: add-patch.c:1067 git-add--interactive.perl:1114
+#: add-patch.c:1076 git-add--interactive.perl:1117
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
 msgstr ""
 "Modalità manuale modifica hunt - vedi la fine del file per una guida "
 "veloce.\n"
 
-#: add-patch.c:1071
+#: add-patch.c:1080
 #, c-format
 msgid ""
 "---\n"
@@ -628,7 +628,7 @@ msgstr ""
 "Le righe che iniziano con %c saranno rimosse.\n"
 
 #. TRANSLATORS: 'it' refers to the patch mentioned in the previous messages.
-#: add-patch.c:1085 git-add--interactive.perl:1128
+#: add-patch.c:1094 git-add--interactive.perl:1131
 msgid ""
 "If it does not apply cleanly, you will be given an opportunity to\n"
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
@@ -638,11 +638,11 @@ msgstr ""
 "di modificarla di nuovo. Se tutte le righe dell'hunk saranno state\n"
 "rimosse, la modifica sarà interrotta e l'hunk non sarà modificato.\n"
 
-#: add-patch.c:1118
+#: add-patch.c:1127
 msgid "could not parse hunk header"
 msgstr "impossibile analizzare l'header hunk"
 
-#: add-patch.c:1163
+#: add-patch.c:1172
 msgid "'git apply --cached' failed"
 msgstr "'git apply --cached' non riuscito"
 
@@ -658,26 +658,26 @@ msgstr "'git apply --cached' non riuscito"
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1232 git-add--interactive.perl:1241
+#: add-patch.c:1241 git-add--interactive.perl:1244
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
 "L'hunk modificato non può essere applicato senza problemi. Modificarlo di "
 "nuovo (se rispondi \"no\", sarà eliminato!) [y/n]? "
 
-#: add-patch.c:1275
+#: add-patch.c:1284
 msgid "The selected hunks do not apply to the index!"
 msgstr "Gli hunk selezionati non si applicano senza problemi all'indice!"
 
-#: add-patch.c:1276 git-add--interactive.perl:1345
+#: add-patch.c:1285 git-add--interactive.perl:1348
 msgid "Apply them to the worktree anyway? "
 msgstr "Vuoi comunque applicarli all'albero di lavoro? "
 
-#: add-patch.c:1283 git-add--interactive.perl:1348
+#: add-patch.c:1292 git-add--interactive.perl:1351
 msgid "Nothing was applied.\n"
 msgstr "Non è stato applicato nulla.\n"
 
-#: add-patch.c:1340
+#: add-patch.c:1349
 msgid ""
 "j - leave this hunk undecided, see next undecided hunk\n"
 "J - leave this hunk undecided, see next hunk\n"
@@ -701,69 +701,69 @@ msgstr ""
 "e - modifica manualmente l'hunk corrente\n"
 "? - stampa una guida\n"
 
-#: add-patch.c:1463 add-patch.c:1473
+#: add-patch.c:1511 add-patch.c:1521
 msgid "No previous hunk"
 msgstr "Nessun hunk precedente"
 
-#: add-patch.c:1468 add-patch.c:1478
+#: add-patch.c:1516 add-patch.c:1526
 msgid "No next hunk"
 msgstr "Nessun hunk successivo"
 
-#: add-patch.c:1484
+#: add-patch.c:1532
 msgid "No other hunks to goto"
 msgstr "Nessun altro hunk a cui andare"
 
-#: add-patch.c:1495 git-add--interactive.perl:1594
+#: add-patch.c:1543 git-add--interactive.perl:1608
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "a quale hunk desideri andare (premi <Invio> per vederne altri)? "
 
-#: add-patch.c:1496 git-add--interactive.perl:1596
+#: add-patch.c:1544 git-add--interactive.perl:1610
 msgid "go to which hunk? "
 msgstr "a quale hunk desideri andare? "
 
-#: add-patch.c:1507
+#: add-patch.c:1555
 #, c-format
 msgid "Invalid number: '%s'"
 msgstr "Numero non valido: '%s'"
 
-#: add-patch.c:1512
+#: add-patch.c:1560
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
 msgstr[0] "Mi dispiace, è disponibile solo %d hunk."
 msgstr[1] "Mi dispiace, sono disponibili solo %d hunk."
 
-#: add-patch.c:1521
+#: add-patch.c:1569
 msgid "No other hunks to search"
 msgstr "Nessun altro hunk in cui eseguire la ricerca"
 
-#: add-patch.c:1527 git-add--interactive.perl:1640
+#: add-patch.c:1575 git-add--interactive.perl:1663
 msgid "search for regex? "
 msgstr "cercare un'espressione regolare? "
 
-#: add-patch.c:1542
+#: add-patch.c:1590
 #, c-format
 msgid "Malformed search regexp %s: %s"
 msgstr "Espressione regolare di ricerca %s malformata: %s"
 
-#: add-patch.c:1559
+#: add-patch.c:1607
 msgid "No hunk matches the given pattern"
 msgstr "Nessun hunk corrisponde al pattern fornito"
 
-#: add-patch.c:1566
+#: add-patch.c:1614
 msgid "Sorry, cannot split this hunk"
 msgstr "Mi dispiace, non posso suddividere quest'hunk"
 
-#: add-patch.c:1570
+#: add-patch.c:1618
 #, c-format
 msgid "Split into %d hunks."
 msgstr "Suddiviso in %d hunk."
 
-#: add-patch.c:1574
+#: add-patch.c:1622
 msgid "Sorry, cannot edit this hunk"
 msgstr "Mi dispiace, non posso modificare quest'hunk"
 
-#: add-patch.c:1625
+#: add-patch.c:1674
 msgid "'git apply' failed"
 msgstr "'git apply' non riuscito"
 
@@ -830,7 +830,7 @@ msgstr ""
 msgid "Exiting because of an unresolved conflict."
 msgstr "Esco a causa di un conflitto non risolto."
 
-#: advice.c:278 builtin/merge.c:1353
+#: advice.c:278 builtin/merge.c:1349
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Il merge non è stato concluso (esiste MERGE_HEAD)."
 
@@ -1140,7 +1140,7 @@ msgstr "patch non riuscita: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "impossibile eseguire il checkout di '%s'"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:61 setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:72 setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "lettura di %s non riuscita"
@@ -1160,7 +1160,7 @@ msgstr "il percorso %s è stato rinominato/eliminato"
 msgid "%s: does not exist in index"
 msgstr "%s: non esiste nell'indice"
 
-#: apply.c:3537 apply.c:3708
+#: apply.c:3537 apply.c:3708 apply.c:3953
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: non corrisponde all'indice"
@@ -1209,366 +1209,361 @@ msgstr "%s: tipo errato"
 msgid "%s has type %o, expected %o"
 msgstr "%s ha il tipo %o, atteso %o"
 
-#: apply.c:3878 apply.c:3880 read-cache.c:830 read-cache.c:856
-#: read-cache.c:1325
+#: apply.c:3892 apply.c:3894 read-cache.c:832 read-cache.c:858
+#: read-cache.c:1313
 #, c-format
 msgid "invalid path '%s'"
 msgstr "percorso '%s' non valido"
 
-#: apply.c:3936
+#: apply.c:3950
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: esiste già nell'indice"
 
-#: apply.c:3939
+#: apply.c:3956
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: esiste già nella directory di lavoro"
 
-#: apply.c:3959
+#: apply.c:3976
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "il nuovo modo (%o) di %s non corrisponde al vecchio modo (%o)"
 
-#: apply.c:3964
+#: apply.c:3981
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "il nuovo modo (%o) di %s non corrisponde al vecchio modo (%o) di %s"
 
-#: apply.c:3984
+#: apply.c:4001
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "il file interessato '%s' si trova oltre un collegamento simbolico"
 
-#: apply.c:3988
+#: apply.c:4005
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: la patch non si applica correttamente"
 
-#: apply.c:4003
+#: apply.c:4020
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Controllo della patch %s in corso..."
 
-#: apply.c:4095
+#: apply.c:4112
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "le informazioni SHA1 per il sottomodulo %s sono mancanti o inutili"
 
-#: apply.c:4102
+#: apply.c:4119
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "modifica modo per %s che non è nell'HEAD corrente"
 
-#: apply.c:4105
+#: apply.c:4122
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "le informazioni SHA1 sono mancanti o inutili (%s)."
 
-#: apply.c:4114
+#: apply.c:4131
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "impossibile aggiungere %s all'indice temporaneo"
 
-#: apply.c:4124
+#: apply.c:4141
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "impossibile scrivere l'indice temporaneo in %s"
 
-#: apply.c:4262
+#: apply.c:4279
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "impossibile rimuovere %s dall'indice"
 
-#: apply.c:4296
+#: apply.c:4313
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "patch corrotta per il sottomodulo %s"
 
-#: apply.c:4302
+#: apply.c:4319
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "impossibile eseguire lo stat del file appena creato '%s'"
 
-#: apply.c:4310
+#: apply.c:4327
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "impossibile creare l'archivio di backup per il file appena creato %s"
 
-#: apply.c:4316 apply.c:4461
+#: apply.c:4333 apply.c:4478
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "impossibile aggiungere la voce della cache per %s"
 
-#: apply.c:4359
+#: apply.c:4376 builtin/bisect--helper.c:537
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "scrittura in '%s' non riuscita"
 
-#: apply.c:4363
+#: apply.c:4380
 #, c-format
 msgid "closing file '%s'"
 msgstr "chiusura del file '%s' in corso"
 
-#: apply.c:4433
+#: apply.c:4450
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "impossibile scrivere il file '%s' con modo %o"
 
-#: apply.c:4531
+#: apply.c:4548
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Patch %s applicata correttamente."
 
-#: apply.c:4539
+#: apply.c:4556
 msgid "internal error"
 msgstr "errore interno"
 
-#: apply.c:4542
+#: apply.c:4559
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Applicazione della patch %%s con %d frammento respinto..."
 msgstr[1] "Applicazione della patch %%s con %d frammenti respinti..."
 
-#: apply.c:4553
+#: apply.c:4570
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "nome file .rej troncato a %.*s.rej"
 
-#: apply.c:4561 builtin/fetch.c:902 builtin/fetch.c:1195
+#: apply.c:4578 builtin/fetch.c:927 builtin/fetch.c:1228
 #, c-format
 msgid "cannot open %s"
 msgstr "impossibile aprire %s"
 
-#: apply.c:4575
+#: apply.c:4592
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Frammento %d applicato correttamente."
 
-#: apply.c:4579
+#: apply.c:4596
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Frammento %d respinto."
 
-#: apply.c:4698
+#: apply.c:4715
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Patch '%s' ignorata."
 
-#: apply.c:4706
+#: apply.c:4723
 msgid "unrecognized input"
 msgstr "input non riconosciuto"
 
-#: apply.c:4726
+#: apply.c:4743
 msgid "unable to read index file"
 msgstr "impossibile leggere il file index"
 
-#: apply.c:4883
+#: apply.c:4900
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "impossibile aprire la patch '%s': %s"
 
-#: apply.c:4910
+#: apply.c:4927
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "%d errore di spazi bianchi soppresso"
 msgstr[1] "%d errori di spazi bianchi soppressi"
 
-#: apply.c:4916 apply.c:4931
+#: apply.c:4933 apply.c:4948
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d riga aggiunge errori di spazi bianchi."
 msgstr[1] "%d righe aggiungono errori di spazi bianchi."
 
-#: apply.c:4924
+#: apply.c:4941
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d riga applicata dopo la correzione di errori di spazi bianchi."
 msgstr[1] "%d righe applicate dopo la correzione di errori di spazi bianchi."
 
-#: apply.c:4940 builtin/add.c:612 builtin/mv.c:301 builtin/rm.c:406
+#: apply.c:4957 builtin/add.c:618 builtin/mv.c:304 builtin/rm.c:406
 msgid "Unable to write new index file"
 msgstr "Impossibile scrivere il nuovo file index"
 
-#: apply.c:4968
+#: apply.c:4985
 msgid "don't apply changes matching the given path"
 msgstr "non applicare le modifiche corrispondenti al percorso specificato"
 
-#: apply.c:4971
+#: apply.c:4988
 msgid "apply changes matching the given path"
 msgstr "applica le modifiche corrispondenti al percorso specificato"
 
-#: apply.c:4973 builtin/am.c:2259
+#: apply.c:4990 builtin/am.c:2279
 msgid "num"
 msgstr "num"
 
-#: apply.c:4974
+#: apply.c:4991
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "rimuovi <num> barre iniziali dai percorsi diff tradizionali"
 
-#: apply.c:4977
+#: apply.c:4994
 msgid "ignore additions made by the patch"
 msgstr "ignora le aggiunte create dalla patch"
 
-#: apply.c:4979
+#: apply.c:4996
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "invece di applicare la patch, visualizza l'output di diffstat per l'input"
 
-#: apply.c:4983
+#: apply.c:5000
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "visualizza il numero di righe aggiunte ed eliminate in notazione decimale"
 
-#: apply.c:4985
+#: apply.c:5002
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "invece di applicare la patch, visualizza un riassunto per l'input"
 
-#: apply.c:4987
+#: apply.c:5004
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "invece di applicare la patch, verifica se può essere applicata"
 
-#: apply.c:4989
+#: apply.c:5006
 msgid "make sure the patch is applicable to the current index"
 msgstr "assicura che la patch sia applicabile all'indice corrente"
 
-#: apply.c:4991
+#: apply.c:5008
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "contrassegna i nuovi file con `git add --intent-to-add`"
 
-#: apply.c:4993
+#: apply.c:5010
 msgid "apply a patch without touching the working tree"
 msgstr "applica una patch senza modificare l'albero di lavoro"
 
-#: apply.c:4995
+#: apply.c:5012
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 "accetta una patch che apporta modifiche al di fuori dell'area di lavoro"
 
-#: apply.c:4998
+#: apply.c:5015
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "applica anche la patch (da usare con --stat/--summary/--check)"
 
-#: apply.c:5000
+#: apply.c:5017
 msgid "attempt three-way merge if a patch does not apply"
 msgstr "prova un merge a tre vie se la patch non si applica correttamente"
 
-#: apply.c:5002
+#: apply.c:5019
 msgid "build a temporary index based on embedded index information"
 msgstr "compila un index temporaneo basato sulle informazioni indice incluse"
 
-#: apply.c:5005 builtin/checkout-index.c:173 builtin/ls-files.c:525
+#: apply.c:5022 builtin/checkout-index.c:173 builtin/ls-files.c:525
 msgid "paths are separated with NUL character"
 msgstr "i percorsi sono separati con un carattere NUL"
 
-#: apply.c:5007
+#: apply.c:5024
 msgid "ensure at least <n> lines of context match"
 msgstr "assicura che almeno <n> righe di contesto corrispondano"
 
-#: apply.c:5008 builtin/am.c:2238 builtin/interpret-trailers.c:98
+#: apply.c:5025 builtin/am.c:2258 builtin/interpret-trailers.c:98
 #: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
-#: builtin/pack-objects.c:3530 builtin/rebase.c:1332
+#: builtin/pack-objects.c:3562 builtin/rebase.c:1340
 msgid "action"
 msgstr "azione"
 
-#: apply.c:5009
+#: apply.c:5026
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "rileva righe nuove o modificate che hanno errori di spazi bianchi"
 
-#: apply.c:5012 apply.c:5015
+#: apply.c:5029 apply.c:5032
 msgid "ignore changes in whitespace when finding context"
 msgstr "ignora modifiche agli spazi bianchi durante la ricerca dei contesti"
 
-#: apply.c:5018
+#: apply.c:5035
 msgid "apply the patch in reverse"
 msgstr "applica la patch in maniera inversa"
 
-#: apply.c:5020
+#: apply.c:5037
 msgid "don't expect at least one line of context"
 msgstr "non aspettare almeno una riga di contesto"
 
-#: apply.c:5022
+#: apply.c:5039
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "lascia i frammenti respinti nei file *.rej corrispondenti"
 
-#: apply.c:5024
+#: apply.c:5041
 msgid "allow overlapping hunks"
 msgstr "consenti la sovrapposizione dei frammenti"
 
-#: apply.c:5025 builtin/add.c:323 builtin/check-ignore.c:22
-#: builtin/commit.c:1366 builtin/count-objects.c:98 builtin/fsck.c:775
-#: builtin/log.c:2186 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5042 builtin/add.c:329 builtin/check-ignore.c:22
+#: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:775
+#: builtin/log.c:2270 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr "visualizza ulteriori dettagli"
 
-#: apply.c:5027
+#: apply.c:5044
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr ""
 "tollera carattere fine riga rilevato erroneamente come mancante alla fine "
 "del file"
 
-#: apply.c:5030
+#: apply.c:5047
 msgid "do not trust the line counts in the hunk headers"
 msgstr ""
 "non fare affidamento sul numero di righe nelle intestazioni dei frammenti"
 
-#: apply.c:5032 builtin/am.c:2247
+#: apply.c:5049 builtin/am.c:2267
 msgid "root"
 msgstr "radice"
 
-#: apply.c:5033
+#: apply.c:5050
 msgid "prepend <root> to all filenames"
 msgstr "anteponi <radice> a tutti i nomi file"
 
-#: archive-tar.c:125 archive-zip.c:351
+#: archive-tar.c:125 archive-zip.c:345
 #, c-format
 msgid "cannot stream blob %s"
 msgstr "impossibile eseguire lo streaming del blob %s"
 
-#: archive-tar.c:266 archive-zip.c:369
+#: archive-tar.c:265 archive-zip.c:358
 #, c-format
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "modo file non supportato: 0%o (SHA1: %s)"
 
-#: archive-tar.c:293 archive-zip.c:359
-#, c-format
-msgid "cannot read %s"
-msgstr "impossibile leggere %s"
-
-#: archive-tar.c:465
+#: archive-tar.c:449
 #, c-format
 msgid "unable to start '%s' filter"
 msgstr "impossibile avviare il filtro '%s'"
 
-#: archive-tar.c:468
+#: archive-tar.c:452
 msgid "unable to redirect descriptor"
 msgstr "impossibile ridirezionare il descrittore"
 
-#: archive-tar.c:475
+#: archive-tar.c:459
 #, c-format
 msgid "'%s' filter reported error"
 msgstr "il filtro '%s' ha segnalato un errore"
 
-#: archive-zip.c:319
+#: archive-zip.c:318
 #, c-format
 msgid "path is not valid UTF-8: %s"
 msgstr "il percorso non è codificato validamente in UTF-8: %s"
 
-#: archive-zip.c:323
+#: archive-zip.c:322
 #, c-format
 msgid "path too long (%d chars, SHA1: %s): %s"
 msgstr "percorso troppo lungo (%d caratteri, SHA1: %s): %s"
 
-#: archive-zip.c:480 builtin/pack-objects.c:243 builtin/pack-objects.c:246
+#: archive-zip.c:469 builtin/pack-objects.c:244 builtin/pack-objects.c:247
 #, c-format
 msgid "deflate error (%d)"
 msgstr "errore deflate (%d)"
 
-#: archive-zip.c:615
+#: archive-zip.c:603
 #, c-format
 msgid "timestamp too large for this system: %<PRIuMAX>"
 msgstr "timestamp troppo grande per questo sistema: %<PRIuMAX>"
@@ -1592,119 +1587,149 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <repository> [--exec <comando>] --list"
 
-#: archive.c:377 builtin/add.c:181 builtin/add.c:588 builtin/rm.c:315
+#: archive.c:192
+#, c-format
+msgid "cannot read %s"
+msgstr "impossibile leggere %s"
+
+#: archive.c:345 sequencer.c:445 sequencer.c:1706 sequencer.c:2852
+#: sequencer.c:3293 sequencer.c:3402 builtin/am.c:263 builtin/commit.c:786
+#: builtin/merge.c:1124
+#, c-format
+msgid "could not read '%s'"
+msgstr "impossibile leggere '%s'"
+
+#: archive.c:430 builtin/add.c:181 builtin/add.c:594 builtin/rm.c:315
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "lo specificatore percorso '%s' non corrisponde ad alcun file"
 
-#: archive.c:401
+#: archive.c:454
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "riferimento non esistente: %.*s"
 
-#: archive.c:407
+#: archive.c:460
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "%s non è un nome oggetto valido"
 
-#: archive.c:420
+#: archive.c:473
 #, c-format
 msgid "not a tree object: %s"
 msgstr "%s non è un oggetto albero valido"
 
-#: archive.c:432
+#: archive.c:485
 msgid "current working directory is untracked"
 msgstr "la directory di lavoro corrente non è tracciata"
 
-#: archive.c:464
+#: archive.c:526
+#, c-format
+msgid "File not found: %s"
+msgstr "File non trovato: %s"
+
+#: archive.c:528
+#, c-format
+msgid "Not a regular file: %s"
+msgstr "non è un file regolare: %s"
+
+#: archive.c:553
 msgid "fmt"
 msgstr "fmt"
 
-#: archive.c:464
+#: archive.c:553
 msgid "archive format"
 msgstr "formato archivio"
 
-#: archive.c:465 builtin/log.c:1674
+#: archive.c:554 builtin/log.c:1760
 msgid "prefix"
 msgstr "prefisso"
 
-#: archive.c:466
+#: archive.c:555
 msgid "prepend prefix to each pathname in the archive"
 msgstr "anteponi <prefisso> a ogni nome percorso nell'archivio"
 
-#: archive.c:467 builtin/blame.c:861 builtin/blame.c:865 builtin/blame.c:866
-#: builtin/commit-tree.c:117 builtin/config.c:130 builtin/fast-export.c:1208
-#: builtin/fast-export.c:1210 builtin/fast-export.c:1214 builtin/grep.c:907
-#: builtin/hash-object.c:105 builtin/ls-files.c:561 builtin/ls-files.c:564
-#: builtin/notes.c:412 builtin/notes.c:578 builtin/read-tree.c:123
-#: parse-options.h:190
+#: archive.c:556 archive.c:559 builtin/blame.c:884 builtin/blame.c:888
+#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:133
+#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
+#: builtin/fast-export.c:1214 builtin/grep.c:908 builtin/hash-object.c:105
+#: builtin/ls-files.c:561 builtin/ls-files.c:564 builtin/notes.c:412
+#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:190
 msgid "file"
 msgstr "file"
 
-#: archive.c:468 builtin/archive.c:90
+#: archive.c:557
+msgid "add untracked file to archive"
+msgstr "aggiungi il file non tracciato all'archivio"
+
+#: archive.c:560 builtin/archive.c:90
 msgid "write the archive to this file"
 msgstr "scrivi l'archivio in questo file"
 
-#: archive.c:470
+#: archive.c:562
 msgid "read .gitattributes in working directory"
 msgstr "leggi il file .gitattributes nella directory di lavoro"
 
-#: archive.c:471
+#: archive.c:563
 msgid "report archived files on stderr"
 msgstr "elenca i file archiviati sullo standard error"
 
-#: archive.c:472
+#: archive.c:564
 msgid "store only"
 msgstr "salva solamente"
 
-#: archive.c:473
+#: archive.c:565
 msgid "compress faster"
 msgstr "comprimi più velocemente"
 
-#: archive.c:481
+#: archive.c:573
 msgid "compress better"
 msgstr "comprimi meglio"
 
-#: archive.c:484
+#: archive.c:576
 msgid "list supported archive formats"
 msgstr "elenca i formati archivio supportati"
 
-#: archive.c:486 builtin/archive.c:91 builtin/clone.c:113 builtin/clone.c:116
-#: builtin/submodule--helper.c:1406 builtin/submodule--helper.c:1911
+#: archive.c:578 builtin/archive.c:91 builtin/clone.c:113 builtin/clone.c:116
+#: builtin/submodule--helper.c:1830 builtin/submodule--helper.c:2335
 msgid "repo"
 msgstr "repository"
 
-#: archive.c:487 builtin/archive.c:92
+#: archive.c:579 builtin/archive.c:92
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "recupera l'archivio dal repository remoto <repository>"
 
-#: archive.c:488 builtin/archive.c:93 builtin/difftool.c:715
+#: archive.c:580 builtin/archive.c:93 builtin/difftool.c:715
 #: builtin/notes.c:498
 msgid "command"
 msgstr "comando"
 
-#: archive.c:489 builtin/archive.c:94
+#: archive.c:581 builtin/archive.c:94
 msgid "path to the remote git-upload-archive command"
 msgstr "percorso al comando remoto git-upload-archive"
 
-#: archive.c:496
+#: archive.c:588
 msgid "Unexpected option --remote"
 msgstr "Opzione --remote inattesa"
 
-#: archive.c:498
+#: archive.c:590
 msgid "Option --exec can only be used together with --remote"
 msgstr "L'opzione --exec può essere usata solo con --remote"
 
-#: archive.c:500
+#: archive.c:592
 msgid "Unexpected option --output"
 msgstr "Opzione --output inattesa"
 
-#: archive.c:522
+#: archive.c:594
+msgid "Options --add-file and --remote cannot be used together"
+msgstr "Le opzioni --add-file e --remote non possono essere usate insieme"
+
+#: archive.c:616
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Formato archivio '%s' sconosciuto"
 
-#: archive.c:529
+#: archive.c:623
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argomento non supportato per il formato '%s': -%d"
@@ -1727,22 +1752,22 @@ msgstr ""
 "I pattern negativi sono ignorati negli attributi git\n"
 "Usa '\\!' per specificare letteralmente un punto esclamativo iniziale."
 
-#: bisect.c:468
+#: bisect.c:476
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Contenuto mal racchiuso fra virgolette nel file '%s': %s"
 
-#: bisect.c:678
+#: bisect.c:686
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Impossibile eseguire un'ulteriore bisezione!\n"
 
-#: bisect.c:745
+#: bisect.c:753
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "%s non è un nome commit valido"
 
-#: bisect.c:770
+#: bisect.c:778
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1751,7 +1776,7 @@ msgstr ""
 "La base del merge %s non funziona.\n"
 "Ciò significa che il bug è stato corretto fra %s e [%s].\n"
 
-#: bisect.c:775
+#: bisect.c:783
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1760,7 +1785,7 @@ msgstr ""
 "La base del merge %s è nuova.\n"
 "La proprietà è stata modificata fra %s e [%s].\n"
 
-#: bisect.c:780
+#: bisect.c:788
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1769,7 +1794,7 @@ msgstr ""
 "La base del merge %s è %s.\n"
 "Ciò significa che il primo commit '%s' è fra %s e [%s].\n"
 
-#: bisect.c:788
+#: bisect.c:796
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1780,7 +1805,7 @@ msgstr ""
 "git bisect non può funzionare correttamente in questo caso.\n"
 "Forse hai confuso le revisioni %s con quelle %s?\n"
 
-#: bisect.c:801
+#: bisect.c:809
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1791,36 +1816,36 @@ msgstr ""
 "Non è possibile essere sicuri che il primo commit %s sia fra %s e %s.\n"
 "Continuo comunque."
 
-#: bisect.c:840
+#: bisect.c:848
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Bisezione: dev'essere testata una base del merge\n"
 
-#: bisect.c:890
+#: bisect.c:898
 #, c-format
 msgid "a %s revision is needed"
 msgstr "è richiesta una revisione %s"
 
-#: bisect.c:920 builtin/notes.c:177 builtin/tag.c:255
+#: bisect.c:928 builtin/notes.c:177 builtin/tag.c:255
 #, c-format
 msgid "could not create file '%s'"
 msgstr "impossibile creare il file '%s'"
 
-#: bisect.c:966 builtin/merge.c:151
+#: bisect.c:974 builtin/merge.c:150
 #, c-format
 msgid "could not read file '%s'"
 msgstr "impossibile leggere il file '%s'"
 
-#: bisect.c:997
+#: bisect.c:1014
 msgid "reading bisect refs failed"
 msgstr "lettura riferimenti della bisezione non riuscita"
 
-#: bisect.c:1019
+#: bisect.c:1044
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s era sia %s sia %s\n"
 
-#: bisect.c:1028
+#: bisect.c:1053
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1829,7 +1854,7 @@ msgstr ""
 "Nessun commit testabile trovato.\n"
 "Forse hai iniziato il procedimento specificando parametri percorso errati?\n"
 
-#: bisect.c:1057
+#: bisect.c:1082
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1839,7 +1864,7 @@ msgstr[1] "(circa %d passi)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1063
+#: bisect.c:1088
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
@@ -1848,41 +1873,41 @@ msgstr[0] ""
 msgstr[1] ""
 "Bisezione in corso: %d revisioni rimanenti da testare dopo questa %s\n"
 
-#: blame.c:2777
+#: blame.c:2778
 msgid "--contents and --reverse do not blend well."
 msgstr "--contents e --reverse non sono compatibili."
 
-#: blame.c:2791
+#: blame.c:2792
 msgid "cannot use --contents with final commit object name"
 msgstr "impossibile usare --contents con il nome oggetto del commit finale"
 
-#: blame.c:2812
+#: blame.c:2813
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "le opzioni --reverse e --first-parent se usate insieme richiedono che sia "
 "specificato l'ultimo commit"
 
-#: blame.c:2821 bundle.c:187 ref-filter.c:2200 remote.c:1924 sequencer.c:2018
-#: sequencer.c:4466 submodule.c:847 builtin/commit.c:1047 builtin/log.c:405
-#: builtin/log.c:1012 builtin/log.c:1541 builtin/log.c:1945 builtin/log.c:2235
-#: builtin/merge.c:415 builtin/pack-objects.c:3348 builtin/pack-objects.c:3363
-#: builtin/shortlog.c:192
+#: blame.c:2822 bundle.c:213 ref-filter.c:2264 remote.c:2020 sequencer.c:2105
+#: sequencer.c:4606 submodule.c:855 builtin/commit.c:1045 builtin/log.c:404
+#: builtin/log.c:1020 builtin/log.c:1622 builtin/log.c:2029 builtin/log.c:2319
+#: builtin/merge.c:414 builtin/pack-objects.c:3380 builtin/pack-objects.c:3395
+#: builtin/shortlog.c:320
 msgid "revision walk setup failed"
 msgstr "impostazione percorso revisioni non riuscita"
 
-#: blame.c:2839
+#: blame.c:2840
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
 "le opzioni --reverse e --first-parent se usate insieme richiedono che sia "
 "specificato un intervallo nella catena del primo commit genitore"
 
-#: blame.c:2850
+#: blame.c:2851
 #, c-format
 msgid "no such path %s in %s"
 msgstr "il percorso %s in %s non esiste"
 
-#: blame.c:2861
+#: blame.c:2862
 #, c-format
 msgid "cannot read blob %s for path %s"
 msgstr "impossibile leggere il blob %s per il percorso %s"
@@ -2034,88 +2059,104 @@ msgstr "Il checkout di '%s' è già stato eseguito in '%s'"
 msgid "HEAD of working tree %s is not updated"
 msgstr "L'HEAD dell'albero di lavoro %s non è aggiornato"
 
-#: bundle.c:47
+#: bundle.c:41
 #, c-format
-msgid "'%s' does not look like a v2 bundle file"
-msgstr "'%s' non sembra essere un file bundle v2"
+msgid "unrecognized bundle hash algorithm: %s"
+msgstr "algoritmo hash bundle non riconosciuto: %s"
 
-#: bundle.c:69
-msgid "unknown hash algorithm length"
-msgstr "lunghezza algoritmo hash sconosciuta"
+#: bundle.c:45
+#, c-format
+msgid "unknown capability '%s'"
+msgstr "capacità '%s' sconosciuta"
 
-#: bundle.c:84
+#: bundle.c:71
+#, c-format
+msgid "'%s' does not look like a v2 or v3 bundle file"
+msgstr "'%s' non sembra essere un file bundle v2 o v3"
+
+#: bundle.c:110
 #, c-format
 msgid "unrecognized header: %s%s (%d)"
 msgstr "intestazione non riconosciuta: %s%s (%d)"
 
-#: bundle.c:110 rerere.c:480 rerere.c:690 sequencer.c:2270 sequencer.c:3034
+#: bundle.c:136 rerere.c:480 rerere.c:690 sequencer.c:2357 sequencer.c:3142
 #: builtin/commit.c:814
 #, c-format
 msgid "could not open '%s'"
 msgstr "impossibile aprire '%s'"
 
-#: bundle.c:163
+#: bundle.c:189
 msgid "Repository lacks these prerequisite commits:"
 msgstr "Dal repository mancano questi commit richiesti come prerequisito:"
 
-#: bundle.c:166
+#: bundle.c:192
 msgid "need a repository to verify a bundle"
 msgstr "è necessario un repository per verificare un bundle"
 
-#: bundle.c:217
+#: bundle.c:243
 #, c-format
 msgid "The bundle contains this ref:"
 msgid_plural "The bundle contains these %d refs:"
 msgstr[0] "Il bundle contiene questo riferimento:"
 msgstr[1] "Il bundle contiene questi %d riferimenti:"
 
-#: bundle.c:224
+#: bundle.c:250
 msgid "The bundle records a complete history."
 msgstr "Nel bundle è registrata una cronologia completa."
 
-#: bundle.c:226
+#: bundle.c:252
 #, c-format
 msgid "The bundle requires this ref:"
 msgid_plural "The bundle requires these %d refs:"
 msgstr[0] "Il bundle richiede questo riferimento:"
 msgstr[1] "Il bundle richiede questi %d riferimenti:"
 
-#: bundle.c:293
+#: bundle.c:319
 msgid "unable to dup bundle descriptor"
 msgstr "impossibile duplicare il descrittore bundle"
 
-#: bundle.c:300
+#: bundle.c:326
 msgid "Could not spawn pack-objects"
 msgstr "Impossibile avviare pack-objects"
 
-#: bundle.c:311
+#: bundle.c:337
 msgid "pack-objects died"
 msgstr "comando pack-objects morto"
 
-#: bundle.c:353
+#: bundle.c:379
 msgid "rev-list died"
 msgstr "comando rev-list morto"
 
-#: bundle.c:402
+#: bundle.c:428
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
 msgstr "il riferimento '%s' è escluso dalle opzioni di rev-list"
 
-#: bundle.c:481 builtin/log.c:208 builtin/log.c:1834 builtin/shortlog.c:306
+#: bundle.c:498
+#, c-format
+msgid "unsupported bundle version %d"
+msgstr "versione bundle %d non supportata"
+
+#: bundle.c:500
+#, c-format
+msgid "cannot write bundle version %d with algorithm %s"
+msgstr "impossibile scrivere il bundle versione %d con l'algoritmo %s"
+
+#: bundle.c:522 builtin/log.c:207 builtin/log.c:1918 builtin/shortlog.c:461
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "argomento non riconosciuto: %s"
 
-#: bundle.c:489
+#: bundle.c:530
 msgid "Refusing to create empty bundle."
 msgstr "Mi rifiuto di creare un bundle vuoto."
 
-#: bundle.c:499
+#: bundle.c:540
 #, c-format
 msgid "cannot create '%s'"
 msgstr "impossibile creare '%s'"
 
-#: bundle.c:524
+#: bundle.c:565
 msgid "index-pack died"
 msgstr "comando index-pack morto"
 
@@ -2124,261 +2165,254 @@ msgstr "comando index-pack morto"
 msgid "invalid color value: %.*s"
 msgstr "valore colore non valido: %.*s"
 
-#: commit-graph.c:238
+#: commit-graph.c:188 midx.c:46
+msgid "invalid hash version"
+msgstr "versione hash non valida"
+
+#: commit-graph.c:246
 msgid "commit-graph file is too small"
 msgstr "il file grafo dei commit %s è troppo piccolo"
 
-#: commit-graph.c:303
+#: commit-graph.c:311
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "la firma del grafo dei commit %X non corrisponde alla firma %X"
 
-#: commit-graph.c:310
+#: commit-graph.c:318
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "la versione del grafo dei commit %X non corrisponde alla versione %X"
 
-#: commit-graph.c:317
+#: commit-graph.c:325
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr ""
 "la versione hash del grafo dei commit %X non corrisponde alla versione %X"
 
-#: commit-graph.c:339
-msgid "commit-graph chunk lookup table entry missing; file may be incomplete"
-msgstr ""
-"voce blocco grafo dei commit mancante nella tabella di ricerca; il file "
-"potrebbe non essere completo"
+#: commit-graph.c:342
+#, c-format
+msgid "commit-graph file is too small to hold %u chunks"
+msgstr "il file grafo dei commit è troppo piccolo per contenere %u chunk"
 
-#: commit-graph.c:349
+#: commit-graph.c:361
 #, c-format
 msgid "commit-graph improper chunk offset %08x%08x"
 msgstr "offset blocco grafo dei commit improprio %08x%08x"
 
-#: commit-graph.c:417
+#: commit-graph.c:433
 #, c-format
 msgid "commit-graph chunk id %08x appears multiple times"
 msgstr "l'ID del blocco grafo dei commit %08x compare più volte"
 
-#: commit-graph.c:491
+#: commit-graph.c:499
 msgid "commit-graph has no base graphs chunk"
 msgstr "il grafo dei commit non ha un blocco grafi di base"
 
-#: commit-graph.c:501
+#: commit-graph.c:509
 msgid "commit-graph chain does not match"
 msgstr "la catena del grafo dei commit non corrisponde"
 
-#: commit-graph.c:549
+#: commit-graph.c:557
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "catena grafo dei commit non valida: la riga '%s' non è un hash"
 
-#: commit-graph.c:573
+#: commit-graph.c:581
 msgid "unable to find all commit-graph files"
 msgstr "impossibile trovare tutti i file grafo dei commit"
 
-#: commit-graph.c:706 commit-graph.c:770
+#: commit-graph.c:721 commit-graph.c:785
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "posizione commit non valida. Il grafo dei commit è probabilmente corrotto"
 
-#: commit-graph.c:727
+#: commit-graph.c:742
 #, c-format
 msgid "could not find commit %s"
 msgstr "impossibile trovare il commit %s"
 
-#: commit-graph.c:1009 builtin/am.c:1292
+#: commit-graph.c:1042 builtin/am.c:1306
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "impossibile analizzare il commit %s"
 
-#: commit-graph.c:1157
-msgid "Writing changed paths Bloom filters index"
-msgstr ""
-"Scrittura dell'indice dei filtri di Bloom per i percorsi modificati in corso"
-
-#: commit-graph.c:1182
-msgid "Writing changed paths Bloom filters data"
-msgstr ""
-"Scrittura dei dati dei filtri di Bloom per i percorsi modificati in corso"
-
-#: commit-graph.c:1221 builtin/pack-objects.c:2832
+#: commit-graph.c:1265 builtin/pack-objects.c:2864
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "impossibile recuperare il tipo dell'oggetto %s"
 
-#: commit-graph.c:1257
+#: commit-graph.c:1301
 msgid "Loading known commits in commit graph"
 msgstr "Caricamento commit noti nel grafo dei commit in corso"
 
-#: commit-graph.c:1274
+#: commit-graph.c:1318
 msgid "Expanding reachable commits in commit graph"
 msgstr "Espansione dei commit raggiungibili nel grafo dei commit in corso"
 
-#: commit-graph.c:1294
+#: commit-graph.c:1338
 msgid "Clearing commit marks in commit graph"
 msgstr "Rimozione dei contrassegni commit nel grafo dei commit in corso"
 
-#: commit-graph.c:1313
+#: commit-graph.c:1357
 msgid "Computing commit graph generation numbers"
 msgstr "Calcolo numeri generazione del grafo dei commit in corso"
 
-#: commit-graph.c:1367
+#: commit-graph.c:1424
 msgid "Computing commit changed paths Bloom filters"
 msgstr ""
 "Calcolo dei filtri di Bloom per i percorsi modificati nei commit in corso"
 
-#: commit-graph.c:1423
+#: commit-graph.c:1501
 msgid "Collecting referenced commits"
 msgstr "Raccolta dei commit referenziati in corso"
 
-#: commit-graph.c:1447
+#: commit-graph.c:1526
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Ricerca dei commit per il grafo dei commit in %d pack in corso"
 msgstr[1] "Ricerca dei commit per il grafo dei commit in %d pack in corso"
 
-#: commit-graph.c:1460
+#: commit-graph.c:1539
 #, c-format
 msgid "error adding pack %s"
 msgstr "errore durante l'aggiunta del pack %s"
 
-#: commit-graph.c:1464
+#: commit-graph.c:1543
 #, c-format
 msgid "error opening index for %s"
 msgstr "errore durante l'apertura dell'indice per %s"
 
-#: commit-graph.c:1503
+#: commit-graph.c:1582
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 "Ricerca dei commit per il grafo dei commit fra gli oggetti nei pack in corso"
 
-#: commit-graph.c:1518
+#: commit-graph.c:1597
 msgid "Counting distinct commits in commit graph"
 msgstr "Conteggio commit distinti nel grafo dei commit in corso"
 
-#: commit-graph.c:1550
+#: commit-graph.c:1629
 msgid "Finding extra edges in commit graph"
 msgstr "Ricerca degli archi aggiuntivi nel grafo dei commit in corso"
 
-#: commit-graph.c:1599
+#: commit-graph.c:1678
 msgid "failed to write correct number of base graph ids"
 msgstr "impossibile scrivere il numero esatto degli ID grafo di base"
 
-#: commit-graph.c:1633 midx.c:812
+#: commit-graph.c:1720 midx.c:826
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "impossibile creare le prime directory di %s"
 
-#: commit-graph.c:1646
+#: commit-graph.c:1733
 msgid "unable to create temporary graph layer"
 msgstr "impossibile creare il livello grafico temporaneo"
 
-#: commit-graph.c:1651
+#: commit-graph.c:1738
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "impossibile modificare i permessi condivisi per '%s'"
 
-#: commit-graph.c:1728
+#: commit-graph.c:1808
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Scrittura in %d passaggio del grafo dei commit in corso"
 msgstr[1] "Scrittura in %d passaggi del grafo dei commit in corso"
 
-#: commit-graph.c:1773
+#: commit-graph.c:1853
 msgid "unable to open commit-graph chain file"
 msgstr "impossibile aprire il file catena grafo dei commit"
 
-#: commit-graph.c:1789
+#: commit-graph.c:1869
 msgid "failed to rename base commit-graph file"
 msgstr "impossibile ridenominare il file di base grafo dei commit"
 
-#: commit-graph.c:1809
+#: commit-graph.c:1889
 msgid "failed to rename temporary commit-graph file"
 msgstr "impossibile ridenominare il file temporaneo grafo dei commit"
 
-#: commit-graph.c:1935
+#: commit-graph.c:2015
 msgid "Scanning merged commits"
 msgstr "Scansione dei commit sottoposti a merge in corso"
 
-#: commit-graph.c:1946
+#: commit-graph.c:2026
 #, c-format
 msgid "unexpected duplicate commit id %s"
 msgstr "ID commit duplicato inatteso: %s"
 
-#: commit-graph.c:1969
+#: commit-graph.c:2049
 msgid "Merging commit-graph"
 msgstr "Merge del grafo dei commit in corso"
 
-#: commit-graph.c:2156
+#: commit-graph.c:2259
 #, c-format
 msgid "the commit graph format cannot write %d commits"
 msgstr ""
 "il formato del grafo dei commit non può essere usato per scrivere %d commit"
 
-#: commit-graph.c:2167
+#: commit-graph.c:2270
 msgid "too many commits to write graph"
 msgstr "troppi commit da scrivere nel grafo"
 
-#: commit-graph.c:2260
+#: commit-graph.c:2363
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "il file del grafo dei commit ha un checksum non corretto e probabilmente è "
 "corrotto"
 
-#: commit-graph.c:2270
+#: commit-graph.c:2373
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "il grafo dei commit ha un ordine OID non corretto: %s seguito da %s"
 
-#: commit-graph.c:2280 commit-graph.c:2295
+#: commit-graph.c:2383 commit-graph.c:2398
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "il grafo dei commit ha un valore fanout non corretto: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2287
+#: commit-graph.c:2390
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "impossibile analizzare il commit %s nel grafo dei commit"
 
-#: commit-graph.c:2305
+#: commit-graph.c:2408
 msgid "Verifying commits in commit graph"
 msgstr "Verifica dei commit nel grafo dei commit in corso"
 
-#: commit-graph.c:2320
+#: commit-graph.c:2423
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "impossibile analizzare il commit %s dal database oggetti per il grafo dei "
 "commit"
 
-#: commit-graph.c:2327
+#: commit-graph.c:2430
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "l'OID dell'albero radice per il commit %s nel grafo dei commit è %s != %s"
 
-#: commit-graph.c:2337
+#: commit-graph.c:2440
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "l'elenco genitori nel grafo dei commit per il commit %s è troppo lungo"
 
-#: commit-graph.c:2346
+#: commit-graph.c:2449
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "il genitore nel grafo dei commit per %s è %s != %s"
 
-#: commit-graph.c:2360
+#: commit-graph.c:2463
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 "l'elenco genitori nel grafo dei commit per il commit %s è finito prima del "
 "previsto"
 
-#: commit-graph.c:2365
+#: commit-graph.c:2468
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2386,7 +2420,7 @@ msgstr ""
 "il grafo dei commit ha un numero generazione zero per il commit %s ma non "
 "pari a zero per gli altri"
 
-#: commit-graph.c:2369
+#: commit-graph.c:2472
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2394,19 +2428,19 @@ msgstr ""
 "il grafo dei commit ha un numero generazione non pari a zero per il commit "
 "%s ma pari a zero per gli altri"
 
-#: commit-graph.c:2385
+#: commit-graph.c:2488
 #, c-format
 msgid "commit-graph generation for commit %s is %u != %u"
 msgstr "il numero generazione nel grafo dei commit per il commit %s è %u != %u"
 
-#: commit-graph.c:2391
+#: commit-graph.c:2494
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "la data per il commit %s nel grafo dei commit è %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:2739 builtin/am.c:359 builtin/am.c:403
-#: builtin/am.c:1371 builtin/am.c:2013 builtin/replace.c:457
+#: commit.c:52 sequencer.c:2845 builtin/am.c:373 builtin/am.c:417
+#: builtin/am.c:1385 builtin/am.c:2031 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "impossibile analizzare %s"
@@ -2510,7 +2544,7 @@ msgstr "la chiave non contiene una sezione: %s"
 msgid "key does not contain variable name: %s"
 msgstr "la chiave non contiene un nome variabile: %s"
 
-#: config.c:408 sequencer.c:2456
+#: config.c:408 sequencer.c:2547
 #, c-format
 msgid "invalid key: %s"
 msgstr "chiave non valida: %s"
@@ -2651,7 +2685,7 @@ msgstr "valore malformato per %s: %s"
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "dev'essere nothing, matching, simple, upstream o current"
 
-#: config.c:1533 builtin/pack-objects.c:3617
+#: config.c:1533 builtin/pack-objects.c:3649
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "livello compressione pack %d non valido"
@@ -2680,105 +2714,105 @@ msgstr "analisi di %s non riuscita"
 msgid "unable to parse command-line config"
 msgstr "impossibile analizzare la configurazione a riga di comando"
 
-#: config.c:2113
+#: config.c:2122
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "si è verificato un errore imprevisto durante la lettura dei file di "
 "configurazione"
 
-#: config.c:2283
+#: config.c:2296
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s non valido: '%s'"
 
-#: config.c:2328
+#: config.c:2341
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "il valore splitIndex.maxPercentChange '%d' dovrebbe essere compreso fra 0 e "
 "100"
 
-#: config.c:2374
+#: config.c:2387
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "impossibile analizzare '%s' dalla configurazione a riga di comando"
 
-#: config.c:2376
+#: config.c:2389
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "variabile configurazione '%s' errata nel file '%s' alla riga %d"
 
-#: config.c:2457
+#: config.c:2470
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "nome sezione '%s' non valido"
 
-#: config.c:2489
+#: config.c:2502
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s ha più valori"
 
-#: config.c:2518
+#: config.c:2531
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "scrittura del nuovo file di configurazione %s non riuscita"
 
-#: config.c:2770 config.c:3094
+#: config.c:2783 config.c:3107
 #, c-format
 msgid "could not lock config file %s"
 msgstr "impossibile bloccare il file di configurazione %s"
 
-#: config.c:2781
+#: config.c:2794
 #, c-format
 msgid "opening %s"
 msgstr "apertura di %s in corso"
 
-#: config.c:2816 builtin/config.c:344
+#: config.c:2829 builtin/config.c:354
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "pattern non valido: %s"
 
-#: config.c:2841
+#: config.c:2854
 #, c-format
 msgid "invalid config file %s"
 msgstr "file di configurazione %s non valido"
 
-#: config.c:2854 config.c:3107
+#: config.c:2867 config.c:3120
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat di %s non riuscita"
 
-#: config.c:2865
+#: config.c:2878
 #, c-format
 msgid "unable to mmap '%s'"
 msgstr "impossibile eseguire mmap su '%s'"
 
-#: config.c:2874 config.c:3112
+#: config.c:2887 config.c:3125
 #, c-format
 msgid "chmod on %s failed"
 msgstr "esecuzione chmod su %s non riuscita"
 
-#: config.c:2959 config.c:3209
+#: config.c:2972 config.c:3222
 #, c-format
 msgid "could not write config file %s"
 msgstr "impossibile scrivere il file di configurazione %s"
 
-#: config.c:2993
+#: config.c:3006
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "impossibile impostare '%s' a '%s'"
 
-#: config.c:2995 builtin/remote.c:655 builtin/remote.c:849 builtin/remote.c:857
+#: config.c:3008 builtin/remote.c:656 builtin/remote.c:850 builtin/remote.c:858
 #, c-format
 msgid "could not unset '%s'"
 msgstr "impossibile eliminare l'impostazione di '%s'"
 
-#: config.c:3085
+#: config.c:3098
 #, c-format
 msgid "invalid section name: %s"
 msgstr "nome sezione non valido: %s"
 
-#: config.c:3252
+#: config.c:3265
 #, c-format
 msgid "missing value for '%s'"
 msgstr "valore mancante per '%s'"
@@ -2950,23 +2984,23 @@ msgstr "la variante SSH 'simple' non supporta l'impostazione della porta"
 msgid "strange pathname '%s' blocked"
 msgstr "percorso strano '%s' bloccato"
 
-#: connect.c:1407
+#: connect.c:1408
 msgid "unable to fork"
 msgstr "impossibile eseguire fork"
 
-#: connected.c:109 builtin/fsck.c:209 builtin/prune.c:45
+#: connected.c:108 builtin/fsck.c:209 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Controllo connessione in corso"
 
-#: connected.c:121
+#: connected.c:120
 msgid "Could not run 'git rev-list'"
 msgstr "Impossibile eseguire 'git-rev-list'"
 
-#: connected.c:141
+#: connected.c:144
 msgid "failed write to rev-list"
 msgstr "scrittura nella rev-list non riuscita"
 
-#: connected.c:148
+#: connected.c:149
 msgid "failed to close rev-list's stdin"
 msgstr "chiusura standard input della rev-list non riuscita"
 
@@ -3043,40 +3077,40 @@ msgid "encoding '%s' from %s to %s and back is not the same"
 msgstr ""
 "il risultato della codifica di '%s' da %s a %s e viceversa non è lo stesso"
 
-#: convert.c:668
+#: convert.c:665
 #, c-format
 msgid "cannot fork to run external filter '%s'"
 msgstr "impossibile eseguire fork per eseguire il filtro esterno '%s'"
 
-#: convert.c:688
+#: convert.c:685
 #, c-format
 msgid "cannot feed the input to external filter '%s'"
 msgstr "impossibile fornire l'input al filtro esterno '%s'"
 
-#: convert.c:695
+#: convert.c:692
 #, c-format
 msgid "external filter '%s' failed %d"
 msgstr "esecuzione del filtro esterno '%s' non riuscita: %d"
 
-#: convert.c:730 convert.c:733
+#: convert.c:727 convert.c:730
 #, c-format
 msgid "read from external filter '%s' failed"
 msgstr "lettura dal filtro esterno '%s' non riuscita"
 
-#: convert.c:736 convert.c:791
+#: convert.c:733 convert.c:788
 #, c-format
 msgid "external filter '%s' failed"
 msgstr "esecuzione del filtro esterno '%s' non riuscita"
 
-#: convert.c:840
+#: convert.c:837
 msgid "unexpected filter type"
 msgstr "tipo filtro inatteso"
 
-#: convert.c:851
+#: convert.c:848
 msgid "path name too long for external filter"
 msgstr "nome percorso troppo lungo per il filtro esterno"
 
-#: convert.c:943
+#: convert.c:940
 #, c-format
 msgid ""
 "external filter '%s' is not available anymore although not all paths have "
@@ -3085,16 +3119,16 @@ msgstr ""
 "il filtro esterno '%s' non è più disponibile nonostante non tutti i percorsi "
 "siano stati filtrati"
 
-#: convert.c:1243
+#: convert.c:1240
 msgid "true/false are no valid working-tree-encodings"
 msgstr "true/false non sono codifiche dell'albero di lavoro valide"
 
-#: convert.c:1431 convert.c:1465
+#: convert.c:1428 convert.c:1462
 #, c-format
 msgid "%s: clean filter '%s' failed"
 msgstr "%s: esecuzione del filtro clean '%s' non riuscita"
 
-#: convert.c:1511
+#: convert.c:1508
 #, c-format
 msgid "%s: smudge filter %s failed"
 msgstr "%s: esecuzione del filtro smudge '%s' non riuscita"
@@ -3113,17 +3147,17 @@ msgid "refusing to work with credential missing protocol field"
 msgstr ""
 "mi rifiuto di lavorare se il campo protocol della credenziale è mancante"
 
-#: credential.c:396
+#: credential.c:394
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr "l'URL contiene un carattere nuova riga nella sua componente %s: %s"
 
-#: credential.c:440
+#: credential.c:438
 #, c-format
 msgid "url has no scheme: %s"
 msgstr "l'URL non ha uno schema: %s"
 
-#: credential.c:513
+#: credential.c:511
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr "impossibile analizzare l'URL della credenziale: %s"
@@ -3288,36 +3322,36 @@ msgstr ""
 "Trovati errori nella variabile di configurazione 'diff.dirstat':\n"
 "%s"
 
-#: diff.c:4243
+#: diff.c:4269
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "processo esterno diff morto, mi fermo a %s"
 
-#: diff.c:4589
+#: diff.c:4618
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr ""
 "le opzioni --name-only, --name-status, --check e -s sono mutuamente esclusive"
 
-#: diff.c:4592
+#: diff.c:4621
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "le opzioni -G, -S e --find-object sono mutuamente esclusive"
 
-#: diff.c:4670
+#: diff.c:4699
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow richiede esattamente uno specificatore percorso"
 
-#: diff.c:4718
+#: diff.c:4747
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "valore non valido per --stat: %s"
 
-#: diff.c:4723 diff.c:4728 diff.c:4733 diff.c:4738 diff.c:5250
-#: parse-options.c:197 parse-options.c:201
+#: diff.c:4752 diff.c:4757 diff.c:4762 diff.c:4767 diff.c:5279
+#: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s richiede un valore numerico"
 
-#: diff.c:4755
+#: diff.c:4784
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3326,42 +3360,42 @@ msgstr ""
 "Analisi del parametro dell'opzione --dirstat/-X non riuscita:\n"
 "%s"
 
-#: diff.c:4840
+#: diff.c:4869
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "classe modifica '%c' sconosciuta in --diff-filter=%s"
 
-#: diff.c:4864
+#: diff.c:4893
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "valore sconosciuto dopo ws-error-highlight=%.*s"
 
-#: diff.c:4878
+#: diff.c:4907
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "impossibile risolvere '%s'"
 
-#: diff.c:4928 diff.c:4934
+#: diff.c:4957 diff.c:4963
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s richiede il formato <n>/<m>"
 
-#: diff.c:4946
+#: diff.c:4975
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s richiede un carattere, ricevuto '%s'"
 
-#: diff.c:4967
+#: diff.c:4996
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "argomento --color-moved errato: %s"
 
-#: diff.c:4986
+#: diff.c:5015
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "modo non valido '%s' in --color-moved-ws"
 
-#: diff.c:5026
+#: diff.c:5055
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3369,151 +3403,151 @@ msgstr ""
 "l'opzione diff-algorithm accetta i valori \"myers\", \"minimal\", \"patience"
 "\" e \"histogram\""
 
-#: diff.c:5062 diff.c:5082
+#: diff.c:5091 diff.c:5111
 #, c-format
 msgid "invalid argument to %s"
 msgstr "argomento non valido per %s"
 
-#: diff.c:5219
+#: diff.c:5248
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "analisi del parametro dell'opzione --submodule non riuscita: '%s'"
 
-#: diff.c:5275
+#: diff.c:5304
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "argomento --word-diff errato: %s"
 
-#: diff.c:5298
+#: diff.c:5327
 msgid "Diff output format options"
 msgstr "Opzioni formato output diff"
 
-#: diff.c:5300 diff.c:5306
+#: diff.c:5329 diff.c:5335
 msgid "generate patch"
 msgstr "genera patch"
 
-#: diff.c:5303 builtin/log.c:177
+#: diff.c:5332 builtin/log.c:176
 msgid "suppress diff output"
 msgstr "non visualizzare l'output del diff"
 
-#: diff.c:5308 diff.c:5422 diff.c:5429
+#: diff.c:5337 diff.c:5451 diff.c:5458
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5309 diff.c:5312
+#: diff.c:5338 diff.c:5341
 msgid "generate diffs with <n> lines context"
 msgstr "genera diff con <n> righe di contesto"
 
-#: diff.c:5314
+#: diff.c:5343
 msgid "generate the diff in raw format"
 msgstr "genera il diff in formato grezzo"
 
-#: diff.c:5317
+#: diff.c:5346
 msgid "synonym for '-p --raw'"
 msgstr "sinonimo di '-p --raw'"
 
-#: diff.c:5321
+#: diff.c:5350
 msgid "synonym for '-p --stat'"
 msgstr "sinonimo di '-p --stat'"
 
-#: diff.c:5325
+#: diff.c:5354
 msgid "machine friendly --stat"
 msgstr "--stat leggibile da una macchina"
 
-#: diff.c:5328
+#: diff.c:5357
 msgid "output only the last line of --stat"
 msgstr "emetti in output solo l'ultima riga di --stat"
 
-#: diff.c:5330 diff.c:5338
+#: diff.c:5359 diff.c:5367
 msgid "<param1,param2>..."
 msgstr "<parametro1,parametro2>..."
 
-#: diff.c:5331
+#: diff.c:5360
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "emetti in output la distribuzione del numero di modifiche relativo a ogni "
 "sottodirectory"
 
-#: diff.c:5335
+#: diff.c:5364
 msgid "synonym for --dirstat=cumulative"
 msgstr "sinonimo di --dirstat=cumulative"
 
-#: diff.c:5339
+#: diff.c:5368
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "sinonimo di --dirstat=files,parametro1,parametro2..."
 
-#: diff.c:5343
+#: diff.c:5372
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "avvisa se le modifiche introducono marcatori conflitto o errori spazi bianchi"
 
-#: diff.c:5346
+#: diff.c:5375
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "riassunto conciso (ad es. elementi creati, ridenominati e modifiche modi)"
 
-#: diff.c:5349
+#: diff.c:5378
 msgid "show only names of changed files"
 msgstr "visualizza solo i nomi dei file modificati"
 
-#: diff.c:5352
+#: diff.c:5381
 msgid "show only names and status of changed files"
 msgstr "visualizza solo i nomi e lo stato dei file modificati"
 
-#: diff.c:5354
+#: diff.c:5383
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<ampiezza>[,<ampiezza nome>[,<numero>]]"
 
-#: diff.c:5355
+#: diff.c:5384
 msgid "generate diffstat"
 msgstr "genera diffstat"
 
-#: diff.c:5357 diff.c:5360 diff.c:5363
+#: diff.c:5386 diff.c:5389 diff.c:5392
 msgid "<width>"
 msgstr "<ampiezza>"
 
-#: diff.c:5358
+#: diff.c:5387
 msgid "generate diffstat with a given width"
 msgstr "genera il diffstat con un'ampiezza specificata"
 
-#: diff.c:5361
+#: diff.c:5390
 msgid "generate diffstat with a given name width"
 msgstr "genera il diffstat con un'ampiezza nomi specificata"
 
-#: diff.c:5364
+#: diff.c:5393
 msgid "generate diffstat with a given graph width"
 msgstr "genera il diffstat con un'ampiezza grafo specificata"
 
-#: diff.c:5366
+#: diff.c:5395
 msgid "<count>"
 msgstr "<numero>"
 
-#: diff.c:5367
+#: diff.c:5396
 msgid "generate diffstat with limited lines"
 msgstr "genera il diffstat con righe limitate"
 
-#: diff.c:5370
+#: diff.c:5399
 msgid "generate compact summary in diffstat"
 msgstr "genera riassunto conciso nel diffstat"
 
-#: diff.c:5373
+#: diff.c:5402
 msgid "output a binary diff that can be applied"
 msgstr "stampa in output un diff binario che può essere applicato"
 
-#: diff.c:5376
+#: diff.c:5405
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "visualizza i nomi oggetto pre e post immagine nelle righe \"indice\""
 
-#: diff.c:5378
+#: diff.c:5407
 msgid "show colored diff"
 msgstr "visualizza diff colorato"
 
-#: diff.c:5379
+#: diff.c:5408
 msgid "<kind>"
 msgstr "<tipo>"
 
-#: diff.c:5380
+#: diff.c:5409
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3521,7 +3555,7 @@ msgstr ""
 "evidenzia gli errori di spazi bianchi nelle righe 'contesto', 'vecchie' o "
 "'nuove' nel diff"
 
-#: diff.c:5383
+#: diff.c:5412
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3529,91 +3563,91 @@ msgstr ""
 "non rimuovere i nomi percorso e usare caratteri NUL come terminatori campo "
 "in --raw o --numstat"
 
-#: diff.c:5386 diff.c:5389 diff.c:5392 diff.c:5498
+#: diff.c:5415 diff.c:5418 diff.c:5421 diff.c:5527
 msgid "<prefix>"
 msgstr "<prefisso>"
 
-#: diff.c:5387
+#: diff.c:5416
 msgid "show the given source prefix instead of \"a/\""
 msgstr "visualizza il prefisso sorgente specificato invece di \"a/\""
 
-#: diff.c:5390
+#: diff.c:5419
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "visualizza il prefisso destinazione specificato invece di \"b/\""
 
-#: diff.c:5393
+#: diff.c:5422
 msgid "prepend an additional prefix to every line of output"
 msgstr "anteponi un prefisso aggiuntivo ad ogni riga dell'output"
 
-#: diff.c:5396
+#: diff.c:5425
 msgid "do not show any source or destination prefix"
 msgstr "non visualizzare alcun prefisso sorgente o destinazione"
 
-#: diff.c:5399
+#: diff.c:5428
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "visualizza il contesto tra gli hunk del diff fino al numero di righe "
 "specificato"
 
-#: diff.c:5403 diff.c:5408 diff.c:5413
+#: diff.c:5432 diff.c:5437 diff.c:5442
 msgid "<char>"
 msgstr "<carattere>"
 
-#: diff.c:5404
+#: diff.c:5433
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "specifica il carattere che indica una nuova riga al posto di '+'"
 
-#: diff.c:5409
+#: diff.c:5438
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "specifica il carattere che indica una vecchia riga al posto di '-'"
 
-#: diff.c:5414
+#: diff.c:5443
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "specifica il carattere che indica un contesto al posto di ' '"
 
-#: diff.c:5417
+#: diff.c:5446
 msgid "Diff rename options"
 msgstr "Opzioni rinominazione diff"
 
-#: diff.c:5418
+#: diff.c:5447
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5419
+#: diff.c:5448
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "spezza modifiche di riscrittura completa in coppie eliminazione/creazione"
 
-#: diff.c:5423
+#: diff.c:5452
 msgid "detect renames"
 msgstr "rileva le ridenominazioni"
 
-#: diff.c:5427
+#: diff.c:5456
 msgid "omit the preimage for deletes"
 msgstr "ometti la preimmagine per le eliminazioni"
 
-#: diff.c:5430
+#: diff.c:5459
 msgid "detect copies"
 msgstr "rileva le copie"
 
-#: diff.c:5434
+#: diff.c:5463
 msgid "use unmodified files as source to find copies"
 msgstr "usa file non modificati come sorgente per trovare copie"
 
-#: diff.c:5436
+#: diff.c:5465
 msgid "disable rename detection"
 msgstr "disabilita rilevamento ridenominazione"
 
-#: diff.c:5439
+#: diff.c:5468
 msgid "use empty blobs as rename source"
 msgstr "usa blob vuoti come sorgente ridenominazione"
 
-#: diff.c:5441
+#: diff.c:5470
 msgid "continue listing the history of a file beyond renames"
 msgstr ""
 "continua a elencare la cronologia di un file al di là delle ridenominazioni"
 
-#: diff.c:5444
+#: diff.c:5473
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3621,159 +3655,159 @@ msgstr ""
 "impedisci il rilevamento ridenominazione/copia se il numero delle "
 "destinazioni ridenominazione/copia eccede il limite specificato"
 
-#: diff.c:5446
+#: diff.c:5475
 msgid "Diff algorithm options"
 msgstr "Opzioni algoritmo diff"
 
-#: diff.c:5448
+#: diff.c:5477
 msgid "produce the smallest possible diff"
 msgstr "produci il diff più piccolo possibile"
 
-#: diff.c:5451
+#: diff.c:5480
 msgid "ignore whitespace when comparing lines"
 msgstr "ignora gli spazi bianchi durante il confronto delle righe"
 
-#: diff.c:5454
+#: diff.c:5483
 msgid "ignore changes in amount of whitespace"
 msgstr "ignora le modifiche al numero degli spazi bianchi"
 
-#: diff.c:5457
+#: diff.c:5486
 msgid "ignore changes in whitespace at EOL"
 msgstr "ignora modifiche agli spazi bianchi a fine riga"
 
-#: diff.c:5460
+#: diff.c:5489
 msgid "ignore carrier-return at the end of line"
 msgstr "ignora carattere ritorno a capo a fine riga"
 
-#: diff.c:5463
+#: diff.c:5492
 msgid "ignore changes whose lines are all blank"
 msgstr "ignora modifiche che riguardano solo righe vuote"
 
-#: diff.c:5466
+#: diff.c:5495
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "euristica per spostare i limiti degli hunk nel diff per una lettura agevole"
 
-#: diff.c:5469
+#: diff.c:5498
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "genera il diff usando l'algoritmo \"patience diff\""
 
-#: diff.c:5473
+#: diff.c:5502
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "genera il diff usando l'algoritmo \"histogram diff\""
 
-#: diff.c:5475
+#: diff.c:5504
 msgid "<algorithm>"
 msgstr "<algoritmo>"
 
-#: diff.c:5476
+#: diff.c:5505
 msgid "choose a diff algorithm"
 msgstr "seleziona un algoritmo diff"
 
-#: diff.c:5478
+#: diff.c:5507
 msgid "<text>"
 msgstr "<testo>"
 
-#: diff.c:5479
+#: diff.c:5508
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "genera il diff usando l'algoritmo \"anchored diff\""
 
-#: diff.c:5481 diff.c:5490 diff.c:5493
+#: diff.c:5510 diff.c:5519 diff.c:5522
 msgid "<mode>"
 msgstr "<modalità>"
 
-#: diff.c:5482
+#: diff.c:5511
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "visualizza il diff parola per parola usando <modalità> per delimitare le "
 "parole modificate"
 
-#: diff.c:5484 diff.c:5487 diff.c:5532
+#: diff.c:5513 diff.c:5516 diff.c:5561
 msgid "<regex>"
 msgstr "<espressione regolare>"
 
-#: diff.c:5485
+#: diff.c:5514
 msgid "use <regex> to decide what a word is"
 msgstr "usa <espressione regolare> per decidere cosa costituisce una parola"
 
-#: diff.c:5488
+#: diff.c:5517
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr ""
 "equivalente di --word-diff=color --word-diff-regex=<espressione regolare>"
 
-#: diff.c:5491
+#: diff.c:5520
 msgid "moved lines of code are colored differently"
 msgstr "le righe di codice spostate sono colorate in modo diverso"
 
-#: diff.c:5494
+#: diff.c:5523
 msgid "how white spaces are ignored in --color-moved"
 msgstr "modo in cui sono ignorati gli spazi bianchi in --color-moved"
 
-#: diff.c:5497
+#: diff.c:5526
 msgid "Other diff options"
 msgstr "Altre opzioni diff"
 
-#: diff.c:5499
+#: diff.c:5528
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "se eseguito da una sottodirectory, escludi le modifiche esterne ad essa e "
 "visualizza i percorsi relativi"
 
-#: diff.c:5503
+#: diff.c:5532
 msgid "treat all files as text"
 msgstr "tratta tutti i file come se fossero di testo"
 
-#: diff.c:5505
+#: diff.c:5534
 msgid "swap two inputs, reverse the diff"
 msgstr "scambia i due input, genera un diff al contrario"
 
-#: diff.c:5507
+#: diff.c:5536
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr "esci con codice 1 se ci sono differenze, con 0 altrimenti"
 
-#: diff.c:5509
+#: diff.c:5538
 msgid "disable all output of the program"
 msgstr "disabilita l'intero output del programma"
 
-#: diff.c:5511
+#: diff.c:5540
 msgid "allow an external diff helper to be executed"
 msgstr "consenti l'esecuzione di un helper diff esterno"
 
-#: diff.c:5513
+#: diff.c:5542
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "esegui filtri di conversione in testo esterni quando si confrontano file "
 "binari"
 
-#: diff.c:5515
+#: diff.c:5544
 msgid "<when>"
 msgstr "<quando>"
 
-#: diff.c:5516
+#: diff.c:5545
 msgid "ignore changes to submodules in the diff generation"
 msgstr "ignora le modifiche ai sottomoduli durante la generazione del diff"
 
-#: diff.c:5519
+#: diff.c:5548
 msgid "<format>"
 msgstr "<formato>"
 
-#: diff.c:5520
+#: diff.c:5549
 msgid "specify how differences in submodules are shown"
 msgstr "specifica come verranno visualizzate le differenze nei sottomoduli"
 
-#: diff.c:5524
+#: diff.c:5553
 msgid "hide 'git add -N' entries from the index"
 msgstr "nascondi le voci 'git add -N' nell'indice"
 
-#: diff.c:5527
+#: diff.c:5556
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "tratta le voci 'git add -N' come reali nell'indice"
 
-#: diff.c:5529
+#: diff.c:5558
 msgid "<string>"
 msgstr "<stringa>"
 
-#: diff.c:5530
+#: diff.c:5559
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3781,7 +3815,7 @@ msgstr ""
 "cerca differenze che modificano il numero di occorrenze della stringa "
 "specificata"
 
-#: diff.c:5533
+#: diff.c:5562
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3789,24 +3823,24 @@ msgstr ""
 "cerca differenze che modificano il numero di occorrenze dell'espressione "
 "regolare specificata"
 
-#: diff.c:5536
+#: diff.c:5565
 msgid "show all changes in the changeset with -S or -G"
 msgstr "visualizza tutte le modifiche nel changeset con -S o -G"
 
-#: diff.c:5539
+#: diff.c:5568
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "tratta la <stringa> nell'opzione -S come un'espressione regolare POSIX estesa"
 
-#: diff.c:5542
+#: diff.c:5571
 msgid "control the order in which files appear in the output"
 msgstr "controlla l'ordine con cui i file appariranno nell'output"
 
-#: diff.c:5543
+#: diff.c:5572
 msgid "<object-id>"
 msgstr "<ID oggetto>"
 
-#: diff.c:5544
+#: diff.c:5573
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3814,34 +3848,34 @@ msgstr ""
 "cerca differenze che modificano il numero di occorrenze dell'oggetto "
 "specificato"
 
-#: diff.c:5546
+#: diff.c:5575
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5547
+#: diff.c:5576
 msgid "select files by diff type"
 msgstr "seleziona file in base al tipo diff"
 
-#: diff.c:5549
+#: diff.c:5578
 msgid "<file>"
 msgstr "<file>"
 
-#: diff.c:5550
+#: diff.c:5579
 msgid "Output to a specific file"
 msgstr "Salva l'output in un file specifico"
 
-#: diff.c:6205
+#: diff.c:6236
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
 "il rilevamento ridenominazione non esatta è stato omesso per la presenza di "
 "troppi file."
 
-#: diff.c:6208
+#: diff.c:6239
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "trovate solo copie dai percorsi modificati per la presenza di troppi file."
 
-#: diff.c:6211
+#: diff.c:6242
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3858,62 +3892,62 @@ msgstr "lettura dell'orderfile '%s' non riuscita"
 msgid "Performing inexact rename detection"
 msgstr "Rilevamento ridenominazione non esatta in corso"
 
-#: dir.c:573
+#: dir.c:578
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
 msgstr ""
 "lo specificatore percorso '%s' non corrisponde ad alcun file noto a git"
 
-#: dir.c:713 dir.c:742 dir.c:755
+#: dir.c:718 dir.c:747 dir.c:760
 #, c-format
 msgid "unrecognized pattern: '%s'"
 msgstr "pattern non riconosciuto: '%s'"
 
-#: dir.c:772 dir.c:786
+#: dir.c:777 dir.c:791
 #, c-format
 msgid "unrecognized negative pattern: '%s'"
 msgstr "pattern negativo non riconosciuto: '%s'"
 
-#: dir.c:804
+#: dir.c:809
 #, c-format
 msgid "your sparse-checkout file may have issues: pattern '%s' is repeated"
 msgstr ""
 "il file sparse-checkout potrebbe avere dei problemi: il pattern '%s' è "
 "ripetuto"
 
-#: dir.c:814
+#: dir.c:819
 msgid "disabling cone pattern matching"
 msgstr "disabilito il pattern matching di tipo cone"
 
-#: dir.c:1191
+#: dir.c:1198
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "impossibile usare %s come file di esclusione"
 
-#: dir.c:2296
+#: dir.c:2305
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "impossibile aprire la directory '%s'"
 
-#: dir.c:2596
+#: dir.c:2605
 msgid "failed to get kernel name and information"
 msgstr "impossibile ottenere il nome e le informazioni sul kernel"
 
-#: dir.c:2720
+#: dir.c:2729
 msgid "untracked cache is disabled on this system or location"
 msgstr "la cache non tracciata è disabilitata su questo sistema o percorso"
 
-#: dir.c:3502
+#: dir.c:3520
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "file index corrotto nel repository %s"
 
-#: dir.c:3547 dir.c:3552
+#: dir.c:3565 dir.c:3570
 #, c-format
 msgid "could not create directories for %s"
 msgstr "impossibile creare le directory per %s"
 
-#: dir.c:3581
+#: dir.c:3599
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "impossibile migrare la directory git da '%s' a '%s'"
@@ -3948,248 +3982,248 @@ msgstr "impossibile impostare GIT_DIR a '%s'"
 msgid "too many args to run %s"
 msgstr "troppi argomenti per eseguire %s"
 
-#: fetch-pack.c:152
+#: fetch-pack.c:176
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: attesa lista shallow"
 
-#: fetch-pack.c:155
+#: fetch-pack.c:179
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: atteso pacchetto flush dopo lista shallow"
 
-#: fetch-pack.c:166
+#: fetch-pack.c:190
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: attesi ACK/NAK, ricevuto pacchetto flush"
 
-#: fetch-pack.c:186
+#: fetch-pack.c:210
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: attesi ACK/NAK, ricevuto '%s'"
 
-#: fetch-pack.c:197
+#: fetch-pack.c:221
 msgid "unable to write to remote"
 msgstr "impossibile scrivere sul remoto"
 
-#: fetch-pack.c:259
+#: fetch-pack.c:282
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc richiede multi_ack_detailed"
 
-#: fetch-pack.c:358 fetch-pack.c:1408
+#: fetch-pack.c:375 fetch-pack.c:1397
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "riga shallow non valida: '%s'"
 
-#: fetch-pack.c:364 fetch-pack.c:1414
+#: fetch-pack.c:381 fetch-pack.c:1403
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "riga unshallow non valida: '%s'"
 
-#: fetch-pack.c:366 fetch-pack.c:1416
+#: fetch-pack.c:383 fetch-pack.c:1405
 #, c-format
 msgid "object not found: %s"
 msgstr "oggetto non trovato: %s"
 
-#: fetch-pack.c:369 fetch-pack.c:1419
+#: fetch-pack.c:386 fetch-pack.c:1408
 #, c-format
 msgid "error in object: %s"
 msgstr "errore nell'oggetto: %s"
 
-#: fetch-pack.c:371 fetch-pack.c:1421
+#: fetch-pack.c:388 fetch-pack.c:1410
 #, c-format
 msgid "no shallow found: %s"
 msgstr "nessuno shallow trovato: %s"
 
-#: fetch-pack.c:374 fetch-pack.c:1425
+#: fetch-pack.c:391 fetch-pack.c:1414
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "attesi shallow/unshallow, ricevuto %s"
 
-#: fetch-pack.c:416
+#: fetch-pack.c:431
 #, c-format
 msgid "got %s %d %s"
 msgstr "ricevuto %s %d %s"
 
-#: fetch-pack.c:433
+#: fetch-pack.c:448
 #, c-format
 msgid "invalid commit %s"
 msgstr "commit non valido: %s"
 
-#: fetch-pack.c:464
+#: fetch-pack.c:479
 msgid "giving up"
 msgstr "smetto di provare"
 
-#: fetch-pack.c:477 progress.c:336
+#: fetch-pack.c:492 progress.c:339
 msgid "done"
 msgstr "fatto"
 
-#: fetch-pack.c:489
+#: fetch-pack.c:504
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "ricevuto %s (%d) %s"
 
-#: fetch-pack.c:535
+#: fetch-pack.c:540
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Contrassegno %s come completo"
 
-#: fetch-pack.c:756
+#: fetch-pack.c:755
 #, c-format
 msgid "already have %s (%s)"
 msgstr "ho già %s (%s)"
 
-#: fetch-pack.c:821
+#: fetch-pack.c:824
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr ""
 "fetch-pack: impossibile eseguire il fork del demultiplexer della banda "
 "laterlae"
 
-#: fetch-pack.c:829
+#: fetch-pack.c:832
 msgid "protocol error: bad pack header"
 msgstr "errore protocollo: intestazione pack non valida"
 
-#: fetch-pack.c:910
+#: fetch-pack.c:916
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: impossibile eseguire il fork di %s"
 
-#: fetch-pack.c:927
+#: fetch-pack.c:933
 #, c-format
 msgid "%s failed"
 msgstr "%s non riuscito"
 
-#: fetch-pack.c:929
+#: fetch-pack.c:935
 msgid "error in sideband demultiplexer"
 msgstr "errore nel demultiplexer della banda laterale"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:978
 #, c-format
 msgid "Server version is %.*s"
 msgstr "La versione del server è %.*s"
 
-#: fetch-pack.c:981 fetch-pack.c:987 fetch-pack.c:990 fetch-pack.c:996
-#: fetch-pack.c:1000 fetch-pack.c:1004 fetch-pack.c:1008 fetch-pack.c:1012
-#: fetch-pack.c:1016 fetch-pack.c:1020 fetch-pack.c:1024 fetch-pack.c:1028
-#: fetch-pack.c:1034 fetch-pack.c:1040 fetch-pack.c:1045 fetch-pack.c:1050
+#: fetch-pack.c:983 fetch-pack.c:989 fetch-pack.c:992 fetch-pack.c:998
+#: fetch-pack.c:1002 fetch-pack.c:1006 fetch-pack.c:1010 fetch-pack.c:1014
+#: fetch-pack.c:1018 fetch-pack.c:1022 fetch-pack.c:1026 fetch-pack.c:1030
+#: fetch-pack.c:1036 fetch-pack.c:1042 fetch-pack.c:1047 fetch-pack.c:1052
 #, c-format
 msgid "Server supports %s"
 msgstr "Il server supporta %s"
 
-#: fetch-pack.c:983
+#: fetch-pack.c:985
 msgid "Server does not support shallow clients"
 msgstr "Il server non supporta client shallow"
 
-#: fetch-pack.c:1043
+#: fetch-pack.c:1045
 msgid "Server does not support --shallow-since"
 msgstr "Il server non supporta --shallow-since"
 
-#: fetch-pack.c:1048
+#: fetch-pack.c:1050
 msgid "Server does not support --shallow-exclude"
 msgstr "Il server non supporta --shallow-exclude"
 
-#: fetch-pack.c:1052
+#: fetch-pack.c:1054
 msgid "Server does not support --deepen"
 msgstr "Il server non supporta --deepen"
 
-#: fetch-pack.c:1054
+#: fetch-pack.c:1056
 msgid "Server does not support this repository's object format"
 msgstr "Il server non supporta il formato oggetti di questo repository"
 
-#: fetch-pack.c:1071
+#: fetch-pack.c:1069
 msgid "no common commits"
 msgstr "nessun commit in comune"
 
-#: fetch-pack.c:1083 fetch-pack.c:1639
+#: fetch-pack.c:1081 fetch-pack.c:1619
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: recupero non riuscito."
 
-#: fetch-pack.c:1211
+#: fetch-pack.c:1205
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "algoritmi non corrispondenti: client %s; server %s"
 
-#: fetch-pack.c:1215
+#: fetch-pack.c:1209
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "il server non supporta l'algoritmo '%s'"
 
-#: fetch-pack.c:1235
+#: fetch-pack.c:1229
 msgid "Server does not support shallow requests"
 msgstr "Il server non supporta le richieste shallow"
 
-#: fetch-pack.c:1242
+#: fetch-pack.c:1236
 msgid "Server supports filter"
 msgstr "Il server supporta filter"
 
-#: fetch-pack.c:1286
+#: fetch-pack.c:1275
 msgid "unable to write request to remote"
 msgstr "impossibile scrivere la richiesta sul remoto"
 
-#: fetch-pack.c:1304
+#: fetch-pack.c:1293
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "errore durante la lettura dell'intestazione di sezione '%s'"
 
-#: fetch-pack.c:1310
+#: fetch-pack.c:1299
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "atteso '%s', ricevuto '%s'"
 
-#: fetch-pack.c:1371
+#: fetch-pack.c:1360
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "riga di conferma inattesa: '%s'"
 
-#: fetch-pack.c:1376
+#: fetch-pack.c:1365
 #, c-format
 msgid "error processing acks: %d"
 msgstr "errore durante l'elaborazione degli ack: %d"
 
-#: fetch-pack.c:1386
+#: fetch-pack.c:1375
 msgid "expected packfile to be sent after 'ready'"
 msgstr "ci si attendeva che il packfile fosse inviato dopo 'ready'"
 
-#: fetch-pack.c:1388
+#: fetch-pack.c:1377
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 "ci si attendeva che nessun'altra sezione fosse inviata in assenza di 'ready'"
 
-#: fetch-pack.c:1430
+#: fetch-pack.c:1419
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "errore durante l'elaborazione delle informazioni shallow: %d"
 
-#: fetch-pack.c:1477
+#: fetch-pack.c:1466
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "atteso wanted-ref, ricevuto '%s'"
 
-#: fetch-pack.c:1482
+#: fetch-pack.c:1471
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "wanted-ref inatteso: '%s'"
 
-#: fetch-pack.c:1487
+#: fetch-pack.c:1476
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "errore durante l'elaborazione dei riferimenti desiderati: %d"
 
-#: fetch-pack.c:1517
+#: fetch-pack.c:1506
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: atteso pacchetto fine risposta"
 
-#: fetch-pack.c:1921
+#: fetch-pack.c:1887
 msgid "no matching remote head"
 msgstr "nessun head remoto corrispondente"
 
-#: fetch-pack.c:1944 builtin/clone.c:692
+#: fetch-pack.c:1910 builtin/clone.c:692
 msgid "remote did not send all necessary objects"
 msgstr "il remoto non ha inviato tutti gli oggetti necessari"
 
-#: fetch-pack.c:1971
+#: fetch-pack.c:1937
 #, c-format
 msgid "no such remote ref %s"
 msgstr "riferimento remoto non esistente: %s"
 
-#: fetch-pack.c:1974
+#: fetch-pack.c:1940
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Il server non consente richieste per l'oggetto non pubblicizzato %s"
@@ -4307,8 +4341,8 @@ msgid "unsupported command listing type '%s'"
 msgstr "tipo elenco comandi non supportato: '%s'"
 
 #: help.c:403
-msgid "The common Git guides are:"
-msgstr "Le guide Git comuni sono:"
+msgid "The Git concept guides are:"
+msgstr "Le guide Git concettuali sono:"
 
 #: help.c:427
 msgid "See 'git help <command>' to read about a specific subcommand"
@@ -4393,7 +4427,15 @@ msgstr[1] ""
 "\n"
 "Intendevi uno di questi?"
 
-#: ident.c:349
+#: ident.c:353
+msgid "Author identity unknown\n"
+msgstr "Identità autore sconosciuta\n"
+
+#: ident.c:356
+msgid "Committer identity unknown\n"
+msgstr "Identità autore del commit sconosciuta\n"
+
+#: ident.c:362
 msgid ""
 "\n"
 "*** Please tell me who you are.\n"
@@ -4419,70 +4461,70 @@ msgstr ""
 "Ometti --global per impostare l'identità solo in questo repository.\n"
 "\n"
 
-#: ident.c:379
+#: ident.c:397
 msgid "no email was given and auto-detection is disabled"
 msgstr ""
 "nessun indirizzo e-mail specificato e rilevamento automatico disabilitato"
 
-#: ident.c:384
+#: ident.c:402
 #, c-format
 msgid "unable to auto-detect email address (got '%s')"
 msgstr ""
 "impossibile rilevare automaticamente l'indirizzo e-mail (ho ricavato '%s')"
 
-#: ident.c:401
+#: ident.c:419
 msgid "no name was given and auto-detection is disabled"
 msgstr "nessun nome specificato e rilevamento automatico disabilitato"
 
-#: ident.c:407
+#: ident.c:425
 #, c-format
 msgid "unable to auto-detect name (got '%s')"
 msgstr "impossibile rilevare automaticamente il nome (ho ricavato '%s')"
 
-#: ident.c:415
+#: ident.c:433
 #, c-format
 msgid "empty ident name (for <%s>) not allowed"
 msgstr "nome ident vuoto (per <%s>) non consentito"
 
-#: ident.c:421
+#: ident.c:439
 #, c-format
 msgid "name consists only of disallowed characters: %s"
 msgstr "il nome è composto solo da caratteri non consentiti: %s"
 
-#: ident.c:436 builtin/commit.c:634
+#: ident.c:454 builtin/commit.c:634
 #, c-format
 msgid "invalid date format: %s"
 msgstr "formato data non valido: %s"
 
-#: list-objects-filter-options.c:58
+#: list-objects-filter-options.c:81
 msgid "expected 'tree:<depth>'"
 msgstr "atteso 'tree:<profondità>'"
 
-#: list-objects-filter-options.c:73
+#: list-objects-filter-options.c:96
 msgid "sparse:path filters support has been dropped"
 msgstr "il supporto per i filtri sparse:percorso è stato rimosso"
 
-#: list-objects-filter-options.c:86
+#: list-objects-filter-options.c:109
 #, c-format
 msgid "invalid filter-spec '%s'"
 msgstr "specificatore filtro '%s' non valido"
 
-#: list-objects-filter-options.c:102
+#: list-objects-filter-options.c:125
 #, c-format
 msgid "must escape char in sub-filter-spec: '%c'"
 msgstr ""
 "è necessario eseguire l'escape del carattere nello specificatore del "
 "sottofiltro: '%c'"
 
-#: list-objects-filter-options.c:144
+#: list-objects-filter-options.c:167
 msgid "expected something after combine:"
 msgstr "atteso qualcosa dopo la ricombinazione:"
 
-#: list-objects-filter-options.c:226
+#: list-objects-filter-options.c:249
 msgid "multiple filter-specs cannot be combined"
 msgstr "non è possibile combinare più specificatori filtro"
 
-#: list-objects-filter-options.c:330
+#: list-objects-filter-options.c:361
 msgid "unable to upgrade repository format to support partial clone"
 msgstr ""
 "impossibile aggiornare il formato repository per supportare il clone parziale"
@@ -4857,7 +4899,7 @@ msgstr "aggiunta/aggiunta"
 msgid "Skipped %s (merged same as existing)"
 msgstr "Omesso %s (elemento sottoposto a merge uguale a quello esistente)"
 
-#: merge-recursive.c:3101 git-submodule.sh:959
+#: merge-recursive.c:3101
 msgid "submodule"
 msgstr "sottomodulo"
 
@@ -4947,22 +4989,22 @@ msgstr "Già aggiornato!"
 msgid "merging of trees %s and %s failed"
 msgstr "merge degli alberi %s e %s non riuscito"
 
-#: merge-recursive.c:3549
+#: merge-recursive.c:3550
 msgid "Merging:"
 msgstr "Merge in corso:"
 
-#: merge-recursive.c:3562
+#: merge-recursive.c:3563
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "trovato %u antenato comune:"
 msgstr[1] "trovati %u antenati comuni:"
 
-#: merge-recursive.c:3612
+#: merge-recursive.c:3613
 msgid "merge returned no commit"
 msgstr "il merge non ha restituito alcun commit"
 
-#: merge-recursive.c:3671
+#: merge-recursive.c:3672
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -4971,12 +5013,12 @@ msgstr ""
 "Le tue modifiche locali ai seguenti file sarebbero sovrascritte dal merge:\n"
 "  %s"
 
-#: merge-recursive.c:3768
+#: merge-recursive.c:3769
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Impossibile analizzare l'oggetto '%s'"
 
-#: merge-recursive.c:3786 builtin/merge.c:705 builtin/merge.c:885
+#: merge-recursive.c:3787 builtin/merge.c:702 builtin/merge.c:881
 msgid "Unable to write index."
 msgstr "Impossibile scrivere l'indice."
 
@@ -4984,172 +5026,178 @@ msgstr "Impossibile scrivere l'indice."
 msgid "failed to read the cache"
 msgstr "lettura della cache non riuscita"
 
-#: merge.c:108 rerere.c:720 builtin/am.c:1878 builtin/am.c:1912
-#: builtin/checkout.c:559 builtin/checkout.c:822 builtin/clone.c:816
+#: merge.c:109 rerere.c:720 builtin/am.c:1896 builtin/am.c:1930
+#: builtin/checkout.c:560 builtin/checkout.c:816 builtin/clone.c:816
 #: builtin/stash.c:265
 msgid "unable to write new index file"
 msgstr "impossibile scrivere il nuovo file index"
 
-#: midx.c:68
+#: midx.c:79
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "il file multi-pack-index %s è troppo piccolo"
 
-#: midx.c:84
+#: midx.c:95
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "la firma del multi-pack-index 0x%08x non corrisponde alla firma 0x%08x"
 
-#: midx.c:89
+#: midx.c:100
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "versione %d multi-pack-index non riconosciuta"
 
-#: midx.c:94
+#: midx.c:105
 #, c-format
-msgid "hash version %u does not match"
-msgstr "la versione dell'hash %u non corrisponde"
+msgid "multi-pack-index hash version %u does not match version %u"
+msgstr ""
+"la versione dell'hash multi-pack-index %u non corrisponde alla versione %u"
 
-#: midx.c:108
+#: midx.c:122
 msgid "invalid chunk offset (too large)"
 msgstr "offset blocco non valido (troppo grande)"
 
-#: midx.c:132
+#: midx.c:146
 msgid "terminating multi-pack-index chunk id appears earlier than expected"
 msgstr "l'ID blocco finale multi-pack-index compare prima di quanto previsto"
 
-#: midx.c:145
+#: midx.c:159
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "dal multi-pack-index manca il blocco richiesto pack-name"
 
-#: midx.c:147
+#: midx.c:161
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "dal multi-pack-index manca il blocco richiesto fanout OID"
 
-#: midx.c:149
+#: midx.c:163
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "dal multi-pack-index manca il blocco richiesto lookup OID"
 
-#: midx.c:151
+#: midx.c:165
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "dal multi-pack-index manca il blocco richiesto offset oggetti"
 
-#: midx.c:165
+#: midx.c:179
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "nomi pack multi-pack-index in disordine: '%s' appare prima di '%s'"
 
-#: midx.c:208
+#: midx.c:222
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "pack-int-id non valido: %u (%u pack totali)"
 
-#: midx.c:258
+#: midx.c:272
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "nel multi-pack-index è salvato un offset a 64 bit, ma off_t è troppo piccolo"
 
-#: midx.c:286
+#: midx.c:300
 msgid "error preparing packfile from multi-pack-index"
 msgstr "errore durante la preparazione del packfile dal multi-pack-index"
 
-#: midx.c:470
+#: midx.c:485
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "aggiunta del packfile '%s' non riuscita"
 
-#: midx.c:476
+#: midx.c:491
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "apertura del pack-index '%s' non riuscita"
 
-#: midx.c:536
+#: midx.c:551
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "ricerca dell'oggetto %d nel packfile non riuscita"
 
-#: midx.c:840
+#: midx.c:853
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Aggiunta dei file pack al multi-pack-index in corso"
 
-#: midx.c:873
+#: midx.c:886
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "non ho visto il file pack %s da scartare"
 
-#: midx.c:925
+#: midx.c:938
 msgid "no pack files to index."
 msgstr "nessun file pack da indicizzare."
 
-#: midx.c:977
+#: midx.c:990
 msgid "Writing chunks to multi-pack-index"
 msgstr "Scrittura dei chunk nel multi-pack-index in corso"
 
-#: midx.c:1056
+#: midx.c:1068
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "pulizia del multi-pack-index %s non riuscita"
 
-#: midx.c:1112
+#: midx.c:1124
+msgid "multi-pack-index file exists, but failed to parse"
+msgstr ""
+"il file multi-pack-index esiste, ma non è stato possibile interpretarlo"
+
+#: midx.c:1132
 msgid "Looking for referenced packfiles"
 msgstr "Ricerca di file pack referenziati in corso"
 
-#: midx.c:1127
+#: midx.c:1147
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 "fanout oid in disordine: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1132
+#: midx.c:1152
 msgid "the midx contains no oid"
 msgstr "il midx non contiene alcun OID"
 
-#: midx.c:1141
+#: midx.c:1161
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Verifica ordine OID nel multi-pack-index in corso"
 
-#: midx.c:1150
+#: midx.c:1170
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "lookup oid in disordine: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1170
+#: midx.c:1190
 msgid "Sorting objects by packfile"
 msgstr "Ordinamento degli oggetti nel packfile in corso"
 
-#: midx.c:1177
+#: midx.c:1197
 msgid "Verifying object offsets"
 msgstr "Verifica offset oggetti in corso"
 
-#: midx.c:1193
+#: midx.c:1213
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "caricamento voce pack per oid[%d] = %s non riuscito"
 
-#: midx.c:1199
+#: midx.c:1219
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "caricamento pack-index per il packfile %s non riuscito"
 
-#: midx.c:1208
+#: midx.c:1228
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "offset oggetto non corretto per oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1233
+#: midx.c:1253
 msgid "Counting referenced objects"
 msgstr "Conteggio degli oggetti referenziati in corso"
 
-#: midx.c:1243
+#: midx.c:1263
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Ricerca ed eliminazione dei file pack non referenziati in corso"
 
-#: midx.c:1433
+#: midx.c:1454
 msgid "could not start pack-objects"
 msgstr "impossibile avviare pack-objects"
 
-#: midx.c:1452
+#: midx.c:1474
 msgid "could not finish pack-objects"
 msgstr "impossibile finire pack-objects"
 
@@ -5235,7 +5283,7 @@ msgstr "impossibile analizzare l'oggetto: %s"
 msgid "hash mismatch %s"
 msgstr "hash non corrispondente: %s"
 
-#: pack-bitmap.c:815 pack-bitmap.c:821 builtin/pack-objects.c:2184
+#: pack-bitmap.c:815 pack-bitmap.c:821 builtin/pack-objects.c:2216
 #, c-format
 msgid "unable to get size of %s"
 msgstr "impossibile recuperare le dimensioni di %s"
@@ -5244,13 +5292,13 @@ msgstr "impossibile recuperare le dimensioni di %s"
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "offset collocato prima della fine del packfile (.idx corrotto?)"
 
-#: packfile.c:1900
+#: packfile.c:1922
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 "offset collocato prima dell'inizio dell'indice pack per %s (indice corrotto?)"
 
-#: packfile.c:1904
+#: packfile.c:1926
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
@@ -5271,7 +5319,7 @@ msgstr "data scadenza '%s' malformata"
 msgid "option `%s' expects \"always\", \"auto\", or \"never\""
 msgstr "l'opzione `%s' richiede \"always\", \"auto\" o \"never\""
 
-#: parse-options-cb.c:130 parse-options-cb.c:147
+#: parse-options-cb.c:132 parse-options-cb.c:149
 #, c-format
 msgid "malformed object name '%s'"
 msgstr "nome oggetto '%s' malformato"
@@ -5317,31 +5365,31 @@ msgstr "opzione ambigua: %s (potrebbe essere --%s%s o --%s%s)"
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "forse intendevi `--%s` (con due trattini)?"
 
-#: parse-options.c:663 parse-options.c:963
+#: parse-options.c:666 parse-options.c:971
 #, c-format
 msgid "alias of --%s"
 msgstr "alias di --%s"
 
-#: parse-options.c:854
+#: parse-options.c:862
 #, c-format
 msgid "unknown option `%s'"
 msgstr "opzione sconosciuta `%s'"
 
-#: parse-options.c:856
+#: parse-options.c:864
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "opzione `%c` sconosciuta"
 
-#: parse-options.c:858
+#: parse-options.c:866
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "opzione non ASCII sconosciuta presente nella stringa: `%s'"
 
-#: parse-options.c:882
+#: parse-options.c:890
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:901
+#: parse-options.c:909
 #, c-format
 msgid "usage: %s"
 msgstr "uso: %s"
@@ -5349,17 +5397,17 @@ msgstr "uso: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:907
+#: parse-options.c:915
 #, c-format
 msgid "   or: %s"
 msgstr "  oppure: %s"
 
-#: parse-options.c:910
+#: parse-options.c:918
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:949
+#: parse-options.c:957
 msgid "-NUM"
 msgstr "-NUM"
 
@@ -5503,7 +5551,7 @@ msgstr "errore protocollo: carattere lunghezza riga non valido: %.4s"
 msgid "protocol error: bad line length %d"
 msgstr "errore protocollo: lunghezza riga non valida: %d"
 
-#: pkt-line.c:373
+#: pkt-line.c:373 sideband.c:150
 #, c-format
 msgid "remote error: %s"
 msgstr "errore remoto: %s"
@@ -5517,15 +5565,26 @@ msgstr "Aggiornamento indice in corso"
 msgid "unable to create threaded lstat: %s"
 msgstr "impossibile creare lstat in versione threaded: %s"
 
-#: pretty.c:982
+#: pretty.c:983
 msgid "unable to parse --pretty format"
 msgstr "impossibile analizzare il formato --pretty"
 
-#: promisor-remote.c:23
-msgid "Remote with no URL"
-msgstr "Remoto senza URL"
+#: promisor-remote.c:30
+msgid "promisor-remote: unable to fork off fetch subprocess"
+msgstr ""
+"promisor-remote: impossibile eseguire il fork del sottoprocesso di fetch"
 
-#: promisor-remote.c:58
+#: promisor-remote.c:35 promisor-remote.c:37
+msgid "promisor-remote: could not write to fetch subprocess"
+msgstr "promisor-remote: impossibile scrivere sul sottoprocesso di fetch"
+
+#: promisor-remote.c:41
+msgid "promisor-remote: could not close stdin to fetch subprocess"
+msgstr ""
+"promisor-remote: impossibile chiudere lo standard input del sottoprocesso di"
+" fetch"
+
+#: promisor-remote.c:53
 #, c-format
 msgid "promisor remote name cannot begin with '/': %s"
 msgstr "il nome del remoto promettente non può iniziare con '/': %s"
@@ -5542,7 +5601,7 @@ msgstr "impossibile avviare `log`"
 msgid "could not read `log` output"
 msgstr "impossibile leggere l'output di `log`"
 
-#: range-diff.c:98 sequencer.c:5143
+#: range-diff.c:98 sequencer.c:5283
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "impossibile analizzare il commit '%s'"
@@ -5570,52 +5629,52 @@ msgstr "generazione del diff non riuscita"
 msgid "could not parse log for '%s'"
 msgstr "impossibile analizzare il registro di '%s'"
 
-#: read-cache.c:680
+#: read-cache.c:682
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr "non aggiungerò l'alias file '%s' ('%s' esiste già nell'indice)"
 
-#: read-cache.c:696
+#: read-cache.c:698
 msgid "cannot create an empty blob in the object database"
 msgstr "impossibile creare un blob vuoto nel database oggetti"
 
-#: read-cache.c:718
+#: read-cache.c:720
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: è possibile aggiungere solo file regolari, collegamenti simbolici o "
 "directory Git"
 
-#: read-cache.c:723
+#: read-cache.c:725
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "'%s' non ha un commit di cui è stato eseguito il checkout"
 
-#: read-cache.c:775
+#: read-cache.c:777
 #, c-format
 msgid "unable to index file '%s'"
 msgstr "impossibile indicizzare il file '%s'"
 
-#: read-cache.c:794
+#: read-cache.c:796
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr "impossibile aggiungere '%s' all'indice"
 
-#: read-cache.c:805
+#: read-cache.c:807
 #, c-format
 msgid "unable to stat '%s'"
 msgstr "impossibile eseguire stat su '%s'"
 
-#: read-cache.c:1330
+#: read-cache.c:1318
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' compare sia come file sia come directory"
 
-#: read-cache.c:1536
+#: read-cache.c:1524
 msgid "Refresh index"
 msgstr "Aggiornamento indice"
 
-#: read-cache.c:1651
+#: read-cache.c:1639
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -5624,7 +5683,7 @@ msgstr ""
 "index.version impostato, ma il valore non è valido.\n"
 "Uso la versione %i"
 
-#: read-cache.c:1661
+#: read-cache.c:1649
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -5633,139 +5692,139 @@ msgstr ""
 "GIT_INDEX_VERSION impostato, ma il valore non è valido.\n"
 "Uso la versione %i"
 
-#: read-cache.c:1717
+#: read-cache.c:1705
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "firma non valida: 0x%08x"
 
-#: read-cache.c:1720
+#: read-cache.c:1708
 #, c-format
 msgid "bad index version %d"
 msgstr "versione indice non valida: %d"
 
-#: read-cache.c:1729
+#: read-cache.c:1717
 msgid "bad index file sha1 signature"
 msgstr "firma SHA1 file indice non valida"
 
-#: read-cache.c:1759
+#: read-cache.c:1747
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "l'indice usa l'estensione %.4s che non comprendiamo"
 
-#: read-cache.c:1761
+#: read-cache.c:1749
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "estensione %.4s ignorata"
 
-#: read-cache.c:1798
+#: read-cache.c:1786
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "formato voce indice sconosciuto: 0x%08x"
 
-#: read-cache.c:1814
+#: read-cache.c:1802
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "campo nome malformato nell'indice, vicino al percorso '%s'"
 
-#: read-cache.c:1871
+#: read-cache.c:1859
 msgid "unordered stage entries in index"
 msgstr "voci stage non ordinate nell'indice"
 
-#: read-cache.c:1874
+#: read-cache.c:1862
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "voci stage multiple per il file sottoposto a merge '%s'"
 
-#: read-cache.c:1877
+#: read-cache.c:1865
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "voci stage non ordinate per '%s'"
 
-#: read-cache.c:1983 read-cache.c:2271 rerere.c:565 rerere.c:599 rerere.c:1111
-#: submodule.c:1619 builtin/add.c:532 builtin/check-ignore.c:181
-#: builtin/checkout.c:488 builtin/checkout.c:674 builtin/clean.c:991
+#: read-cache.c:1971 read-cache.c:2262 rerere.c:565 rerere.c:599 rerere.c:1111
+#: submodule.c:1628 builtin/add.c:538 builtin/check-ignore.c:181
+#: builtin/checkout.c:489 builtin/checkout.c:675 builtin/clean.c:991
 #: builtin/commit.c:364 builtin/diff-tree.c:121 builtin/grep.c:507
-#: builtin/mv.c:145 builtin/reset.c:247 builtin/rm.c:290
+#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:290
 #: builtin/submodule--helper.c:332
 msgid "index file corrupt"
 msgstr "file indice corrotto"
 
-#: read-cache.c:2124
+#: read-cache.c:2115
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "impossibile creare il thread load_cache_entries: %s"
 
-#: read-cache.c:2137
+#: read-cache.c:2128
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "impossibile bloccare il thread load_cache_entries: %s"
 
-#: read-cache.c:2170
+#: read-cache.c:2161
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: apertura del file indice non riuscita"
 
-#: read-cache.c:2174
+#: read-cache.c:2165
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: impossibile eseguire stat sull'indice aperto"
 
-#: read-cache.c:2178
+#: read-cache.c:2169
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: file indice più piccolo della dimensione attesa"
 
-#: read-cache.c:2182
+#: read-cache.c:2173
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s: impossibile mappare il file indice"
 
-#: read-cache.c:2224
+#: read-cache.c:2215
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "impossibile creare il thread load_index_extensions: %s"
 
-#: read-cache.c:2251
+#: read-cache.c:2242
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "impossibile bloccare il thread load_index_extensions: %s"
 
-#: read-cache.c:2283
+#: read-cache.c:2274
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "impossibile aggiornare l'indice condiviso '%s'"
 
-#: read-cache.c:2330
+#: read-cache.c:2321
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "indice corrotto, atteso %s in %s, presente %s"
 
-#: read-cache.c:3026 strbuf.c:1171 wrapper.c:630 builtin/merge.c:1130
+#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1126
 #, c-format
 msgid "could not close '%s'"
 msgstr "impossibile chiudere '%s'"
 
-#: read-cache.c:3129 sequencer.c:2355 sequencer.c:4066
+#: read-cache.c:3120 sequencer.c:2446 sequencer.c:4185
 #, c-format
 msgid "could not stat '%s'"
 msgstr "impossibile eseguire lo stat di '%s'"
 
-#: read-cache.c:3142
+#: read-cache.c:3133
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "impossibile aprire la directory git: %s"
 
-#: read-cache.c:3154
+#: read-cache.c:3145
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "impossibile eseguire unlink: %s"
 
-#: read-cache.c:3179
+#: read-cache.c:3170
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "impossibile correggere i permessi di '%s'"
 
-#: read-cache.c:3328
+#: read-cache.c:3319
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: impossibile ripiegare sullo stadio 0"
@@ -5840,7 +5899,7 @@ msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Rebase di %s su %s (%d comando)"
 msgstr[1] "Rebase di %s su %s (%d comandi)"
 
-#: rebase-interactive.c:72 git-rebase--preserve-merges.sh:228
+#: rebase-interactive.c:72 git-rebase--preserve-merges.sh:218
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -5849,7 +5908,7 @@ msgstr ""
 "Non eliminare alcuna riga. Usa esplicitamente 'drop' per rimuovere un "
 "commit.\n"
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:232
+#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:222
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -5857,7 +5916,7 @@ msgstr ""
 "\n"
 "Rimuovendo una riga da qui IL COMMIT CORRISPONDENTE ANDRÀ PERDUTO.\n"
 
-#: rebase-interactive.c:81 git-rebase--preserve-merges.sh:871
+#: rebase-interactive.c:81 git-rebase--preserve-merges.sh:861
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -5871,7 +5930,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:86 git-rebase--preserve-merges.sh:948
+#: rebase-interactive.c:86 git-rebase--preserve-merges.sh:938
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -5881,14 +5940,14 @@ msgstr ""
 "Ciò nonostante, se rimuovi tutto, il rebase sarà annullato.\n"
 "\n"
 
-#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3463
-#: sequencer.c:3489 sequencer.c:5248 builtin/fsck.c:347 builtin/rebase.c:258
+#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3571
+#: sequencer.c:3597 sequencer.c:5389 builtin/fsck.c:347 builtin/rebase.c:264
 #, c-format
 msgid "could not write '%s'"
 msgstr "impossibile scrivere '%s'"
 
-#: rebase-interactive.c:116 builtin/rebase.c:190 builtin/rebase.c:216
-#: builtin/rebase.c:240
+#: rebase-interactive.c:116 builtin/rebase.c:196 builtin/rebase.c:222
+#: builtin/rebase.c:246
 #, c-format
 msgid "could not write '%s'."
 msgstr "impossibile scrivere '%s'."
@@ -5921,14 +5980,14 @@ msgstr ""
 "I comportamenti possibili sono ignore, warn, error.\n"
 "\n"
 
-#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2274
-#: builtin/rebase.c:176 builtin/rebase.c:201 builtin/rebase.c:227
-#: builtin/rebase.c:252
+#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2361
+#: builtin/rebase.c:182 builtin/rebase.c:207 builtin/rebase.c:233
+#: builtin/rebase.c:258
 #, c-format
 msgid "could not read '%s'."
 msgstr "impossibile leggere '%s'."
 
-#: ref-filter.c:42 wt-status.c:1977
+#: ref-filter.c:42 wt-status.c:1973
 msgid "gone"
 msgstr "sparito"
 
@@ -5947,122 +6006,127 @@ msgstr "prima di %d"
 msgid "ahead %d, behind %d"
 msgstr "dopo %d, prima di %d"
 
-#: ref-filter.c:165
+#: ref-filter.c:169
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "formato atteso: %%(color:<colore>)"
 
-#: ref-filter.c:167
+#: ref-filter.c:171
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "colore non riconosciuto: %%(color:%s)"
 
-#: ref-filter.c:189
+#: ref-filter.c:193
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Atteso valore intero: refname:lstrip=%s"
 
-#: ref-filter.c:193
+#: ref-filter.c:197
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Atteso valore intero: refname:rstrip=%s"
 
-#: ref-filter.c:195
+#: ref-filter.c:199
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "argomento %%(%s) non riconosciuto: %s"
 
-#: ref-filter.c:250
+#: ref-filter.c:254
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) non accetta argomenti"
 
-#: ref-filter.c:272
+#: ref-filter.c:276
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "argomento %%(objectsize) non riconosciuto: %s"
 
-#: ref-filter.c:280
+#: ref-filter.c:284
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) non accetta argomenti"
 
-#: ref-filter.c:292
+#: ref-filter.c:296
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) non accetta argomenti"
 
-#: ref-filter.c:301
+#: ref-filter.c:309
 #, c-format
-msgid "%%(subject) does not take arguments"
-msgstr "%%(subject) non accetta argomenti"
+msgid "unrecognized %%(subject) argument: %s"
+msgstr "argomento %%(subject) non riconosciuto: %s"
 
-#: ref-filter.c:323
+#: ref-filter.c:330
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "argomento %%(trailers) sconosciuto: %s"
 
-#: ref-filter.c:352
+#: ref-filter.c:363
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "atteso valore positivo in contents:lines=%s"
 
-#: ref-filter.c:354
+#: ref-filter.c:365
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "argomento %%(contents) non riconosciuto: %s"
 
-#: ref-filter.c:369
+#: ref-filter.c:380
 #, c-format
-msgid "positive value expected objectname:short=%s"
-msgstr "atteso valore positivo in objectname:short=%s"
+msgid "positive value expected '%s' in %%(%s)"
+msgstr "atteso valore positivo '%s' in %%(%s)"
 
-#: ref-filter.c:373
+#: ref-filter.c:384
 #, c-format
-msgid "unrecognized %%(objectname) argument: %s"
-msgstr "argomento %%(objectname) non riconosciuto: %s"
+msgid "unrecognized argument '%s' in %%(%s)"
+msgstr "argomento non riconosciuto '%s' in %%(%s)"
 
-#: ref-filter.c:403
+#: ref-filter.c:398
+#, c-format
+msgid "unrecognized email option: %s"
+msgstr "opzione e-mail non riconosciuta: %s"
+
+#: ref-filter.c:428
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "formato atteso: %%(align:<ampiezza>,<posizione>)"
 
-#: ref-filter.c:415
+#: ref-filter.c:440
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "valore non riconosciuto: position:%s"
 
-#: ref-filter.c:422
+#: ref-filter.c:447
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "valore non riconosciuto: width:%s"
 
-#: ref-filter.c:431
+#: ref-filter.c:456
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "argomento %%(align) non riconosciuto: %s"
 
-#: ref-filter.c:439
+#: ref-filter.c:464
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "attesa ampiezza positiva con l'atom %%(align)"
 
-#: ref-filter.c:457
+#: ref-filter.c:482
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "argomento %%(if) non riconosciuto: %s"
 
-#: ref-filter.c:559
+#: ref-filter.c:584
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "nome campo malformato: %.*s"
 
-#: ref-filter.c:586
+#: ref-filter.c:611
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "nome campo sconosciuto: %.*s"
 
-#: ref-filter.c:590
+#: ref-filter.c:615
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
@@ -6070,116 +6134,106 @@ msgstr ""
 "non è un repository git, ma il campo '%.*s' richiede l'accesso ai dati "
 "oggetto"
 
-#: ref-filter.c:714
+#: ref-filter.c:739
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "formato: atomo %%(if) usato senza un atomo %%(then)"
 
-#: ref-filter.c:777
+#: ref-filter.c:802
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "formato: atomo %%(then) usato senza un atomo %%(if)"
 
-#: ref-filter.c:779
+#: ref-filter.c:804
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "formato: atomo %%(then) usato più di una volta"
 
-#: ref-filter.c:781
+#: ref-filter.c:806
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "formato: atomo %%(then) usato dopo %%(else)"
 
-#: ref-filter.c:809
+#: ref-filter.c:834
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "formato: atomo %%(else) usato senza un atomo %%(if)"
 
-#: ref-filter.c:811
+#: ref-filter.c:836
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "formato: atomo %%(else) usato senza un atomo %%(then)"
 
-#: ref-filter.c:813
+#: ref-filter.c:838
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "formato: atomo %%(else) usato più di una volta"
 
-#: ref-filter.c:828
+#: ref-filter.c:853
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "formato: atomo %%(end) usato senza l'atomo corrispondente"
 
-#: ref-filter.c:885
+#: ref-filter.c:910
 #, c-format
 msgid "malformed format string %s"
 msgstr "stringa di formato %s malformata"
 
-#: ref-filter.c:1486
+#: ref-filter.c:1541
 #, c-format
 msgid "no branch, rebasing %s"
 msgstr "nessun branch, eseguo il rebase di %s"
 
-#: ref-filter.c:1489
+#: ref-filter.c:1544
 #, c-format
 msgid "no branch, rebasing detached HEAD %s"
 msgstr "nessun branch, eseguo il rebase dell'HEAD scollegato %s"
 
-#: ref-filter.c:1492
+#: ref-filter.c:1547
 #, c-format
 msgid "no branch, bisect started on %s"
 msgstr "nessun branch, bisezione avviata su %s"
 
-#: ref-filter.c:1502
+#: ref-filter.c:1557
 msgid "no branch"
 msgstr "nessun branch"
 
-#: ref-filter.c:1538 ref-filter.c:1747
+#: ref-filter.c:1591 ref-filter.c:1800
 #, c-format
 msgid "missing object %s for %s"
 msgstr "oggetto %s mancante per %s"
 
-#: ref-filter.c:1548
+#: ref-filter.c:1601
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer non riuscito su %s per %s"
 
-#: ref-filter.c:2001
+#: ref-filter.c:2054
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "oggetto malformato in '%s'"
 
-#: ref-filter.c:2090
+#: ref-filter.c:2143
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "ignoro il riferimento con il nome malformato %s"
 
-#: ref-filter.c:2095 refs.c:657
+#: ref-filter.c:2148 refs.c:657
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "ignoro il riferimento rotto %s"
 
-#: ref-filter.c:2395
+#: ref-filter.c:2464
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "formato: atomo %%(end) mancante"
 
-#: ref-filter.c:2495
-#, c-format
-msgid "option `%s' is incompatible with --merged"
-msgstr "l'opzione `%s' non è compatibile con --merged"
-
-#: ref-filter.c:2498
-#, c-format
-msgid "option `%s' is incompatible with --no-merged"
-msgstr "l'opzione `%s' non è compatibile con --no-merged"
-
-#: ref-filter.c:2508
+#: ref-filter.c:2563
 #, c-format
 msgid "malformed object name %s"
 msgstr "nome dell'oggetto %s malformato"
 
-#: ref-filter.c:2513
+#: ref-filter.c:2568
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "l'opzione `%s' deve puntare ad un commit"
@@ -6204,158 +6258,120 @@ msgstr "nome branch non valido: %s = %s"
 msgid "ignoring dangling symref %s"
 msgstr "ignoro il riferimento simbolico pendente %s"
 
-#: refs.c:792
-#, c-format
-msgid "could not open '%s' for writing: %s"
-msgstr "impossibile aprire '%s' in scrittura: %s"
-
-#: refs.c:802 refs.c:853
-#, c-format
-msgid "could not read ref '%s'"
-msgstr "impossibile leggere il riferimento '%s'"
-
-#: refs.c:808
-#, c-format
-msgid "ref '%s' already exists"
-msgstr "il riferimento '%s' esiste già"
-
-#: refs.c:813
-#, c-format
-msgid "unexpected object ID when writing '%s'"
-msgstr "ID oggetto inatteso durante la scrittura di '%s'"
-
-#: refs.c:821 sequencer.c:408 sequencer.c:2721 sequencer.c:2925
-#: sequencer.c:2939 sequencer.c:3195 sequencer.c:5159 strbuf.c:1168
-#: wrapper.c:628
-#, c-format
-msgid "could not write to '%s'"
-msgstr "impossibile scrivere su '%s'"
-
-#: refs.c:848 strbuf.c:1166 wrapper.c:196 wrapper.c:366 builtin/am.c:719
-#: builtin/rebase.c:852
-#, c-format
-msgid "could not open '%s' for writing"
-msgstr "impossibile aprire '%s' in scrittura"
-
-#: refs.c:855
-#, c-format
-msgid "unexpected object ID when deleting '%s'"
-msgstr "ID oggetto inatteso durante l'eliminazione di '%s'"
-
-#: refs.c:986
+#: refs.c:892
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "il registro per il riferimento %s ha delle voci mancanti dopo %s"
 
-#: refs.c:992
+#: refs.c:898
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "il registro per il riferimento %s è terminato inaspettatamente a %s"
 
-#: refs.c:1051
+#: refs.c:957
 #, c-format
 msgid "log for %s is empty"
 msgstr "il registro per %s è vuoto"
 
-#: refs.c:1143
+#: refs.c:1049
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "mi rifiuto di aggiornare il riferimento con il nome non valido '%s'"
 
-#: refs.c:1219
+#: refs.c:1120
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref per il riferimento '%s' non riuscita: %s"
 
-#: refs.c:2011
+#: refs.c:1944
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "aggiornamenti multipli per il riferimento '%s' non consentiti"
 
-#: refs.c:2098
+#: refs.c:2024
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "aggiornamenti riferimento vietati nell'ambiente quarantena"
 
-#: refs.c:2109
+#: refs.c:2035
 msgid "ref updates aborted by hook"
 msgstr "aggiornamento ref interrotto dall'hook"
 
-#: refs.c:2209 refs.c:2239
+#: refs.c:2135 refs.c:2165
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' esiste già; impossibile creare '%s'"
 
-#: refs.c:2215 refs.c:2250
+#: refs.c:2141 refs.c:2176
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "impossibile gestire '%s' e '%s' contemporaneamente"
 
-#: refs/files-backend.c:1233
+#: refs/files-backend.c:1228
 #, c-format
 msgid "could not remove reference %s"
 msgstr "impossibile rimuovere il riferimento %s"
 
-#: refs/files-backend.c:1247 refs/packed-backend.c:1541
-#: refs/packed-backend.c:1551
+#: refs/files-backend.c:1242 refs/packed-backend.c:1542
+#: refs/packed-backend.c:1552
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "impossibile eliminare il riferimento %s: %s"
 
-#: refs/files-backend.c:1250 refs/packed-backend.c:1554
+#: refs/files-backend.c:1245 refs/packed-backend.c:1555
 #, c-format
 msgid "could not delete references: %s"
 msgstr "impossibile eliminare i riferimenti: %s"
 
-#: refspec.c:137
+#: refspec.c:167
 #, c-format
 msgid "invalid refspec '%s'"
 msgstr "specificatore riferimento '%s' non valido"
 
-#: remote.c:355
+#: remote.c:351
 #, c-format
 msgid "config remote shorthand cannot begin with '/': %s"
 msgstr ""
 "la forma breve della configurazione del remoto non può iniziare con '/': %s"
 
-#: remote.c:403
+#: remote.c:399
 msgid "more than one receivepack given, using the first"
 msgstr "è stata specificata più di una direttiva receivepack, uso la prima"
 
-#: remote.c:411
+#: remote.c:407
 msgid "more than one uploadpack given, using the first"
 msgstr "è stata specificata più di una direttiva uploadpack, uso la prima"
 
-#: remote.c:594
+#: remote.c:590
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Impossibile recuperare sia %s sia %s in %s"
 
-#: remote.c:598
+#: remote.c:594
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s solitamente traccia %s, non %s"
 
-#: remote.c:602
+#: remote.c:598
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s traccia sia %s sia %s"
 
-#: remote.c:670
+#: remote.c:666
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "la chiave '%s' del pattern non aveva un '*'"
 
-#: remote.c:680
+#: remote.c:676
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "il valore '%s' del pattern non ha un '*'"
 
-#: remote.c:986
+#: remote.c:1073
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "nessuna corrispondenza per lo specificatore riferimento sorgente %s"
 
-#: remote.c:991
+#: remote.c:1078
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr ""
@@ -6366,7 +6382,7 @@ msgstr ""
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1006
+#: remote.c:1093
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -6392,7 +6408,7 @@ msgstr ""
 "Nessuna delle due opzioni ha funzionato, quindi ci siamo arresi.\n"
 "Devi specificare un riferimento completamente qualificato."
 
-#: remote.c:1026
+#: remote.c:1113
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -6403,7 +6419,7 @@ msgstr ""
 "è un oggetto tag. Forse intendevi creare un nuovo\n"
 "branch eseguendo il push a '%s:refs/heads/%s'?"
 
-#: remote.c:1031
+#: remote.c:1118
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -6414,7 +6430,7 @@ msgstr ""
 "è un oggetto tag. Forse intendevi creare un nuovo\n"
 "branch eseguendo il push a '%s:refs/tags/%s'?"
 
-#: remote.c:1036
+#: remote.c:1123
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -6426,7 +6442,7 @@ msgstr ""
 "tag a un nuovo albero eseguendo il push a\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1041
+#: remote.c:1128
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -6438,121 +6454,121 @@ msgstr ""
 "tag a un nuovo blob eseguendo il push a\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1077
+#: remote.c:1164
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "%s non può essere risolto in un branch"
 
-#: remote.c:1088
+#: remote.c:1175
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "impossibile eliminare '%s': il riferimento remoto non esiste"
 
-#: remote.c:1100
+#: remote.c:1187
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr ""
 "sono state trovate più corrispondenze per lo specificatore riferimento "
 "destinazione %s"
 
-#: remote.c:1107
+#: remote.c:1194
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr ""
 "lo specificatore riferimento destinazione %s riceve dati da più di una "
 "sorgente"
 
-#: remote.c:1610 remote.c:1711
+#: remote.c:1703 remote.c:1804
 msgid "HEAD does not point to a branch"
 msgstr "HEAD non punta ad un branch"
 
-#: remote.c:1619
+#: remote.c:1712
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "branch '%s' non esistente"
 
-#: remote.c:1622
+#: remote.c:1715
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "nessun upstream configurato per il branch '%s'"
 
-#: remote.c:1628
+#: remote.c:1721
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr ""
 "branch upstream '%s' non memorizzato come branch che ne traccia uno remoto"
 
-#: remote.c:1643
+#: remote.c:1736
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr ""
 "la destinazione del push '%s' sul remoto '%s' non ha un branch locale che la "
 "traccia"
 
-#: remote.c:1655
+#: remote.c:1748
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "il branch '%s' non ha un remoto per il push"
 
-#: remote.c:1665
+#: remote.c:1758
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "gli specificatori riferimento per '%s' non includono '%s'"
 
-#: remote.c:1678
+#: remote.c:1771
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "il push non ha una destinazione (push.default è 'nothing')"
 
-#: remote.c:1700
+#: remote.c:1793
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "impossibile risolvere il push 'simple' a una singola destinazione"
 
-#: remote.c:1826
+#: remote.c:1922
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "impossibile trovare il riferimento remoto %s"
 
-#: remote.c:1839
+#: remote.c:1935
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ignoro localmente il riferimento strano '%s'"
 
-#: remote.c:2002
+#: remote.c:2098
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Il tuo branch è basato su '%s', ma l'upstream è scomparso.\n"
 
-#: remote.c:2006
+#: remote.c:2102
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (usa \"git branch --unset-upstream\" per correggere la situazione)\n"
 
-#: remote.c:2009
+#: remote.c:2105
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Il tuo branch è aggiornato rispetto a '%s'.\n"
 
-#: remote.c:2013
+#: remote.c:2109
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Il tuo branch e '%s' fanno riferimento a commit differenti.\n"
 
-#: remote.c:2016
+#: remote.c:2112
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (usa \"%s\" per visualizzare i dettagli)\n"
 
-#: remote.c:2020
+#: remote.c:2116
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Il tuo branch è avanti rispetto a '%s' di %d commit.\n"
 msgstr[1] "Il tuo branch è avanti rispetto a '%s' di %d commit.\n"
 
-#: remote.c:2026
+#: remote.c:2122
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (usa \"git push\" per pubblicare i tuoi commit locali)\n"
 
-#: remote.c:2029
+#: remote.c:2125
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -6564,11 +6580,11 @@ msgstr[1] ""
 "Il tuo branch, rispetto a '%s', è indietro di %d commit e ne posso eseguire "
 "il fast forward.\n"
 
-#: remote.c:2037
+#: remote.c:2133
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (usa \"git pull\" per aggiornare il tuo branch locale)\n"
 
-#: remote.c:2040
+#: remote.c:2136
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -6583,11 +6599,11 @@ msgstr[1] ""
 "Il tuo branch e '%s' sono diventati divergenti\n"
 "e hanno rispettivamente %d e %d commit differenti.\n"
 
-#: remote.c:2050
+#: remote.c:2146
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr "  (usa \"git pull\" per eseguire il merge del branch remoto nel tuo)\n"
 
-#: remote.c:2241
+#: remote.c:2337
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "impossibile analizzare il nome oggetto atteso '%s'"
@@ -6606,11 +6622,6 @@ msgstr "riferimento sostitutivo duplicato: %s"
 #, c-format
 msgid "replace depth too high for object %s"
 msgstr "profondità sostituzione troppo elevata per l'oggetto %s"
-
-#: repository.c:94 builtin/init-db.c:188
-#, c-format
-msgid "The hash algorithm %s is not supported in this build."
-msgstr "L'algoritmo hash %s non è supportato in questa compilazione."
 
 #: rerere.c:217 rerere.c:226 rerere.c:229
 msgid "corrupt MERGE_RR"
@@ -6670,8 +6681,8 @@ msgstr "impossibile eseguire l'unlink dell'oggetto smarrito '%s'"
 msgid "Recorded preimage for '%s'"
 msgstr "Salvata preimmagine di '%s'"
 
-#: rerere.c:881 submodule.c:2078 builtin/log.c:1891
-#: builtin/submodule--helper.c:1454 builtin/submodule--helper.c:1466
+#: rerere.c:881 submodule.c:2082 builtin/log.c:1975
+#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:1890
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "impossibile creare la directory '%s'"
@@ -6709,25 +6720,30 @@ msgstr "impossibile aprire la directory cache rr"
 msgid "could not determine HEAD revision"
 msgstr "impossibile determinare la revisione HEAD"
 
-#: reset.c:70 reset.c:76 sequencer.c:3318
+#: reset.c:70 reset.c:76 sequencer.c:3426
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "impossibile trovare l'albero di %s"
 
-#: revision.c:2661
+#: revision.c:2344
+msgid "--unpacked=<packfile> no longer supported"
+msgstr "--unpacked=<packfile> non è più supportato"
+
+#: revision.c:2364
+#, c-format
+msgid "unknown value for --diff-merges: %s"
+msgstr "valore sconosciuto per --diff-merges: %s"
+
+#: revision.c:2702
 msgid "your current branch appears to be broken"
 msgstr "sembra che il tuo branch corrente sia rotto"
 
-#: revision.c:2664
+#: revision.c:2705
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "il tuo branch corrente '%s' non ha ancora commit"
 
-#: revision.c:2873
-msgid "--first-parent is incompatible with --bisect"
-msgstr "--first-parent non è compatibile con --bisect"
-
-#: revision.c:2877
+#: revision.c:2915
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L non supporta ancora formati diff oltre a -p e -s"
 
@@ -6735,12 +6751,12 @@ msgstr "-L non supporta ancora formati diff oltre a -p e -s"
 msgid "open /dev/null failed"
 msgstr "apertura di /dev/null non riuscita"
 
-#: run-command.c:1269
+#: run-command.c:1270
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "impossibile creare il thread async: %s"
 
-#: run-command.c:1333
+#: run-command.c:1334
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
@@ -6765,19 +6781,19 @@ msgstr "impossibile analizzare lo stato decompressione del remoto: %s"
 msgid "remote unpack failed: %s"
 msgstr "decompressione sul remoto non riuscita: %s"
 
-#: send-pack.c:308
+#: send-pack.c:372
 msgid "failed to sign the push certificate"
 msgstr "firma del certificato per il push non riuscita"
 
-#: send-pack.c:394
+#: send-pack.c:460
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr "il ricevente non supporta l'algoritmo hash di questo repository"
 
-#: send-pack.c:403
+#: send-pack.c:469
 msgid "the receiving end does not support --signed push"
 msgstr "il ricevente non supporta i push --signed"
 
-#: send-pack.c:405
+#: send-pack.c:471
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -6785,47 +6801,47 @@ msgstr ""
 "non invio un certificato push perché il ricevente non supporta i push --"
 "signed"
 
-#: send-pack.c:417
+#: send-pack.c:483
 msgid "the receiving end does not support --atomic push"
 msgstr "il ricevente non supporta i push --atomic"
 
-#: send-pack.c:422
+#: send-pack.c:488
 msgid "the receiving end does not support push options"
 msgstr "il ricevente non supporta le opzioni push"
 
-#: sequencer.c:192
+#: sequencer.c:194
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "modalità pulizia messaggio commit non valida: '%s'"
 
-#: sequencer.c:297
+#: sequencer.c:308
 #, c-format
 msgid "could not delete '%s'"
 msgstr "impossibile eliminare '%s'"
 
-#: sequencer.c:316 builtin/rebase.c:743 builtin/rebase.c:1582 builtin/rm.c:385
+#: sequencer.c:329 builtin/rebase.c:749 builtin/rebase.c:1590 builtin/rm.c:385
 #, c-format
 msgid "could not remove '%s'"
 msgstr "impossibile rimuovere '%s'"
 
-#: sequencer.c:326
+#: sequencer.c:339
 msgid "revert"
 msgstr "revert"
 
-#: sequencer.c:328
+#: sequencer.c:341
 msgid "cherry-pick"
 msgstr "cherry-pick"
 
-#: sequencer.c:330
+#: sequencer.c:343
 msgid "rebase"
 msgstr "rebase"
 
-#: sequencer.c:332
+#: sequencer.c:345
 #, c-format
 msgid "unknown action: %d"
 msgstr "azione sconosciuta: %d"
 
-#: sequencer.c:390
+#: sequencer.c:404
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -6833,7 +6849,7 @@ msgstr ""
 "dopo aver risolto i conflitti, contrassegna i percorsi corretti\n"
 "con 'git add <path>' o 'git rm <path>'"
 
-#: sequencer.c:393
+#: sequencer.c:407
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
@@ -6843,43 +6859,43 @@ msgstr ""
 "con 'git add <path>' o 'git rm <path>' ed esegui\n"
 "il commit del risultato con 'git commit'"
 
-#: sequencer.c:406 sequencer.c:2921
+#: sequencer.c:420 sequencer.c:3028
 #, c-format
 msgid "could not lock '%s'"
 msgstr "impossibile bloccare '%s'"
 
-#: sequencer.c:413
+#: sequencer.c:422 sequencer.c:2827 sequencer.c:3032 sequencer.c:3046
+#: sequencer.c:3303 sequencer.c:5299 strbuf.c:1168 wrapper.c:631
+#, c-format
+msgid "could not write to '%s'"
+msgstr "impossibile scrivere su '%s'"
+
+#: sequencer.c:427
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "impossibile scrivere il carattere di fine riga in '%s'"
 
-#: sequencer.c:418 sequencer.c:2726 sequencer.c:2927 sequencer.c:2941
-#: sequencer.c:3203
+#: sequencer.c:432 sequencer.c:2832 sequencer.c:3034 sequencer.c:3048
+#: sequencer.c:3311
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "finalizzazione di '%s' non riuscita"
 
-#: sequencer.c:431 sequencer.c:1620 sequencer.c:2746 sequencer.c:3185
-#: sequencer.c:3294 builtin/am.c:249 builtin/commit.c:786 builtin/merge.c:1128
-#, c-format
-msgid "could not read '%s'"
-msgstr "impossibile leggere '%s'"
-
-#: sequencer.c:457
+#: sequencer.c:471
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "le tue modifiche locali sarebbero sovrascritte da %s."
 
-#: sequencer.c:461
+#: sequencer.c:475
 msgid "commit your changes or stash them to proceed."
 msgstr "esegui il commit delle modifiche o lo stash per procedere."
 
-#: sequencer.c:493
+#: sequencer.c:507
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: fast forward"
 
-#: sequencer.c:532 builtin/tag.c:566
+#: sequencer.c:546 builtin/tag.c:566
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Modalità pulizia non valida: %s"
@@ -6887,65 +6903,65 @@ msgstr "Modalità pulizia non valida: %s"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:626
+#: sequencer.c:640
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: impossibile scrivere il nuovo file indice"
 
-#: sequencer.c:643
+#: sequencer.c:657
 msgid "unable to update cache tree"
 msgstr "impossibile aggiornare l'albero cache"
 
-#: sequencer.c:657
+#: sequencer.c:671
 msgid "could not resolve HEAD commit"
 msgstr "impossibile risolvere il commit HEAD"
 
-#: sequencer.c:737
+#: sequencer.c:751
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "nessuna chiave presente in '%.*s'"
 
-#: sequencer.c:748
+#: sequencer.c:762
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "impossibile rimuovere gli apici dal valore di '%s'"
 
-#: sequencer.c:785 wrapper.c:198 wrapper.c:368 builtin/am.c:710
-#: builtin/am.c:802 builtin/merge.c:1125 builtin/rebase.c:896
+#: sequencer.c:799 wrapper.c:201 wrapper.c:371 builtin/am.c:724
+#: builtin/am.c:816 builtin/merge.c:1121 builtin/rebase.c:902
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "impossibile aprire '%s' in lettura"
 
-#: sequencer.c:795
+#: sequencer.c:809
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' già specificato"
 
-#: sequencer.c:800
+#: sequencer.c:814
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' già specificato"
 
-#: sequencer.c:805
+#: sequencer.c:819
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' già specificato"
 
-#: sequencer.c:809
+#: sequencer.c:823
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "variabile '%s' sconosciuta"
 
-#: sequencer.c:814
+#: sequencer.c:828
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "'GIT_AUTHOR_NAME' mancante"
 
-#: sequencer.c:816
+#: sequencer.c:830
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "'GIT_AUTHOR_EMAIL' mancante"
 
-#: sequencer.c:818
+#: sequencer.c:832
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "'GIT_AUTHOR_DATE' mancante"
 
-#: sequencer.c:867
+#: sequencer.c:897
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -6975,11 +6991,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1141
+#: sequencer.c:1178
 msgid "'prepare-commit-msg' hook failed"
 msgstr "hook 'prepare-commit-msg' non riuscito"
 
-#: sequencer.c:1147
+#: sequencer.c:1184
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7006,7 +7022,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1160
+#: sequencer.c:1197
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7032,333 +7048,342 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1202
+#: sequencer.c:1239
 msgid "couldn't look up newly created commit"
 msgstr "impossibile trovare il commit appena creato"
 
-#: sequencer.c:1204
+#: sequencer.c:1241
 msgid "could not parse newly created commit"
 msgstr "impossibile analizzare il commit appena creato"
 
-#: sequencer.c:1250
+#: sequencer.c:1287
 msgid "unable to resolve HEAD after creating commit"
 msgstr "impossibile risolvere HEAD dopo la creazione del commit"
 
-#: sequencer.c:1252
+#: sequencer.c:1289
 msgid "detached HEAD"
 msgstr "HEAD scollegato"
 
-#: sequencer.c:1256
+#: sequencer.c:1293
 msgid " (root-commit)"
 msgstr " (commit radice)"
 
-#: sequencer.c:1277
+#: sequencer.c:1314
 msgid "could not parse HEAD"
 msgstr "impossibile analizzare HEAD"
 
-#: sequencer.c:1279
+#: sequencer.c:1316
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "L'HEAD %s non è un commit!"
 
-#: sequencer.c:1283 sequencer.c:1357 builtin/commit.c:1579
+#: sequencer.c:1320 sequencer.c:1395 builtin/commit.c:1577
 msgid "could not parse HEAD commit"
 msgstr "impossibile analizzare il commit HEAD"
 
-#: sequencer.c:1335 sequencer.c:1980
+#: sequencer.c:1373 sequencer.c:2067
 msgid "unable to parse commit author"
 msgstr "impossibile analizzare l'autore del commit"
 
-#: sequencer.c:1346 builtin/am.c:1566 builtin/merge.c:695
+#: sequencer.c:1384 builtin/am.c:1580 builtin/merge.c:692
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree non è riuscito a scrivere un albero"
 
-#: sequencer.c:1379 sequencer.c:1450
+#: sequencer.c:1417 sequencer.c:1535
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "impossibile leggere il messaggio di commit da '%s'"
 
-#: sequencer.c:1406 builtin/am.c:1588 builtin/commit.c:1680 builtin/merge.c:894
-#: builtin/merge.c:919
+#: sequencer.c:1446 sequencer.c:1478
+#, c-format
+msgid "invalid author identity '%s'"
+msgstr "identità autore '%s' non valida"
+
+#: sequencer.c:1452
+msgid "corrupt author: missing date information"
+msgstr "informazioni sull'autore corrotte: informazioni sulla data mancanti"
+
+#: sequencer.c:1491 builtin/am.c:1606 builtin/commit.c:1678 builtin/merge.c:890
+#: builtin/merge.c:915
 msgid "failed to write commit object"
 msgstr "scrittura dell'oggetto del commit non riuscita"
 
-#: sequencer.c:1433 sequencer.c:4118
+#: sequencer.c:1518 sequencer.c:4237
 #, c-format
 msgid "could not update %s"
 msgstr "impossibile aggiornare %s"
 
-#: sequencer.c:1481
+#: sequencer.c:1567
 #, c-format
 msgid "could not parse commit %s"
 msgstr "impossibile analizzare il commit %s"
 
-#: sequencer.c:1486
+#: sequencer.c:1572
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "impossibile analizzare il commit genitore %s"
 
-#: sequencer.c:1569 sequencer.c:1680
+#: sequencer.c:1655 sequencer.c:1766
 #, c-format
 msgid "unknown command: %d"
 msgstr "comando sconosciuto: %d"
 
-#: sequencer.c:1627 sequencer.c:1652
+#: sequencer.c:1713 sequencer.c:1738
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Questa è una combinazione di %d commit."
 
-#: sequencer.c:1637
+#: sequencer.c:1723
 msgid "need a HEAD to fixup"
 msgstr "è necessaria un'HEAD per il fixup"
 
-#: sequencer.c:1639 sequencer.c:3230
+#: sequencer.c:1725 sequencer.c:3338
 msgid "could not read HEAD"
 msgstr "impossibile leggere l'HEAD"
 
-#: sequencer.c:1641
+#: sequencer.c:1727
 msgid "could not read HEAD's commit message"
 msgstr "impossibile leggere il messaggio di commit dell'HEAD"
 
-#: sequencer.c:1647
+#: sequencer.c:1733
 #, c-format
 msgid "cannot write '%s'"
 msgstr "impossibile scrivere '%s'"
 
-#: sequencer.c:1654 git-rebase--preserve-merges.sh:496
+#: sequencer.c:1740 git-rebase--preserve-merges.sh:486
 msgid "This is the 1st commit message:"
 msgstr "Questo è il primo messaggio di commit:"
 
-#: sequencer.c:1662
+#: sequencer.c:1748
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "impossibile leggere il messaggio di commit di %s"
 
-#: sequencer.c:1669
+#: sequencer.c:1755
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Questo è il messaggio di commit numero %d:"
 
-#: sequencer.c:1675
+#: sequencer.c:1761
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Il messaggio di commit numero %d sarà saltato:"
 
-#: sequencer.c:1763
+#: sequencer.c:1849
 msgid "your index file is unmerged."
 msgstr "il file indice non è stato sottoposto a merge."
 
-#: sequencer.c:1770
+#: sequencer.c:1856
 msgid "cannot fixup root commit"
 msgstr "impossibile eseguire il fixup sul commit radice"
 
-#: sequencer.c:1789
+#: sequencer.c:1875
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "il commit %s è un merge ma non è stata specificata l'opzione -m."
 
-#: sequencer.c:1797 sequencer.c:1805
+#: sequencer.c:1883 sequencer.c:1891
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "il commit %s non ha il genitore %d"
 
-#: sequencer.c:1811
+#: sequencer.c:1897
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "impossibile ottenere il messaggio di commit per %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1830
+#: sequencer.c:1916
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: impossibile analizzare il commit genitore %s"
 
-#: sequencer.c:1895
+#: sequencer.c:1981
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "impossibile ridenominare '%s' in '%s'"
 
-#: sequencer.c:1952
+#: sequencer.c:2038
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "non è stato possibile eseguire il revert di %s... %s"
 
-#: sequencer.c:1953
+#: sequencer.c:2039
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "non è stato possibile applicare %s... %s"
 
-#: sequencer.c:1972
+#: sequencer.c:2059
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "scarto %s %s - i contenuti della patch sono già upstream\n"
 
-#: sequencer.c:2030
+#: sequencer.c:2117
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: lettura dell'indice non riuscita"
 
-#: sequencer.c:2037
+#: sequencer.c:2124
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: aggiornamento dell'indice non riuscito"
 
-#: sequencer.c:2114
+#: sequencer.c:2201
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s non accetta argomenti: '%s'"
 
-#: sequencer.c:2123
+#: sequencer.c:2210
 #, c-format
 msgid "missing arguments for %s"
 msgstr "argomenti mancanti per %s"
 
-#: sequencer.c:2154
+#: sequencer.c:2241
 #, c-format
 msgid "could not parse '%s'"
 msgstr "impossibile analizzare '%s'"
 
-#: sequencer.c:2215
+#: sequencer.c:2302
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "riga %d non valida: %.*s"
 
-#: sequencer.c:2226
+#: sequencer.c:2313
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "impossibile eseguire '%s' senza un commit precedente"
 
-#: sequencer.c:2310
+#: sequencer.c:2399
 msgid "cancelling a cherry picking in progress"
 msgstr "annullo un'operazione di cherry-pick in corso"
 
-#: sequencer.c:2317
+#: sequencer.c:2408
 msgid "cancelling a revert in progress"
 msgstr "annullo un'operazione di revert in corso"
 
-#: sequencer.c:2361
+#: sequencer.c:2452
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "correggi la situazione usando 'git rebase --edit-todo'."
 
-#: sequencer.c:2363
+#: sequencer.c:2454
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "foglio istruzioni inutilizzabile: '%s'"
 
-#: sequencer.c:2368
+#: sequencer.c:2459
 msgid "no commits parsed."
 msgstr "nessun commit analizzato."
 
-#: sequencer.c:2379
+#: sequencer.c:2470
 msgid "cannot cherry-pick during a revert."
 msgstr "impossibile eseguire un cherry-pick durante un revert."
 
-#: sequencer.c:2381
+#: sequencer.c:2472
 msgid "cannot revert during a cherry-pick."
 msgstr "impossibile eseguire un revert durante un cherry-pick."
 
-#: sequencer.c:2459
+#: sequencer.c:2550
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "valore non valido per %s: %s"
 
-#: sequencer.c:2556
+#: sequencer.c:2657
 msgid "unusable squash-onto"
 msgstr "squash-onto inutilizzabile"
 
-#: sequencer.c:2576
+#: sequencer.c:2677
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "foglio opzioni malformati: '%s'"
 
-#: sequencer.c:2664 sequencer.c:4469
+#: sequencer.c:2769 sequencer.c:4609
 msgid "empty commit set passed"
 msgstr "è stato passato un insieme di commit vuoto"
 
-#: sequencer.c:2680
+#: sequencer.c:2786
 msgid "revert is already in progress"
 msgstr "un'operazione di revert è già in corso"
 
-#: sequencer.c:2682
+#: sequencer.c:2788
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "prova \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2685
+#: sequencer.c:2791
 msgid "cherry-pick is already in progress"
 msgstr "un'operazione di cherry-pick è già in corso"
 
-#: sequencer.c:2687
+#: sequencer.c:2793
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "prova \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2701
+#: sequencer.c:2807
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "impossibile creare la directory sequencer '%s'"
 
-#: sequencer.c:2716
+#: sequencer.c:2822
 msgid "could not lock HEAD"
 msgstr "impossibile bloccare HEAD"
 
-#: sequencer.c:2776 sequencer.c:4206
+#: sequencer.c:2882 sequencer.c:4325
 msgid "no cherry-pick or revert in progress"
 msgstr "nessuna operazione di cherry-pick o revert in corso"
 
-#: sequencer.c:2778 sequencer.c:2789
+#: sequencer.c:2884 sequencer.c:2895
 msgid "cannot resolve HEAD"
 msgstr "impossibile risolvere HEAD"
 
-#: sequencer.c:2780 sequencer.c:2824
+#: sequencer.c:2886 sequencer.c:2930
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 "impossibile interrompere l'operazione da un branch che deve essere ancora "
 "creato"
 
-#: sequencer.c:2810 builtin/grep.c:744
+#: sequencer.c:2916 builtin/grep.c:745
 #, c-format
 msgid "cannot open '%s'"
 msgstr "impossibile aprire '%s'"
 
-#: sequencer.c:2812
+#: sequencer.c:2918
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "impossibile leggere '%s': %s"
 
-#: sequencer.c:2813
+#: sequencer.c:2919
 msgid "unexpected end of file"
 msgstr "fine del file inattesa"
 
-#: sequencer.c:2819
+#: sequencer.c:2925
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr ""
 "il file '%s' in cui è stato salvato l'HEAD prima del cherry pick è corrotto"
 
-#: sequencer.c:2830
+#: sequencer.c:2936
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Sembra che tu abbia spostato l'HEAD. Non eseguo il rewind, controlla l'HEAD!"
 
-#: sequencer.c:2871
+#: sequencer.c:2977
 msgid "no revert in progress"
 msgstr "nessun revert in corso"
 
-#: sequencer.c:2879
+#: sequencer.c:2986
 msgid "no cherry-pick in progress"
 msgstr "nessun cherry-pick in corso"
 
-#: sequencer.c:2889
+#: sequencer.c:2996
 msgid "failed to skip the commit"
 msgstr "salto del commit non riuscito"
 
-#: sequencer.c:2896
+#: sequencer.c:3003
 msgid "there is nothing to skip"
 msgstr "non c'è nulla da saltare"
 
-#: sequencer.c:2899
+#: sequencer.c:3006
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -7367,16 +7392,16 @@ msgstr ""
 "hai già eseguito il commit?\n"
 "prova \"git %s --continue\""
 
-#: sequencer.c:3060 sequencer.c:4098
+#: sequencer.c:3168 sequencer.c:4217
 msgid "cannot read HEAD"
 msgstr "impossibile leggere l'HEAD"
 
-#: sequencer.c:3077
+#: sequencer.c:3185
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "impossibile copiare '%s' in '%s'"
 
-#: sequencer.c:3085
+#: sequencer.c:3193
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -7395,27 +7420,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3095
+#: sequencer.c:3203
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Impossibile applicare %s... %.*s"
 
-#: sequencer.c:3102
+#: sequencer.c:3210
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Impossibile eseguire il merge di %.*s"
 
-#: sequencer.c:3116 sequencer.c:3120 builtin/difftool.c:641
+#: sequencer.c:3224 sequencer.c:3228 builtin/difftool.c:641
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "impossibile copiare '%s' in '%s'"
 
-#: sequencer.c:3132
+#: sequencer.c:3240
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Eseguo %s\n"
 
-#: sequencer.c:3147
+#: sequencer.c:3255
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -7430,11 +7455,11 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3153
+#: sequencer.c:3261
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "e sono state apportate modifiche all'indice e/o all'albero di lavoro\n"
 
-#: sequencer.c:3159
+#: sequencer.c:3267
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -7451,90 +7476,90 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3220
+#: sequencer.c:3328
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "nome etichetta illecito: '%.*s'"
 
-#: sequencer.c:3274
+#: sequencer.c:3382
 msgid "writing fake root commit"
 msgstr "scrittura commit radice falso in corso"
 
-#: sequencer.c:3279
+#: sequencer.c:3387
 msgid "writing squash-onto"
 msgstr "scrittura squash-onto in corso"
 
-#: sequencer.c:3363
+#: sequencer.c:3471
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "impossibile risolvere '%s'"
 
-#: sequencer.c:3394
+#: sequencer.c:3502
 msgid "cannot merge without a current revision"
 msgstr "impossibile eseguire il merge senza una revisione corrente"
 
-#: sequencer.c:3416
+#: sequencer.c:3524
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "impossibile analizzare '%.*s'"
 
-#: sequencer.c:3425
+#: sequencer.c:3533
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "non c'è nulla di cui eseguire il merge: '%.*s'"
 
-#: sequencer.c:3437
+#: sequencer.c:3545
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "il merge octopus non può essere eseguito su un [nuovo commit radice]"
 
-#: sequencer.c:3453
+#: sequencer.c:3561
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "impossibile ottenere il messaggio di commit per '%s'"
 
-#: sequencer.c:3613
+#: sequencer.c:3730
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "non è stato nemmeno possibile tentare di eseguire il merge di '%.*s'"
 
-#: sequencer.c:3629
+#: sequencer.c:3746
 msgid "merge: Unable to write new index file"
 msgstr "merge: impossibile scrivere il nuovo file indice"
 
-#: sequencer.c:3703
+#: sequencer.c:3820
 msgid "Cannot autostash"
 msgstr "Impossibile eseguire lo stash automatico"
 
-#: sequencer.c:3706
+#: sequencer.c:3823
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Risposta stash non attesa: '%s'"
 
-#: sequencer.c:3712
+#: sequencer.c:3829
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Impossibile creare la directory '%s'"
 
-#: sequencer.c:3715
+#: sequencer.c:3832
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Stash automatico creato: %s\n"
 
-#: sequencer.c:3719
+#: sequencer.c:3836
 msgid "could not reset --hard"
 msgstr "impossibile eseguire reset --hard"
 
-#: sequencer.c:3744
+#: sequencer.c:3861
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Stash automatico applicato.\n"
 
-#: sequencer.c:3756
+#: sequencer.c:3873
 #, c-format
 msgid "cannot store %s"
 msgstr "impossibile memorizzare %s"
 
-#: sequencer.c:3759
+#: sequencer.c:3876
 #, c-format
 msgid ""
 "%s\n"
@@ -7545,34 +7570,34 @@ msgstr ""
 "Le tue modifiche sono al sicuro nello stash.\n"
 "Puoi eseguire \"git stash pop\" o \"git stash drop\" in qualunque momento.\n"
 
-#: sequencer.c:3764
+#: sequencer.c:3881
 msgid "Applying autostash resulted in conflicts."
 msgstr "L'applicazione dello stash automatico ha generato dei conflitti."
 
-#: sequencer.c:3765
+#: sequencer.c:3882
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Uno stash automatica esiste già; creo una nuova voce stash."
 
-#: sequencer.c:3857
+#: sequencer.c:3974
 #, c-format
 msgid "%s: not a valid OID"
 msgstr "%s: non è un OID valido"
 
-#: sequencer.c:3862 git-rebase--preserve-merges.sh:779
+#: sequencer.c:3979 git-rebase--preserve-merges.sh:769
 msgid "could not detach HEAD"
 msgstr "impossibile scollegare l'HEAD"
 
-#: sequencer.c:3877
+#: sequencer.c:3994
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Fermato a HEAD\n"
 
-#: sequencer.c:3879
+#: sequencer.c:3996
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Fermato a %s\n"
 
-#: sequencer.c:3887
+#: sequencer.c:4004
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -7594,59 +7619,59 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:3931
+#: sequencer.c:4050
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Rebase in corso (%d/%d)%s"
 
-#: sequencer.c:3976
+#: sequencer.c:4095
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Fermato a %s... %.*s\n"
 
-#: sequencer.c:4047
+#: sequencer.c:4166
 #, c-format
 msgid "unknown command %d"
 msgstr "comando %d sconosciuto"
 
-#: sequencer.c:4106
+#: sequencer.c:4225
 msgid "could not read orig-head"
 msgstr "impossibile leggere orig-head"
 
-#: sequencer.c:4111
+#: sequencer.c:4230
 msgid "could not read 'onto'"
 msgstr "impossibile leggere 'onto'"
 
-#: sequencer.c:4125
+#: sequencer.c:4244
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "impossibile aggiornare l'HEAD a %s"
 
-#: sequencer.c:4185
+#: sequencer.c:4304
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Rebase e aggiornamento di %s eseguiti con successo.\n"
 
-#: sequencer.c:4218
+#: sequencer.c:4337
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 "impossibile eseguire il rebase: ci sono delle modifiche non in staging."
 
-#: sequencer.c:4227
+#: sequencer.c:4346
 msgid "cannot amend non-existing commit"
 msgstr "impossibile modificare un commit inesistente"
 
-#: sequencer.c:4229
+#: sequencer.c:4348
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "file non valido: '%s'"
 
-#: sequencer.c:4231
+#: sequencer.c:4350
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "contenuti non validi: '%s'"
 
-#: sequencer.c:4234
+#: sequencer.c:4353
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -7657,50 +7682,55 @@ msgstr ""
 "di lavoro. Eseguine prima il commit e quindi esegui nuovamente 'git rebase\n"
 "--continue'."
 
-#: sequencer.c:4270 sequencer.c:4309
+#: sequencer.c:4389 sequencer.c:4428
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "impossibile scrivere il file: '%s'"
 
-#: sequencer.c:4324
+#: sequencer.c:4444
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "impossibile rimuovere CHERRY_PICK_HEAD"
 
-#: sequencer.c:4331
+#: sequencer.c:4451
 msgid "could not commit staged changes."
 msgstr "impossibile eseguire il commit delle modifiche in staging."
 
-#: sequencer.c:4446
+#: sequencer.c:4477
+#, c-format
+msgid "invalid committer '%s'"
+msgstr "autore del commit non valido: '%s'"
+
+#: sequencer.c:4586
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: impossibile eseguire il cherry pick di un %s"
 
-#: sequencer.c:4450
+#: sequencer.c:4590
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: revisione non valida"
 
-#: sequencer.c:4485
+#: sequencer.c:4625
 msgid "can't revert as initial commit"
 msgstr "impossibile eseguire il revert come commit iniziale"
 
-#: sequencer.c:4962
+#: sequencer.c:5102
 msgid "make_script: unhandled options"
 msgstr "make_script: opzioni non gestite"
 
-#: sequencer.c:4965
+#: sequencer.c:5105
 msgid "make_script: error preparing revisions"
 msgstr "make_script: errore durante la preparazione delle revisioni"
 
-#: sequencer.c:5206 sequencer.c:5223
+#: sequencer.c:5347 sequencer.c:5364
 msgid "nothing to do"
 msgstr "nulla da fare"
 
-#: sequencer.c:5242
+#: sequencer.c:5383
 msgid "could not skip unnecessary pick commands"
 msgstr "impossibile saltare i comandi pick non necessari"
 
-#: sequencer.c:5336
+#: sequencer.c:5480
 msgid "the script was already rearranged."
 msgstr "lo script è già stato riordinato."
 
@@ -7758,84 +7788,90 @@ msgstr ""
 msgid "this operation must be run in a work tree"
 msgstr "quest'operazione deve essere eseguita in un albero di lavoro"
 
-#: setup.c:604
+#: setup.c:661
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr "Attesa versione repository Git <= %d, trovata %d"
 
-#: setup.c:612
+#: setup.c:669
 msgid "unknown repository extensions found:"
 msgstr "trovate estensioni repository sconosciute:"
 
-#: setup.c:631
+#: setup.c:681
+msgid "repo version is 0, but v1-only extensions found:"
+msgstr ""
+"la versione del repository è 0, ma sono state trovate estensioni proprie solo"
+" della versione 1:"
+
+#: setup.c:700
 #, c-format
 msgid "error opening '%s'"
 msgstr "errore durante l'apertura di '%s'"
 
-#: setup.c:633
+#: setup.c:702
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr "'%s' troppo grande per essere un file .git"
 
-#: setup.c:635
+#: setup.c:704
 #, c-format
 msgid "error reading %s"
 msgstr "errore durante la lettura di %s"
 
-#: setup.c:637
+#: setup.c:706
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr "formato file Git non valido: %s"
 
-#: setup.c:639
+#: setup.c:708
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr "nessun percorso presente nel file Git: %s"
 
-#: setup.c:641
+#: setup.c:710
 #, c-format
 msgid "not a git repository: %s"
 msgstr "%s non è un repository Git"
 
-#: setup.c:743
+#: setup.c:812
 #, c-format
 msgid "'$%s' too big"
 msgstr "'$%s' è troppo grande"
 
-#: setup.c:757
+#: setup.c:826
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr "'%s' non è un repository Git"
 
-#: setup.c:786 setup.c:788 setup.c:819
+#: setup.c:855 setup.c:857 setup.c:888
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr "impossibile modificare la directory corrente in '%s'"
 
-#: setup.c:791 setup.c:847 setup.c:857 setup.c:896 setup.c:904
+#: setup.c:860 setup.c:916 setup.c:926 setup.c:965 setup.c:973
 msgid "cannot come back to cwd"
 msgstr "impossibile tornare alla directory di lavoro corrente"
 
-#: setup.c:918
+#: setup.c:987
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "stat di '%*s%s%s' non riuscito"
 
-#: setup.c:1156
+#: setup.c:1225
 msgid "Unable to read current working directory"
 msgstr "Impossibile leggere la directory di lavoro corrente"
 
-#: setup.c:1165 setup.c:1171
+#: setup.c:1234 setup.c:1240
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "impossibile entrare in '%s'"
 
-#: setup.c:1176
+#: setup.c:1245
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr "%s non è un repository Git (né lo è alcuna delle directory genitrici)"
 
-#: setup.c:1182
+#: setup.c:1251
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -7845,7 +7881,7 @@ msgstr ""
 "Mi fermo al limite del filesystem (l'opzione GIT_DISCOVERY_ACROSS_FILESYSTEM "
 "non è impostata)."
 
-#: setup.c:1293
+#: setup.c:1362
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -7855,15 +7891,15 @@ msgstr ""
 "(0%.3o).\n"
 "Il proprietario dei file deve avere sempre i permessi di lettura e scrittura."
 
-#: setup.c:1340
+#: setup.c:1409
 msgid "open /dev/null or dup failed"
 msgstr "apertura di /dev/null o dup non riuscita"
 
-#: setup.c:1355
+#: setup.c:1424
 msgid "fork failed"
 msgstr "fork non riuscita"
 
-#: setup.c:1360
+#: setup.c:1429
 msgid "setsid failed"
 msgstr "setsid non riuscita"
 
@@ -7948,12 +7984,12 @@ msgstr "mmap non riuscita"
 msgid "object file %s is empty"
 msgstr "l'oggetto %s è vuoto"
 
-#: sha1-file.c:1274 sha1-file.c:2454
+#: sha1-file.c:1274 sha1-file.c:2467
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "oggetto sciolto '%s' corrotto"
 
-#: sha1-file.c:1276 sha1-file.c:2458
+#: sha1-file.c:1276 sha1-file.c:2471
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "dati inutilizzabili presenti alla fine dell'oggetto sciolto '%s'"
@@ -7982,148 +8018,148 @@ msgstr "impossibile analizzare l'intestazione %s con --allow-unknown-type"
 msgid "unable to parse %s header"
 msgstr "impossibile analizzare l'intestazione %s"
 
-#: sha1-file.c:1640
+#: sha1-file.c:1641
 #, c-format
 msgid "failed to read object %s"
 msgstr "lettura dell'oggetto %s non riuscita"
 
-#: sha1-file.c:1644
+#: sha1-file.c:1645
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "%s sostitutivo non trovato per %s"
 
-#: sha1-file.c:1648
+#: sha1-file.c:1649
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "l'oggetto sciolto %s (salvato in %s) è corrotto"
 
-#: sha1-file.c:1652
+#: sha1-file.c:1653
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "l'oggetto archiviato %s (salvato in %s) è corrotto"
 
-#: sha1-file.c:1757
+#: sha1-file.c:1758
 #, c-format
 msgid "unable to write file %s"
 msgstr "impossibile scrivere il file %s"
 
-#: sha1-file.c:1764
+#: sha1-file.c:1765
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "impossibile impostare i permessi a '%s'"
 
-#: sha1-file.c:1771
+#: sha1-file.c:1772
 msgid "file write error"
 msgstr "errore di scrittura del file"
 
-#: sha1-file.c:1791
+#: sha1-file.c:1792
 msgid "error when closing loose object file"
 msgstr "errore durante la chiusura del file oggetto sciolto"
 
-#: sha1-file.c:1856
+#: sha1-file.c:1857
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "permessi non sufficienti per l'aggiunta di un oggetto al database repository "
 "%s"
 
-#: sha1-file.c:1858
+#: sha1-file.c:1859
 msgid "unable to create temporary file"
 msgstr "impossibile creare il file temporaneo"
 
-#: sha1-file.c:1882
+#: sha1-file.c:1883
 msgid "unable to write loose object file"
 msgstr "impossibile scrivere il file oggetto sciolto"
 
-#: sha1-file.c:1888
+#: sha1-file.c:1889
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "impossibile comprimere con deflate il nuovo oggetto %s (%d)"
 
-#: sha1-file.c:1892
+#: sha1-file.c:1893
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd non riuscita sull'oggetto %s (%d)"
 
-#: sha1-file.c:1896
+#: sha1-file.c:1897
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "sono confuso dall'origine dati oggetto non stabile per %s"
 
-#: sha1-file.c:1906 builtin/pack-objects.c:1085
+#: sha1-file.c:1907 builtin/pack-objects.c:1086
 #, c-format
 msgid "failed utime() on %s"
 msgstr "utime() di %s non riuscita"
 
-#: sha1-file.c:1983
+#: sha1-file.c:1984
 #, c-format
 msgid "cannot read object for %s"
 msgstr "impossibile leggere l'oggetto per %s"
 
-#: sha1-file.c:2022
+#: sha1-file.c:2035
 msgid "corrupt commit"
 msgstr "commit corrotto"
 
-#: sha1-file.c:2030
+#: sha1-file.c:2043
 msgid "corrupt tag"
 msgstr "tag corrotto"
 
-#: sha1-file.c:2130
+#: sha1-file.c:2143
 #, c-format
 msgid "read error while indexing %s"
 msgstr "errore di lettura durante l'indicizzazione di %s"
 
-#: sha1-file.c:2133
+#: sha1-file.c:2146
 #, c-format
 msgid "short read while indexing %s"
 msgstr "lettura troppo breve durante l'indicizzazione di %s"
 
-#: sha1-file.c:2206 sha1-file.c:2216
+#: sha1-file.c:2219 sha1-file.c:2229
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: inserimento del record nel database non riuscito"
 
-#: sha1-file.c:2222
+#: sha1-file.c:2235
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: tipo di file non supportato"
 
-#: sha1-file.c:2246
+#: sha1-file.c:2259
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s non è un oggetto valido"
 
-#: sha1-file.c:2248
+#: sha1-file.c:2261
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s non è un oggetto '%s' valido"
 
-#: sha1-file.c:2275 builtin/index-pack.c:155
+#: sha1-file.c:2288 builtin/index-pack.c:197
 #, c-format
 msgid "unable to open %s"
 msgstr "impossibile aprire %s"
 
-#: sha1-file.c:2465 sha1-file.c:2518
+#: sha1-file.c:2478 sha1-file.c:2531
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "mancata corrispondenza per %s (atteso %s)"
 
-#: sha1-file.c:2489
+#: sha1-file.c:2502
 #, c-format
 msgid "unable to mmap %s"
 msgstr "impossibile eseguire mmap su %s"
 
-#: sha1-file.c:2494
+#: sha1-file.c:2507
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "impossibile decomprimere l'intestazione di %s"
 
-#: sha1-file.c:2500
+#: sha1-file.c:2513
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "impossibile analizzare l'intestazione di %s"
 
-#: sha1-file.c:2511
+#: sha1-file.c:2524
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "impossibile decomprimere i contenuti di %s"
@@ -8171,12 +8207,12 @@ msgstr "il log per '%.*s' è disponibile solo fino al %s"
 msgid "log for '%.*s' only has %d entries"
 msgstr "il log per '%.*s' ha solo %d voci"
 
-#: sha1-name.c:1689
+#: sha1-name.c:1702
 #, c-format
 msgid "path '%s' exists on disk, but not in '%.*s'"
 msgstr "il percorso '%s' esiste su disco, ma non in '%.*s'"
 
-#: sha1-name.c:1695
+#: sha1-name.c:1708
 #, c-format
 msgid ""
 "path '%s' exists, but not '%s'\n"
@@ -8185,12 +8221,12 @@ msgstr ""
 "il percorso '%s' esiste, ma non '%s'\n"
 "suggerimento: forse intendevi '%.*s:%s' ossia '%.*s:./%s'?"
 
-#: sha1-name.c:1704
+#: sha1-name.c:1717
 #, c-format
 msgid "path '%s' does not exist in '%.*s'"
 msgstr "il percorso '%s' non esiste in '%.*s'"
 
-#: sha1-name.c:1732
+#: sha1-name.c:1745
 #, c-format
 msgid ""
 "path '%s' is in the index, but not at stage %d\n"
@@ -8199,7 +8235,7 @@ msgstr ""
 "il percorso '%s' è nell'indice, ma non nel passo %d\n"
 "suggerimento: Forse intendevi ':%d:%s'?"
 
-#: sha1-name.c:1748
+#: sha1-name.c:1761
 #, c-format
 msgid ""
 "path '%s' is in the index, but not '%s'\n"
@@ -8208,23 +8244,23 @@ msgstr ""
 "il percorso '%s' è nell'indice, ma non '%s'\n"
 "suggerimento: Forse intendevi ':%d:%s' ossia ':%d:./%s'?"
 
-#: sha1-name.c:1756
+#: sha1-name.c:1769
 #, c-format
 msgid "path '%s' exists on disk, but not in the index"
 msgstr "il percorso '%s' esiste su disco, ma non nell'indice"
 
-#: sha1-name.c:1758
+#: sha1-name.c:1771
 #, c-format
 msgid "path '%s' does not exist (neither on disk nor in the index)"
 msgstr "il percorso '%s' non esiste (né su disco né nell'indice)"
 
-#: sha1-name.c:1771
+#: sha1-name.c:1784
 msgid "relative path syntax can't be used outside working tree"
 msgstr ""
 "la sintassi per i percorsi relativi non può essere usata al di fuori "
 "dell'albero di lavoro"
 
-#: sha1-name.c:1909
+#: sha1-name.c:1922
 #, c-format
 msgid "invalid object name '%.*s'."
 msgstr "nome oggetto non valido: '%.*s'."
@@ -8280,6 +8316,12 @@ msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] "%u byte/s"
 msgstr[1] "%u byte/s"
+
+#: strbuf.c:1166 wrapper.c:199 wrapper.c:369 builtin/am.c:733
+#: builtin/rebase.c:858
+#, c-format
+msgid "could not open '%s' for writing"
+msgstr "impossibile aprire '%s' in scrittura"
 
 #: strbuf.c:1175
 #, c-format
@@ -8347,7 +8389,7 @@ msgstr "Lo specificatore percorso '%s' è nel sottomodulo '%.*s'"
 msgid "bad --ignore-submodules argument: %s"
 msgstr "argomento --ignore-submodules errato: %s"
 
-#: submodule.c:815
+#: submodule.c:816
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8356,12 +8398,12 @@ msgstr ""
 "Il sottomodulo nel commit %s e nel percorso '%s' collide con un sottomodulo "
 "con lo stesso nome. Lo salto."
 
-#: submodule.c:910
+#: submodule.c:919
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "la voce sottomodulo '%s' (%s) è un %s, non un commit"
 
-#: submodule.c:995
+#: submodule.c:1004
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8370,36 +8412,36 @@ msgstr ""
 "Impossibile eseguire il comando 'git rev-list <commit> --not --remotes -n 1' "
 "nel sottomodulo %s"
 
-#: submodule.c:1118
+#: submodule.c:1127
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "il processo per il sottomodulo '%s' non è uscito con successo"
 
-#: submodule.c:1147 builtin/branch.c:678 builtin/submodule--helper.c:2045
+#: submodule.c:1156 builtin/branch.c:678 builtin/submodule--helper.c:2469
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Impossibile risolvere HEAD come riferimento valido."
 
-#: submodule.c:1158
+#: submodule.c:1167
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Push del sottomodulo '%s' in corso\n"
 
-#: submodule.c:1161
+#: submodule.c:1170
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Impossibile eseguire il push del sottomodulo '%s'\n"
 
-#: submodule.c:1453
+#: submodule.c:1462
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Recupero del sottomodulo %s%s in corso\n"
 
-#: submodule.c:1483
+#: submodule.c:1492
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Impossibile accedere al sottomodulo '%s'\n"
 
-#: submodule.c:1637
+#: submodule.c:1646
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8408,66 +8450,66 @@ msgstr ""
 "Errore durante il recupero del sottomodulo:\n"
 "%s"
 
-#: submodule.c:1662
+#: submodule.c:1671
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' non riconosciuto come repository Git"
 
-#: submodule.c:1679
+#: submodule.c:1688
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Impossibile eseguire 'git status --porcelain=2' nel sottomodulo %s"
 
-#: submodule.c:1720
+#: submodule.c:1729
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr ""
 "Esecuzione di 'git status --porcelain=2' non riuscita nel sottomodulo %s"
 
-#: submodule.c:1800
+#: submodule.c:1804
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "impossibile avviare 'git status' nel sottomodulo '%s'"
 
-#: submodule.c:1813
+#: submodule.c:1817
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "impossibile eseguire 'git status' nel sottomodulo '%s'"
 
-#: submodule.c:1828
+#: submodule.c:1832
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr ""
 "Impossibile annullare l'impostazione dell'opzione core.worktree nel "
 "sottomodulo '%s'"
 
-#: submodule.c:1855 submodule.c:2165
+#: submodule.c:1859 submodule.c:2169
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "impossibile eseguire l'azione ricorsivamente nel sottomodulo '%s'"
 
-#: submodule.c:1876
+#: submodule.c:1880
 msgid "could not reset submodule index"
 msgstr "impossibile ripristinare l'indice del sottomodulo"
 
-#: submodule.c:1918
+#: submodule.c:1922
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "il sottomodulo '%s' ha l'indice sporco"
 
-#: submodule.c:1970
+#: submodule.c:1974
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Impossibile aggiornare il sottomodulo '%s'."
 
-#: submodule.c:2038
+#: submodule.c:2042
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr ""
 "la directory Git del sottomodulo '%s' è all'interno della directory Git "
 "'%.*s'"
 
-#: submodule.c:2059
+#: submodule.c:2063
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8475,17 +8517,17 @@ msgstr ""
 "relocate_gitdir non è supportata per il sottomodulo '%s' con più di un "
 "albero di lavoro"
 
-#: submodule.c:2071 submodule.c:2130
+#: submodule.c:2075 submodule.c:2134
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "impossibile ricercare il nome per il sottomodulo '%s'"
 
-#: submodule.c:2075
+#: submodule.c:2079
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "mi rifiuto di spostare '%s' in una directory Git esistente"
 
-#: submodule.c:2082
+#: submodule.c:2086
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8496,65 +8538,65 @@ msgstr ""
 "'%s' a\n"
 "'%s'\n"
 
-#: submodule.c:2210
+#: submodule.c:2214
 msgid "could not start ls-files in .."
 msgstr "impossibile avviare ls-files in .."
 
-#: submodule.c:2250
+#: submodule.c:2254
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree ha restituito il valore di ritorno inatteso %d"
 
-#: trailer.c:238
+#: trailer.c:236
 #, c-format
 msgid "running trailer command '%s' failed"
 msgstr "esecuzione del comando finale '%s' non riuscita"
 
-#: trailer.c:485 trailer.c:490 trailer.c:495 trailer.c:549 trailer.c:553
-#: trailer.c:557
+#: trailer.c:483 trailer.c:488 trailer.c:493 trailer.c:547 trailer.c:551
+#: trailer.c:555
 #, c-format
 msgid "unknown value '%s' for key '%s'"
 msgstr "valore '%s' sconosciuto per la chiave '%s'"
 
-#: trailer.c:539 trailer.c:544 builtin/remote.c:298 builtin/remote.c:323
+#: trailer.c:537 trailer.c:542 builtin/remote.c:298 builtin/remote.c:323
 #, c-format
 msgid "more than one %s"
 msgstr "più di un %s"
 
-#: trailer.c:730
+#: trailer.c:728
 #, c-format
 msgid "empty trailer token in trailer '%.*s'"
 msgstr "token finale vuoto nella stringa finale '%.*s'"
 
-#: trailer.c:750
+#: trailer.c:748
 #, c-format
 msgid "could not read input file '%s'"
 msgstr "impossibile leggere il file di input '%s'"
 
-#: trailer.c:753
+#: trailer.c:751
 msgid "could not read from stdin"
 msgstr "impossibile leggere dallo standard input"
 
-#: trailer.c:1011 wrapper.c:673
+#: trailer.c:1009 wrapper.c:676
 #, c-format
 msgid "could not stat %s"
 msgstr "impossibile eseguire lo stat di '%s'"
 
-#: trailer.c:1013
+#: trailer.c:1011
 #, c-format
 msgid "file %s is not a regular file"
 msgstr "il file %s non è un file regolare"
 
-#: trailer.c:1015
+#: trailer.c:1013
 #, c-format
 msgid "file %s is not writable by user"
 msgstr "il file %s non è scrivibile dall'utente"
 
-#: trailer.c:1027
+#: trailer.c:1025
 msgid "could not open temporary file"
 msgstr "impossibile aprire un file temporaneo"
 
-#: trailer.c:1067
+#: trailer.c:1065
 #, c-format
 msgid "could not rename temporary file to %s"
 msgstr "impossibile ridenominare il file temporaneo in %s"
@@ -8603,7 +8645,7 @@ msgstr "impossibile eseguire fast-import"
 msgid "error while running fast-import"
 msgstr "errore durante l'esecuzione di fast-import"
 
-#: transport-helper.c:549 transport-helper.c:1156
+#: transport-helper.c:549 transport-helper.c:1226
 #, c-format
 msgid "could not read ref %s"
 msgstr "impossibile leggere il riferimento %s"
@@ -8623,7 +8665,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr "percorso servizio remoto non valido"
 
-#: transport-helper.c:661 transport.c:1347
+#: transport-helper.c:661 transport.c:1428
 msgid "operation not supported by protocol"
 msgstr "operazione non supportata dal protocollo"
 
@@ -8632,61 +8674,65 @@ msgstr "operazione non supportata dal protocollo"
 msgid "can't connect to subservice %s"
 msgstr "impossibile connettersi al sottoservizio %s"
 
-#: transport-helper.c:740
+#: transport-helper.c:745
+msgid "'option' without a matching 'ok/error' directive"
+msgstr "'option' senza una direttiva corrispondente 'ok/error'"
+
+#: transport-helper.c:788
 #, c-format
 msgid "expected ok/error, helper said '%s'"
 msgstr "attesi ok/error, l'helper ha inviato '%s'"
 
-#: transport-helper.c:793
+#: transport-helper.c:841
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "l'helper ha segnalato uno stato inatteso di %s"
 
-#: transport-helper.c:854
+#: transport-helper.c:924
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "l'helper %s non supporta dry-run"
 
-#: transport-helper.c:857
+#: transport-helper.c:927
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "l'helper %s non supporta --signed"
 
-#: transport-helper.c:860
+#: transport-helper.c:930
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "l'helper %s non supporta --signed=if-asked"
 
-#: transport-helper.c:865
+#: transport-helper.c:935
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "l'helper %s non supporta --atomic"
 
-#: transport-helper.c:871
+#: transport-helper.c:941
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "l'helper %s non supporta 'push-option'"
 
-#: transport-helper.c:970
+#: transport-helper.c:1040
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr ""
 "l'helper remoto non supporta il push; è necessario uno specificatore "
 "riferimento"
 
-#: transport-helper.c:975
+#: transport-helper.c:1045
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "l'helper %s non supporta 'force'"
 
-#: transport-helper.c:1022
+#: transport-helper.c:1092
 msgid "couldn't run fast-export"
 msgstr "impossibile eseguire fast-export"
 
-#: transport-helper.c:1027
+#: transport-helper.c:1097
 msgid "error while running fast-export"
 msgstr "errore durante l'esecuzione di fast-export"
 
-#: transport-helper.c:1052
+#: transport-helper.c:1122
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -8695,52 +8741,52 @@ msgstr ""
 "Nessun riferimento in comune e nessuno specificato; non eseguo nulla.\n"
 "Forse dovresti specificare un branch.\n"
 
-#: transport-helper.c:1133
+#: transport-helper.c:1203
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "formato oggetto non supportato: '%s'"
 
-#: transport-helper.c:1142
+#: transport-helper.c:1212
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "risposta malformata nell'elenco riferimenti: %s"
 
-#: transport-helper.c:1294
+#: transport-helper.c:1364
 #, c-format
 msgid "read(%s) failed"
 msgstr "read(%s) non riuscita"
 
-#: transport-helper.c:1321
+#: transport-helper.c:1391
 #, c-format
 msgid "write(%s) failed"
 msgstr "write(%s) non riuscita"
 
-#: transport-helper.c:1370
+#: transport-helper.c:1440
 #, c-format
 msgid "%s thread failed"
 msgstr "thread %s non riuscito"
 
-#: transport-helper.c:1374
+#: transport-helper.c:1444
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "join non riuscita per il thread %s: %s"
 
-#: transport-helper.c:1393 transport-helper.c:1397
+#: transport-helper.c:1463 transport-helper.c:1467
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "impossibile avviare il thread per la copia dei dati: %s"
 
-#: transport-helper.c:1434
+#: transport-helper.c:1504
 #, c-format
 msgid "%s process failed to wait"
 msgstr "wait non riuscita per il processo %s"
 
-#: transport-helper.c:1438
+#: transport-helper.c:1508
 #, c-format
 msgid "%s process failed"
 msgstr "processo %s non riuscito"
 
-#: transport-helper.c:1456 transport-helper.c:1465
+#: transport-helper.c:1526 transport-helper.c:1535
 msgid "can't start thread for copying data"
 msgstr "impossibile avviare il thread per la copia dei dati"
 
@@ -8759,37 +8805,37 @@ msgstr "impossibile leggere il bundle '%s'"
 msgid "transport: invalid depth option '%s'"
 msgstr "trasporto: opzione profondità '%s' non valida"
 
-#: transport.c:272
+#: transport.c:269
 msgid "see protocol.version in 'git help config' for more details"
 msgstr "vedi protocol.version in 'git help config' per maggiori dettagli"
 
-#: transport.c:273
+#: transport.c:270
 msgid "server options require protocol version 2 or later"
 msgstr "le opzioni server richiedono la versione 2 o successiva del protocollo"
 
-#: transport.c:631
+#: transport.c:712
 msgid "could not parse transport.color.* config"
 msgstr "impossibile analizzare la configurazione transport.color.*"
 
-#: transport.c:704
+#: transport.c:785
 msgid "support for protocol v2 not implemented yet"
 msgstr "supporto alla versione 2 del protocollo non ancora implementato"
 
-#: transport.c:838
+#: transport.c:919
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "valore sconosciuto per la configurazione '%s': %s"
 
-#: transport.c:904
+#: transport.c:985
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "trasporto '%s' non consentito"
 
-#: transport.c:957
+#: transport.c:1038
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync non è più supportato"
 
-#: transport.c:1059
+#: transport.c:1140
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -8798,7 +8844,7 @@ msgstr ""
 "I seguenti percorsi sottomodulo contengono modifiche\n"
 "non trovate su nessun remoto:\n"
 
-#: transport.c:1063
+#: transport.c:1144
 #, c-format
 msgid ""
 "\n"
@@ -8825,11 +8871,11 @@ msgstr ""
 "per eseguirne il push a un remoto.\n"
 "\n"
 
-#: transport.c:1071
+#: transport.c:1152
 msgid "Aborting."
 msgstr "Interrompo l'operazione."
 
-#: transport.c:1216
+#: transport.c:1297
 msgid "failed to push all needed submodules"
 msgstr "push di tutti i sottomoduli richiesti non riuscito"
 
@@ -9122,7 +9168,7 @@ msgstr ""
 msgid "Updating index flags"
 msgstr "Aggiornamento dei contrassegni indice in corso"
 
-#: upload-pack.c:1415
+#: upload-pack.c:1516
 msgid "expected flush after fetch arguments"
 msgstr "atteso flush dopo recupero argomenti"
 
@@ -9159,50 +9205,86 @@ msgstr "parte percorso '..' non valida"
 msgid "Fetching objects"
 msgstr "Recupero oggetti in corso"
 
-#: worktree.c:248 builtin/am.c:2098
+#: worktree.c:236 builtin/am.c:2116
 #, c-format
 msgid "failed to read '%s'"
 msgstr "lettura di '%s' non riuscita"
 
-#: worktree.c:295
+#: worktree.c:283
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr ""
 "'%s' nell'albero di lavoro principale non è la directory del repository"
 
-#: worktree.c:306
+#: worktree.c:294
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr ""
 "il file '%s' non contiene il percorso assoluto alla posizione dell'albero di "
 "lavoro"
 
-#: worktree.c:318
+#: worktree.c:306
 #, c-format
 msgid "'%s' does not exist"
 msgstr "'%s' non esiste"
 
-#: worktree.c:324
+#: worktree.c:312
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "'%s' non è un file .git, codice d'errore %d"
 
-#: worktree.c:333
+#: worktree.c:321
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "'%s' non punta a '%s'"
 
-#: wrapper.c:194 wrapper.c:364
+#: worktree.c:587
+msgid "not a directory"
+msgstr "non è una directory"
+
+#: worktree.c:596
+msgid ".git is not a file"
+msgstr ".git non è un file"
+
+#: worktree.c:598
+msgid ".git file broken"
+msgstr "file .git corrotto"
+
+#: worktree.c:600
+msgid ".git file incorrect"
+msgstr "file .git non corretto"
+
+#: worktree.c:670
+msgid "not a valid path"
+msgstr "non è un percorso valido"
+
+#: worktree.c:676
+msgid "unable to locate repository; .git is not a file"
+msgstr "impossibile trovare il repository; .git non è un file"
+
+#: worktree.c:679
+msgid "unable to locate repository; .git file broken"
+msgstr "impossibile trovare il repository; file .git corrotto"
+
+#: worktree.c:685
+msgid "gitdir unreadable"
+msgstr "gitdir non leggibile"
+
+#: worktree.c:689
+msgid "gitdir incorrect"
+msgstr "gitdir non corretto"
+
+#: wrapper.c:197 wrapper.c:367
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr "impossibile aprire '%s' in lettura e scrittura"
 
-#: wrapper.c:395 wrapper.c:596
+#: wrapper.c:398 wrapper.c:599
 #, c-format
 msgid "unable to access '%s'"
 msgstr "impossibile accedere a '%s'"
 
-#: wrapper.c:604
+#: wrapper.c:607
 msgid "unable to get current working directory"
 msgstr "impossibile ottenere la directory di lavoro corrente"
 
@@ -9245,11 +9327,11 @@ msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr ""
 "  (usa \"git rm <file>...\" per contrassegnare il conflitto come risolto)"
 
-#: wt-status.c:211 wt-status.c:1072
+#: wt-status.c:211 wt-status.c:1070
 msgid "Changes to be committed:"
 msgstr "Modifiche di cui verrà eseguito il commit:"
 
-#: wt-status.c:234 wt-status.c:1081
+#: wt-status.c:234 wt-status.c:1079
 msgid "Changes not staged for commit:"
 msgstr "Modifiche non nell'area di staging per il commit:"
 
@@ -9285,94 +9367,94 @@ msgstr ""
 "  (usa \"git %s <file>...\" per includere l'elemento fra quelli di cui verrà "
 "eseguito il commit)"
 
-#: wt-status.c:268
+#: wt-status.c:266
 msgid "both deleted:"
 msgstr "entrambi eliminati:"
 
-#: wt-status.c:270
+#: wt-status.c:268
 msgid "added by us:"
 msgstr "aggiunto da noi:"
 
-#: wt-status.c:272
+#: wt-status.c:270
 msgid "deleted by them:"
 msgstr "eliminato da loro:"
 
-#: wt-status.c:274
+#: wt-status.c:272
 msgid "added by them:"
 msgstr "aggiunto da loro:"
 
-#: wt-status.c:276
+#: wt-status.c:274
 msgid "deleted by us:"
 msgstr "eliminato da noi:"
 
-#: wt-status.c:278
+#: wt-status.c:276
 msgid "both added:"
 msgstr "entrambi aggiunti:"
 
-#: wt-status.c:280
+#: wt-status.c:278
 msgid "both modified:"
 msgstr "entrambi modificati:"
 
-#: wt-status.c:290
+#: wt-status.c:288
 msgid "new file:"
 msgstr "nuovo file:"
 
-#: wt-status.c:292
+#: wt-status.c:290
 msgid "copied:"
 msgstr "copiato:"
 
-#: wt-status.c:294
+#: wt-status.c:292
 msgid "deleted:"
 msgstr "eliminato:"
 
-#: wt-status.c:296
+#: wt-status.c:294
 msgid "modified:"
 msgstr "modificato:"
 
-#: wt-status.c:298
+#: wt-status.c:296
 msgid "renamed:"
 msgstr "rinominato:"
 
-#: wt-status.c:300
+#: wt-status.c:298
 msgid "typechange:"
 msgstr "modifica tipo:"
 
-#: wt-status.c:302
+#: wt-status.c:300
 msgid "unknown:"
 msgstr "sconosciuto:"
 
-#: wt-status.c:304
+#: wt-status.c:302
 msgid "unmerged:"
 msgstr "non sottoposto a merge:"
 
-#: wt-status.c:384
+#: wt-status.c:382
 msgid "new commits, "
 msgstr "nuovi commit, "
 
-#: wt-status.c:386
+#: wt-status.c:384
 msgid "modified content, "
 msgstr "contenuto modificato, "
 
-#: wt-status.c:388
+#: wt-status.c:386
 msgid "untracked content, "
 msgstr "contenuto non tracciato, "
 
-#: wt-status.c:904
+#: wt-status.c:903
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Lo stash attualmente ha %d voce"
 msgstr[1] "Lo stash attualmente ha %d voci"
 
-#: wt-status.c:936
+#: wt-status.c:934
 msgid "Submodules changed but not updated:"
 msgstr "Sottomoduli modificati ma non aggiornati:"
 
-#: wt-status.c:938
+#: wt-status.c:936
 msgid "Submodule changes to be committed:"
 msgstr "Modifiche ai sottomoduli di cui verrà eseguito il commit:"
 
-#: wt-status.c:1020
+#: wt-status.c:1018
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -9380,7 +9462,7 @@ msgstr ""
 "Non modificare o rimuovere la riga soprastante.\n"
 "Tutto ciò che si trova al di sotto di essa sarà ignorato."
 
-#: wt-status.c:1112
+#: wt-status.c:1110
 #, c-format
 msgid ""
 "\n"
@@ -9392,111 +9474,111 @@ msgstr ""
 "precedenti/successivi nel branch.\n"
 "Puoi usare '--no-ahead-behind' per evitare il calcolo.\n"
 
-#: wt-status.c:1142
+#: wt-status.c:1140
 msgid "You have unmerged paths."
 msgstr "Hai dei percorsi non sottoposti a merge."
 
-#: wt-status.c:1145
+#: wt-status.c:1143
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (risolvi i conflitti ed esegui \"git commit\")"
 
-#: wt-status.c:1147
+#: wt-status.c:1145
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (usa \"git merge --abort\" per interrompere il merge)"
 
-#: wt-status.c:1151
+#: wt-status.c:1149
 msgid "All conflicts fixed but you are still merging."
 msgstr "Tutti i conflitti sono stati risolti ma il merge è ancora in corso."
 
-#: wt-status.c:1154
+#: wt-status.c:1152
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (usa \"git commit\" per terminare il merge)"
 
-#: wt-status.c:1163
+#: wt-status.c:1161
 msgid "You are in the middle of an am session."
 msgstr "Sei nel bel mezzo di una sessione am."
 
-#: wt-status.c:1166
+#: wt-status.c:1164
 msgid "The current patch is empty."
 msgstr "La patch corrente è vuota."
 
-#: wt-status.c:1170
+#: wt-status.c:1168
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (risolvi i conflitti e quindi esegui \"git am --continue\")"
 
-#: wt-status.c:1172
+#: wt-status.c:1170
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (usa \"git am --skip\" per saltare questa patch)"
 
-#: wt-status.c:1174
+#: wt-status.c:1172
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr "  (usa \"git am --abort\" per ripristinare il branch originario)"
 
-#: wt-status.c:1307
+#: wt-status.c:1305
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo è mancante."
 
-#: wt-status.c:1309
+#: wt-status.c:1307
 msgid "No commands done."
 msgstr "Nessun comando eseguito."
 
-#: wt-status.c:1312
+#: wt-status.c:1310
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Ultimo comando eseguito (%d comando eseguito):"
 msgstr[1] "Ultimi comandi eseguiti (%d comandi eseguiti):"
 
-#: wt-status.c:1323
+#: wt-status.c:1321
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (vedi di più nel file %s)"
 
-#: wt-status.c:1328
+#: wt-status.c:1326
 msgid "No commands remaining."
 msgstr "Nessun comando rimanente."
 
-#: wt-status.c:1331
+#: wt-status.c:1329
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Prossimo comando da eseguire (%d comando rimanente):"
 msgstr[1] "Prossimi comandi da eseguire (%d comandi rimanenti):"
 
-#: wt-status.c:1339
+#: wt-status.c:1337
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr ""
 "  (usa \"git rebase --edit-todo\" per visualizzare e modificare le "
 "operazioni)"
 
-#: wt-status.c:1351
+#: wt-status.c:1349
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Attualmente stai eseguendo il rebase del branch '%s' su '%s'."
 
-#: wt-status.c:1356
+#: wt-status.c:1354
 msgid "You are currently rebasing."
 msgstr "Attualmente stai eseguendo un rebase."
 
-#: wt-status.c:1369
+#: wt-status.c:1367
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr "  (risolvi i conflitti e quindi esegui \"git rebase --continue\")"
 
-#: wt-status.c:1371
+#: wt-status.c:1369
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (usa \"git rebase --skip\" per saltare questa patch)"
 
-#: wt-status.c:1373
+#: wt-status.c:1371
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr ""
 "  (usa \"git rebase --abort\" per eseguire il checkout del branch originario)"
 
-#: wt-status.c:1380
+#: wt-status.c:1378
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr ""
 "  (tutti i conflitti sono stati risolti: esegui \"git rebase --continue\")"
 
-#: wt-status.c:1384
+#: wt-status.c:1382
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -9504,151 +9586,151 @@ msgstr ""
 "Attualmente stai dividendo un commit durante il rebase del branch '%s' su "
 "'%s'."
 
-#: wt-status.c:1389
+#: wt-status.c:1387
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Attualmente stai dividendo un commit durante un rebase."
 
-#: wt-status.c:1392
+#: wt-status.c:1390
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Una volta che la tua directory di lavoro è pulita, esegui \"git rebase --"
 "continue\")"
 
-#: wt-status.c:1396
+#: wt-status.c:1394
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Attualmente stai modificando un commit durante il rebase del branch '%s' su "
 "'%s'."
 
-#: wt-status.c:1401
+#: wt-status.c:1399
 msgid "You are currently editing a commit during a rebase."
 msgstr "Attualmente stai modificando un commit durante un rebase."
 
-#: wt-status.c:1404
+#: wt-status.c:1402
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr "  (usa \"git commit --amend\" per correggere il commit corrente)"
 
-#: wt-status.c:1406
+#: wt-status.c:1404
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (usa \"git rebase --continue\" una volta soddisfatto delle tue modifiche)"
 
-#: wt-status.c:1417
+#: wt-status.c:1415
 msgid "Cherry-pick currently in progress."
 msgstr "Cherry-pick in corso."
 
-#: wt-status.c:1420
+#: wt-status.c:1418
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Attualmente stai eseguendo il cherry-pick del commit %s."
 
-#: wt-status.c:1427
+#: wt-status.c:1425
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (risolvi i conflitti ed esegui \"git cherry-pick --continue\")"
 
-#: wt-status.c:1430
+#: wt-status.c:1428
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (esegui \"git cherry-pick --continue\" per continuare)"
 
-#: wt-status.c:1433
+#: wt-status.c:1431
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (tutti i conflitti sono stati risolti: esegui \"git cherry-pick --continue"
 "\")"
 
-#: wt-status.c:1435
+#: wt-status.c:1433
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr "  (usa \"git cherry-pick --skip\" per saltare questa patch)"
 
-#: wt-status.c:1437
+#: wt-status.c:1435
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (usa \"git cherry-pick --abort\" per annullare l'operazione di cherry-pick)"
 
-#: wt-status.c:1447
+#: wt-status.c:1445
 msgid "Revert currently in progress."
 msgstr "Revert in corso."
 
-#: wt-status.c:1450
+#: wt-status.c:1448
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Attualmente stai eseguendo il revert del commit %s."
 
-#: wt-status.c:1456
+#: wt-status.c:1454
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (risolvi i conflitti ed esegui \"git revert --continue\")"
 
-#: wt-status.c:1459
+#: wt-status.c:1457
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (esegui \"git revert --continue\" per continuare)"
 
-#: wt-status.c:1462
+#: wt-status.c:1460
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr ""
 "  (tutti i conflitti sono stati risolti: esegui \"git revert --continue\")"
 
-#: wt-status.c:1464
+#: wt-status.c:1462
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (usa \"git revert --skip\" per saltare questa patch)"
 
-#: wt-status.c:1466
+#: wt-status.c:1464
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr "  (usa \"git revert --abort\" per annullare l'operazione di revert)"
 
-#: wt-status.c:1476
+#: wt-status.c:1474
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Attualmente stai eseguendo una bisezione partendo dal branch '%s'."
 
-#: wt-status.c:1480
+#: wt-status.c:1478
 msgid "You are currently bisecting."
 msgstr "Attualmente stai eseguendo una bisezione."
 
-#: wt-status.c:1483
+#: wt-status.c:1481
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr "  (usa \"git bisect reset\" per tornare al branch originario)"
 
-#: wt-status.c:1494
+#: wt-status.c:1492
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr ""
 "Sei in uno sparse checkout in cui è presente il %d%% dei file tracciati."
 
-#: wt-status.c:1733
+#: wt-status.c:1731
 msgid "On branch "
 msgstr "Sul branch "
 
-#: wt-status.c:1740
+#: wt-status.c:1738
 msgid "interactive rebase in progress; onto "
 msgstr "rebase interattivo in corso su "
 
-#: wt-status.c:1742
+#: wt-status.c:1740
 msgid "rebase in progress; onto "
 msgstr "rebase in corso su "
 
-#: wt-status.c:1752
+#: wt-status.c:1750
 msgid "Not currently on any branch."
 msgstr "Attualmente non sei su alcun branch."
 
-#: wt-status.c:1769
+#: wt-status.c:1767
 msgid "Initial commit"
 msgstr "Commit iniziale"
 
-#: wt-status.c:1770
+#: wt-status.c:1768
 msgid "No commits yet"
 msgstr "Non ci sono ancora commit"
 
-#: wt-status.c:1784
+#: wt-status.c:1782
 msgid "Untracked files"
 msgstr "File non tracciati"
 
-#: wt-status.c:1786
+#: wt-status.c:1784
 msgid "Ignored files"
 msgstr "File ignorati"
 
-#: wt-status.c:1790
+#: wt-status.c:1788
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -9660,26 +9742,26 @@ msgstr ""
 "ma devi stare attento a non dimenticarti di aggiungere\n"
 "autonomamente i file nuovi (vedi 'git help status')."
 
-#: wt-status.c:1796
+#: wt-status.c:1794
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "File non tracciati non elencati%s"
 
-#: wt-status.c:1798
+#: wt-status.c:1796
 msgid " (use -u option to show untracked files)"
 msgstr " (usa l'opzione -u per visualizzare i file non tracciati)"
 
-#: wt-status.c:1804
+#: wt-status.c:1802
 msgid "No changes"
 msgstr "Nessuna modifica"
 
-#: wt-status.c:1809
+#: wt-status.c:1807
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "nessuna modifica aggiunta al commit (usa \"git add\" e/o \"git commit -a\")\n"
 
-#: wt-status.c:1812
+#: wt-status.c:1811
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "nessuna modifica aggiunta al commit\n"
@@ -9693,68 +9775,68 @@ msgstr ""
 "non è stato aggiunto nulla al commit ma sono presenti file non tracciati "
 "(usa \"git add\" per tracciarli)\n"
 
-#: wt-status.c:1818
+#: wt-status.c:1819
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr ""
 "non è stato aggiunto nulla al commit ma sono presenti file non tracciati\n"
 
-#: wt-status.c:1821
+#: wt-status.c:1823
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "non c'è nulla di cui eseguire il commit (crea/copia dei file e usa \"git add"
 "\" per tracciarli)\n"
 
-#: wt-status.c:1824 wt-status.c:1829
+#: wt-status.c:1827 wt-status.c:1833
 #, c-format
 msgid "nothing to commit\n"
 msgstr "non c'è nulla di cui eseguire il commit\n"
 
-#: wt-status.c:1827
+#: wt-status.c:1830
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr ""
 "non c'è nulla di cui eseguire il commit (usa -u per visualizzare i file non "
 "tracciati)\n"
 
-#: wt-status.c:1831
+#: wt-status.c:1835
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "non c'è nulla di cui eseguire il commit, l'albero di lavoro è pulito\n"
 
-#: wt-status.c:1944
+#: wt-status.c:1940
 msgid "No commits yet on "
 msgstr "Non ci sono ancora commit su"
 
-#: wt-status.c:1948
+#: wt-status.c:1944
 msgid "HEAD (no branch)"
 msgstr "HEAD (nessun branch)"
 
-#: wt-status.c:1979
+#: wt-status.c:1975
 msgid "different"
 msgstr "differente"
 
-#: wt-status.c:1981 wt-status.c:1989
+#: wt-status.c:1977 wt-status.c:1985
 msgid "behind "
 msgstr "indietro "
 
-#: wt-status.c:1984 wt-status.c:1987
+#: wt-status.c:1980 wt-status.c:1983
 msgid "ahead "
 msgstr "avanti "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2509
+#: wt-status.c:2505
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "impossibile eseguire %s: ci sono delle modifiche non in staging."
 
-#: wt-status.c:2515
+#: wt-status.c:2511
 msgid "additionally, your index contains uncommitted changes."
 msgstr ""
 "inoltre, l'indice contiene modifiche di cui non è stato eseguito il commit."
 
-#: wt-status.c:2517
+#: wt-status.c:2513
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
@@ -9788,111 +9870,111 @@ msgstr "elimina '%s'\n"
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Modifiche non nell'area di staging dopo l'aggiornamento dell'indice:"
 
-#: builtin/add.c:266 builtin/rev-parse.c:904
+#: builtin/add.c:272 builtin/rev-parse.c:904
 msgid "Could not read the index"
 msgstr "Impossibile leggere l'indice"
 
-#: builtin/add.c:277
+#: builtin/add.c:283
 #, c-format
 msgid "Could not open '%s' for writing."
 msgstr "Impossibile aprire '%s' in scrittura."
 
-#: builtin/add.c:281
+#: builtin/add.c:287
 msgid "Could not write patch"
 msgstr "Impossibile scrivere la patch"
 
-#: builtin/add.c:284
+#: builtin/add.c:290
 msgid "editing patch failed"
 msgstr "modifica della patch non riuscita"
 
-#: builtin/add.c:287
+#: builtin/add.c:293
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Impossibile eseguire lo stat di '%s'"
 
-#: builtin/add.c:289
+#: builtin/add.c:295
 msgid "Empty patch. Aborted."
 msgstr "Patch vuota. Operazione interrotta."
 
-#: builtin/add.c:294
+#: builtin/add.c:300
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Impossibile applicare '%s'"
 
-#: builtin/add.c:302
+#: builtin/add.c:308
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "I seguenti percorsi sono ignorati da uno dei file .gitignore:\n"
 
-#: builtin/add.c:322 builtin/clean.c:904 builtin/fetch.c:164 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:548
-#: builtin/remote.c:1421 builtin/rm.c:242 builtin/send-pack.c:165
+#: builtin/add.c:328 builtin/clean.c:904 builtin/fetch.c:166 builtin/mv.c:124
+#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:538
+#: builtin/remote.c:1422 builtin/rm.c:242 builtin/send-pack.c:184
 msgid "dry run"
 msgstr "test controllato"
 
-#: builtin/add.c:325
+#: builtin/add.c:331
 msgid "interactive picking"
 msgstr "scelta interattiva"
 
-#: builtin/add.c:326 builtin/checkout.c:1533 builtin/reset.c:308
+#: builtin/add.c:332 builtin/checkout.c:1529 builtin/reset.c:308
 msgid "select hunks interactively"
 msgstr "seleziona gli hunk in modalità interattiva"
 
-#: builtin/add.c:327
+#: builtin/add.c:333
 msgid "edit current diff and apply"
 msgstr "modifica il diff corrente e applicalo"
 
-#: builtin/add.c:328
+#: builtin/add.c:334
 msgid "allow adding otherwise ignored files"
 msgstr "consenti l'aggiunta di file altrimenti ignorati"
 
-#: builtin/add.c:329
+#: builtin/add.c:335
 msgid "update tracked files"
 msgstr "aggiorna i file tracciati"
 
-#: builtin/add.c:330
+#: builtin/add.c:336
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "rinormalizza i fine riga dei file tracciati (implica -u)"
 
-#: builtin/add.c:331
+#: builtin/add.c:337
 msgid "record only the fact that the path will be added later"
 msgstr "salva solo il fatto che il percorso sarà aggiunto successivamente"
 
-#: builtin/add.c:332
+#: builtin/add.c:338
 msgid "add changes from all tracked and untracked files"
 msgstr "aggiungi le modifiche da tutti i file tracciati e non"
 
-#: builtin/add.c:335
+#: builtin/add.c:341
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "ignora i percorsi eliminati nell'albero di lavoro (come --no-all)"
 
-#: builtin/add.c:337
+#: builtin/add.c:343
 msgid "don't add, only refresh the index"
 msgstr "non eseguire l'aggiunta, aggiorna solo l'indice"
 
-#: builtin/add.c:338
+#: builtin/add.c:344
 msgid "just skip files which cannot be added because of errors"
 msgstr ""
 "salta semplicemente i file che non possono essere aggiunti a causa di errori"
 
-#: builtin/add.c:339
+#: builtin/add.c:345
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
 "controlla se i file - anche quelli mancanti - sono ignorati durante il test "
 "controllato"
 
-#: builtin/add.c:341 builtin/update-index.c:1004
+#: builtin/add.c:347 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "esegui l'override del bit eseguibile dei file elencati"
 
-#: builtin/add.c:343
+#: builtin/add.c:349
 msgid "warn when adding an embedded repository"
 msgstr "emetti un avviso quando si aggiunge un repository incorporato"
 
-#: builtin/add.c:345
+#: builtin/add.c:351
 msgid "backend for `git stash -p`"
 msgstr "backend per `git stash -p`"
 
-#: builtin/add.c:363
+#: builtin/add.c:369
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -9923,12 +10005,12 @@ msgstr ""
 "\n"
 "Vedi \"git help submodule\" per ulteriori informazioni."
 
-#: builtin/add.c:391
+#: builtin/add.c:397
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "aggiunta repository Git incorporato in corso: %s"
 
-#: builtin/add.c:410
+#: builtin/add.c:416
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -9938,49 +10020,49 @@ msgstr ""
 "Per disabilitare questo messaggio, esegui\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:419
+#: builtin/add.c:425
 msgid "adding files failed"
 msgstr "aggiunta dei file non riuscita"
 
-#: builtin/add.c:447 builtin/commit.c:345
+#: builtin/add.c:453 builtin/commit.c:345
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr "--pathspec-from-file non è compatibile con --interactive/--patch"
 
-#: builtin/add.c:464
+#: builtin/add.c:470
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "--pathspec-from-file non è compatibile con --edit"
 
-#: builtin/add.c:476
+#: builtin/add.c:482
 msgid "-A and -u are mutually incompatible"
 msgstr "-A e -u non sono compatibili fra loro"
 
-#: builtin/add.c:479
+#: builtin/add.c:485
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr "L'opzione --ignore-missing può essere usata solo con --dry-run"
 
-#: builtin/add.c:483
+#: builtin/add.c:489
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "Il parametro --chmod '%s' deve essere -x o +x"
 
-#: builtin/add.c:501 builtin/checkout.c:1701 builtin/commit.c:351
-#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1506
+#: builtin/add.c:507 builtin/checkout.c:1697 builtin/commit.c:351
+#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1503
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr ""
 "--pathspec-from-file non è compatibile con gli argomenti specificatore "
 "percorso"
 
-#: builtin/add.c:508 builtin/checkout.c:1713 builtin/commit.c:357
-#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1512
+#: builtin/add.c:514 builtin/checkout.c:1709 builtin/commit.c:357
+#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1509
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul richiede --pathspec-from-file"
 
-#: builtin/add.c:512
+#: builtin/add.c:518
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Non è stato specificato nulla, non è stato aggiunto nulla.\n"
 
-#: builtin/add.c:514
+#: builtin/add.c:520
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -9990,111 +10072,116 @@ msgstr ""
 "Per disabilitare questo messaggio, esegui\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:352
+#: builtin/am.c:160
+#, c-format
+msgid "invalid committer: %s"
+msgstr "autore commit non valido: %s"
+
+#: builtin/am.c:366
 msgid "could not parse author script"
 msgstr "impossibile analizzare lo script author"
 
-#: builtin/am.c:436
+#: builtin/am.c:450
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' è stato eliminato dall'hook applypatch-msg"
 
-#: builtin/am.c:478
+#: builtin/am.c:492
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Riga di input malformata: '%s'."
 
-#: builtin/am.c:516
+#: builtin/am.c:530
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Copia delle note da '%s' a '%s' non riuscita"
 
-#: builtin/am.c:542
+#: builtin/am.c:556
 msgid "fseek failed"
 msgstr "fseek non riuscita"
 
-#: builtin/am.c:730
+#: builtin/am.c:744
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "impossibile analizzare la patch '%s'"
 
-#: builtin/am.c:795
+#: builtin/am.c:809
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Può essere applicata solo una serie di patch StGIT per volta"
 
-#: builtin/am.c:843
+#: builtin/am.c:857
 msgid "invalid timestamp"
 msgstr "timestamp non valido"
 
-#: builtin/am.c:848 builtin/am.c:860
+#: builtin/am.c:862 builtin/am.c:874
 msgid "invalid Date line"
 msgstr "riga Date non valida"
 
-#: builtin/am.c:855
+#: builtin/am.c:869
 msgid "invalid timezone offset"
 msgstr "offset fuso orario non valido"
 
-#: builtin/am.c:948
+#: builtin/am.c:962
 msgid "Patch format detection failed."
 msgstr "Rilevamento del formato della patch non riuscito."
 
-#: builtin/am.c:953 builtin/clone.c:409
+#: builtin/am.c:967 builtin/clone.c:409
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "creazione della directory '%s' non riuscita"
 
-#: builtin/am.c:958
+#: builtin/am.c:972
 msgid "Failed to split patches."
 msgstr "Divisione delle patch non riuscita."
 
-#: builtin/am.c:1089
+#: builtin/am.c:1103
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "Una volta risolto questo problema, esegui \"%s --continue\"."
 
-#: builtin/am.c:1090
+#: builtin/am.c:1104
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr "Se preferisci saltare questa patch, esegui invece \"%s --skip\"."
 
-#: builtin/am.c:1091
+#: builtin/am.c:1105
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Per ripristinare il branch originario e terminare il patching, esegui \"%s --"
 "abort\"."
 
-#: builtin/am.c:1174
+#: builtin/am.c:1188
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch inviata con format=flowed; gli spazi al termine delle righe potrebbero "
 "essere andati perduti."
 
-#: builtin/am.c:1202
+#: builtin/am.c:1216
 msgid "Patch is empty."
 msgstr "La patch è vuota."
 
-#: builtin/am.c:1267
+#: builtin/am.c:1281
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "riga autore mancante nel commit %s"
 
-#: builtin/am.c:1270
+#: builtin/am.c:1284
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "riga ident non valida: %.*s"
 
-#: builtin/am.c:1489
+#: builtin/am.c:1503
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Dal repository mancano i blob necessari per ripiegare sul merge a tre vie."
 
-#: builtin/am.c:1491
+#: builtin/am.c:1505
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Utilizzo le informazioni dell'indice per ricostruire un albero di base..."
 
-#: builtin/am.c:1510
+#: builtin/am.c:1524
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10102,24 +10189,24 @@ msgstr ""
 "Hai modificato manualmente la patch?\n"
 "Non può essere applicata ai blob registrati nel suo indice."
 
-#: builtin/am.c:1516
+#: builtin/am.c:1530
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Ripiego sul patching della base e sul merge a tre vie..."
 
-#: builtin/am.c:1542
+#: builtin/am.c:1556
 msgid "Failed to merge in the changes."
 msgstr "Merge delle modifiche non riuscito."
 
-#: builtin/am.c:1574
+#: builtin/am.c:1588
 msgid "applying to an empty history"
 msgstr "applicazione a una cronologia vuota"
 
-#: builtin/am.c:1621 builtin/am.c:1625
+#: builtin/am.c:1639 builtin/am.c:1643
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "impossibile riprendere l'attività: %s non esiste."
 
-#: builtin/am.c:1643
+#: builtin/am.c:1661
 msgid "Commit Body is:"
 msgstr "Il corpo del commit è:"
 
@@ -10127,41 +10214,41 @@ msgstr "Il corpo del commit è:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1653
+#: builtin/am.c:1671
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Applico? Sì [y]/No [n]/Modifica [e]/[V]isualizza patch/[A]ccetta tutto:"
 
-#: builtin/am.c:1699 builtin/commit.c:395
+#: builtin/am.c:1717 builtin/commit.c:395
 msgid "unable to write index file"
 msgstr "impossibile scrivere il file indice"
 
-#: builtin/am.c:1703
+#: builtin/am.c:1721
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Indice sporco: impossibile applicare le patch (elemento sporco: %s)"
 
-#: builtin/am.c:1743 builtin/am.c:1811
+#: builtin/am.c:1761 builtin/am.c:1829
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Applicazione in corso: %.*s"
 
-#: builtin/am.c:1760
+#: builtin/am.c:1778
 msgid "No changes -- Patch already applied."
 msgstr "Nessuna modifica -- patch già applicata."
 
-#: builtin/am.c:1766
+#: builtin/am.c:1784
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Patch non riuscita a %s %.*s"
 
-#: builtin/am.c:1770
+#: builtin/am.c:1788
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "Usa 'git am --show-current-patch=diff' per visualizzare la patch non riuscita"
 
-#: builtin/am.c:1814
+#: builtin/am.c:1832
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10171,7 +10258,7 @@ msgstr ""
 "Se non rimane nulla da aggiungere all'area di staging, forse qualcos'altro\n"
 "ha già introdotto le stesse modifiche; potresti voler saltare questa patch."
 
-#: builtin/am.c:1821
+#: builtin/am.c:1839
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -10184,17 +10271,17 @@ msgstr ""
 "Potresti eseguire `git rm` su un file per accettarne la risoluzione "
 "\"eliminato da loro\"."
 
-#: builtin/am.c:1928 builtin/am.c:1932 builtin/am.c:1944 builtin/reset.c:347
+#: builtin/am.c:1946 builtin/am.c:1950 builtin/am.c:1962 builtin/reset.c:347
 #: builtin/reset.c:355
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Impossibile analizzare l'oggetto '%s'."
 
-#: builtin/am.c:1980
+#: builtin/am.c:1998
 msgid "failed to clean index"
 msgstr "pulizia dell'indice non riuscita"
 
-#: builtin/am.c:2024
+#: builtin/am.c:2042
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10203,160 +10290,160 @@ msgstr ""
 "'am'.\n"
 "Non ritorno indietro a ORIG_HEAD"
 
-#: builtin/am.c:2131
+#: builtin/am.c:2149
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Valore non valido per --patch-format: %s"
 
-#: builtin/am.c:2171
+#: builtin/am.c:2191
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Valore non valido per --show-current-patch: %s"
 
-#: builtin/am.c:2175
+#: builtin/am.c:2195
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr "--show-current-patch=%s non è compatibile con --show-current-patch=%s"
 
-#: builtin/am.c:2206
+#: builtin/am.c:2226
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<opzioni>] [(<mbox> | <Maildir>)...]"
 
-#: builtin/am.c:2207
+#: builtin/am.c:2227
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<opzioni>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2213
+#: builtin/am.c:2233
 msgid "run interactively"
 msgstr "esegui in modalità interattiva"
 
-#: builtin/am.c:2215
+#: builtin/am.c:2235
 msgid "historical option -- no-op"
 msgstr "opzione storica -- non esegue nulla"
 
-#: builtin/am.c:2217
+#: builtin/am.c:2237
 msgid "allow fall back on 3way merging if needed"
 msgstr "consenti il ripiego sul merge a tre vie se necessario"
 
-#: builtin/am.c:2218 builtin/init-db.c:559 builtin/prune-packed.c:16
-#: builtin/repack.c:306 builtin/stash.c:816
+#: builtin/am.c:2238 builtin/init-db.c:558 builtin/prune-packed.c:16
+#: builtin/repack.c:309 builtin/stash.c:816
 msgid "be quiet"
 msgstr "non visualizzare messaggi"
 
-#: builtin/am.c:2220
+#: builtin/am.c:2240
 msgid "add a Signed-off-by line to the commit message"
 msgstr "aggiungi una riga Signed-off-by al messaggio di commit"
 
-#: builtin/am.c:2223
+#: builtin/am.c:2243
 msgid "recode into utf8 (default)"
 msgstr "converti codifica in UTF-8 (impostazione predefinita)"
 
-#: builtin/am.c:2225
+#: builtin/am.c:2245
 msgid "pass -k flag to git-mailinfo"
 msgstr "fornisci l'argomento -k a git-mailinfo"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2247
 msgid "pass -b flag to git-mailinfo"
 msgstr "fornisci l'argomento -b a git-mailinfo"
 
-#: builtin/am.c:2229
+#: builtin/am.c:2249
 msgid "pass -m flag to git-mailinfo"
 msgstr "fornisci l'argomento -m a git-mailinfo"
 
-#: builtin/am.c:2231
+#: builtin/am.c:2251
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "fornisci a git-mailsplit l'argomento --keep-cr per il formato mbox"
 
-#: builtin/am.c:2234
+#: builtin/am.c:2254
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "non fornire l'argomento --keep-cr a git-mailsplit indipendentemente dal "
 "valore di am.keepcr"
 
-#: builtin/am.c:2237
+#: builtin/am.c:2257
 msgid "strip everything before a scissors line"
 msgstr "rimuovi tutte le righe prima di una riga \"taglia qui\""
 
-#: builtin/am.c:2239 builtin/am.c:2242 builtin/am.c:2245 builtin/am.c:2248
-#: builtin/am.c:2251 builtin/am.c:2254 builtin/am.c:2257 builtin/am.c:2260
-#: builtin/am.c:2266
+#: builtin/am.c:2259 builtin/am.c:2262 builtin/am.c:2265 builtin/am.c:2268
+#: builtin/am.c:2271 builtin/am.c:2274 builtin/am.c:2277 builtin/am.c:2280
+#: builtin/am.c:2286
 msgid "pass it through git-apply"
 msgstr "passa l'argomento a git-apply"
 
-#: builtin/am.c:2256 builtin/commit.c:1397 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:891 builtin/merge.c:252
+#: builtin/am.c:2276 builtin/commit.c:1395 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:892 builtin/merge.c:251
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1329 builtin/repack.c:317 builtin/repack.c:321
-#: builtin/repack.c:323 builtin/show-branch.c:650 builtin/show-ref.c:172
+#: builtin/rebase.c:1335 builtin/repack.c:320 builtin/repack.c:324
+#: builtin/repack.c:326 builtin/show-branch.c:650 builtin/show-ref.c:172
 #: builtin/tag.c:404 parse-options.h:154 parse-options.h:175
 #: parse-options.h:316
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2262 builtin/branch.c:659 builtin/for-each-ref.c:38
-#: builtin/replace.c:556 builtin/tag.c:438 builtin/verify-tag.c:38
-#: bugreport.c:137
+#: builtin/am.c:2282 builtin/branch.c:659 builtin/bugreport.c:135
+#: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:438
+#: builtin/verify-tag.c:38
 msgid "format"
 msgstr "formato"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2283
 msgid "format the patch(es) are in"
 msgstr "il formato delle patch"
 
-#: builtin/am.c:2269
+#: builtin/am.c:2289
 msgid "override error message when patch failure occurs"
 msgstr ""
 "esegui l'override del messaggio d'errore quando si verifica un errore legato "
 "alle patch"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2291
 msgid "continue applying patches after resolving a conflict"
 msgstr ""
 "continua l'applicazione delle patch dopo la risoluzione di un conflitto"
 
-#: builtin/am.c:2274
+#: builtin/am.c:2294
 msgid "synonyms for --continue"
 msgstr "sinonimi di --continue"
 
-#: builtin/am.c:2277
+#: builtin/am.c:2297
 msgid "skip the current patch"
 msgstr "salta la patch corrente"
 
-#: builtin/am.c:2280
+#: builtin/am.c:2300
 msgid "restore the original branch and abort the patching operation."
 msgstr "ripristina il branch originario e interrompi l'operazione di patching."
 
-#: builtin/am.c:2283
+#: builtin/am.c:2303
 msgid "abort the patching operation but keep HEAD where it is."
 msgstr "interrompi l'operazione di patching ma mantieni HEAD dov'è."
 
-#: builtin/am.c:2287
+#: builtin/am.c:2307
 msgid "show the patch being applied"
 msgstr "visualizza la patch in fase di applicazione"
 
-#: builtin/am.c:2292
+#: builtin/am.c:2312
 msgid "lie about committer date"
 msgstr "menti sulla data del commit"
 
-#: builtin/am.c:2294
+#: builtin/am.c:2314
 msgid "use current timestamp for author date"
 msgstr "usa il timestamp corrente come data autore"
 
-#: builtin/am.c:2296 builtin/commit-tree.c:120 builtin/commit.c:1517
-#: builtin/merge.c:289 builtin/pull.c:175 builtin/rebase.c:524
-#: builtin/rebase.c:1380 builtin/revert.c:117 builtin/tag.c:419
+#: builtin/am.c:2316 builtin/commit-tree.c:120 builtin/commit.c:1515
+#: builtin/merge.c:288 builtin/pull.c:175 builtin/rebase.c:530
+#: builtin/rebase.c:1388 builtin/revert.c:117 builtin/tag.c:419
 msgid "key-id"
 msgstr "ID chiave"
 
-#: builtin/am.c:2297 builtin/rebase.c:525 builtin/rebase.c:1381
+#: builtin/am.c:2317 builtin/rebase.c:531 builtin/rebase.c:1389
 msgid "GPG-sign commits"
 msgstr "firma i commit con GPG"
 
-#: builtin/am.c:2300
+#: builtin/am.c:2320
 msgid "(internal use for git-rebase)"
 msgstr "(a uso interno per git-rebase)"
 
-#: builtin/am.c:2318
+#: builtin/am.c:2338
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10364,18 +10451,18 @@ msgstr ""
 "L'opzione -b/--binary non esegue nulla da molto tempo e\n"
 "sarà rimossa. Non usarla più."
 
-#: builtin/am.c:2325
+#: builtin/am.c:2345
 msgid "failed to read the index"
 msgstr "lettura dell'indice non riuscita"
 
-#: builtin/am.c:2340
+#: builtin/am.c:2360
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
 "la directory di rebase precedente %s esiste ancora ma è stata specificata "
 "un'mbox."
 
-#: builtin/am.c:2364
+#: builtin/am.c:2384
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10384,11 +10471,11 @@ msgstr ""
 "Trovata directory smarrita %s.\n"
 "Usa \"git am --abort\" per eliminarla."
 
-#: builtin/am.c:2370
+#: builtin/am.c:2390
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Operazione di risoluzione non in corso, non riprendiamo."
 
-#: builtin/am.c:2380
+#: builtin/am.c:2400
 msgid "interactive mode requires patches on the command line"
 msgstr ""
 "la modalità interattiva richiede che le patch siano fornite sulla riga di "
@@ -10428,25 +10515,25 @@ msgstr "git archive: errore del protocollo"
 msgid "git archive: expected a flush"
 msgstr "git archive: atteso un flush"
 
-#: builtin/bisect--helper.c:22
-msgid "git bisect--helper --next-all [--no-checkout]"
-msgstr "git bisect--helper --next-all [--no-checkout]"
-
 #: builtin/bisect--helper.c:23
+msgid "git bisect--helper --next-all"
+msgstr "git bisect--helper --next-all"
+
+#: builtin/bisect--helper.c:24
 msgid "git bisect--helper --write-terms <bad_term> <good_term>"
 msgstr ""
 "git bisect--helper --write-terms <termine revisione non funzionante> "
 "<termine revisione funzionante>"
 
-#: builtin/bisect--helper.c:24
+#: builtin/bisect--helper.c:25
 msgid "git bisect--helper --bisect-clean-state"
 msgstr "git bisect--helper --bisect-clean-state"
 
-#: builtin/bisect--helper.c:25
+#: builtin/bisect--helper.c:26
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<commit>]"
 
-#: builtin/bisect--helper.c:26
+#: builtin/bisect--helper.c:27
 msgid ""
 "git bisect--helper --bisect-write [--no-log] <state> <revision> <good_term> "
 "<bad_term>"
@@ -10454,7 +10541,7 @@ msgstr ""
 "git bisect--helper --bisect-write [--no-log] <stato> <revisione> <termine "
 "revisione funzionante> <termine revisione non funzionante>"
 
-#: builtin/bisect--helper.c:27
+#: builtin/bisect--helper.c:28
 msgid ""
 "git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
 "<bad_term>"
@@ -10462,63 +10549,82 @@ msgstr ""
 "git bisect--helper --bisect-check-and-set-terms <comando> <termine revisione "
 "funzionante> <termine revisione non funzionante>"
 
-#: builtin/bisect--helper.c:28
+#: builtin/bisect--helper.c:29
 msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
 msgstr ""
 "git bisect--helper --bisect-next-check <termine revisione funzionante> "
 "<termine revisione non funzionante> [<termine>]"
 
-#: builtin/bisect--helper.c:29
-msgid ""
-"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
-"term-new]"
-msgstr ""
-"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
-"term-new]"
-
 #: builtin/bisect--helper.c:30
 msgid ""
-"git bisect--helper --bisect-start [--term-{old,good}=<term> --term-{new,bad}"
-"=<term>][--no-checkout] [<bad> [<good>...]] [--] [<paths>...]"
+"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
+"term-new]"
 msgstr ""
-"git bisect--helper --bisect-start [--term-{old,good}=<termine> --term-{new,"
-"bad}=<termine>][--no-checkout] [<non funzionante> [<funzionante>...]] [--] "
-"[<percorsi>...]"
+"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
+"term-new]"
 
-#: builtin/bisect--helper.c:86
+#: builtin/bisect--helper.c:31
+msgid ""
+"git bisect--helper --bisect-start [--term-{new,bad}=<term> --term-{old,good}"
+"=<term>] [--no-checkout] [--first-parent] [<bad> [<good>...]] [--] "
+"[<paths>...]"
+msgstr ""
+"git bisect--helper --bisect-start [--term-{new,bad}=<termine>"
+" --term-{old,good}=<termine>] [--no-checkout] [--first-parent] [<non"
+" funzionante> [<funzionante>...]] [--] [<percorsi>...]"
+
+#: builtin/bisect--helper.c:33
+msgid "git bisect--helper --bisect-next"
+msgstr "git bisect--helper --bisect-next"
+
+#: builtin/bisect--helper.c:34
+msgid "git bisect--helper --bisect-auto-next"
+msgstr "git bisect--helper --bisect-auto-next"
+
+#: builtin/bisect--helper.c:35
+msgid "git bisect--helper --bisect-autostart"
+msgstr "git bisect--helper --bisect-autostart"
+
+#: builtin/bisect--helper.c:97
+#, c-format
+msgid "cannot open file '%s' in mode '%s'"
+msgstr "impossibile aprire il file '%s' in modalità '%s'"
+
+#: builtin/bisect--helper.c:104
+#, c-format
+msgid "could not write to file '%s'"
+msgstr "impossibile scrivere il file '%s'"
+
+#: builtin/bisect--helper.c:143
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "'%s' non è un termine valido"
 
-#: builtin/bisect--helper.c:90
+#: builtin/bisect--helper.c:147
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "impossibile usare il comando nativo '%s' come termine"
 
-#: builtin/bisect--helper.c:100
+#: builtin/bisect--helper.c:157
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "impossibile cambiare il significato del termine '%s'"
 
-#: builtin/bisect--helper.c:111
+#: builtin/bisect--helper.c:167
 msgid "please use two different terms"
 msgstr "usa due termini differenti"
 
-#: builtin/bisect--helper.c:118
-msgid "could not open the file BISECT_TERMS"
-msgstr "impossibile aprire il file BISECT_TERMS"
-
-#: builtin/bisect--helper.c:155
+#: builtin/bisect--helper.c:207
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "Non stiamo eseguendo un bisect.\n"
 
-#: builtin/bisect--helper.c:163
+#: builtin/bisect--helper.c:215
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "'%s' non è un commit valido"
 
-#: builtin/bisect--helper.c:172
+#: builtin/bisect--helper.c:224
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -10526,27 +10632,27 @@ msgstr ""
 "impossibile eseguire il checkout dell'HEAD originario '%s'. Prova con 'git "
 "bisect reset <commit>'."
 
-#: builtin/bisect--helper.c:216
+#: builtin/bisect--helper.c:268
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Argomento bisect_write errato: %s"
 
-#: builtin/bisect--helper.c:221
+#: builtin/bisect--helper.c:273
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "impossibile recuperare l'OID della revisione '%s'"
 
-#: builtin/bisect--helper.c:233
+#: builtin/bisect--helper.c:285
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "impossibile aprire il file '%s'"
 
-#: builtin/bisect--helper.c:259
+#: builtin/bisect--helper.c:311
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Comando non valido: attualmente stai eseguendo una bisezione %s/%s"
 
-#: builtin/bisect--helper.c:286
+#: builtin/bisect--helper.c:338
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -10555,7 +10661,7 @@ msgstr ""
 "Devi specificare almeno una revisione %s ed una %s.\n"
 "Puoi usare \"git bisect %s\" e \"git bisect %s\" per questo scopo."
 
-#: builtin/bisect--helper.c:290
+#: builtin/bisect--helper.c:342
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -10566,7 +10672,7 @@ msgstr ""
 "Quindi devi specificare almeno una revisione %s ed una %s.\n"
 "Puoi usare \"git bisect %s\" e \"git bisect %s\" a questo scopo."
 
-#: builtin/bisect--helper.c:310
+#: builtin/bisect--helper.c:362
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "eseguo la bisezione solo con un commit %s"
@@ -10575,15 +10681,15 @@ msgstr "eseguo la bisezione solo con un commit %s"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:318
+#: builtin/bisect--helper.c:370
 msgid "Are you sure [Y/n]? "
 msgstr "Sei sicuro? [Y/n] "
 
-#: builtin/bisect--helper.c:379
+#: builtin/bisect--helper.c:431
 msgid "no terms defined"
 msgstr "nessun termine definito"
 
-#: builtin/bisect--helper.c:382
+#: builtin/bisect--helper.c:434
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -10592,7 +10698,7 @@ msgstr ""
 "I tuoi termini correnti sono %s per lo stato vecchio\n"
 "e %s per lo stato nuovo.\n"
 
-#: builtin/bisect--helper.c:392
+#: builtin/bisect--helper.c:444
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -10601,286 +10707,329 @@ msgstr ""
 "argomento %s non valido per 'git bisect terms'.\n"
 "Le opzioni supportate sono: --term-good|--term-old e --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:460 builtin/bisect--helper.c:473
+#: builtin/bisect--helper.c:511
+msgid "revision walk setup failed\n"
+msgstr "impostazione percorso revisioni non riuscita\n"
+
+#: builtin/bisect--helper.c:533
+#, c-format
+msgid "could not open '%s' for appending"
+msgstr "impossibile aprire '%s' per accodare dati"
+
+#: builtin/bisect--helper.c:651 builtin/bisect--helper.c:664
 msgid "'' is not a valid term"
 msgstr "'' non è un termine valido"
 
-#: builtin/bisect--helper.c:483
+#: builtin/bisect--helper.c:674
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "opzione non riconosciuta: '%s'"
 
-#: builtin/bisect--helper.c:487
+#: builtin/bisect--helper.c:678
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "sembra che '%s' non sia una revisione valida"
 
-#: builtin/bisect--helper.c:519
+#: builtin/bisect--helper.c:709
 msgid "bad HEAD - I need a HEAD"
 msgstr "HEAD non valida - ho bisogno di un'HEAD"
 
-#: builtin/bisect--helper.c:534
+#: builtin/bisect--helper.c:724
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
 "checkout di '%s' non riuscito. Prova con 'git bisect start <branch valido>'."
 
-#: builtin/bisect--helper.c:555
+#: builtin/bisect--helper.c:745
 msgid "won't bisect on cg-seek'ed tree"
 msgstr "non eseguirò la bisezione su un albero sottoposto a cg-seek"
 
-#: builtin/bisect--helper.c:558
+#: builtin/bisect--helper.c:748
 msgid "bad HEAD - strange symbolic ref"
 msgstr "head non valida - riferimento simbolico strano"
 
-#: builtin/bisect--helper.c:582
+#: builtin/bisect--helper.c:775
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "riferimento non valido: '%s'"
 
-#: builtin/bisect--helper.c:638
+#: builtin/bisect--helper.c:827
+msgid "You need to start by \"git bisect start\"\n"
+msgstr "Devi iniziare con \"git bisect start\"\n"
+
+#. TRANSLATORS: Make sure to include [Y] and [n] in your
+#. translation. The program will only accept English input
+#. at this point.
+#.
+#: builtin/bisect--helper.c:838
+msgid "Do you want me to do it for you [Y/n]? "
+msgstr "Vuoi che me ne occupi io [Y/n]? "
+
+#: builtin/bisect--helper.c:866
 msgid "perform 'git bisect next'"
 msgstr "esegui 'git bisect next'"
 
-#: builtin/bisect--helper.c:640
+#: builtin/bisect--helper.c:868
 msgid "write the terms to .git/BISECT_TERMS"
 msgstr "scrivi i termini in .git/BISECT_TERMS"
 
-#: builtin/bisect--helper.c:642
+#: builtin/bisect--helper.c:870
 msgid "cleanup the bisection state"
 msgstr "pulisci lo stato bisezione"
 
-#: builtin/bisect--helper.c:644
+#: builtin/bisect--helper.c:872
 msgid "check for expected revs"
 msgstr "controlla se le revisioni attese sono presenti"
 
-#: builtin/bisect--helper.c:646
+#: builtin/bisect--helper.c:874
 msgid "reset the bisection state"
 msgstr "reimposta lo stato della bisezione"
 
-#: builtin/bisect--helper.c:648
+#: builtin/bisect--helper.c:876
 msgid "write out the bisection state in BISECT_LOG"
 msgstr "scrivi lo stato della bisezione in BISECT_LOG"
 
-#: builtin/bisect--helper.c:650
+#: builtin/bisect--helper.c:878
 msgid "check and set terms in a bisection state"
 msgstr "controlla e imposta i termini in uno stato bisezione"
 
-#: builtin/bisect--helper.c:652
+#: builtin/bisect--helper.c:880
 msgid "check whether bad or good terms exist"
 msgstr ""
 "controlla se esistono termini per revisioni non funzionanti o funzionanti"
 
-#: builtin/bisect--helper.c:654
+#: builtin/bisect--helper.c:882
 msgid "print out the bisect terms"
 msgstr "stampa i termini della bisezione"
 
-#: builtin/bisect--helper.c:656
+#: builtin/bisect--helper.c:884
 msgid "start the bisect session"
 msgstr "inizia la sessione di bisezione"
 
-#: builtin/bisect--helper.c:658
-msgid "update BISECT_HEAD instead of checking out the current commit"
-msgstr "aggiorna BISECT_HEAD anziché eseguire il checkout del commit corrente"
+#: builtin/bisect--helper.c:886
+msgid "find the next bisection commit"
+msgstr "trova il prossimo commit della bisezione"
 
-#: builtin/bisect--helper.c:660
+#: builtin/bisect--helper.c:888
+msgid "verify the next bisection state then checkout the next bisection commit"
+msgstr ""
+"verifica il prossimo stato della bisezione, quindi esegui il checkout del"
+" prossimo commit della bisezione"
+
+#: builtin/bisect--helper.c:890
+msgid "start the bisection if it has not yet been started"
+msgstr "avvia la bisezione se non è già stata avviata"
+
+#: builtin/bisect--helper.c:892
 msgid "no log for BISECT_WRITE"
 msgstr "non registrare le operazioni eseguite per BISECT_WRITE"
 
-#: builtin/bisect--helper.c:678
+#: builtin/bisect--helper.c:910
 msgid "--write-terms requires two arguments"
 msgstr "--write-terms richiede due argomenti"
 
-#: builtin/bisect--helper.c:682
+#: builtin/bisect--helper.c:914
 msgid "--bisect-clean-state requires no arguments"
 msgstr "--bisect-clean-state non richiede argomenti"
 
-#: builtin/bisect--helper.c:689
+#: builtin/bisect--helper.c:921
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset richiede o nessun argomento o un commit"
 
-#: builtin/bisect--helper.c:693
+#: builtin/bisect--helper.c:925
 msgid "--bisect-write requires either 4 or 5 arguments"
 msgstr "--bisect-write richiede o quattro o cinque argomenti"
 
-#: builtin/bisect--helper.c:699
+#: builtin/bisect--helper.c:931
 msgid "--check-and-set-terms requires 3 arguments"
 msgstr "--check-and-set-terms richiede tre argomenti"
 
-#: builtin/bisect--helper.c:705
+#: builtin/bisect--helper.c:937
 msgid "--bisect-next-check requires 2 or 3 arguments"
 msgstr "--bisect-next-check richiede due o tre argomenti"
 
-#: builtin/bisect--helper.c:711
+#: builtin/bisect--helper.c:943
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms richiede zero o un argomento"
 
-#: builtin/blame.c:31
+#: builtin/bisect--helper.c:952
+msgid "--bisect-next requires 0 arguments"
+msgstr "--bisect-next richiede zero argomenti"
+
+#: builtin/bisect--helper.c:958
+msgid "--bisect-auto-next requires 0 arguments"
+msgstr "--bisect-auto-next richiede zero argomenti"
+
+#: builtin/bisect--helper.c:964
+msgid "--bisect-autostart does not accept arguments"
+msgstr "--bisect-autostart non accetta argomenti"
+
+#: builtin/blame.c:32
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
 msgstr "git blame [<opzioni>] [<opzioni revisione>] [<revisione>] [--] <file>"
 
-#: builtin/blame.c:36
+#: builtin/blame.c:37
 msgid "<rev-opts> are documented in git-rev-list(1)"
 msgstr "le <opzioni revisione> sono documentate in git-rev-list(1)"
 
-#: builtin/blame.c:409
+#: builtin/blame.c:410
 #, c-format
 msgid "expecting a color: %s"
 msgstr "atteso colore: %s"
 
-#: builtin/blame.c:416
+#: builtin/blame.c:417
 msgid "must end with a color"
 msgstr "deve terminare con un colore"
 
-#: builtin/blame.c:729
+#: builtin/blame.c:730
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "colore '%s' non valido in color.blame.repeatedLines"
 
-#: builtin/blame.c:747
+#: builtin/blame.c:748
 msgid "invalid value for blame.coloring"
 msgstr "valore non valido per blame.coloring"
 
-#: builtin/blame.c:822
+#: builtin/blame.c:845
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "impossibile trovare la revisione %s da ignorare"
 
-#: builtin/blame.c:844
+#: builtin/blame.c:867
 msgid "Show blame entries as we find them, incrementally"
 msgstr ""
 "Visualizza le voci blame incrementalmente, a mano a mano che le troviamo"
 
-#: builtin/blame.c:845
-msgid "Show blank SHA-1 for boundary commits (Default: off)"
+#: builtin/blame.c:868
+msgid "Do not show object names of boundary commits (Default: off)"
 msgstr ""
-"Visualizza un hash SHA-1 vuoto per i commit limite (impostazione "
-"predefinita: off)"
+"Non visualizzare i nomi degli oggetti dei commit limite (impostazione"
+" predefinita: off)"
 
-#: builtin/blame.c:846
+#: builtin/blame.c:869
 msgid "Do not treat root commits as boundaries (Default: off)"
 msgstr ""
 "Non gestire i commit radice come commit limite (impostazione predefinita: "
 "off)"
 
-#: builtin/blame.c:847
+#: builtin/blame.c:870
 msgid "Show work cost statistics"
 msgstr "Visualizza le statistiche sul costo dell'operazione"
 
-#: builtin/blame.c:848
+#: builtin/blame.c:871
 msgid "Force progress reporting"
 msgstr "Forza l'indicazione d'avanzamento dell'operazione"
 
-#: builtin/blame.c:849
+#: builtin/blame.c:872
 msgid "Show output score for blame entries"
 msgstr "Visualizza il punteggio di output per le voci blame"
 
-#: builtin/blame.c:850
+#: builtin/blame.c:873
 msgid "Show original filename (Default: auto)"
 msgstr ""
 "Visualizza il nome file originario (impostazione predefinita: automatico)"
 
-#: builtin/blame.c:851
+#: builtin/blame.c:874
 msgid "Show original linenumber (Default: off)"
 msgstr ""
 "Visualizza il numero di riga originario (impostazione predefinita: off)"
 
-#: builtin/blame.c:852
+#: builtin/blame.c:875
 msgid "Show in a format designed for machine consumption"
 msgstr ""
 "Visualizza l'output in un formato progettato per l'utilizzo da parte di una "
 "macchina"
 
-#: builtin/blame.c:853
+#: builtin/blame.c:876
 msgid "Show porcelain format with per-line commit information"
 msgstr ""
 "Visualizza il formato porcelain con le informazioni sul commit per ogni riga"
 
-#: builtin/blame.c:854
+#: builtin/blame.c:877
 msgid "Use the same output mode as git-annotate (Default: off)"
 msgstr ""
 "Usa la stessa modalità di output di git-annotate (impostazione predefinita: "
 "off)"
 
-#: builtin/blame.c:855
+#: builtin/blame.c:878
 msgid "Show raw timestamp (Default: off)"
 msgstr "Visualizza il timestamp grezzo (impostazione predefinita: off)"
 
-#: builtin/blame.c:856
+#: builtin/blame.c:879
 msgid "Show long commit SHA1 (Default: off)"
 msgstr ""
 "Visualizza l'hash SHA1 del commit in forma lunga (impostazione predefinita: "
 "off)"
 
-#: builtin/blame.c:857
+#: builtin/blame.c:880
 msgid "Suppress author name and timestamp (Default: off)"
 msgstr ""
 "Non visualizzare il nome autore e il timestamp (impostazione predefinita: "
 "off)"
 
-#: builtin/blame.c:858
+#: builtin/blame.c:881
 msgid "Show author email instead of name (Default: off)"
 msgstr ""
 "Visualizza l'indirizzo e-mail dell'autore invece del nome (impostazione "
 "predefinita: off)"
 
-#: builtin/blame.c:859
+#: builtin/blame.c:882
 msgid "Ignore whitespace differences"
 msgstr "Ignora le differenze relative agli spazi bianchi"
 
-#: builtin/blame.c:860 builtin/log.c:1721
+#: builtin/blame.c:883 builtin/log.c:1808
 msgid "rev"
 msgstr "revisione"
 
-#: builtin/blame.c:860
+#: builtin/blame.c:883
 msgid "Ignore <rev> when blaming"
 msgstr "Ignora <revisione> durante l'esecuzione del blame"
 
-#: builtin/blame.c:861
+#: builtin/blame.c:884
 msgid "Ignore revisions from <file>"
 msgstr "Ignora le revisioni specificate in <file>"
 
-#: builtin/blame.c:862
+#: builtin/blame.c:885
 msgid "color redundant metadata from previous line differently"
 msgstr "colora in modo differente i metadati ridondanti della riga precedente"
 
-#: builtin/blame.c:863
+#: builtin/blame.c:886
 msgid "color lines by age"
 msgstr "colora le righe in base all'età"
 
-#: builtin/blame.c:864
+#: builtin/blame.c:887
 msgid "Spend extra cycles to find better match"
 msgstr "Usa cicli extra per trovare una corrispondenza migliore"
 
-#: builtin/blame.c:865
+#: builtin/blame.c:888
 msgid "Use revisions from <file> instead of calling git-rev-list"
 msgstr "Usa le revisioni salvate in <file> anziché richiamare git-rev-list"
 
-#: builtin/blame.c:866
+#: builtin/blame.c:889
 msgid "Use <file>'s contents as the final image"
 msgstr "Usa i contenuti di <file> come immagine finale"
 
-#: builtin/blame.c:867 builtin/blame.c:868
+#: builtin/blame.c:890 builtin/blame.c:891
 msgid "score"
 msgstr "punteggio"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:890
 msgid "Find line copies within and across files"
 msgstr "Trova copie delle righe all'interno e fra file"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:891
 msgid "Find line movements within and across files"
 msgstr "Trova righe spostate all'interno e fra file"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:892
 msgid "n,m"
 msgstr "n,m"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:892
 msgid "Process only line range n,m, counting from 1"
 msgstr "Elabora solo l'intervallo righe n,m, contandole da 1"
 
-#: builtin/blame.c:921
+#: builtin/blame.c:944
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress non può essere usato con --incremental o con i formati porcelain"
@@ -10893,24 +11042,24 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:972
+#: builtin/blame.c:995
 msgid "4 years, 11 months ago"
 msgstr "4 anni, 11 giorni fa"
 
-#: builtin/blame.c:1087
+#: builtin/blame.c:1110
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "il file %s ha solo %lu riga"
 msgstr[1] "il file %s ha solo %lu righe"
 
-#: builtin/blame.c:1133
+#: builtin/blame.c:1156
 msgid "Blaming lines"
 msgstr "Eseguo il blame sulle righe"
 
 #: builtin/branch.c:29
-msgid "git branch [<options>] [-r | -a] [--merged | --no-merged]"
-msgstr "git branch [<opzioni>] [-r | -a] [--merged | --no-merged]"
+msgid "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
+msgstr "git branch [<opzioni>] [-r | -a] [--merged] [--no-merged]"
 
 #: builtin/branch.c:30
 msgid "git branch [<options>] [-l] [-f] <branch-name> [<start-point>]"
@@ -11122,7 +11271,7 @@ msgstr "imposta la modalità tracking (vedi git-pull(1))"
 msgid "do not use"
 msgstr "non usare"
 
-#: builtin/branch.c:626 builtin/rebase.c:520
+#: builtin/branch.c:626 builtin/rebase.c:526
 msgid "upstream"
 msgstr "upstream"
 
@@ -11330,6 +11479,106 @@ msgstr ""
 "l'opzione '--set-upstream' non è più supportata. Usa '--track' o '--set-"
 "upstream-to'."
 
+#: builtin/bugreport.c:15
+msgid "git version:\n"
+msgstr "versione di git:\n"
+
+#: builtin/bugreport.c:21
+#, c-format
+msgid "uname() failed with error '%s' (%d)\n"
+msgstr "uname() non riuscita: errore '%s' (%d)\n"
+
+#: builtin/bugreport.c:31
+msgid "compiler info: "
+msgstr "informazioni sul compilatore: "
+
+#: builtin/bugreport.c:34
+msgid "libc info: "
+msgstr "informazioni su libc: "
+
+#: builtin/bugreport.c:80
+msgid "not run from a git repository - no hooks to show\n"
+msgstr ""
+"comando non eseguito da un repository Git - nessun hook da visualizzare\n"
+
+#: builtin/bugreport.c:90
+msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
+msgstr "git bugreport [-o|--output-directory <file>] [-s|--suffix <formato>]"
+
+#: builtin/bugreport.c:97
+msgid ""
+"Thank you for filling out a Git bug report!\n"
+"Please answer the following questions to help us understand your issue.\n"
+"\n"
+"What did you do before the bug happened? (Steps to reproduce your issue)\n"
+"\n"
+"What did you expect to happen? (Expected behavior)\n"
+"\n"
+"What happened instead? (Actual behavior)\n"
+"\n"
+"What's different between what you expected and what actually happened?\n"
+"\n"
+"Anything else you want to add:\n"
+"\n"
+"Please review the rest of the bug report below.\n"
+"You can delete any lines you don't wish to share.\n"
+msgstr ""
+"Grazie per voler compilare una segnalazione d'errore per Git!\n"
+"Rispondi alle seguenti domande per consentirci di capire il problema.\n"
+"\n"
+"Cos'hai fatto prima che si verificasse l'errore? (Passaggi per riprodurre "
+"il\n"
+"problema)\n"
+"\n"
+"Cosa ti aspettavi che succedesse? (Comportamento atteso)\n"
+"\n"
+"Cosa è successo invece? (Comportamento reale)\n"
+"\n"
+"Cosa c'è di diverso fra quello che ti aspettavi e ciò che in realtà è\n"
+"successo?\n"
+"\n"
+"Altre note che desideri aggiungere:\n"
+"\n"
+"Rivedi il resto della segnalazione d'errore qui sotto.\n"
+"Puoi eliminare le righe che non desideri condividere.\n"
+
+#: builtin/bugreport.c:134
+msgid "specify a destination for the bugreport file"
+msgstr ""
+"specifica una destinazione per il file contenente la segnalazione d'errore"
+
+#: builtin/bugreport.c:136
+msgid "specify a strftime format suffix for the filename"
+msgstr "specifica un suffisso in formato strftime per il nome del file"
+
+#: builtin/bugreport.c:158
+#, c-format
+msgid "could not create leading directories for '%s'"
+msgstr "impossibile creare le prime directory per '%s'"
+
+#: builtin/bugreport.c:165
+msgid "System Info"
+msgstr "Informazioni di sistema"
+
+#: builtin/bugreport.c:168
+msgid "Enabled Hooks"
+msgstr "Hook abilitati"
+
+#: builtin/bugreport.c:175
+#, c-format
+msgid "couldn't create a new file at '%s'"
+msgstr "impossibile creare un nuovo file in '%s'"
+
+#: builtin/bugreport.c:178
+#, c-format
+msgid "unable to write to %s"
+msgstr "impossibile scrivere su %s"
+
+#: builtin/bugreport.c:188
+#, c-format
+msgid "Created new report at '%s'.\n"
+msgstr "Nuovo report creato in '%s'.\n"
+
 #: builtin/bundle.c:15 builtin/bundle.c:23
 msgid "git bundle create [<options>] <file> <git-rev-list args>"
 msgstr "git bundle create [<opzioni>] <file> <argomenti git-rev-list>"
@@ -11346,46 +11595,50 @@ msgstr "git bundle list-heads <file> [<nome riferimento>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <file> [<nome riferimento>...]"
 
-#: builtin/bundle.c:66 builtin/pack-objects.c:3448
+#: builtin/bundle.c:67 builtin/pack-objects.c:3480
 msgid "do not show progress meter"
 msgstr "non visualizzare la barra di avanzamento"
 
-#: builtin/bundle.c:68 builtin/pack-objects.c:3450
+#: builtin/bundle.c:69 builtin/pack-objects.c:3482
 msgid "show progress meter"
 msgstr "visualizza la barra di avanzamento"
 
-#: builtin/bundle.c:70 builtin/pack-objects.c:3452
+#: builtin/bundle.c:71 builtin/pack-objects.c:3484
 msgid "show progress meter during object writing phase"
 msgstr ""
 "visualizza la barra di avanzamento durante la fase di scrittura oggetti"
 
-#: builtin/bundle.c:73 builtin/pack-objects.c:3455
+#: builtin/bundle.c:74 builtin/pack-objects.c:3487
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "simile a --all-progress quando è visualizzata la barra di avanzamento"
 
-#: builtin/bundle.c:93
+#: builtin/bundle.c:76
+msgid "specify bundle format version"
+msgstr "specifica la versione del formato bundle"
+
+#: builtin/bundle.c:96
 msgid "Need a repository to create a bundle."
 msgstr "Per creare un bundle è necessario un repository."
 
-#: builtin/bundle.c:104
+#: builtin/bundle.c:107
 msgid "do not show bundle details"
 msgstr "non visualizzare i dettagli sul bundle"
 
-#: builtin/bundle.c:119
+#: builtin/bundle.c:122
 #, c-format
 msgid "%s is okay\n"
 msgstr "%s è corretto\n"
 
-#: builtin/bundle.c:160
+#: builtin/bundle.c:163
 msgid "Need a repository to unbundle."
 msgstr "Per decomprimere un bundle è necessario un repository."
 
-#: builtin/bundle.c:168 builtin/remote.c:1686
+#: builtin/bundle.c:171 builtin/remote.c:1687
 msgid "be verbose; must be placed before a subcommand"
 msgstr ""
 "visualizza ulteriori dettagli; deve essere collocato prima di un sottocomando"
 
-#: builtin/bundle.c:190 builtin/remote.c:1717
+#: builtin/bundle.c:193 builtin/remote.c:1718
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Sottocomando sconosciuto: %s"
@@ -11403,8 +11656,8 @@ msgid ""
 "git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
 "symlinks] [--textconv | --filters]"
 msgstr ""
-"git cat-file (--batch[=<formato>] | --batch-check[=<formato>])"
-" [--follow-symlinks] [--textconv | --filters]"
+"git cat-file (--batch[=<formato>] | --batch-check[=<formato>]) [--follow-"
+"symlinks] [--textconv | --filters]"
 
 #: builtin/cat-file.c:620
 msgid "only one batch option may be specified"
@@ -11438,7 +11691,7 @@ msgstr "esegui textconv sul contenuto dell'oggetto (per gli oggetti blob)"
 msgid "for blob objects, run filters on object's content"
 msgstr "esegui i filtri sul contenuto dell'oggetto (per gli oggetti blob)"
 
-#: builtin/cat-file.c:648 git-submodule.sh:958
+#: builtin/cat-file.c:648
 msgid "blob"
 msgstr "blob"
 
@@ -11502,7 +11755,7 @@ msgstr "leggi i nomi dei file dallo standard input"
 msgid "terminate input and output records by a NUL character"
 msgstr "termina i record di input e output con un carattere NUL"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1486 builtin/gc.c:537
+#: builtin/check-ignore.c:21 builtin/checkout.c:1482 builtin/gc.c:538
 #: builtin/worktree.c:561
 msgid "suppress progress reporting"
 msgstr "non visualizzare l'avanzamento dell'operazione"
@@ -11593,8 +11846,8 @@ msgid "write the content to temporary files"
 msgstr "scrivi il contenuto in file temporanei"
 
 #: builtin/checkout-index.c:178 builtin/column.c:31
-#: builtin/submodule--helper.c:1400 builtin/submodule--helper.c:1403
-#: builtin/submodule--helper.c:1411 builtin/submodule--helper.c:1909
+#: builtin/submodule--helper.c:1824 builtin/submodule--helper.c:1827
+#: builtin/submodule--helper.c:1835 builtin/submodule--helper.c:2333
 #: builtin/worktree.c:754
 msgid "string"
 msgstr "stringa"
@@ -11638,85 +11891,85 @@ msgstr "il percorso '%s' non ha la loro versione"
 msgid "path '%s' does not have all necessary versions"
 msgstr "il percorso '%s' non ha tutte le versioni necessarie"
 
-#: builtin/checkout.c:256
+#: builtin/checkout.c:258
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "il percorso '%s' non ha le versioni necessarie"
 
-#: builtin/checkout.c:274
+#: builtin/checkout.c:275
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "percorso '%s': impossibile eseguire il merge"
 
-#: builtin/checkout.c:290
+#: builtin/checkout.c:291
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Impossibile aggiungere il risultato del merge per '%s'"
 
-#: builtin/checkout.c:395
+#: builtin/checkout.c:396
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Ricreato %d conflitto di merge"
 msgstr[1] "Ricreati %d conflitti di merge"
 
-#: builtin/checkout.c:400
+#: builtin/checkout.c:401
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "Aggiornato %d percorso da %s"
 msgstr[1] "Aggiornati %d percorsi da %s"
 
-#: builtin/checkout.c:407
+#: builtin/checkout.c:408
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "Aggiornato %d percorso dall'indice"
 msgstr[1] "Aggiornati %d percorsi dall'indice"
 
-#: builtin/checkout.c:430 builtin/checkout.c:433 builtin/checkout.c:436
-#: builtin/checkout.c:440
+#: builtin/checkout.c:431 builtin/checkout.c:434 builtin/checkout.c:437
+#: builtin/checkout.c:441
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "'%s' non può essere usato con i percorsi in fase di aggiornamento"
 
-#: builtin/checkout.c:443 builtin/checkout.c:446
+#: builtin/checkout.c:444 builtin/checkout.c:447
 #, c-format
 msgid "'%s' cannot be used with %s"
 msgstr "'%s' non può essere usato con %s"
 
-#: builtin/checkout.c:450
+#: builtin/checkout.c:451
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Impossibile aggiornare dei percorsi e passare al branch '%s' "
 "contemporaneamente."
 
-#: builtin/checkout.c:454
+#: builtin/checkout.c:455
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "né '%s' né '%s' sono stati specificati"
 
-#: builtin/checkout.c:458
+#: builtin/checkout.c:459
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "'%s' dev'essere usato quando '%s' non è specificato"
 
-#: builtin/checkout.c:463 builtin/checkout.c:468
+#: builtin/checkout.c:464 builtin/checkout.c:469
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "'%s' o '%s' non possono essere usati con %s"
 
-#: builtin/checkout.c:527 builtin/checkout.c:534
+#: builtin/checkout.c:528 builtin/checkout.c:535
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "il percorso '%s' non è stato sottoposto a merge"
 
-#: builtin/checkout.c:702
+#: builtin/checkout.c:703
 msgid "you need to resolve your current index first"
 msgstr "prima devi risolvere l'indice corrente"
 
-#: builtin/checkout.c:756
+#: builtin/checkout.c:757
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -11725,50 +11978,50 @@ msgstr ""
 "impossibile continuare con modifiche in stage nei file seguenti:\n"
 "%s"
 
-#: builtin/checkout.c:859
+#: builtin/checkout.c:853
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Impossibile esaminare il registro dei riferimenti per '%s': %s\n"
 
-#: builtin/checkout.c:901
+#: builtin/checkout.c:895
 msgid "HEAD is now at"
 msgstr "HEAD si trova ora a"
 
-#: builtin/checkout.c:905 builtin/clone.c:720
+#: builtin/checkout.c:899 builtin/clone.c:720
 msgid "unable to update HEAD"
 msgstr "impossibile aggiornare HEAD"
 
-#: builtin/checkout.c:909
+#: builtin/checkout.c:903
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Ripristina il branch '%s'\n"
 
-#: builtin/checkout.c:912
+#: builtin/checkout.c:906
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Si è già su '%s'\n"
 
-#: builtin/checkout.c:916
+#: builtin/checkout.c:910
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Si è passati al branch '%s' e lo si è reimpostato\n"
 
-#: builtin/checkout.c:918 builtin/checkout.c:1342
+#: builtin/checkout.c:912 builtin/checkout.c:1338
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Si è passati a un nuovo branch '%s'\n"
 
-#: builtin/checkout.c:920
+#: builtin/checkout.c:914
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Si è passati al branch '%s'\n"
 
-#: builtin/checkout.c:971
+#: builtin/checkout.c:965
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ...e altri %d.\n"
 
-#: builtin/checkout.c:977
+#: builtin/checkout.c:971
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -11791,7 +12044,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:996
+#: builtin/checkout.c:990
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -11818,19 +12071,19 @@ msgstr[1] ""
 " git branch <nome del nuovo branch> %s\n"
 "\n"
 
-#: builtin/checkout.c:1031
+#: builtin/checkout.c:1025
 msgid "internal error in revision walk"
 msgstr "errore interno durante la visita delle revisioni"
 
-#: builtin/checkout.c:1035
+#: builtin/checkout.c:1029
 msgid "Previous HEAD position was"
 msgstr "La precedente posizione di HEAD era"
 
-#: builtin/checkout.c:1075 builtin/checkout.c:1337
+#: builtin/checkout.c:1069 builtin/checkout.c:1333
 msgid "You are on a branch yet to be born"
 msgstr "Sei su un branch che deve ancora essere creato"
 
-#: builtin/checkout.c:1150
+#: builtin/checkout.c:1146
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -11839,7 +12092,7 @@ msgstr ""
 "'%s' potrebbe essere sia un file locale, sia un branch da tracciare.\n"
 "Usa -- (e facoltativamente --no-guess) per rimuovere l'ambiguità"
 
-#: builtin/checkout.c:1157
+#: builtin/checkout.c:1153
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -11860,51 +12113,51 @@ msgstr ""
 "rispetto a un particolare remoto, ad es. 'origin', potresti voler\n"
 "impostare checkout.defaultRemote=origin nel tuo file di configurazione."
 
-#: builtin/checkout.c:1167
+#: builtin/checkout.c:1163
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' corrisponde a più (%d) branch che ne tracciano uno remoto"
 
-#: builtin/checkout.c:1233
+#: builtin/checkout.c:1229
 msgid "only one reference expected"
 msgstr "atteso solo un riferimento"
 
-#: builtin/checkout.c:1250
+#: builtin/checkout.c:1246
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "atteso solo un riferimento, %d specificati."
 
-#: builtin/checkout.c:1296 builtin/worktree.c:342 builtin/worktree.c:510
+#: builtin/checkout.c:1292 builtin/worktree.c:342 builtin/worktree.c:510
 #, c-format
 msgid "invalid reference: %s"
 msgstr "riferimento non valido: %s"
 
-#: builtin/checkout.c:1309 builtin/checkout.c:1675
+#: builtin/checkout.c:1305 builtin/checkout.c:1671
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "il riferimento non è un albero: %s"
 
-#: builtin/checkout.c:1356
+#: builtin/checkout.c:1352
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "atteso branch, ricevuto tag '%s'"
 
-#: builtin/checkout.c:1358
+#: builtin/checkout.c:1354
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "atteso branch, ricevuto branch remoto '%s'"
 
-#: builtin/checkout.c:1359 builtin/checkout.c:1367
+#: builtin/checkout.c:1355 builtin/checkout.c:1363
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "atteso branch, ricevuto '%s'"
 
-#: builtin/checkout.c:1362
+#: builtin/checkout.c:1358
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "atteso branch, ricevuto commit '%s'"
 
-#: builtin/checkout.c:1378
+#: builtin/checkout.c:1374
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -11912,7 +12165,7 @@ msgstr ""
 "impossibile cambiare branch durante un merge\n"
 "Considera l'uso di \"git merge --quit\" o di \"git worktree add\"."
 
-#: builtin/checkout.c:1382
+#: builtin/checkout.c:1378
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -11920,7 +12173,7 @@ msgstr ""
 "impossibile cambiare branch nel bel mezzo di una sessione am\n"
 "Considera l'uso di \"git am --quit\" o di \"git worktree add\"."
 
-#: builtin/checkout.c:1386
+#: builtin/checkout.c:1382
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -11928,7 +12181,7 @@ msgstr ""
 "impossibile cambiare branch durante un rebase\n"
 "Considera l'uso di \"git rebase --quit\" o di \"git worktree add\"."
 
-#: builtin/checkout.c:1390
+#: builtin/checkout.c:1386
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -11936,7 +12189,7 @@ msgstr ""
 "impossibile cambiare branch durante un cherry-pick\n"
 "Considera l'uso di \"git cherry-pick --quit\" o di \"git worktree add\"."
 
-#: builtin/checkout.c:1394
+#: builtin/checkout.c:1390
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -11944,149 +12197,149 @@ msgstr ""
 "impossibile cambiare branch durante un revert\n"
 "Considera l'uso di \"git revert --quit\" o di \"git worktree add\"."
 
-#: builtin/checkout.c:1398
+#: builtin/checkout.c:1394
 msgid "you are switching branch while bisecting"
 msgstr "stai cambiando branch durante una bisezione"
 
-#: builtin/checkout.c:1405
+#: builtin/checkout.c:1401
 msgid "paths cannot be used with switching branches"
 msgstr "i percorsi non possono essere usati passando da un branch a un altro"
 
-#: builtin/checkout.c:1408 builtin/checkout.c:1412 builtin/checkout.c:1416
+#: builtin/checkout.c:1404 builtin/checkout.c:1408 builtin/checkout.c:1412
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' non può essere usato passando da un branch a un altro"
 
-#: builtin/checkout.c:1420 builtin/checkout.c:1423 builtin/checkout.c:1426
-#: builtin/checkout.c:1431 builtin/checkout.c:1436
+#: builtin/checkout.c:1416 builtin/checkout.c:1419 builtin/checkout.c:1422
+#: builtin/checkout.c:1427 builtin/checkout.c:1432
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' non può essere usato con '%s'"
 
-#: builtin/checkout.c:1433
+#: builtin/checkout.c:1429
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' non accetta l'argomento <punto di partenza>"
 
-#: builtin/checkout.c:1441
+#: builtin/checkout.c:1437
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Impossibile cambiare branch per passare a '%s' che non è un commit"
 
-#: builtin/checkout.c:1448
+#: builtin/checkout.c:1444
 msgid "missing branch or commit argument"
 msgstr "argomento branch o commit mancante"
 
-#: builtin/checkout.c:1490 builtin/clone.c:91 builtin/commit-graph.c:82
-#: builtin/commit-graph.c:189 builtin/fetch.c:168 builtin/merge.c:288
-#: builtin/multi-pack-index.c:27 builtin/pull.c:119 builtin/push.c:561
-#: builtin/send-pack.c:173
+#: builtin/checkout.c:1486 builtin/clone.c:91 builtin/commit-graph.c:84
+#: builtin/commit-graph.c:222 builtin/fetch.c:172 builtin/merge.c:287
+#: builtin/multi-pack-index.c:27 builtin/pull.c:119 builtin/push.c:551
+#: builtin/send-pack.c:192
 msgid "force progress reporting"
 msgstr "forza l'indicazione d'avanzamento dell'operazione"
 
-#: builtin/checkout.c:1491
+#: builtin/checkout.c:1487
 msgid "perform a 3-way merge with the new branch"
 msgstr "esegui un merge a tre vie con il nuovo branch"
 
-#: builtin/checkout.c:1492 builtin/log.c:1709 parse-options.h:322
+#: builtin/checkout.c:1488 builtin/log.c:1795 parse-options.h:322
 msgid "style"
 msgstr "stile"
 
-#: builtin/checkout.c:1493
+#: builtin/checkout.c:1489
 msgid "conflict style (merge or diff3)"
 msgstr "stile conflitti (merge o diff3)"
 
-#: builtin/checkout.c:1505 builtin/worktree.c:558
+#: builtin/checkout.c:1501 builtin/worktree.c:558
 msgid "detach HEAD at named commit"
 msgstr "scollega l'HEAD al commit specificato"
 
-#: builtin/checkout.c:1506
+#: builtin/checkout.c:1502
 msgid "set upstream info for new branch"
 msgstr "imposta le informazioni sull'upstream per il nuovo branch"
 
-#: builtin/checkout.c:1508
+#: builtin/checkout.c:1504
 msgid "force checkout (throw away local modifications)"
 msgstr "esegui forzatamente il checkout (scarta le modifiche locali)"
 
-#: builtin/checkout.c:1510
+#: builtin/checkout.c:1506
 msgid "new-branch"
 msgstr "nuovo branch"
 
-#: builtin/checkout.c:1510
+#: builtin/checkout.c:1506
 msgid "new unparented branch"
 msgstr "nuovo branch senza genitore"
 
-#: builtin/checkout.c:1512 builtin/merge.c:292
+#: builtin/checkout.c:1508 builtin/merge.c:291
 msgid "update ignored files (default)"
 msgstr "aggiorna i file ignorati (impostazione predefinita)"
 
-#: builtin/checkout.c:1515
+#: builtin/checkout.c:1511
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "non controllare se un altro albero di lavoro contiene il riferimento "
 "specificato"
 
-#: builtin/checkout.c:1528
+#: builtin/checkout.c:1524
 msgid "checkout our version for unmerged files"
 msgstr ""
 "esegui il checkout della nostra versione per i file non sottoposti a merge"
 
-#: builtin/checkout.c:1531
+#: builtin/checkout.c:1527
 msgid "checkout their version for unmerged files"
 msgstr ""
 "esegui il checkout della loro versione per i file non sottoposti a merge"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1531
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "non limitare gli specificatori percorso solo alle voci sparse"
 
-#: builtin/checkout.c:1590
+#: builtin/checkout.c:1586
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "le opzioni -%c, -%c e --orphan sono mutuamente esclusive"
 
-#: builtin/checkout.c:1594
+#: builtin/checkout.c:1590
 msgid "-p and --overlay are mutually exclusive"
 msgstr "le opzioni -p e --overlay sono mutualmente esclusive"
 
-#: builtin/checkout.c:1631
+#: builtin/checkout.c:1627
 msgid "--track needs a branch name"
 msgstr "--track richiede il nome di un branch"
 
-#: builtin/checkout.c:1636
+#: builtin/checkout.c:1632
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "nome del branch mancante; prova con -%c"
 
-#: builtin/checkout.c:1668
+#: builtin/checkout.c:1664
 #, c-format
 msgid "could not resolve %s"
 msgstr "impossibile risolvere %s"
 
-#: builtin/checkout.c:1684
+#: builtin/checkout.c:1680
 msgid "invalid path specification"
 msgstr "specificatore percorso non valido"
 
-#: builtin/checkout.c:1691
+#: builtin/checkout.c:1687
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "'%s' non è un commit e non si può creare un branch '%s' che parta da esso"
 
-#: builtin/checkout.c:1695
+#: builtin/checkout.c:1691
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach non accetta un percorso '%s' come argomento"
 
-#: builtin/checkout.c:1704
+#: builtin/checkout.c:1700
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file non è compatibile con --detach"
 
-#: builtin/checkout.c:1707 builtin/reset.c:325 builtin/stash.c:1503
+#: builtin/checkout.c:1703 builtin/reset.c:325 builtin/stash.c:1500
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file non è compatibile con --patch"
 
-#: builtin/checkout.c:1718
+#: builtin/checkout.c:1716
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12094,70 +12347,70 @@ msgstr ""
 "git checkout: --ours/--theirs, --force e --merge sono incompatibili quando\n"
 "si esegue il checkout dell'indice."
 
-#: builtin/checkout.c:1723
+#: builtin/checkout.c:1721
 msgid "you must specify path(s) to restore"
 msgstr "devi specificare il percorso/i percorsi da ripristinare"
 
-#: builtin/checkout.c:1749 builtin/checkout.c:1751 builtin/checkout.c:1800
-#: builtin/checkout.c:1802 builtin/clone.c:121 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2295 builtin/worktree.c:554
+#: builtin/checkout.c:1747 builtin/checkout.c:1749 builtin/checkout.c:1798
+#: builtin/checkout.c:1800 builtin/clone.c:121 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2719 builtin/worktree.c:554
 #: builtin/worktree.c:556
 msgid "branch"
 msgstr "branch"
 
-#: builtin/checkout.c:1750
+#: builtin/checkout.c:1748
 msgid "create and checkout a new branch"
 msgstr "crea un nuovo branch ed eseguine il checkout"
 
-#: builtin/checkout.c:1752
+#: builtin/checkout.c:1750
 msgid "create/reset and checkout a branch"
 msgstr "crea/reimposta un branch ed eseguine il checkout"
 
-#: builtin/checkout.c:1753
+#: builtin/checkout.c:1751
 msgid "create reflog for new branch"
 msgstr "crea il registro dei riferimenti per il nuovo branch"
 
-#: builtin/checkout.c:1755
+#: builtin/checkout.c:1753
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "prevedi 'git checkout <branch inesistente>' (impostazione predefinita)"
 
-#: builtin/checkout.c:1756
+#: builtin/checkout.c:1754
 msgid "use overlay mode (default)"
 msgstr "usa modalità overlay (impostazione predefinita)"
 
-#: builtin/checkout.c:1801
+#: builtin/checkout.c:1799
 msgid "create and switch to a new branch"
 msgstr "crea un nuovo branch e passa a quest'ultimo"
 
-#: builtin/checkout.c:1803
+#: builtin/checkout.c:1801
 msgid "create/reset and switch to a branch"
 msgstr "crea/reimposta un branch e passa a quest'ultimo"
 
-#: builtin/checkout.c:1805
+#: builtin/checkout.c:1803
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "prevedi 'git switch <branch inesistente>'"
 
-#: builtin/checkout.c:1807
+#: builtin/checkout.c:1805
 msgid "throw away local modifications"
 msgstr "scarta le modifiche locali"
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1839
 msgid "which tree-ish to checkout from"
 msgstr "albero da cui eseguire il checkout"
 
-#: builtin/checkout.c:1843
+#: builtin/checkout.c:1841
 msgid "restore the index"
 msgstr "ripristina l'indice"
 
-#: builtin/checkout.c:1845
+#: builtin/checkout.c:1843
 msgid "restore the working tree (default)"
 msgstr "ripristina l'albero di lavoro (impostazione predefinita)"
 
-#: builtin/checkout.c:1847
+#: builtin/checkout.c:1845
 msgid "ignore unmerged entries"
 msgstr "ignora voci non sottoposte a merge"
 
-#: builtin/checkout.c:1848
+#: builtin/checkout.c:1846
 msgid "use overlay mode"
 msgstr "usa modalità overlay"
 
@@ -12304,7 +12557,7 @@ msgid "remove whole directories"
 msgstr "rimuovi intere directory"
 
 #: builtin/clean.c:909 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:909 builtin/log.c:182 builtin/log.c:184
+#: builtin/grep.c:910 builtin/log.c:181 builtin/log.c:183
 #: builtin/ls-files.c:558 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
@@ -12350,7 +12603,7 @@ msgstr "git clone [<opzioni>] [--] <repository> [<directory>]"
 msgid "don't create a checkout"
 msgstr "non creare un checkout"
 
-#: builtin/clone.c:94 builtin/clone.c:96 builtin/init-db.c:554
+#: builtin/clone.c:94 builtin/clone.c:96 builtin/init-db.c:553
 msgid "create a bare repository"
 msgstr "crea un repository spoglio"
 
@@ -12382,26 +12635,26 @@ msgstr "inizializza sottomoduli durante la clonazione"
 msgid "number of submodules cloned in parallel"
 msgstr "numero di sottomoduli clonati in parallelo"
 
-#: builtin/clone.c:111 builtin/init-db.c:551
+#: builtin/clone.c:111 builtin/init-db.c:550
 msgid "template-directory"
 msgstr "directory modelli"
 
-#: builtin/clone.c:112 builtin/init-db.c:552
+#: builtin/clone.c:112 builtin/init-db.c:551
 msgid "directory from which templates will be used"
 msgstr "directory da cui saranno recuperati i modelli"
 
-#: builtin/clone.c:114 builtin/clone.c:116 builtin/submodule--helper.c:1407
-#: builtin/submodule--helper.c:1912
+#: builtin/clone.c:114 builtin/clone.c:116 builtin/submodule--helper.c:1831
+#: builtin/submodule--helper.c:2336
 msgid "reference repository"
 msgstr "repository di riferimento"
 
-#: builtin/clone.c:118 builtin/submodule--helper.c:1409
-#: builtin/submodule--helper.c:1914
+#: builtin/clone.c:118 builtin/submodule--helper.c:1833
+#: builtin/submodule--helper.c:2338
 msgid "use --reference only while cloning"
 msgstr "usa --reference solo durante la clonazione"
 
-#: builtin/clone.c:119 builtin/column.c:27 builtin/init-db.c:562
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3514 builtin/repack.c:329
+#: builtin/clone.c:119 builtin/column.c:27 builtin/init-db.c:561
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3546 builtin/repack.c:332
 msgid "name"
 msgstr "nome"
 
@@ -12417,7 +12670,7 @@ msgstr "esegui il checkout di <branch> anziché dell'HEAD del remoto"
 msgid "path to git-upload-pack on the remote"
 msgstr "percorso al comando remoto git-upload-pack"
 
-#: builtin/clone.c:125 builtin/fetch.c:169 builtin/grep.c:848
+#: builtin/clone.c:125 builtin/fetch.c:173 builtin/grep.c:849
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "profondità"
@@ -12426,7 +12679,7 @@ msgstr "profondità"
 msgid "create a shallow clone of that depth"
 msgstr "crea un clone shallow con questa profondità"
 
-#: builtin/clone.c:127 builtin/fetch.c:171 builtin/pack-objects.c:3503
+#: builtin/clone.c:127 builtin/fetch.c:175 builtin/pack-objects.c:3535
 #: builtin/pull.c:211
 msgid "time"
 msgstr "tempo"
@@ -12435,19 +12688,19 @@ msgstr "tempo"
 msgid "create a shallow clone since a specific time"
 msgstr "crea un clone shallow a partire dall'istante specificato"
 
-#: builtin/clone.c:129 builtin/fetch.c:173 builtin/fetch.c:196
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1304
+#: builtin/clone.c:129 builtin/fetch.c:177 builtin/fetch.c:200
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1311
 msgid "revision"
 msgstr "revisione"
 
-#: builtin/clone.c:130 builtin/fetch.c:174 builtin/pull.c:215
+#: builtin/clone.c:130 builtin/fetch.c:178 builtin/pull.c:215
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 "aumenta la profondità della cronologia del clone shallow fino alla revisione "
 "specificata esclusa"
 
-#: builtin/clone.c:132 builtin/submodule--helper.c:1419
-#: builtin/submodule--helper.c:1928
+#: builtin/clone.c:132 builtin/submodule--helper.c:1843
+#: builtin/submodule--helper.c:2352
 msgid "clone only one branch, HEAD or --branch"
 msgstr "clona solo un branch, HEAD o quello specificato con --branch"
 
@@ -12459,11 +12712,11 @@ msgstr "non clonare alcun tag e fai sì che i fetch successivi non li seguano"
 msgid "any cloned submodules will be shallow"
 msgstr "tutti i sottomoduli clonati saranno shallow"
 
-#: builtin/clone.c:137 builtin/init-db.c:560
+#: builtin/clone.c:137 builtin/init-db.c:559
 msgid "gitdir"
 msgstr "directory Git"
 
-#: builtin/clone.c:138 builtin/init-db.c:561
+#: builtin/clone.c:138 builtin/init-db.c:560
 msgid "separate git dir from working tree"
 msgstr "separa la directory Git dall'albero di lavoro"
 
@@ -12475,23 +12728,23 @@ msgstr "chiave=valore"
 msgid "set config inside the new repository"
 msgstr "imposta la configurazione nel nuovo repository"
 
-#: builtin/clone.c:142 builtin/fetch.c:191 builtin/ls-remote.c:76
-#: builtin/pull.c:230 builtin/push.c:570 builtin/send-pack.c:171
+#: builtin/clone.c:142 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/pull.c:230 builtin/push.c:560 builtin/send-pack.c:190
 msgid "server-specific"
 msgstr "specifica del server"
 
-#: builtin/clone.c:142 builtin/fetch.c:191 builtin/ls-remote.c:76
-#: builtin/pull.c:231 builtin/push.c:570 builtin/send-pack.c:172
+#: builtin/clone.c:142 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/pull.c:231 builtin/push.c:560 builtin/send-pack.c:191
 msgid "option to transmit"
 msgstr "opzione da trasmettere"
 
-#: builtin/clone.c:143 builtin/fetch.c:192 builtin/pull.c:234
-#: builtin/push.c:571
+#: builtin/clone.c:143 builtin/fetch.c:196 builtin/pull.c:234
+#: builtin/push.c:561
 msgid "use IPv4 addresses only"
 msgstr "usa solo indirizzi IPv4"
 
-#: builtin/clone.c:145 builtin/fetch.c:194 builtin/pull.c:237
-#: builtin/push.c:573
+#: builtin/clone.c:145 builtin/fetch.c:198 builtin/pull.c:237
+#: builtin/push.c:563
 msgid "use IPv6 addresses only"
 msgstr "usa solo indirizzi IPv6"
 
@@ -12597,66 +12850,72 @@ msgstr "impossibile eseguire il repack per pulire l'area di lavoro"
 msgid "cannot unlink temporary alternates file"
 msgstr "impossibile eseguire l'unlink del file alternates temporaneo"
 
-#: builtin/clone.c:971 builtin/receive-pack.c:1982
+#: builtin/clone.c:970 builtin/receive-pack.c:2434
 msgid "Too many arguments."
 msgstr "Troppi argomenti."
 
-#: builtin/clone.c:975
+#: builtin/clone.c:974
 msgid "You must specify a repository to clone."
 msgstr "Devi specificare un repository da clonare."
 
-#: builtin/clone.c:988
+#: builtin/clone.c:987
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "le opzioni --bare e --origin %s non sono compatibili."
 
-#: builtin/clone.c:991
+#: builtin/clone.c:990
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "le opzioni --bare e --separate-git-dir non sono compatibili."
 
-#: builtin/clone.c:1007
+#: builtin/clone.c:1006
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "il repository '%s' non esiste"
 
-#: builtin/clone.c:1011 builtin/fetch.c:1794
+#: builtin/clone.c:1010 builtin/fetch.c:1841
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "la profondità %s non è un numero positivo"
 
-#: builtin/clone.c:1021
+#: builtin/clone.c:1020
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr ""
 "il percorso di destinazione '%s' esiste già e non è una directory vuota."
 
-#: builtin/clone.c:1033
+#: builtin/clone.c:1026
+#, c-format
+msgid "repository path '%s' already exists and is not an empty directory."
+msgstr ""
+"il percorso del repository '%s' esiste già e non è una directory vuota."
+
+#: builtin/clone.c:1040
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "l'albero di lavoro '%s' esiste già."
 
-#: builtin/clone.c:1048 builtin/clone.c:1069 builtin/difftool.c:271
-#: builtin/log.c:1886 builtin/worktree.c:354 builtin/worktree.c:386
+#: builtin/clone.c:1055 builtin/clone.c:1076 builtin/difftool.c:271
+#: builtin/log.c:1970 builtin/worktree.c:354 builtin/worktree.c:386
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "impossibile creare le prime directory di '%s'"
 
-#: builtin/clone.c:1053
+#: builtin/clone.c:1060
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "impossibile creare la directory dell'albero di lavoro '%s'"
 
-#: builtin/clone.c:1073
+#: builtin/clone.c:1080
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Clone nel repository spoglio '%s' in corso...\n"
 
-#: builtin/clone.c:1075
+#: builtin/clone.c:1082
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Clone in '%s' in corso...\n"
 
-#: builtin/clone.c:1099
+#: builtin/clone.c:1106
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -12664,38 +12923,65 @@ msgstr ""
 "il clone --recursive non è compatibile né con --reference né con --reference-"
 "if-able"
 
-#: builtin/clone.c:1164
+#: builtin/clone.c:1170
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "L'opzione --depth è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1166
+#: builtin/clone.c:1172
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr "L'opzione --shallow-since è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1168
+#: builtin/clone.c:1174
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr "L'opzione --shallow-exclude è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1170
+#: builtin/clone.c:1176
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr "L'opzione --filter è ignorata nei cloni locali; usa file://."
 
-#: builtin/clone.c:1173
+#: builtin/clone.c:1179
 msgid "source repository is shallow, ignoring --local"
 msgstr "il repository sorgente è shallow, ignoro l'opzione --local"
 
-#: builtin/clone.c:1178
+#: builtin/clone.c:1184
 msgid "--local is ignored"
 msgstr "l'opzione --local è ignorata"
 
-#: builtin/clone.c:1262 builtin/clone.c:1270
+#: builtin/clone.c:1268 builtin/clone.c:1276
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Il branch remoto %s non è stato trovato nell'upstream %s"
 
-#: builtin/clone.c:1273
+#: builtin/clone.c:1279
 msgid "You appear to have cloned an empty repository."
 msgstr "Sembra che tu abbia clonato un repository vuoto."
+
+#: builtin/credential-cache.c:154
+msgid "credential-cache unavailable; no unix socket support"
+msgstr "credential-cache non disponibile; supporto socket UNIX non presente"
+
+#: builtin/credential-cache--daemon.c:226
+#, c-format
+msgid ""
+"The permissions on your socket directory are too loose; other\n"
+"users may be able to read your cached credentials. Consider running:\n"
+"\n"
+"\tchmod 0700 %s"
+msgstr ""
+"I permessi sulla directory del socket sono troppo laschi; altri\n"
+"utenti potrebbero essere in grado di leggere le credenziali nella\n"
+"cache. Valuta di eseguire:\n"
+"\n"
+"\tchmod 0700 %s"
+
+#: builtin/credential-cache--daemon.c:275
+msgid "print debugging messages to stderr"
+msgstr "stampa i messaggi di debug sullo standard error"
+
+#: builtin/credential-cache--daemon.c:315
+msgid "credential-cache--daemon unavailable; no unix socket support"
+msgstr ""
+"credential-cache--daemon non disponibile; supporto socket UNIX non presente"
 
 #: builtin/column.c:10
 msgid "git column [<options>]"
@@ -12729,104 +13015,109 @@ msgstr "Spazi vuoti fra le colonne"
 msgid "--command must be the first argument"
 msgstr "--command deve essere il primo argomento"
 
-#: builtin/commit-graph.c:13 builtin/commit-graph.c:21
+#: builtin/commit-graph.c:13 builtin/commit-graph.c:22
 msgid ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 msgstr ""
 "git commit-graph verify [--object-dir <directory oggetti>] [--shallow] [--"
 "[no-]progress]"
 
-#: builtin/commit-graph.c:14 builtin/commit-graph.c:26
+#: builtin/commit-graph.c:14 builtin/commit-graph.c:27
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
-"paths] [--[no-]progress] <split options>"
+"paths] [--[no-]max-new-filters <n>] [--[no-]progress] <split options>"
 msgstr ""
 "git commit-graph write [--object-dir <directory oggetti>] [--append] [--"
 "split[=<strategia>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
-"paths] [--[no-]progress] <opzioni split>"
+"paths] [--[no-]max-new-filters <n>] [--[no-]progress] <opzioni split>"
 
-#: builtin/commit-graph.c:62
+#: builtin/commit-graph.c:64
 #, c-format
 msgid "could not find object directory matching %s"
 msgstr "impossibile trovare la directory oggetti corrispondente a %s"
 
-#: builtin/commit-graph.c:78 builtin/commit-graph.c:177
-#: builtin/commit-graph.c:276 builtin/fetch.c:180 builtin/log.c:1678
+#: builtin/commit-graph.c:80 builtin/commit-graph.c:210
+#: builtin/commit-graph.c:316 builtin/fetch.c:184 builtin/log.c:1764
 msgid "dir"
 msgstr "directory"
 
-#: builtin/commit-graph.c:79 builtin/commit-graph.c:178
-#: builtin/commit-graph.c:277
+#: builtin/commit-graph.c:81 builtin/commit-graph.c:211
+#: builtin/commit-graph.c:317
 msgid "The object directory to store the graph"
 msgstr "La directory oggetti in cui memorizzare il grafo"
 
-#: builtin/commit-graph.c:81
+#: builtin/commit-graph.c:83
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr "se il grafo dei commit è diviso, verifica solo l'ultimo file"
 
-#: builtin/commit-graph.c:104
+#: builtin/commit-graph.c:106
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr "Impossibile aprire il grafo dei commit '%s'"
 
-#: builtin/commit-graph.c:138
+#: builtin/commit-graph.c:142
 #, c-format
 msgid "unrecognized --split argument, %s"
 msgstr "argomento --split non riconosciuto, %s"
 
-#: builtin/commit-graph.c:151
+#: builtin/commit-graph.c:155
 #, c-format
 msgid "unexpected non-hex object ID: %s"
 msgstr "ID oggetto non esadecimale inatteso: %s"
 
-#: builtin/commit-graph.c:156
+#: builtin/commit-graph.c:160
 #, c-format
 msgid "invalid object: %s"
 msgstr "oggetto non valido: %s"
 
-#: builtin/commit-graph.c:180
+#: builtin/commit-graph.c:213
 msgid "start walk at all refs"
 msgstr "inizia la visita da tutti i riferimenti"
 
-#: builtin/commit-graph.c:182
+#: builtin/commit-graph.c:215
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr ""
 "esamina i pack-index elencati sullo standard input alla ricerca di commit"
 
-#: builtin/commit-graph.c:184
+#: builtin/commit-graph.c:217
 msgid "start walk at commits listed by stdin"
 msgstr "inizia la visita ai commit elencati sullo standard input"
 
-#: builtin/commit-graph.c:186
+#: builtin/commit-graph.c:219
 msgid "include all commits already in the commit-graph file"
 msgstr "includi tutti i commit già presenti nel file commit-graph"
 
-#: builtin/commit-graph.c:188
+#: builtin/commit-graph.c:221
 msgid "enable computation for changed paths"
 msgstr "abilita calcolo percorsi modificati"
 
-#: builtin/commit-graph.c:191
+#: builtin/commit-graph.c:224
 msgid "allow writing an incremental commit-graph file"
 msgstr "consenti la scrittura di un file grafo dei commit incrementale"
 
-#: builtin/commit-graph.c:195
+#: builtin/commit-graph.c:228
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr "numero massimo di commit in un grafo dei commit diviso non di base"
 
-#: builtin/commit-graph.c:197
+#: builtin/commit-graph.c:230
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr "rapporto massimo fra due livelli di un grafo dei commit diviso"
 
-#: builtin/commit-graph.c:199
+#: builtin/commit-graph.c:232
 msgid "only expire files older than a given date-time"
 msgstr "fai scadere solo i file più vecchi di una determinata data e ora"
 
-#: builtin/commit-graph.c:215
+#: builtin/commit-graph.c:234
+msgid "maximum number of changed-path Bloom filters to compute"
+msgstr ""
+"numero massimo dei filtri di Bloom per i percorsi modificati da calcolare"
+
+#: builtin/commit-graph.c:255
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr "usa al più un'opzione fra --reachable, --stdin-commits o --stdin-packs"
 
-#: builtin/commit-graph.c:245
+#: builtin/commit-graph.c:287
 msgid "Collecting commits from input"
 msgstr "Raccolta dei commit dall'input in corso"
 
@@ -12843,7 +13134,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "genitore duplicato %s ignorato"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:547
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:546
 #, c-format
 msgid "not a valid object name %s"
 msgstr "%s non è un nome oggetto valido"
@@ -12871,13 +13162,13 @@ msgstr "genitore"
 msgid "id of a parent commit object"
 msgstr "ID di un oggetto commit genitore"
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1506 builtin/merge.c:273
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1474
+#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:272
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1471
 #: builtin/tag.c:413
 msgid "message"
 msgstr "messaggio"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1506
+#: builtin/commit-tree.c:115 builtin/commit.c:1504
 msgid "commit message"
 msgstr "messaggio di commit"
 
@@ -12885,7 +13176,7 @@ msgstr "messaggio di commit"
 msgid "read commit log message from file"
 msgstr "leggi il messaggio di log del commit da un file"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1518 builtin/merge.c:290
+#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:289
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "firma il commit con GPG"
@@ -13037,12 +13328,12 @@ msgstr ""
 "impossibile selezionare un carattere commento non usato\n"
 "nel messaggio di commit corrente"
 
-#: builtin/commit.c:717 builtin/commit.c:750 builtin/commit.c:1099
+#: builtin/commit.c:717 builtin/commit.c:750 builtin/commit.c:1097
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "impossibile trovare il commit %s"
 
-#: builtin/commit.c:729 builtin/shortlog.c:319
+#: builtin/commit.c:729 builtin/shortlog.c:478
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(lettura del messaggio di log dallo standard input)\n"
@@ -13068,37 +13359,35 @@ msgstr "impossibile leggere MERGE_MSG"
 msgid "could not write commit template"
 msgstr "impossibile scrivere il modello di commit"
 
-#: builtin/commit.c:852
-#, c-format
+#: builtin/commit.c:853
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
-"If this is not correct, please remove the file\n"
-"\t%s\n"
+"If this is not correct, please run\n"
+"\tgit update-ref -d MERGE_HEAD\n"
 "and try again.\n"
 msgstr ""
 "\n"
 "Sembra che tu stia eseguendo il commit di un merge.\n"
-"Se ciò non è corretto, elimina il file\n"
-"\t%s\n"
+"Se ciò non è corretto, esegui\n"
+"\tgit update-ref -d MERGE_HEAD\n"
 "e riprova.\n"
 
-#: builtin/commit.c:857
-#, c-format
+#: builtin/commit.c:858
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
-"If this is not correct, please remove the file\n"
-"\t%s\n"
+"If this is not correct, please run\n"
+"\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "and try again.\n"
 msgstr ""
 "\n"
-"Sembra che tu stia eseguendo il commit di un merge.\n"
-"Se ciò non è corretto, elimina il file\n"
-"\t%s\n"
+"Sembra che tu stia eseguendo il commit di un cherry-pick.\n"
+"Se ciò non è corretto, esegui\n"
+"\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "e riprova.\n"
 
-#: builtin/commit.c:870
+#: builtin/commit.c:868
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13107,7 +13396,7 @@ msgstr ""
 "Immetti il messaggio di commit per le modifiche. Le righe che iniziano\n"
 "con '%c' saranno ignorate e un messaggio vuoto interromperà il commit.\n"
 
-#: builtin/commit.c:878
+#: builtin/commit.c:876
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13118,148 +13407,148 @@ msgstr ""
 "con '%c' saranno mantenute; puoi rimuoverle autonomamente se lo desideri.\n"
 "Un messaggio vuoto interromperà il commit.\n"
 
-#: builtin/commit.c:895
+#: builtin/commit.c:893
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sAutore:           %.*s <%.*s>"
 
-#: builtin/commit.c:903
+#: builtin/commit.c:901
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sData:             %s"
 
-#: builtin/commit.c:910
+#: builtin/commit.c:908
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sEsecutore commit: %.*s <%.*s>"
 
-#: builtin/commit.c:928
+#: builtin/commit.c:926
 msgid "Cannot read index"
 msgstr "Impossibile leggere l'indice"
 
-#: builtin/commit.c:999
+#: builtin/commit.c:997
 msgid "Error building trees"
 msgstr "Errore durante la costruzione degli alberi"
 
-#: builtin/commit.c:1013 builtin/tag.c:276
+#: builtin/commit.c:1011 builtin/tag.c:276
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Fornisci il messaggio usando l'opzione -m o -F.\n"
 
-#: builtin/commit.c:1057
+#: builtin/commit.c:1055
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' non è nel formato 'Nome <e-mail>' e non corrisponde ad alcun "
 "autore esistente"
 
-#: builtin/commit.c:1071
+#: builtin/commit.c:1069
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Modo non valido ignorato: '%s'"
 
-#: builtin/commit.c:1089 builtin/commit.c:1333
+#: builtin/commit.c:1087 builtin/commit.c:1331
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Modo file non tracciati non valido: '%s'"
 
-#: builtin/commit.c:1129
+#: builtin/commit.c:1127
 msgid "--long and -z are incompatible"
 msgstr "--long e -z non sono compatibili"
 
-#: builtin/commit.c:1173
+#: builtin/commit.c:1171
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "L'uso di entrambe le opzioni --reset-author e --author non ha senso"
 
-#: builtin/commit.c:1182
+#: builtin/commit.c:1180
 msgid "You have nothing to amend."
 msgstr "Non c'è nulla da modificare."
 
-#: builtin/commit.c:1185
+#: builtin/commit.c:1183
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Sei nel bel mezzo di un merge - impossibile eseguire l'amend."
 
-#: builtin/commit.c:1187
+#: builtin/commit.c:1185
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "Sei nel bel mezzo di un cherry-pick - impossibile eseguire l'amend."
 
-#: builtin/commit.c:1189
+#: builtin/commit.c:1187
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Sei nel bel mezzo di un rebase - impossibile eseguire l'amend."
 
-#: builtin/commit.c:1192
+#: builtin/commit.c:1190
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Le opzioni --squash e --fixup non possono essere usate insieme"
 
-#: builtin/commit.c:1202
+#: builtin/commit.c:1200
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Solo una delle opzioni -c/-C/-F/--fixup può essere usata."
 
-#: builtin/commit.c:1204
+#: builtin/commit.c:1202
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "L'opzione -m non può essere combinata con -c/-C/-F."
 
-#: builtin/commit.c:1213
+#: builtin/commit.c:1211
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "L'opzione --reset-author può essere usata solo con -C, -c o --amend."
 
-#: builtin/commit.c:1231
+#: builtin/commit.c:1229
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Può essere usata solo una delle opzioni --include/--only/--all/--"
 "interactive/--patch."
 
-#: builtin/commit.c:1237
+#: builtin/commit.c:1235
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "i percorsi '%s ...' non hanno senso con -a"
 
-#: builtin/commit.c:1368 builtin/commit.c:1529
+#: builtin/commit.c:1366 builtin/commit.c:1527
 msgid "show status concisely"
 msgstr "visualizza concisamente lo stato"
 
-#: builtin/commit.c:1370 builtin/commit.c:1531
+#: builtin/commit.c:1368 builtin/commit.c:1529
 msgid "show branch information"
 msgstr "visualizza le informazioni sul branch"
 
-#: builtin/commit.c:1372
+#: builtin/commit.c:1370
 msgid "show stash information"
 msgstr "visualizza le informazioni sullo stash"
 
-#: builtin/commit.c:1374 builtin/commit.c:1533
+#: builtin/commit.c:1372 builtin/commit.c:1531
 msgid "compute full ahead/behind values"
 msgstr "calcola tutti i valori dopo/prima di"
 
-#: builtin/commit.c:1376
+#: builtin/commit.c:1374
 msgid "version"
 msgstr "versione"
 
-#: builtin/commit.c:1376 builtin/commit.c:1535 builtin/push.c:549
+#: builtin/commit.c:1374 builtin/commit.c:1533 builtin/push.c:539
 #: builtin/worktree.c:722
 msgid "machine-readable output"
 msgstr "output leggibile da una macchina"
 
-#: builtin/commit.c:1379 builtin/commit.c:1537
+#: builtin/commit.c:1377 builtin/commit.c:1535
 msgid "show status in long format (default)"
 msgstr "visualizza lo stato in forma lunga (impostazione predefinita)"
 
-#: builtin/commit.c:1382 builtin/commit.c:1540
+#: builtin/commit.c:1380 builtin/commit.c:1538
 msgid "terminate entries with NUL"
 msgstr "termina le voci con NUL"
 
-#: builtin/commit.c:1384 builtin/commit.c:1388 builtin/commit.c:1543
+#: builtin/commit.c:1382 builtin/commit.c:1386 builtin/commit.c:1541
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1392 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1400 parse-options.h:336
 msgid "mode"
 msgstr "modo"
 
-#: builtin/commit.c:1385 builtin/commit.c:1543
+#: builtin/commit.c:1383 builtin/commit.c:1541
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "visualizza file non tracciati, modalità facoltative: all, normal, no. "
 "(Impostazione predefinita: all)"
 
-#: builtin/commit.c:1389
+#: builtin/commit.c:1387
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -13267,11 +13556,11 @@ msgstr ""
 "visualizza file ignorati, modalità facoltative: traditional, matching, no. "
 "(Impostazione predefinita: traditional)"
 
-#: builtin/commit.c:1391 parse-options.h:192
+#: builtin/commit.c:1389 parse-options.h:192
 msgid "when"
 msgstr "quando"
 
-#: builtin/commit.c:1392
+#: builtin/commit.c:1390
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -13279,175 +13568,175 @@ msgstr ""
 "ignora modifiche ai sottomoduli, opzione facoltativa \"quando\": all, dirty, "
 "untracked. (Impostazione predefinita: all)"
 
-#: builtin/commit.c:1394
+#: builtin/commit.c:1392
 msgid "list untracked files in columns"
 msgstr "elenca i file non tracciati in colonne"
 
-#: builtin/commit.c:1395
+#: builtin/commit.c:1393
 msgid "do not detect renames"
 msgstr "non rilevare le ridenominazioni"
 
-#: builtin/commit.c:1397
+#: builtin/commit.c:1395
 msgid "detect renames, optionally set similarity index"
 msgstr ""
 "rileva le ridenominazioni, imposta facoltativamente l'indice di similarità"
 
-#: builtin/commit.c:1417
+#: builtin/commit.c:1415
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Combinazione di argomenti sui file ignorati e non tracciati non supportata"
 
-#: builtin/commit.c:1499
+#: builtin/commit.c:1497
 msgid "suppress summary after successful commit"
 msgstr ""
 "ometti di visualizzare il riepilogo dopo un commit completato con successo"
 
-#: builtin/commit.c:1500
+#: builtin/commit.c:1498
 msgid "show diff in commit message template"
 msgstr "visualizza il diff nel modello del messaggio di commit"
 
-#: builtin/commit.c:1502
+#: builtin/commit.c:1500
 msgid "Commit message options"
 msgstr "Opzioni messaggio di commit"
 
-#: builtin/commit.c:1503 builtin/merge.c:277 builtin/tag.c:415
+#: builtin/commit.c:1501 builtin/merge.c:276 builtin/tag.c:415
 msgid "read message from file"
 msgstr "leggi il messaggio da un file"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1502
 msgid "author"
 msgstr "autore"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1502
 msgid "override author for commit"
 msgstr "sovrascrivi l'autore per il commit"
 
-#: builtin/commit.c:1505 builtin/gc.c:538
+#: builtin/commit.c:1503 builtin/gc.c:539
 msgid "date"
 msgstr "data"
 
-#: builtin/commit.c:1505
+#: builtin/commit.c:1503
 msgid "override date for commit"
 msgstr "sovrascrivi la data per il commit"
 
-#: builtin/commit.c:1507 builtin/commit.c:1508 builtin/commit.c:1509
-#: builtin/commit.c:1510 parse-options.h:328 ref-filter.h:92
+#: builtin/commit.c:1505 builtin/commit.c:1506 builtin/commit.c:1507
+#: builtin/commit.c:1508 parse-options.h:328 ref-filter.h:87
 msgid "commit"
 msgstr "commit"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1505
 msgid "reuse and edit message from specified commit"
 msgstr "riusa il messaggio del commit specificato per poi modificarlo"
 
-#: builtin/commit.c:1508
+#: builtin/commit.c:1506
 msgid "reuse message from specified commit"
 msgstr "riusa il messaggio del commit specificato"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1507
 msgid "use autosquash formatted message to fixup specified commit"
 msgstr ""
 "usa il messaggio in formato autosquash per correggere il commit specificato"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1508
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "usa il messaggio in formato autosquash per eseguire lo squash del commit "
 "specificato"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1509
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "il commit ora ha me come autore (opzione usata con -C/-c/--amend)"
 
-#: builtin/commit.c:1512 builtin/log.c:1655 builtin/merge.c:293
+#: builtin/commit.c:1510 builtin/log.c:1741 builtin/merge.c:292
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add Signed-off-by:"
 msgstr "aggiungi Signed-off-by:"
 
-#: builtin/commit.c:1513
+#: builtin/commit.c:1511
 msgid "use specified template file"
 msgstr "usa il file modello specificato"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1512
 msgid "force edit of commit"
 msgstr "forza la modifica del commit"
 
-#: builtin/commit.c:1516
+#: builtin/commit.c:1514
 msgid "include status in commit message template"
 msgstr "includi lo stato nel modello del messaggio di commit"
 
-#: builtin/commit.c:1521
+#: builtin/commit.c:1519
 msgid "Commit contents options"
 msgstr "Opzioni contenuto commit"
 
-#: builtin/commit.c:1522
+#: builtin/commit.c:1520
 msgid "commit all changed files"
 msgstr "esegui il commit di tutti i file modificati"
 
-#: builtin/commit.c:1523
+#: builtin/commit.c:1521
 msgid "add specified files to index for commit"
 msgstr "aggiungi i file specificati all'indice per il commit"
 
-#: builtin/commit.c:1524
+#: builtin/commit.c:1522
 msgid "interactively add files"
 msgstr "aggiungi i file in modalità interattiva"
 
-#: builtin/commit.c:1525
+#: builtin/commit.c:1523
 msgid "interactively add changes"
 msgstr "aggiungi le modifiche in modalità interattiva"
 
-#: builtin/commit.c:1526
+#: builtin/commit.c:1524
 msgid "commit only specified files"
 msgstr "esegui il commit solo dei file specificati"
 
-#: builtin/commit.c:1527
+#: builtin/commit.c:1525
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "ignora gli hook pre-commit e commit-msg"
 
-#: builtin/commit.c:1528
+#: builtin/commit.c:1526
 msgid "show what would be committed"
 msgstr "visualizza gli elementi di cui sarebbe eseguito il commit"
 
-#: builtin/commit.c:1541
+#: builtin/commit.c:1539
 msgid "amend previous commit"
 msgstr "modifica il commit precedente"
 
-#: builtin/commit.c:1542
+#: builtin/commit.c:1540
 msgid "bypass post-rewrite hook"
 msgstr "ignora l'hook post-rewrite"
 
-#: builtin/commit.c:1549
+#: builtin/commit.c:1547
 msgid "ok to record an empty change"
 msgstr "accetta di registrare una modifica vuota"
 
-#: builtin/commit.c:1551
+#: builtin/commit.c:1549
 msgid "ok to record a change with an empty message"
 msgstr "accetta di registrare una modifica con un messaggio vuoto"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1622
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "File MERGE_HEAD corrotto (%s)"
 
-#: builtin/commit.c:1631
+#: builtin/commit.c:1629
 msgid "could not read MERGE_MODE"
 msgstr "impossibile leggere MERGE_MODE"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1650
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "impossibile leggere il messaggio di commit: %s"
 
-#: builtin/commit.c:1659
+#: builtin/commit.c:1657
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Interrompo il commit a causa di un messaggio di commit vuoto.\n"
 
-#: builtin/commit.c:1664
+#: builtin/commit.c:1662
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Interrompo il commit; non hai modificato il messaggio.\n"
 
-#: builtin/commit.c:1698
+#: builtin/commit.c:1696
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -13463,218 +13752,222 @@ msgstr ""
 msgid "git config [<options>]"
 msgstr "git config [<opzioni>]"
 
-#: builtin/config.c:104 builtin/env--helper.c:23
+#: builtin/config.c:107 builtin/env--helper.c:27
 #, c-format
 msgid "unrecognized --type argument, %s"
 msgstr "argomento --type non riconosciuto: %s"
 
-#: builtin/config.c:116
+#: builtin/config.c:119
 msgid "only one type at a time"
 msgstr "solo un tipo per volta"
 
-#: builtin/config.c:125
+#: builtin/config.c:128
 msgid "Config file location"
 msgstr "Percorso file di configurazione"
 
-#: builtin/config.c:126
+#: builtin/config.c:129
 msgid "use global config file"
 msgstr "usa il file di configurazione globale"
 
-#: builtin/config.c:127
+#: builtin/config.c:130
 msgid "use system config file"
 msgstr "usa il file di configurazione di sistema"
 
-#: builtin/config.c:128
+#: builtin/config.c:131
 msgid "use repository config file"
 msgstr "usa il file di configurazione del repository"
 
-#: builtin/config.c:129
+#: builtin/config.c:132
 msgid "use per-worktree config file"
 msgstr "usa il file di configurazione per albero di lavoro"
 
-#: builtin/config.c:130
+#: builtin/config.c:133
 msgid "use given config file"
 msgstr "usa il file di configurazione specificato"
 
-#: builtin/config.c:131
+#: builtin/config.c:134
 msgid "blob-id"
 msgstr "ID blob"
 
-#: builtin/config.c:131
+#: builtin/config.c:134
 msgid "read config from given blob object"
 msgstr "leggi la configurazione dall'oggetto blob specificato"
 
-#: builtin/config.c:132
+#: builtin/config.c:135
 msgid "Action"
 msgstr "Azione"
 
-#: builtin/config.c:133
+#: builtin/config.c:136
 msgid "get value: name [value-regex]"
 msgstr "ottieni valore: nome [espressione-regolare-valore]"
 
-#: builtin/config.c:134
+#: builtin/config.c:137
 msgid "get all values: key [value-regex]"
 msgstr "ottieni tutti i valori: chiave [espressione-regolare-valore]"
 
-#: builtin/config.c:135
+#: builtin/config.c:138
 msgid "get values for regexp: name-regex [value-regex]"
 msgstr ""
 "ottieni i valori in base a un'espressione regolare: espressione-regolare-"
 "nome [espressione-regolare-valore]"
 
-#: builtin/config.c:136
+#: builtin/config.c:139
 msgid "get value specific for the URL: section[.var] URL"
 msgstr "ottieni il valore specifico per l'URL: sezione[.variabile] URL"
 
-#: builtin/config.c:137
+#: builtin/config.c:140
 msgid "replace all matching variables: name value [value_regex]"
 msgstr ""
 "sostituisci tutte le variabili corrispondenti: nome-valore [espressione-"
 "regolare-valore]"
 
-#: builtin/config.c:138
+#: builtin/config.c:141
 msgid "add a new variable: name value"
 msgstr "aggiungi una nuova variabile: nome valore"
 
-#: builtin/config.c:139
+#: builtin/config.c:142
 msgid "remove a variable: name [value-regex]"
 msgstr "rimuovi una variabile: nome [espressione-regolare-valore]"
 
-#: builtin/config.c:140
+#: builtin/config.c:143
 msgid "remove all matches: name [value-regex]"
 msgstr "rimuovi tutte le corrispondenze: nome [espressione-regolare-valore]"
 
-#: builtin/config.c:141
+#: builtin/config.c:144
 msgid "rename section: old-name new-name"
 msgstr "rinomina sezione: vecchio-nome nuovo-nome"
 
-#: builtin/config.c:142
+#: builtin/config.c:145
 msgid "remove a section: name"
 msgstr "rimuovi una sezione: nome"
 
-#: builtin/config.c:143
+#: builtin/config.c:146
 msgid "list all"
 msgstr "elenca tutti"
 
-#: builtin/config.c:144
+#: builtin/config.c:147
 msgid "open an editor"
 msgstr "apri un editor"
 
-#: builtin/config.c:145
+#: builtin/config.c:148
 msgid "find the color configured: slot [default]"
 msgstr "trova il colore configurato: slot [valore-predefinito]"
 
-#: builtin/config.c:146
+#: builtin/config.c:149
 msgid "find the color setting: slot [stdout-is-tty]"
 msgstr "trova l'impostazione colore: slot [standard-output-è-una-tty]"
 
-#: builtin/config.c:147
+#: builtin/config.c:150
 msgid "Type"
 msgstr "Tipo"
 
-#: builtin/config.c:148 builtin/env--helper.c:38
+#: builtin/config.c:151 builtin/env--helper.c:43
 msgid "value is given this type"
 msgstr "al valore è assegnato questo tipo"
 
-#: builtin/config.c:149
+#: builtin/config.c:152
 msgid "value is \"true\" or \"false\""
 msgstr "il valore è \"true\" o \"false\""
 
-#: builtin/config.c:150
+#: builtin/config.c:153
 msgid "value is decimal number"
 msgstr "il valore è un numero decimale"
 
-#: builtin/config.c:151
+#: builtin/config.c:154
 msgid "value is --bool or --int"
 msgstr "il valore è --bool o --int"
 
-#: builtin/config.c:152
+#: builtin/config.c:155
+msgid "value is --bool or string"
+msgstr "il valore è --bool o una stringa"
+
+#: builtin/config.c:156
 msgid "value is a path (file or directory name)"
 msgstr "il valore è un percorso (nome file o directory)"
 
-#: builtin/config.c:153
+#: builtin/config.c:157
 msgid "value is an expiry date"
 msgstr "il valore è una data di scadenza"
 
-#: builtin/config.c:154
+#: builtin/config.c:158
 msgid "Other"
 msgstr "Altro"
 
-#: builtin/config.c:155
+#: builtin/config.c:159
 msgid "terminate values with NUL byte"
 msgstr "termina i valori con un byte NUL"
 
-#: builtin/config.c:156
+#: builtin/config.c:160
 msgid "show variable names only"
 msgstr "visualizza solo i nomi delle variabili"
 
-#: builtin/config.c:157
+#: builtin/config.c:161
 msgid "respect include directives on lookup"
 msgstr ""
 "rispetta le directory di inclusione durante il recupero delle variabili"
 
-#: builtin/config.c:158
+#: builtin/config.c:162
 msgid "show origin of config (file, standard input, blob, command line)"
 msgstr ""
 "visualizza l'origine del file di configurazione (file, standard input, blob, "
 "riga di comando)"
 
-#: builtin/config.c:159
+#: builtin/config.c:163
 msgid "show scope of config (worktree, local, global, system, command)"
 msgstr ""
 "visualizza l'ambito della configurazione (albero di lavoro, locale, globale, "
 "sistema, comando)"
 
-#: builtin/config.c:160 builtin/env--helper.c:40
+#: builtin/config.c:164 builtin/env--helper.c:45
 msgid "value"
 msgstr "valore"
 
-#: builtin/config.c:160
+#: builtin/config.c:164
 msgid "with --get, use default value when missing entry"
 msgstr "con --get, usa il valore predefinito se la voce è mancante"
 
-#: builtin/config.c:174
+#: builtin/config.c:178
 #, c-format
 msgid "wrong number of arguments, should be %d"
 msgstr "numero di argomenti errato, dovrebbero essere %d"
 
-#: builtin/config.c:176
+#: builtin/config.c:180
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
 msgstr "numero di argomenti errato, dovrebbero essere da %d a %d"
 
-#: builtin/config.c:324
+#: builtin/config.c:334
 #, c-format
 msgid "invalid key pattern: %s"
 msgstr "pattern chiave non valido: %s"
 
-#: builtin/config.c:360
+#: builtin/config.c:370
 #, c-format
 msgid "failed to format default config value: %s"
 msgstr "formattazione del valore configurazione predefinito non riuscita: %s"
 
-#: builtin/config.c:417
+#: builtin/config.c:434
 #, c-format
 msgid "cannot parse color '%s'"
 msgstr "impossibile analizzare il colore '%s'"
 
-#: builtin/config.c:459
+#: builtin/config.c:476
 msgid "unable to parse default color value"
 msgstr "impossibile analizzare il valore colore predefinito"
 
-#: builtin/config.c:512 builtin/config.c:768
+#: builtin/config.c:529 builtin/config.c:789
 msgid "not in a git directory"
 msgstr "non si è in una directory git"
 
-#: builtin/config.c:515
+#: builtin/config.c:532
 msgid "writing to stdin is not supported"
 msgstr "la scrittura su standard input non è supportata"
 
-#: builtin/config.c:518
+#: builtin/config.c:535
 msgid "writing config blobs is not supported"
 msgstr "la scrittura di blob di configurazione non è supportata"
 
-#: builtin/config.c:603
+#: builtin/config.c:620
 #, c-format
 msgid ""
 "# This is Git's per-user configuration file.\n"
@@ -13689,23 +13982,27 @@ msgstr ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 
-#: builtin/config.c:627
+#: builtin/config.c:644
 msgid "only one config file at a time"
 msgstr "solo un file di configurazione per volta"
 
-#: builtin/config.c:632
+#: builtin/config.c:650
 msgid "--local can only be used inside a git repository"
 msgstr "--local può essere usato solo in un repository Git"
 
-#: builtin/config.c:635
+#: builtin/config.c:652
 msgid "--blob can only be used inside a git repository"
 msgstr "--blob può essere usato solo in un repository Git"
 
-#: builtin/config.c:655
+#: builtin/config.c:654
+msgid "--worktree can only be used inside a git repository"
+msgstr "--worktree può essere usato solo in un repository Git"
+
+#: builtin/config.c:676
 msgid "$HOME not set"
 msgstr "$HOME non impostata"
 
-#: builtin/config.c:679
+#: builtin/config.c:700
 msgid ""
 "--worktree cannot be used with multiple working trees unless the config\n"
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
@@ -13716,52 +14013,52 @@ msgstr ""
 "Leggi la sezione \"FILE DI CONFIGURAZIONE\" in \"git help worktree\" per\n"
 "i dettagli"
 
-#: builtin/config.c:714
+#: builtin/config.c:735
 msgid "--get-color and variable type are incoherent"
 msgstr "--get-color e il tipo della variabile non sono coerenti"
 
-#: builtin/config.c:719
+#: builtin/config.c:740
 msgid "only one action at a time"
 msgstr "solo un'azione per volta"
 
-#: builtin/config.c:732
+#: builtin/config.c:753
 msgid "--name-only is only applicable to --list or --get-regexp"
 msgstr "--name-only è applicabile solo a --list o --get-regexp"
 
-#: builtin/config.c:738
+#: builtin/config.c:759
 msgid ""
 "--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
 "list"
 msgstr ""
 "--show-origin è applicabile solo a --get, --get-all, --get-regexp e --list"
 
-#: builtin/config.c:744
+#: builtin/config.c:765
 msgid "--default is only applicable to --get"
 msgstr "--default è applicabile solo a --get"
 
-#: builtin/config.c:757
+#: builtin/config.c:778
 #, c-format
 msgid "unable to read config file '%s'"
 msgstr "impossibile leggere il file di configurazione '%s'"
 
-#: builtin/config.c:760
+#: builtin/config.c:781
 msgid "error processing config file(s)"
 msgstr "errore durante l'elaborazione del/dei file di configurazione"
 
-#: builtin/config.c:770
+#: builtin/config.c:791
 msgid "editing stdin is not supported"
 msgstr "la modifica dello standard input non è supportata"
 
-#: builtin/config.c:772
+#: builtin/config.c:793
 msgid "editing blobs is not supported"
 msgstr "la modifica dei blob non è supportata"
 
-#: builtin/config.c:786
+#: builtin/config.c:807
 #, c-format
 msgid "cannot create configuration file %s"
 msgstr "impossibile creare il file di configurazione %s"
 
-#: builtin/config.c:799
+#: builtin/config.c:820
 #, c-format
 msgid ""
 "cannot overwrite multiple values with a single value\n"
@@ -13770,7 +14067,7 @@ msgstr ""
 "impossibile sovrascrivere valori multipli con un singolo valore\n"
 "       Usa un'espressione regolare, --add o --replace-all per modificare %s."
 
-#: builtin/config.c:873 builtin/config.c:884
+#: builtin/config.c:894 builtin/config.c:905
 #, c-format
 msgid "no such section: %s"
 msgstr "sezione %s non esistente"
@@ -13958,36 +14255,36 @@ msgstr "--broken non è compatibile con le espressioni commit"
 msgid "'%s': not a regular file or symlink"
 msgstr "'%s': non è un file regolare o un collegamento simbolico"
 
-#: builtin/diff.c:242
+#: builtin/diff.c:241
 #, c-format
 msgid "invalid option: %s"
 msgstr "opzione non valida: %s"
 
-#: builtin/diff.c:359
+#: builtin/diff.c:358
 #, c-format
 msgid "%s...%s: no merge base"
 msgstr "%s...%s: non esiste una base per il merge"
 
-#: builtin/diff.c:469
+#: builtin/diff.c:468
 msgid "Not a git repository"
 msgstr "Non è un repository Git"
 
-#: builtin/diff.c:514
+#: builtin/diff.c:513
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "specificato oggetto non valido '%s'."
 
-#: builtin/diff.c:525
+#: builtin/diff.c:524
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "più di due blob specificati: '%s'"
 
-#: builtin/diff.c:530
+#: builtin/diff.c:529
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "specificato oggetto non gestito '%s'."
 
-#: builtin/diff.c:564
+#: builtin/diff.c:563
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: esistono più basi per il merge, utilizzo %s"
@@ -14111,28 +14408,28 @@ msgstr "nessun <comando> specificato per --extcmd=<comando>"
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
 msgstr "git env--helper --type=[bool|ulong] <opzioni> <variabile d'ambiente>"
 
-#: builtin/env--helper.c:37 builtin/hash-object.c:98
+#: builtin/env--helper.c:42 builtin/hash-object.c:98
 msgid "type"
 msgstr "tipo"
 
-#: builtin/env--helper.c:41
+#: builtin/env--helper.c:46
 msgid "default for git_env_*(...) to fall back on"
 msgstr ""
 "impostazione predefinita su cui ripiegheranno le chiamate git_env_*(...)"
 
-#: builtin/env--helper.c:43
+#: builtin/env--helper.c:48
 msgid "be quiet only use git_env_*() value as exit code"
 msgstr ""
 "non visualizzare messaggi, usa solo il valore di git_env_*() come codice "
 "d'uscita"
 
-#: builtin/env--helper.c:62
+#: builtin/env--helper.c:67
 #, c-format
 msgid "option `--default' expects a boolean value with `--type=bool`, not `%s`"
 msgstr ""
 "l'opzione `--default' richiede un valore booleano con `--type=bool`, non `%s`"
 
-#: builtin/env--helper.c:77
+#: builtin/env--helper.c:82
 #, c-format
 msgid ""
 "option `--default' expects an unsigned long value with `--type=ulong`, not `"
@@ -14200,7 +14497,7 @@ msgstr "Usa la funzionalità \"fatto\" per terminare il flusso"
 msgid "Skip output of blob data"
 msgstr "Ometti l'output dei dati dei blob"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1724
+#: builtin/fast-export.c:1223 builtin/log.c:1811
 msgid "refspec"
 msgstr "specificatore riferimento"
 
@@ -14243,7 +14540,38 @@ msgstr ""
 "Impossibile fornire entrambe le opzioni --import-marks e --import-marks-if-"
 "exists"
 
-#: builtin/fetch-pack.c:245
+#: builtin/fast-import.c:3086
+#, c-format
+msgid "Missing from marks for submodule '%s'"
+msgstr "Contrassegni Da mancanti per il sottomodulo '%s'"
+
+#: builtin/fast-import.c:3088
+#, c-format
+msgid "Missing to marks for submodule '%s'"
+msgstr "Contrassegni A mancanti per il sottomodulo '%s'"
+
+#: builtin/fast-import.c:3223
+#, c-format
+msgid "Expected 'mark' command, got %s"
+msgstr "Atteso comando 'mark', ricevuto %s"
+
+#: builtin/fast-import.c:3228
+#, c-format
+msgid "Expected 'to' command, got %s"
+msgstr "Atteso comando 'to', ricevuto %s"
+
+#: builtin/fast-import.c:3320
+msgid "Expected format name:filename for submodule rewrite option"
+msgstr ""
+"Per l'opzione riscrittura sottomodulo ci si attendeva un formato nome:"
+"nomefile"
+
+#: builtin/fast-import.c:3374
+#, c-format
+msgid "feature '%s' forbidden in input without --allow-unsafe-features"
+msgstr "funzionalità '%s' vietata nell'input senza --allow-unsafe-features"
+
+#: builtin/fetch-pack.c:241
 #, c-format
 msgid "Lockfile created but not reported: %s"
 msgstr "File di lock creato ma non segnalato: %s"
@@ -14264,92 +14592,96 @@ msgstr "git fetch --multiple [<opzioni>] [(<repository> | <gruppo>)...]"
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<opzioni>]"
 
-#: builtin/fetch.c:117
+#: builtin/fetch.c:119
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel non può essere negativo"
 
-#: builtin/fetch.c:140 builtin/pull.c:185
+#: builtin/fetch.c:142 builtin/pull.c:185
 msgid "fetch from all remotes"
 msgstr "esegui il fetch da tutti i remoti"
 
-#: builtin/fetch.c:142 builtin/pull.c:245
+#: builtin/fetch.c:144 builtin/pull.c:245
 msgid "set upstream for git pull/fetch"
 msgstr "imposta l'upstream per git pull/fetch"
 
-#: builtin/fetch.c:144 builtin/pull.c:188
+#: builtin/fetch.c:146 builtin/pull.c:188
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "aggiungi i dati a .git/FETCH_HEAD anziché sovrascriverli"
 
-#: builtin/fetch.c:146 builtin/pull.c:191
+#: builtin/fetch.c:148 builtin/pull.c:191
 msgid "path to upload pack on remote end"
 msgstr "percorso in cui caricare il pack sul remoto"
 
-#: builtin/fetch.c:147
+#: builtin/fetch.c:149
 msgid "force overwrite of local reference"
 msgstr "forza la sovrascrittura del riferimento locale"
 
-#: builtin/fetch.c:149
+#: builtin/fetch.c:151
 msgid "fetch from multiple remotes"
 msgstr "esegui il fetch da più remoti"
 
-#: builtin/fetch.c:151 builtin/pull.c:195
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "fetch all tags and associated objects"
 msgstr "esegui il fetch di tutti i tag e degli oggetti associati"
 
-#: builtin/fetch.c:153
+#: builtin/fetch.c:155
 msgid "do not fetch all tags (--no-tags)"
 msgstr "non eseguire il fetch di alcun tag (--no-tags)"
 
-#: builtin/fetch.c:155
+#: builtin/fetch.c:157
 msgid "number of submodules fetched in parallel"
 msgstr "numero di sottomoduli recuperati in parallelo"
 
-#: builtin/fetch.c:157 builtin/pull.c:198
+#: builtin/fetch.c:159 builtin/pull.c:198
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "elimina i branch che ne tracciano uno remoto ma non più presenti sul remoto"
 
-#: builtin/fetch.c:159
+#: builtin/fetch.c:161
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "elimina i tag locali non più presenti sul remoto e sovrascrivi i tag "
 "modificati"
 
-#: builtin/fetch.c:160 builtin/fetch.c:183 builtin/pull.c:122
+#: builtin/fetch.c:162 builtin/fetch.c:187 builtin/pull.c:122
 msgid "on-demand"
 msgstr "a richiesta"
 
-#: builtin/fetch.c:161
+#: builtin/fetch.c:163
 msgid "control recursive fetching of submodules"
 msgstr "controlla il recupero ricorsivo dei sottomoduli"
 
-#: builtin/fetch.c:165 builtin/pull.c:206
+#: builtin/fetch.c:168
+msgid "write fetched references to the FETCH_HEAD file"
+msgstr "scrivi i riferimenti recuperati nel file FETCH_HEAD"
+
+#: builtin/fetch.c:169 builtin/pull.c:206
 msgid "keep downloaded pack"
 msgstr "mantieni il pack scaricato"
 
-#: builtin/fetch.c:167
+#: builtin/fetch.c:171
 msgid "allow updating of HEAD ref"
 msgstr "consenti l'aggiornamento del riferimento HEAD"
 
-#: builtin/fetch.c:170 builtin/fetch.c:176 builtin/pull.c:209
+#: builtin/fetch.c:174 builtin/fetch.c:180 builtin/pull.c:209
 #: builtin/pull.c:218
 msgid "deepen history of shallow clone"
 msgstr "aumenta la profondità della cronologia di un clone shallow"
 
-#: builtin/fetch.c:172 builtin/pull.c:212
+#: builtin/fetch.c:176 builtin/pull.c:212
 msgid "deepen history of shallow repository based on time"
 msgstr ""
 "aumenta la profondità della cronologia di un clone shallow in base al tempo"
 
-#: builtin/fetch.c:178 builtin/pull.c:221
+#: builtin/fetch.c:182 builtin/pull.c:221
 msgid "convert to a complete repository"
 msgstr "converti in un repository completo"
 
-#: builtin/fetch.c:181
+#: builtin/fetch.c:185
 msgid "prepend this to submodule path output"
 msgstr "anteponi questo prefisso all'output del percorso del sottomodulo"
 
-#: builtin/fetch.c:184
+#: builtin/fetch.c:188
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -14357,94 +14689,98 @@ msgstr ""
 "impostazione predefinita per il recupero ricorsivo dei sottomoduli (a "
 "priorità minore rispetto ai file di configurazione)"
 
-#: builtin/fetch.c:188 builtin/pull.c:224
+#: builtin/fetch.c:192 builtin/pull.c:224
 msgid "accept refs that update .git/shallow"
 msgstr "accetta i riferimenti che aggiornano .git/shallow"
 
-#: builtin/fetch.c:189 builtin/pull.c:226
+#: builtin/fetch.c:193 builtin/pull.c:226
 msgid "refmap"
 msgstr "mappa riferimenti"
 
-#: builtin/fetch.c:190 builtin/pull.c:227
+#: builtin/fetch.c:194 builtin/pull.c:227
 msgid "specify fetch refmap"
 msgstr "specifica la mappa dei riferimenti per il fetch"
 
-#: builtin/fetch.c:197 builtin/pull.c:240
+#: builtin/fetch.c:201 builtin/pull.c:240
 msgid "report that we have only objects reachable from this object"
 msgstr "segnala che abbiamo solo oggetti raggiungibili da quest'oggetto"
 
-#: builtin/fetch.c:200
-msgid "run 'gc --auto' after fetching"
-msgstr "esegui 'gc --auto' dopo il fetch"
+#: builtin/fetch.c:204 builtin/fetch.c:206
+msgid "run 'maintenance --auto' after fetching"
+msgstr "esegui 'maintenance --auto' dopo il fetch"
 
-#: builtin/fetch.c:202 builtin/pull.c:243
+#: builtin/fetch.c:208 builtin/pull.c:243
 msgid "check for forced-updates on all updated branches"
 msgstr "controlla aggiornamenti forzati su tutti i branch aggiornati"
 
-#: builtin/fetch.c:204
+#: builtin/fetch.c:210
 msgid "write the commit-graph after fetching"
 msgstr "scrivi il grafo dei commit dopo il fetch"
 
-#: builtin/fetch.c:514
+#: builtin/fetch.c:212
+msgid "accept refspecs from stdin"
+msgstr "accetta gli specificatori riferimento dallo standard input"
+
+#: builtin/fetch.c:523
 msgid "Couldn't find remote ref HEAD"
 msgstr "Impossibile trovare l'HEAD del riferimento remoto"
 
-#: builtin/fetch.c:654
+#: builtin/fetch.c:677
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "il valore dell'opzione fetch.output contiene il valore non valido %s"
 
-#: builtin/fetch.c:752
+#: builtin/fetch.c:775
 #, c-format
 msgid "object %s not found"
 msgstr "oggetto %s non trovato"
 
-#: builtin/fetch.c:756
+#: builtin/fetch.c:779
 msgid "[up to date]"
 msgstr "[aggiornato]"
 
-#: builtin/fetch.c:769 builtin/fetch.c:785 builtin/fetch.c:857
+#: builtin/fetch.c:792 builtin/fetch.c:808 builtin/fetch.c:880
 msgid "[rejected]"
 msgstr "[rifiutato]"
 
-#: builtin/fetch.c:770
+#: builtin/fetch.c:793
 msgid "can't fetch in current branch"
 msgstr "impossibile eseguire il fetch nel branch corrente"
 
-#: builtin/fetch.c:780
+#: builtin/fetch.c:803
 msgid "[tag update]"
 msgstr "[tag aggiornato]"
 
-#: builtin/fetch.c:781 builtin/fetch.c:818 builtin/fetch.c:840
-#: builtin/fetch.c:852
+#: builtin/fetch.c:804 builtin/fetch.c:841 builtin/fetch.c:863
+#: builtin/fetch.c:875
 msgid "unable to update local ref"
 msgstr "impossibile aggiornare il riferimento locale"
 
-#: builtin/fetch.c:785
+#: builtin/fetch.c:808
 msgid "would clobber existing tag"
 msgstr "sovrascriverebbe il tag esistente"
 
-#: builtin/fetch.c:807
+#: builtin/fetch.c:830
 msgid "[new tag]"
 msgstr "[nuovo tag]"
 
-#: builtin/fetch.c:810
+#: builtin/fetch.c:833
 msgid "[new branch]"
 msgstr "[nuovo branch]"
 
-#: builtin/fetch.c:813
+#: builtin/fetch.c:836
 msgid "[new ref]"
 msgstr "[nuovo riferimento]"
 
-#: builtin/fetch.c:852
+#: builtin/fetch.c:875
 msgid "forced update"
 msgstr "aggiornamento forzato"
 
-#: builtin/fetch.c:857
+#: builtin/fetch.c:880
 msgid "non-fast-forward"
 msgstr "non fast forward"
 
-#: builtin/fetch.c:878
+#: builtin/fetch.c:901
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -14455,7 +14791,7 @@ msgstr ""
 "riabilitarlo, usa l'opzione '--show-forced-updates' o esegui 'git config\n"
 "fetch.showForcedUpdates true'."
 
-#: builtin/fetch.c:882
+#: builtin/fetch.c:905
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -14467,22 +14803,22 @@ msgstr ""
 "aggiornamenti forzati. Puoi usare '--no-show-forced-updates' o eseguire\n"
 "'git config fetch.showForcedUpdates false' per omettere questo controllo.\n"
 
-#: builtin/fetch.c:914
+#: builtin/fetch.c:939
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s non ha inviato tutti gli oggetti necessari\n"
 
-#: builtin/fetch.c:935
+#: builtin/fetch.c:960
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr "%s rifiutato perché non è consentito aggiornare radici shallow"
 
-#: builtin/fetch.c:1020 builtin/fetch.c:1158
+#: builtin/fetch.c:1053 builtin/fetch.c:1191
 #, c-format
 msgid "From %.*s\n"
 msgstr "Da %.*s\n"
 
-#: builtin/fetch.c:1031
+#: builtin/fetch.c:1064
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -14492,58 +14828,58 @@ msgstr ""
 "eseguire\n"
 " 'git remote prune %s' per rimuovere ogni branch vecchio in conflitto"
 
-#: builtin/fetch.c:1128
+#: builtin/fetch.c:1161
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s diventerà pendente)"
 
-#: builtin/fetch.c:1129
+#: builtin/fetch.c:1162
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s è diventato pendente)"
 
-#: builtin/fetch.c:1161
+#: builtin/fetch.c:1194
 msgid "[deleted]"
 msgstr "[eliminato]"
 
-#: builtin/fetch.c:1162 builtin/remote.c:1112
+#: builtin/fetch.c:1195 builtin/remote.c:1113
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: builtin/fetch.c:1185
+#: builtin/fetch.c:1218
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr ""
 "Mi rifiuto di eseguire il fetch nel branch corrente %s di un repository non "
 "bare"
 
-#: builtin/fetch.c:1204
+#: builtin/fetch.c:1237
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "L'opzione \"%s\" con il valore \"%s\" non è valida per %s"
 
-#: builtin/fetch.c:1207
+#: builtin/fetch.c:1240
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "L'opzione \"%s\" è ignorata per %s\n"
 
-#: builtin/fetch.c:1415
+#: builtin/fetch.c:1448
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "rilevati branch multipli, stato incompatibile con --set-upstream"
 
-#: builtin/fetch.c:1430
+#: builtin/fetch.c:1463
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "non imposto l'upstream per un branch remoto che ne traccia uno remoto"
 
-#: builtin/fetch.c:1432
+#: builtin/fetch.c:1465
 msgid "not setting upstream for a remote tag"
 msgstr "non imposto l'upstream per un tag remoto"
 
-#: builtin/fetch.c:1434
+#: builtin/fetch.c:1467
 msgid "unknown branch type"
 msgstr "tipo branch sconosciuto"
 
-#: builtin/fetch.c:1436
+#: builtin/fetch.c:1469
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -14551,22 +14887,22 @@ msgstr ""
 "nessun branch sorgente trovato.\n"
 "devi specificare esattamente un branch con l'opzione --set-upstream."
 
-#: builtin/fetch.c:1562 builtin/fetch.c:1625
+#: builtin/fetch.c:1598 builtin/fetch.c:1661
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Recupero di %s in corso\n"
 
-#: builtin/fetch.c:1572 builtin/fetch.c:1627 builtin/remote.c:101
+#: builtin/fetch.c:1608 builtin/fetch.c:1663 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Impossibile recuperare %s"
 
-#: builtin/fetch.c:1584
+#: builtin/fetch.c:1620
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "impossibile recuperare '%s' (codice di uscita: %d)\n"
 
-#: builtin/fetch.c:1687
+#: builtin/fetch.c:1724
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -14574,51 +14910,55 @@ msgstr ""
 "Non è stato specificato alcun repository remoto. Specifica un URL o il\n"
 "nome di un remoto da cui dovranno essere recuperate le nuove revisioni."
 
-#: builtin/fetch.c:1724
+#: builtin/fetch.c:1760
 msgid "You need to specify a tag name."
 msgstr "Devi specificare il nome di un tag."
 
-#: builtin/fetch.c:1778
+#: builtin/fetch.c:1825
 msgid "Negative depth in --deepen is not supported"
 msgstr "Le profondità negative in --deepen non sono supportate"
 
-#: builtin/fetch.c:1780
+#: builtin/fetch.c:1827
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "le opzioni --deepen e --depth sono mutualmente esclusive"
 
-#: builtin/fetch.c:1785
+#: builtin/fetch.c:1832
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth e --unshallow non possono essere usati insieme."
 
-#: builtin/fetch.c:1787
+#: builtin/fetch.c:1834
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow su un repository completo non ha senso"
 
-#: builtin/fetch.c:1800
+#: builtin/fetch.c:1851
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all non richiede un repository come argomento"
 
-#: builtin/fetch.c:1802
+#: builtin/fetch.c:1853
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all non ha senso con degli specificatori riferimento"
 
-#: builtin/fetch.c:1811
+#: builtin/fetch.c:1862
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Remoto o gruppo remoti non esistente: %s"
 
-#: builtin/fetch.c:1818
+#: builtin/fetch.c:1869
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "Recuperare un gruppo e specificare gli specificatori riferimento non ha senso"
 
-#: builtin/fetch.c:1836
+#: builtin/fetch.c:1887
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
 msgstr ""
 "--filter può essere usato solo con il remoto configurato nelle estensioni."
 "partialclone"
+
+#: builtin/fetch.c:1891
+msgid "--stdin can only be used when fetching from one remote"
+msgstr "--stdin può essere usato solo durante il fetch da un remoto"
 
 #: builtin/fmt-merge-msg.c:7
 msgid ""
@@ -14655,8 +14995,8 @@ msgid "git for-each-ref [--points-at <object>]"
 msgstr "git for-each-ref [--points-at <oggetto>]"
 
 #: builtin/for-each-ref.c:12
-msgid "git for-each-ref [(--merged | --no-merged) [<commit>]]"
-msgstr "git for-each-ref [(--merged | --no-merged) [<commit>]]"
+msgid "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
+msgstr "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
 
 #: builtin/for-each-ref.c:13
 msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
@@ -14853,7 +15193,7 @@ msgstr "Controllo directory oggetti in corso"
 msgid "Checking %s link"
 msgstr "Controllo collegamento %s"
 
-#: builtin/fsck.c:696 builtin/index-pack.c:843
+#: builtin/fsck.c:696 builtin/index-pack.c:871
 #, c-format
 msgid "invalid %s"
 msgstr "%s non valido"
@@ -14938,7 +15278,7 @@ msgstr "visualizza l'avanzamento"
 msgid "show verbose names for reachable objects"
 msgstr "visualizza nomi dettagliati per gli oggetti raggiungibili"
 
-#: builtin/fsck.c:847 builtin/index-pack.c:225
+#: builtin/fsck.c:847 builtin/index-pack.c:267
 msgid "Checking objects"
 msgstr "Controllo oggetti in corso"
 
@@ -14952,31 +15292,31 @@ msgstr "%s: oggetto mancante"
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "parametro non valido: atteso SHA1, presente '%s'"
 
-#: builtin/gc.c:35
+#: builtin/gc.c:36
 msgid "git gc [<options>]"
 msgstr "git gc [<opzioni>]"
 
-#: builtin/gc.c:90
+#: builtin/gc.c:91
 #, c-format
 msgid "Failed to fstat %s: %s"
 msgstr "fstat di %s non riuscito: %s"
 
-#: builtin/gc.c:126
+#: builtin/gc.c:127
 #, c-format
 msgid "failed to parse '%s' value '%s'"
 msgstr "analisi dell'opzione '%s' con valore '%s' non riuscita"
 
-#: builtin/gc.c:475 builtin/init-db.c:57
+#: builtin/gc.c:476 builtin/init-db.c:58
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "impossibile eseguire lo stat di '%s'"
 
-#: builtin/gc.c:484 builtin/notes.c:240 builtin/tag.c:530
+#: builtin/gc.c:485 builtin/notes.c:240 builtin/tag.c:530
 #, c-format
 msgid "cannot read '%s'"
 msgstr "impossibile leggere '%s'"
 
-#: builtin/gc.c:491
+#: builtin/gc.c:492
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
@@ -14992,56 +15332,56 @@ msgstr ""
 "\n"
 "%s"
 
-#: builtin/gc.c:539
+#: builtin/gc.c:540
 msgid "prune unreferenced objects"
 msgstr "elimina oggetti non referenziati"
 
-#: builtin/gc.c:541
+#: builtin/gc.c:542
 msgid "be more thorough (increased runtime)"
 msgstr "sii più accurato (tempi di esecuzione maggiori)"
 
-#: builtin/gc.c:542
+#: builtin/gc.c:543
 msgid "enable auto-gc mode"
 msgstr "abilita modalità garbage collector automatica"
 
-#: builtin/gc.c:545
+#: builtin/gc.c:546
 msgid "force running gc even if there may be another gc running"
 msgstr ""
 "forza l'esecuzione del garbage collector anche nel caso in cui ve ne "
 "potrebbe essere un altro in esecuzione"
 
-#: builtin/gc.c:548
+#: builtin/gc.c:549
 msgid "repack all other packs except the largest pack"
 msgstr ""
 "esegui il repack di tutti gli altri pack ad eccezione di quello più grande"
 
-#: builtin/gc.c:565
+#: builtin/gc.c:566
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "analisi del valore %s di gc.logexpiry non riuscita"
 
-#: builtin/gc.c:576
+#: builtin/gc.c:577
 #, c-format
 msgid "failed to parse prune expiry value %s"
 msgstr "analisi del valore %s per la scadenza delle eliminazioni non riuscita"
 
-#: builtin/gc.c:596
+#: builtin/gc.c:597
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
 "Comprimo il repository in background per ottenere le migliori prestazioni.\n"
 
-#: builtin/gc.c:598
+#: builtin/gc.c:599
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr "Comprimo il repository per ottenere le migliori prestazioni.\n"
 
-#: builtin/gc.c:599
+#: builtin/gc.c:600
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Vedi \"git help gc\" per le operazioni di manutenzione manuali.\n"
 
-#: builtin/gc.c:639
+#: builtin/gc.c:640
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -15049,12 +15389,66 @@ msgstr ""
 "gc è già in esecuzione sul computer '%s' con PID %<PRIuMAX> (usa --force se "
 "non lo è)"
 
-#: builtin/gc.c:694
+#: builtin/gc.c:695
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Ci sono troppi oggetti sparsi non raggiungibili; esegui 'git prune' per "
 "eliminarli."
+
+#: builtin/gc.c:705
+msgid "git maintenance run [--auto] [--[no-]quiet] [--task=<task>]"
+msgstr "git maintenance run [--auto] [--[no-]quiet] [--task=<attività>]"
+
+#: builtin/gc.c:812
+msgid "failed to write commit-graph"
+msgstr "scrittura del grafo dei commit non riuscita"
+
+#: builtin/gc.c:905
+#, c-format
+msgid "lock file '%s' exists, skipping maintenance"
+msgstr "il file di lock '%s' esiste, ignoro le attività di manutenzione"
+
+#: builtin/gc.c:932
+#, c-format
+msgid "task '%s' failed"
+msgstr "attività '%s' non riuscita"
+
+#: builtin/gc.c:979
+#, c-format
+msgid "'%s' is not a valid task"
+msgstr "'%s' non è un'attività valida"
+
+#: builtin/gc.c:984
+#, c-format
+msgid "task '%s' cannot be selected multiple times"
+msgstr "l'attività '%s' non può essere selezionata più volte"
+
+#: builtin/gc.c:999
+msgid "run tasks based on the state of the repository"
+msgstr "esegui delle attività in base allo stato del repository"
+
+#: builtin/gc.c:1001
+msgid "do not report progress or other information over stderr"
+msgstr ""
+"non visualizzare l'avanzamento o altre informazioni sullo standard error"
+
+#: builtin/gc.c:1002
+msgid "task"
+msgstr "attività"
+
+#: builtin/gc.c:1003
+msgid "run a specific task"
+msgstr "esegui un'attività specifica"
+
+#: builtin/gc.c:1026
+msgid "git maintenance run [<options>]"
+msgstr "git maintenance run [<opzioni>]"
+
+#: builtin/gc.c:1037
+#, c-format
+msgid "invalid subcommand: %s"
+msgstr "sottocomando non valido: %s"
 
 #: builtin/grep.c:30
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
@@ -15075,8 +15469,8 @@ msgstr "specificato numero non valido di thread (%d) per %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:287 builtin/index-pack.c:1537 builtin/index-pack.c:1727
-#: builtin/pack-objects.c:2904
+#: builtin/grep.c:287 builtin/index-pack.c:1581 builtin/index-pack.c:1771
+#: builtin/pack-objects.c:2936
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "non vi è supporto per i thread, ignoro %s"
@@ -15091,247 +15485,247 @@ msgstr "impossibile leggere il tree (%s)"
 msgid "unable to grep from object of type %s"
 msgstr "impossibile eseguire grep su un oggetto di tipo %s"
 
-#: builtin/grep.c:724
+#: builtin/grep.c:725
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "switch '%c' richiede un valore numerico"
 
-#: builtin/grep.c:823
+#: builtin/grep.c:824
 msgid "search in index instead of in the work tree"
 msgstr "cerca nell'index anziché nell'albero di lavoro"
 
-#: builtin/grep.c:825
+#: builtin/grep.c:826
 msgid "find in contents not managed by git"
 msgstr "la ricerca nei contenuti non è gestita da Git"
 
-#: builtin/grep.c:827
+#: builtin/grep.c:828
 msgid "search in both tracked and untracked files"
 msgstr "cerca sia nei file tracciati sia in quelli non tracciati"
 
-#: builtin/grep.c:829
+#: builtin/grep.c:830
 msgid "ignore files specified via '.gitignore'"
 msgstr "ignora i file specificati in '.gitignore'"
 
-#: builtin/grep.c:831
+#: builtin/grep.c:832
 msgid "recursively search in each submodule"
 msgstr "cerca ricorsivamente in ogni sottomodulo"
 
-#: builtin/grep.c:834
+#: builtin/grep.c:835
 msgid "show non-matching lines"
 msgstr "visualizza le righe non corrispondenti"
 
-#: builtin/grep.c:836
+#: builtin/grep.c:837
 msgid "case insensitive matching"
 msgstr "ricerca corrispondenze senza differenze maiuscole/minuscole"
 
-#: builtin/grep.c:838
+#: builtin/grep.c:839
 msgid "match patterns only at word boundaries"
 msgstr "cerca corrispondenze ai pattern solo a inizio/fine parola"
 
-#: builtin/grep.c:840
+#: builtin/grep.c:841
 msgid "process binary files as text"
 msgstr "elabora i file binari come testuali"
 
-#: builtin/grep.c:842
+#: builtin/grep.c:843
 msgid "don't match patterns in binary files"
 msgstr "non cercare corrispondenze ai pattern nei file binari"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:846
 msgid "process binary files with textconv filters"
 msgstr "elabora i file binari con filtri di conversione in testo"
 
-#: builtin/grep.c:847
+#: builtin/grep.c:848
 msgid "search in subdirectories (default)"
 msgstr "cerca nelle sottodirectory (impostazione predefinita)"
 
-#: builtin/grep.c:849
+#: builtin/grep.c:850
 msgid "descend at most <depth> levels"
 msgstr "scendi al più di <profondità> livelli"
 
-#: builtin/grep.c:853
+#: builtin/grep.c:854
 msgid "use extended POSIX regular expressions"
 msgstr "usa espressioni regolari POSIX estese"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:857
 msgid "use basic POSIX regular expressions (default)"
 msgstr "usa espressioni regolari POSIX di base (impostazione predefinita)"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:860
 msgid "interpret patterns as fixed strings"
 msgstr "interpreta i pattern come stringhe fisse"
 
-#: builtin/grep.c:862
+#: builtin/grep.c:863
 msgid "use Perl-compatible regular expressions"
 msgstr "usa espressioni regolari compatibili con Perl"
 
-#: builtin/grep.c:865
+#: builtin/grep.c:866
 msgid "show line numbers"
 msgstr "visualizza numeri di riga"
 
-#: builtin/grep.c:866
+#: builtin/grep.c:867
 msgid "show column number of first match"
 msgstr "visualizza il numero di colonna della prima corrispondenza"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:868
 msgid "don't show filenames"
 msgstr "non visualizzare i nomi file"
 
-#: builtin/grep.c:868
+#: builtin/grep.c:869
 msgid "show filenames"
 msgstr "visualizza i nomi file"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:871
 msgid "show filenames relative to top directory"
 msgstr "visualizza i nomi file relativi alla directory di primo livello"
 
-#: builtin/grep.c:872
+#: builtin/grep.c:873
 msgid "show only filenames instead of matching lines"
 msgstr "visualizza solo i nomi file anziché le righe corrispondenti"
 
-#: builtin/grep.c:874
+#: builtin/grep.c:875
 msgid "synonym for --files-with-matches"
 msgstr "sinonimo di --files-with-matches"
 
-#: builtin/grep.c:877
+#: builtin/grep.c:878
 msgid "show only the names of files without match"
 msgstr "visualizza solo i nomi dei file non corrispondenti"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:880
 msgid "print NUL after filenames"
 msgstr "stampa NUL dopo i nomi file"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:883
 msgid "show only matching parts of a line"
 msgstr "visualizza solo le parti corrispondenti di una riga"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:885
 msgid "show the number of matches instead of matching lines"
 msgstr "visualizza il numero di corrispondenze anziché le righe corrispondenti"
 
-#: builtin/grep.c:885
+#: builtin/grep.c:886
 msgid "highlight matches"
 msgstr "evidenzia corrispondenze"
 
-#: builtin/grep.c:887
+#: builtin/grep.c:888
 msgid "print empty line between matches from different files"
 msgstr "stampa una riga vuota fra le corrispondenze in file differenti"
 
-#: builtin/grep.c:889
+#: builtin/grep.c:890
 msgid "show filename only once above matches from same file"
 msgstr ""
 "visualizza il nome file solo una volta prima delle corrispondenze nello "
 "stesso file"
 
-#: builtin/grep.c:892
+#: builtin/grep.c:893
 msgid "show <n> context lines before and after matches"
 msgstr "visualizza <n> righe di contesto prima e dopo le corrispondenze"
 
-#: builtin/grep.c:895
+#: builtin/grep.c:896
 msgid "show <n> context lines before matches"
 msgstr "visualizza <n> righe di contesto prima delle corrispondenze"
 
-#: builtin/grep.c:897
+#: builtin/grep.c:898
 msgid "show <n> context lines after matches"
 msgstr "visualizza <n> righe di contesto dopo le corrispondenze"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:900
 msgid "use <n> worker threads"
 msgstr "usa <n> thread di lavoro"
 
-#: builtin/grep.c:900
+#: builtin/grep.c:901
 msgid "shortcut for -C NUM"
 msgstr "scorciatoia per -C NUM"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:904
 msgid "show a line with the function name before matches"
 msgstr "visualizza una riga con il nome funzione prima delle corrispondenze"
 
-#: builtin/grep.c:905
+#: builtin/grep.c:906
 msgid "show the surrounding function"
 msgstr "visualizza la funzione circostante"
 
-#: builtin/grep.c:908
+#: builtin/grep.c:909
 msgid "read patterns from file"
 msgstr "leggi le corrispondenze da un file"
 
-#: builtin/grep.c:910
+#: builtin/grep.c:911
 msgid "match <pattern>"
 msgstr "cerca corrispondenze con <pattern>"
 
-#: builtin/grep.c:912
+#: builtin/grep.c:913
 msgid "combine patterns specified with -e"
 msgstr "combina i pattern specificati con -e"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:925
 msgid "indicate hit with exit status without output"
 msgstr ""
 "segnala una corrispondenza con il codice di uscita senza emettere output"
 
-#: builtin/grep.c:926
+#: builtin/grep.c:927
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "visualizza solo le corrispondenze nei file in cui vi sono corrispondenze per "
 "tutti i pattern"
 
-#: builtin/grep.c:928
+#: builtin/grep.c:929
 msgid "show parse tree for grep expression"
 msgstr "visualizza l'albero di analisi per l'espressione grep"
 
-#: builtin/grep.c:932
+#: builtin/grep.c:933
 msgid "pager"
 msgstr "pager"
 
-#: builtin/grep.c:932
+#: builtin/grep.c:933
 msgid "show matching files in the pager"
 msgstr "visualizza i file corrispondenti nel pager"
 
-#: builtin/grep.c:936
+#: builtin/grep.c:937
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "consenti"
 
-#: builtin/grep.c:1003
+#: builtin/grep.c:1004
 msgid "no pattern given"
 msgstr "nessun pattern specificato"
 
-#: builtin/grep.c:1039
+#: builtin/grep.c:1040
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index o --untracked non possono essere usate con le revisioni"
 
-#: builtin/grep.c:1047
+#: builtin/grep.c:1048
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "impossibile risolvere la revisione %s"
 
-#: builtin/grep.c:1077
+#: builtin/grep.c:1078
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "l'opzione --untracked non è supportata con --recurse-submodules"
 
-#: builtin/grep.c:1081
+#: builtin/grep.c:1082
 msgid "invalid option combination, ignoring --threads"
 msgstr "combinazione di opzioni non valida, ignoro --threads"
 
-#: builtin/grep.c:1084 builtin/pack-objects.c:3623
+#: builtin/grep.c:1085 builtin/pack-objects.c:3655
 msgid "no threads support, ignoring --threads"
 msgstr "non vi è supporto per i thread, ignoro --threads"
 
-#: builtin/grep.c:1087 builtin/index-pack.c:1534 builtin/pack-objects.c:2901
+#: builtin/grep.c:1088 builtin/index-pack.c:1578 builtin/pack-objects.c:2933
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "specificato numero non valido di thread (%d)"
 
-#: builtin/grep.c:1121
+#: builtin/grep.c:1122
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "--open-files-in-pager funziona solo sull'albero di lavoro"
 
-#: builtin/grep.c:1147
+#: builtin/grep.c:1148
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached o --untracked non possono essere usate con --no-index"
 
-#: builtin/grep.c:1153
+#: builtin/grep.c:1154
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr "--[no-]exclude-standard non può essere usata per i contenuti tracciati"
 
-#: builtin/grep.c:1161
+#: builtin/grep.c:1162
 msgid "both --cached and trees are given"
 msgstr "sono specificati sia --cached sia degli alberi"
 
@@ -15469,7 +15863,7 @@ msgstr "nessun visualizzatore info ha gestito la richiesta"
 msgid "'%s' is aliased to '%s'"
 msgstr "'%s' è un alias di '%s'"
 
-#: builtin/help.c:534 git.c:367
+#: builtin/help.c:534 git.c:369
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "stringa alias.%s non valida: %s"
@@ -15483,392 +15877,392 @@ msgstr "uso: %s%s"
 msgid "'git help config' for more information"
 msgstr "Vedi 'git help config' per maggiori informazioni"
 
-#: builtin/index-pack.c:185
+#: builtin/index-pack.c:227
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "tipo oggetto non corrispondente in %s"
 
-#: builtin/index-pack.c:205
+#: builtin/index-pack.c:247
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "non si è ricevuto l'oggetto atteso %s"
 
-#: builtin/index-pack.c:208
+#: builtin/index-pack.c:250
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "oggetto %s: atteso tipo %s, trovato %s"
 
-#: builtin/index-pack.c:258
+#: builtin/index-pack.c:300
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "impossibile riempire %d byte"
 msgstr[1] "impossibile riempire %d byte"
 
-#: builtin/index-pack.c:268
+#: builtin/index-pack.c:310
 msgid "early EOF"
 msgstr "EOF prematuro"
 
-#: builtin/index-pack.c:269
+#: builtin/index-pack.c:311
 msgid "read error on input"
 msgstr "errore di lettura in input"
 
-#: builtin/index-pack.c:281
+#: builtin/index-pack.c:323
 msgid "used more bytes than were available"
 msgstr "usati più byte di quelli disponibili"
 
-#: builtin/index-pack.c:288 builtin/pack-objects.c:618
+#: builtin/index-pack.c:330 builtin/pack-objects.c:619
 msgid "pack too large for current definition of off_t"
 msgstr "pack troppo largo per la definizione corrente di off_t"
 
-#: builtin/index-pack.c:291 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:333 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "il pack supera la dimensione massima consentita"
 
-#: builtin/index-pack.c:306 builtin/repack.c:250
+#: builtin/index-pack.c:348 builtin/repack.c:254
 #, c-format
 msgid "unable to create '%s'"
 msgstr "impossibile creare '%s'"
 
-#: builtin/index-pack.c:312
+#: builtin/index-pack.c:354
 #, c-format
 msgid "cannot open packfile '%s'"
 msgstr "impossibile aprire il file pack '%s'"
 
-#: builtin/index-pack.c:326
+#: builtin/index-pack.c:368
 msgid "pack signature mismatch"
 msgstr "la firma del pack non coincide"
 
-#: builtin/index-pack.c:328
+#: builtin/index-pack.c:370
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "versione pack %<PRIu32> non supportata"
 
-#: builtin/index-pack.c:346
+#: builtin/index-pack.c:388
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "il pack ha un oggetto danneggiato all'offset %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:466
+#: builtin/index-pack.c:494
 #, c-format
 msgid "inflate returned %d"
 msgstr "inflate ha restituito il codice %d"
 
-#: builtin/index-pack.c:515
+#: builtin/index-pack.c:543
 msgid "offset value overflow for delta base object"
 msgstr "overflow del valore dell'offset base del delta"
 
-#: builtin/index-pack.c:523
+#: builtin/index-pack.c:551
 msgid "delta base offset is out of bound"
 msgstr "l'offset base del delta è fuori dall'intervallo consentito"
 
-#: builtin/index-pack.c:531
+#: builtin/index-pack.c:559
 #, c-format
 msgid "unknown object type %d"
 msgstr "tipo oggetto %d sconosciuto"
 
-#: builtin/index-pack.c:562
+#: builtin/index-pack.c:590
 msgid "cannot pread pack file"
 msgstr "impossibile eseguire pread sul file pack"
 
-#: builtin/index-pack.c:564
+#: builtin/index-pack.c:592
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "fine del file pack prematura, %<PRIuMAX> byte mancante"
 msgstr[1] "fine del file pack prematura, %<PRIuMAX> byte mancanti"
 
-#: builtin/index-pack.c:590
+#: builtin/index-pack.c:618
 msgid "serious inflate inconsistency"
 msgstr "inconsistenza grave di inflate"
 
-#: builtin/index-pack.c:735 builtin/index-pack.c:741 builtin/index-pack.c:765
-#: builtin/index-pack.c:804 builtin/index-pack.c:813
+#: builtin/index-pack.c:763 builtin/index-pack.c:769 builtin/index-pack.c:793
+#: builtin/index-pack.c:832 builtin/index-pack.c:841
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "TROVATA COLLISIONE SHA1 CON %s !"
 
-#: builtin/index-pack.c:738 builtin/pack-objects.c:170
-#: builtin/pack-objects.c:230 builtin/pack-objects.c:325
+#: builtin/index-pack.c:766 builtin/pack-objects.c:171
+#: builtin/pack-objects.c:231 builtin/pack-objects.c:326
 #, c-format
 msgid "unable to read %s"
 msgstr "impossibile leggere %s"
 
-#: builtin/index-pack.c:802
+#: builtin/index-pack.c:830
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "impossibile leggere le informazioni sull'oggetto esistente: %s"
 
-#: builtin/index-pack.c:810
+#: builtin/index-pack.c:838
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "non è possibile leggere l'oggetto %s esistente"
 
-#: builtin/index-pack.c:824
+#: builtin/index-pack.c:852
 #, c-format
 msgid "invalid blob object %s"
 msgstr "oggetto blob %s non valido"
 
-#: builtin/index-pack.c:827 builtin/index-pack.c:846
+#: builtin/index-pack.c:855 builtin/index-pack.c:874
 msgid "fsck error in packed object"
 msgstr "errore fsck nell'oggetto sottoposto a pack"
 
-#: builtin/index-pack.c:848
+#: builtin/index-pack.c:876
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Non tutti gli oggetti figlio di %s sono raggiungibili"
 
-#: builtin/index-pack.c:920 builtin/index-pack.c:951
+#: builtin/index-pack.c:940 builtin/index-pack.c:987
 msgid "failed to apply delta"
 msgstr "applicazione del delta non riuscita"
 
-#: builtin/index-pack.c:1121
+#: builtin/index-pack.c:1166
 msgid "Receiving objects"
 msgstr "Ricezione degli oggetti"
 
-#: builtin/index-pack.c:1121
+#: builtin/index-pack.c:1166
 msgid "Indexing objects"
 msgstr "Indicizzazione degli oggetti"
 
-#: builtin/index-pack.c:1155
+#: builtin/index-pack.c:1200
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "il pack è corrotto (SHA1 non corrisponde)"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1205
 msgid "cannot fstat packfile"
 msgstr "impossibile eseguire fstat sul file pack"
 
-#: builtin/index-pack.c:1163
+#: builtin/index-pack.c:1208
 msgid "pack has junk at the end"
 msgstr "il pack ha dati inutili alla fine"
 
-#: builtin/index-pack.c:1175
+#: builtin/index-pack.c:1220
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "confusione oltre ogni follia in parse_pack_objects()"
 
-#: builtin/index-pack.c:1198
+#: builtin/index-pack.c:1243
 msgid "Resolving deltas"
 msgstr "Risoluzione dei delta"
 
-#: builtin/index-pack.c:1208 builtin/pack-objects.c:2665
+#: builtin/index-pack.c:1254 builtin/pack-objects.c:2697
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "impossibile creare il thread: %s"
 
-#: builtin/index-pack.c:1249
+#: builtin/index-pack.c:1287
 msgid "confusion beyond insanity"
 msgstr "confusione oltre ogni follia"
 
-#: builtin/index-pack.c:1255
+#: builtin/index-pack.c:1293
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "completato con %d oggetto locale"
 msgstr[1] "completato con %d oggetti locali"
 
-#: builtin/index-pack.c:1267
+#: builtin/index-pack.c:1305
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Checksum in coda inatteso per %s (disco corrotto?)"
 
-#: builtin/index-pack.c:1271
+#: builtin/index-pack.c:1309
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "pack ha %d delta irrisolto"
 msgstr[1] "pack ha %d delta irrisolti"
 
-#: builtin/index-pack.c:1295
+#: builtin/index-pack.c:1333
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "impossibile eseguire deflate sull'oggetto aggiunto alla fine (%d)"
 
-#: builtin/index-pack.c:1391
+#: builtin/index-pack.c:1429
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "l'oggetto locale %s è corrotto"
 
-#: builtin/index-pack.c:1405
+#: builtin/index-pack.c:1449
 #, c-format
 msgid "packfile name '%s' does not end with '.pack'"
 msgstr "il nome del file pack '%s' non termina con '.pack'"
 
-#: builtin/index-pack.c:1430
+#: builtin/index-pack.c:1474
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "impossibile scrivere il file %s '%s'"
 
-#: builtin/index-pack.c:1438
+#: builtin/index-pack.c:1482
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "impossibile chiudere il file %s scritto '%s'"
 
-#: builtin/index-pack.c:1462
+#: builtin/index-pack.c:1506
 msgid "error while closing pack file"
 msgstr "errore nella chiusura del file pack"
 
-#: builtin/index-pack.c:1476
+#: builtin/index-pack.c:1520
 msgid "cannot store pack file"
 msgstr "impossibile archiviare il file pack"
 
-#: builtin/index-pack.c:1484
+#: builtin/index-pack.c:1528
 msgid "cannot store index file"
 msgstr "impossibile archiviare index file"
 
-#: builtin/index-pack.c:1528 builtin/pack-objects.c:2912
+#: builtin/index-pack.c:1572 builtin/pack-objects.c:2944
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "pack.indexversion=%<PRIu32> non valida"
 
-#: builtin/index-pack.c:1592
+#: builtin/index-pack.c:1636
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Impossibile aprire il file pack '%s' esistente"
 
-#: builtin/index-pack.c:1594
+#: builtin/index-pack.c:1638
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Impossibile aprire il file pack idx esistente per '%s'"
 
-#: builtin/index-pack.c:1642
+#: builtin/index-pack.c:1686
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "non delta: %d oggetto"
 msgstr[1] "non delta: %d oggetti"
 
-#: builtin/index-pack.c:1649
+#: builtin/index-pack.c:1693
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "lunghezza della catena = %d: %lu oggetto"
 msgstr[1] "lunghezza della catena = %d: %lu oggetti"
 
-#: builtin/index-pack.c:1689
+#: builtin/index-pack.c:1733
 msgid "Cannot come back to cwd"
 msgstr "impossibile tornare alla directory di lavoro corrente"
 
-#: builtin/index-pack.c:1738 builtin/index-pack.c:1741
-#: builtin/index-pack.c:1757 builtin/index-pack.c:1761
+#: builtin/index-pack.c:1782 builtin/index-pack.c:1785
+#: builtin/index-pack.c:1801 builtin/index-pack.c:1805
 #, c-format
 msgid "bad %s"
 msgstr "%s errato"
 
-#: builtin/index-pack.c:1767 builtin/init-db.c:392 builtin/init-db.c:621
+#: builtin/index-pack.c:1811 builtin/init-db.c:391 builtin/init-db.c:623
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algoritmo hash '%s' sconosciuto"
 
-#: builtin/index-pack.c:1782
+#: builtin/index-pack.c:1826
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin non può essere usato senza --stdin"
 
-#: builtin/index-pack.c:1784
+#: builtin/index-pack.c:1828
 msgid "--stdin requires a git repository"
 msgstr "--stdin richiede un repository Git"
 
-#: builtin/index-pack.c:1786
+#: builtin/index-pack.c:1830
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format non può essere usato con --stdin"
 
-#: builtin/index-pack.c:1792
+#: builtin/index-pack.c:1836
 msgid "--verify with no packfile name given"
 msgstr "--verify senza un nome del file pack specificato"
 
-#: builtin/index-pack.c:1840 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1897 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "errore fsck negli oggetti sottoposti a pack"
 
-#: builtin/init-db.c:63
+#: builtin/init-db.c:64
 #, c-format
 msgid "cannot stat template '%s'"
 msgstr "impossibile eseguire stat sul modello '%s'"
 
-#: builtin/init-db.c:68
+#: builtin/init-db.c:69
 #, c-format
 msgid "cannot opendir '%s'"
 msgstr "impossibile aprire la directory '%s'"
 
-#: builtin/init-db.c:80
+#: builtin/init-db.c:81
 #, c-format
 msgid "cannot readlink '%s'"
 msgstr "impossibile leggere il link '%s'"
 
-#: builtin/init-db.c:82
+#: builtin/init-db.c:83
 #, c-format
 msgid "cannot symlink '%s' '%s'"
 msgstr "impossibile creare il collegamento simbolico da '%s' a '%s'"
 
-#: builtin/init-db.c:88
+#: builtin/init-db.c:89
 #, c-format
 msgid "cannot copy '%s' to '%s'"
 msgstr "impossibile copiare '%s' in '%s'"
 
-#: builtin/init-db.c:92
+#: builtin/init-db.c:93
 #, c-format
 msgid "ignoring template %s"
 msgstr "ignoro il modello %s"
 
-#: builtin/init-db.c:123
+#: builtin/init-db.c:124
 #, c-format
 msgid "templates not found in %s"
 msgstr "modelli non trovati in %s"
 
-#: builtin/init-db.c:138
+#: builtin/init-db.c:139
 #, c-format
 msgid "not copying templates from '%s': %s"
 msgstr "non copio i modelli da '%s': %s"
 
-#: builtin/init-db.c:276
+#: builtin/init-db.c:274
 #, c-format
 msgid "invalid initial branch name: '%s'"
 msgstr "nome branch iniziale non valido: '%s'"
 
-#: builtin/init-db.c:368
+#: builtin/init-db.c:366
 #, c-format
 msgid "unable to handle file type %d"
 msgstr "impossibile gestire il tipo di file %d"
 
-#: builtin/init-db.c:371
+#: builtin/init-db.c:369
 #, c-format
 msgid "unable to move %s to %s"
 msgstr "impossibile spostare %s in %s"
 
-#: builtin/init-db.c:386
+#: builtin/init-db.c:385
 msgid "attempt to reinitialize repository with different hash"
 msgstr "tentativo di reinizializzare il repository con un hash differente"
 
-#: builtin/init-db.c:410 builtin/init-db.c:413
+#: builtin/init-db.c:409 builtin/init-db.c:412
 #, c-format
 msgid "%s already exists"
 msgstr "%s esiste già"
 
-#: builtin/init-db.c:444
+#: builtin/init-db.c:443
 #, c-format
 msgid "re-init: ignored --initial-branch=%s"
 msgstr "re-init: opzione --initial-branch=%s ignorata"
 
-#: builtin/init-db.c:475
+#: builtin/init-db.c:474
 #, c-format
 msgid "Reinitialized existing shared Git repository in %s%s\n"
 msgstr "Reinizializzato repository Git condiviso esistente in %s%s\n"
 
-#: builtin/init-db.c:476
+#: builtin/init-db.c:475
 #, c-format
 msgid "Reinitialized existing Git repository in %s%s\n"
 msgstr "Reinizializzato repository Git esistente in %s%s\n"
 
-#: builtin/init-db.c:480
+#: builtin/init-db.c:479
 #, c-format
 msgid "Initialized empty shared Git repository in %s%s\n"
 msgstr "Inizializzato repository Git condiviso vuoto in %s%s\n"
 
-#: builtin/init-db.c:481
+#: builtin/init-db.c:480
 #, c-format
 msgid "Initialized empty Git repository in %s%s\n"
 msgstr "Inizializzato repository Git vuoto in %s%s\n"
 
-#: builtin/init-db.c:530
+#: builtin/init-db.c:529
 msgid ""
 "git init [-q | --quiet] [--bare] [--template=<template-directory>] [--"
 "shared[=<permissions>]] [<directory>]"
@@ -15876,37 +16270,41 @@ msgstr ""
 "git init [-q | --quiet] [--bare] [--template=<directory-modello>] [--"
 "shared[=<permessi>]] [<directory>]"
 
-#: builtin/init-db.c:556
+#: builtin/init-db.c:555
 msgid "permissions"
 msgstr "permessi"
 
-#: builtin/init-db.c:557
+#: builtin/init-db.c:556
 msgid "specify that the git repository is to be shared amongst several users"
 msgstr "specifica che il repository Git deve essere condiviso con più utenti"
 
-#: builtin/init-db.c:563
+#: builtin/init-db.c:562
 msgid "override the name of the initial branch"
 msgstr "esegui l'override del nome del branch iniziale"
 
-#: builtin/init-db.c:564
+#: builtin/init-db.c:563 builtin/verify-pack.c:74
 msgid "hash"
 msgstr "hash"
 
-#: builtin/init-db.c:565 builtin/show-index.c:22
+#: builtin/init-db.c:564 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "specifica l'algoritmo hash da usare"
 
-#: builtin/init-db.c:598 builtin/init-db.c:603
+#: builtin/init-db.c:571
+msgid "--separate-git-dir and --bare are mutually exclusive"
+msgstr "le opzioni --separate-git-dir e --bare sono mutualmente esclusive"
+
+#: builtin/init-db.c:600 builtin/init-db.c:605
 #, c-format
 msgid "cannot mkdir %s"
 msgstr "impossibile creare la directory %s"
 
-#: builtin/init-db.c:607
+#: builtin/init-db.c:609 builtin/init-db.c:664
 #, c-format
 msgid "cannot chdir to %s"
 msgstr "impossibile modificare la directory corrente in %s"
 
-#: builtin/init-db.c:634
+#: builtin/init-db.c:636
 #, c-format
 msgid ""
 "%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
@@ -15915,10 +16313,14 @@ msgstr ""
 "%s (o --work-tree=<directory>) non consentito senza specificare %s (o --git-"
 "dir=<directory>)"
 
-#: builtin/init-db.c:662
+#: builtin/init-db.c:688
 #, c-format
 msgid "Cannot access work tree '%s'"
 msgstr "Impossibile accedere all'albero di lavoro '%s'"
+
+#: builtin/init-db.c:693
+msgid "--separate-git-dir incompatible with bare repository"
+msgstr "--separate-git-dir non è compatibile con un repository bare"
 
 #: builtin/interpret-trailers.c:16
 msgid ""
@@ -15984,126 +16386,126 @@ msgstr "--trailer con --only-input non ha senso"
 msgid "no input file given for in-place editing"
 msgstr "nessun file di input specificato per la modifica sul posto"
 
-#: builtin/log.c:57
+#: builtin/log.c:56
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git log [<opzioni>] [<intervallo-revisioni>] [[--] <percorso>...]"
 
-#: builtin/log.c:58
+#: builtin/log.c:57
 msgid "git show [<options>] <object>..."
 msgstr "git show [<opzioni>] <oggetto>..."
 
-#: builtin/log.c:111
+#: builtin/log.c:110
 #, c-format
 msgid "invalid --decorate option: %s"
 msgstr "opzione --decorate non valida: %s"
 
-#: builtin/log.c:178
+#: builtin/log.c:177
 msgid "show source"
 msgstr "visualizza sorgente"
 
-#: builtin/log.c:179
+#: builtin/log.c:178
 msgid "Use mail map file"
 msgstr "Usa il file mappatura e-mail"
 
-#: builtin/log.c:182
+#: builtin/log.c:181
 msgid "only decorate refs that match <pattern>"
 msgstr "decora solo i riferimenti corrispondenti a <pattern>"
 
-#: builtin/log.c:184
+#: builtin/log.c:183
 msgid "do not decorate refs that match <pattern>"
 msgstr "non decorare i riferimenti corrispondenti a <pattern>"
 
-#: builtin/log.c:185
+#: builtin/log.c:184
 msgid "decorate options"
 msgstr "opzioni decorazione"
 
-#: builtin/log.c:188
+#: builtin/log.c:187
 msgid "Process line range n,m in file, counting from 1"
 msgstr "Elabora l'intervallo righe n,m nel file, contandole da 1"
 
-#: builtin/log.c:298
+#: builtin/log.c:297
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Output finale: %d %s\n"
 
-#: builtin/log.c:556
+#: builtin/log.c:555
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: file non valido"
 
-#: builtin/log.c:571 builtin/log.c:666
+#: builtin/log.c:570 builtin/log.c:665
 #, c-format
 msgid "could not read object %s"
 msgstr "impossibile leggere l'oggetto %s"
 
-#: builtin/log.c:691
+#: builtin/log.c:690
 #, c-format
 msgid "unknown type: %d"
 msgstr "tipo sconosciuto: %d"
 
-#: builtin/log.c:835
+#: builtin/log.c:839
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr "%s: modo lettera da descrizione non valido"
 
-#: builtin/log.c:842
+#: builtin/log.c:846
 msgid "format.headers without value"
 msgstr "format.headers non ha alcun valore"
 
-#: builtin/log.c:957
+#: builtin/log.c:965
 msgid "name of output directory is too long"
 msgstr "il nome della directory di output è troppo lungo"
 
-#: builtin/log.c:973
+#: builtin/log.c:981
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "impossibile aprire il file patch %s"
 
-#: builtin/log.c:990
+#: builtin/log.c:998
 msgid "need exactly one range"
 msgstr "è necessario specificare esattamente un intervallo"
 
-#: builtin/log.c:1000
+#: builtin/log.c:1008
 msgid "not a range"
 msgstr "il valore non è un intervallo"
 
-#: builtin/log.c:1164
+#: builtin/log.c:1172
 msgid "cover letter needs email format"
 msgstr "la lettera di accompagnamento dev'essere in formato e-mail"
 
-#: builtin/log.c:1170
+#: builtin/log.c:1178
 msgid "failed to create cover-letter file"
 msgstr "creazione del file lettera di accompagnamento non riuscita"
 
-#: builtin/log.c:1249
+#: builtin/log.c:1259
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "valore in-reply-to folle: %s"
 
-#: builtin/log.c:1276
+#: builtin/log.c:1286
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<opzioni>] [<da> | <intervallo revisioni>]"
 
-#: builtin/log.c:1334
+#: builtin/log.c:1344
 msgid "two output directories?"
 msgstr "due directory di output?"
 
-#: builtin/log.c:1445 builtin/log.c:2217 builtin/log.c:2219 builtin/log.c:2231
+#: builtin/log.c:1495 builtin/log.c:2301 builtin/log.c:2303 builtin/log.c:2315
 #, c-format
 msgid "unknown commit %s"
 msgstr "commit %s sconosciuto"
 
-#: builtin/log.c:1455 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1506 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "impossibile risolvere '%s' come riferimento valido"
 
-#: builtin/log.c:1460
+#: builtin/log.c:1515
 msgid "could not find exact merge base"
 msgstr "impossibile trovare esattamente la base del merge"
 
-#: builtin/log.c:1464
+#: builtin/log.c:1525
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -16115,288 +16517,293 @@ msgstr ""
 "In alternativa puoi specificare manualmente il commit di base con\n"
 "--base=<ID commit di base>"
 
-#: builtin/log.c:1484
+#: builtin/log.c:1548
 msgid "failed to find exact merge base"
 msgstr "impossibile trovare esattamente la base del merge"
 
-#: builtin/log.c:1495
+#: builtin/log.c:1565
 msgid "base commit should be the ancestor of revision list"
 msgstr "il commit di base dovrebbe essere l'antenato dell'elenco revisioni"
 
-#: builtin/log.c:1499
+#: builtin/log.c:1575
 msgid "base commit shouldn't be in revision list"
 msgstr "il commit di base non dovrebbe essere nell'elenco revisioni"
 
-#: builtin/log.c:1552
+#: builtin/log.c:1633
 msgid "cannot get patch id"
 msgstr "impossibile ottenere l'ID della patch"
 
-#: builtin/log.c:1604
-msgid "failed to infer range-diff ranges"
-msgstr "inferenza degli intervalli range-diff non riuscita"
+#: builtin/log.c:1690
+msgid "failed to infer range-diff origin of current series"
+msgstr "inferenza dell'origine range-diff della serie corrente non riuscita"
 
-#: builtin/log.c:1650
+#: builtin/log.c:1692
+#, c-format
+msgid "using '%s' as range-diff origin of current series"
+msgstr "uso '%s' come origine range-diff della serie corrente"
+
+#: builtin/log.c:1736
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "usa [PATCH n/m] anche con una singola patch"
 
-#: builtin/log.c:1653
+#: builtin/log.c:1739
 msgid "use [PATCH] even with multiple patches"
 msgstr "usa [PATCH] anche con più patch"
 
-#: builtin/log.c:1657
+#: builtin/log.c:1743
 msgid "print patches to standard out"
 msgstr "stampa le patch sullo standard output"
 
-#: builtin/log.c:1659
+#: builtin/log.c:1745
 msgid "generate a cover letter"
 msgstr "genera una lettera di accompagnamento"
 
-#: builtin/log.c:1661
+#: builtin/log.c:1747
 msgid "use simple number sequence for output file names"
 msgstr "usa una sequenza numerica semplice per i nomi file di output"
 
-#: builtin/log.c:1662
+#: builtin/log.c:1748
 msgid "sfx"
 msgstr "suff"
 
-#: builtin/log.c:1663
+#: builtin/log.c:1749
 msgid "use <sfx> instead of '.patch'"
 msgstr "usa <suff> anziché '.patch'"
 
-#: builtin/log.c:1665
+#: builtin/log.c:1751
 msgid "start numbering patches at <n> instead of 1"
 msgstr "inizia a numerare le patch da <n> anziché da 1"
 
-#: builtin/log.c:1667
+#: builtin/log.c:1753
 msgid "mark the series as Nth re-roll"
 msgstr "contrassegna la serie come l'n-esima versione revisionata"
 
-#: builtin/log.c:1669
+#: builtin/log.c:1755
 msgid "Use [RFC PATCH] instead of [PATCH]"
 msgstr "Usa [RFC PATCH] anziché [PATCH]"
 
-#: builtin/log.c:1672
+#: builtin/log.c:1758
 msgid "cover-from-description-mode"
 msgstr "modo-lettera-da-descrizione"
 
-#: builtin/log.c:1673
+#: builtin/log.c:1759
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
 "genera parti di una lettera d'accompagnamento basandosi sulla descrizione di "
 "un branch"
 
-#: builtin/log.c:1675
+#: builtin/log.c:1761
 msgid "Use [<prefix>] instead of [PATCH]"
 msgstr "Usa [<prefisso>] anziché [PATCH]"
 
-#: builtin/log.c:1678
+#: builtin/log.c:1764
 msgid "store resulting files in <dir>"
 msgstr "salva i file risultanti in <dir>"
 
-#: builtin/log.c:1681
+#: builtin/log.c:1767
 msgid "don't strip/add [PATCH]"
 msgstr "non eliminare/aggiungere [PATCH]"
 
-#: builtin/log.c:1684
+#: builtin/log.c:1770
 msgid "don't output binary diffs"
 msgstr "non mandare in output diff binari"
 
-#: builtin/log.c:1686
+#: builtin/log.c:1772
 msgid "output all-zero hash in From header"
 msgstr "manda in output un hash costituito da soli zeri nell'intestazione From"
 
-#: builtin/log.c:1688
+#: builtin/log.c:1774
 msgid "don't include a patch matching a commit upstream"
 msgstr "non includere una patch corrispondente a un commit upstream"
 
-#: builtin/log.c:1690
+#: builtin/log.c:1776
 msgid "show patch format instead of default (patch + stat)"
 msgstr ""
 "visualizza il formato della patch anziché l'impostazione predefinita (patch "
 "+ stat)"
 
-#: builtin/log.c:1692
+#: builtin/log.c:1778
 msgid "Messaging"
 msgstr "Messaggistica"
 
-#: builtin/log.c:1693
+#: builtin/log.c:1779
 msgid "header"
 msgstr "intestazione"
 
-#: builtin/log.c:1694
+#: builtin/log.c:1780
 msgid "add email header"
 msgstr "aggiungi intestazione e-mail"
 
-#: builtin/log.c:1695 builtin/log.c:1696
+#: builtin/log.c:1781 builtin/log.c:1782
 msgid "email"
 msgstr "e-mail"
 
-#: builtin/log.c:1695
+#: builtin/log.c:1781
 msgid "add To: header"
 msgstr "aggiungi intestazione A:"
 
-#: builtin/log.c:1696
+#: builtin/log.c:1782
 msgid "add Cc: header"
 msgstr "aggiungi intestazione Cc:"
 
-#: builtin/log.c:1697
+#: builtin/log.c:1783
 msgid "ident"
 msgstr "identità"
 
-#: builtin/log.c:1698
+#: builtin/log.c:1784
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "imposta l'indirizzo Da a <identità> (o all'identità di chi ha creato il "
 "commit se assente)"
 
-#: builtin/log.c:1700
+#: builtin/log.c:1786
 msgid "message-id"
 msgstr "ID messaggio"
 
-#: builtin/log.c:1701
+#: builtin/log.c:1787
 msgid "make first mail a reply to <message-id>"
 msgstr "rendi la prima e-mail una risposta a <ID messaggio>"
 
-#: builtin/log.c:1702 builtin/log.c:1705
+#: builtin/log.c:1788 builtin/log.c:1791
 msgid "boundary"
 msgstr "delimitatore"
 
-#: builtin/log.c:1703
+#: builtin/log.c:1789
 msgid "attach the patch"
 msgstr "allega la patch"
 
-#: builtin/log.c:1706
+#: builtin/log.c:1792
 msgid "inline the patch"
 msgstr "includi la patch nel messaggio"
 
-#: builtin/log.c:1710
+#: builtin/log.c:1796
 msgid "enable message threading, styles: shallow, deep"
 msgstr ""
 "abilita il raggruppamento messaggi per conversazione, stili: superficiale, "
 "profondo"
 
-#: builtin/log.c:1712
+#: builtin/log.c:1798
 msgid "signature"
 msgstr "firma"
 
-#: builtin/log.c:1713
+#: builtin/log.c:1799
 msgid "add a signature"
 msgstr "aggiungi una firma"
 
-#: builtin/log.c:1714
+#: builtin/log.c:1800
 msgid "base-commit"
 msgstr "commit di base"
 
-#: builtin/log.c:1715
+#: builtin/log.c:1801
 msgid "add prerequisite tree info to the patch series"
 msgstr ""
 "aggiungi le informazioni prerequisito per l'albero alla serie delle patch"
 
-#: builtin/log.c:1717
+#: builtin/log.c:1804
 msgid "add a signature from a file"
 msgstr "aggiungi una firma da file"
 
-#: builtin/log.c:1718
+#: builtin/log.c:1805
 msgid "don't print the patch filenames"
 msgstr "non stampare i nomi file delle patch"
 
-#: builtin/log.c:1720
+#: builtin/log.c:1807
 msgid "show progress while generating patches"
 msgstr "visualizza l'avanzamento dell'operazione di generazione patch"
 
-#: builtin/log.c:1722
+#: builtin/log.c:1809
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "visualizza le modifiche rispetto a <revisione> nella lettera di "
 "accompagnamento o in una patch singola"
 
-#: builtin/log.c:1725
+#: builtin/log.c:1812
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "visualizza le modifiche rispetto a <specificatore revisione> nella lettera "
 "di accompagnamento o in una patch singola"
 
-#: builtin/log.c:1727
+#: builtin/log.c:1814
 msgid "percentage by which creation is weighted"
 msgstr "percentuale in base a cui viene pesata la creazione"
 
-#: builtin/log.c:1812
+#: builtin/log.c:1896
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "riga ident non valida: %s"
 
-#: builtin/log.c:1827
+#: builtin/log.c:1911
 msgid "-n and -k are mutually exclusive"
 msgstr "le opzioni -n e -k sono mutuamente esclusive"
 
-#: builtin/log.c:1829
+#: builtin/log.c:1913
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
 msgstr "le opzioni --subject-prefix/--rfc e -k sono mutuamente esclusive"
 
-#: builtin/log.c:1837
+#: builtin/log.c:1921
 msgid "--name-only does not make sense"
 msgstr "--name-only non ha senso"
 
-#: builtin/log.c:1839
+#: builtin/log.c:1923
 msgid "--name-status does not make sense"
 msgstr "--name-status non ha senso"
 
-#: builtin/log.c:1841
+#: builtin/log.c:1925
 msgid "--check does not make sense"
 msgstr "--check non ha senso"
 
-#: builtin/log.c:1874
+#: builtin/log.c:1958
 msgid "standard output, or directory, which one?"
 msgstr "standard output, o directory, quale dei due?"
 
-#: builtin/log.c:1978
+#: builtin/log.c:2062
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff richiede --cover-letter o una singola patch"
 
-#: builtin/log.c:1982
+#: builtin/log.c:2066
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:1983
+#: builtin/log.c:2067
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff rispetto alla versione %d:"
 
-#: builtin/log.c:1989
+#: builtin/log.c:2073
 msgid "--creation-factor requires --range-diff"
 msgstr "--creation-factor richiede --range-diff"
 
-#: builtin/log.c:1993
+#: builtin/log.c:2077
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff richiede --cover-letter o una singola patch"
 
-#: builtin/log.c:2001
+#: builtin/log.c:2085
 msgid "Range-diff:"
 msgstr "Range-diff:"
 
-#: builtin/log.c:2002
+#: builtin/log.c:2086
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Range-diff rispetto alla versione %d:"
 
-#: builtin/log.c:2013
+#: builtin/log.c:2097
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "impossibile leggere il file firma '%s'"
 
-#: builtin/log.c:2049
+#: builtin/log.c:2133
 msgid "Generating patches"
 msgstr "Generazione delle patch in corso"
 
-#: builtin/log.c:2093
+#: builtin/log.c:2177
 msgid "failed to create output files"
 msgstr "creazione dei file di output non riuscita"
 
-#: builtin/log.c:2152
+#: builtin/log.c:2236
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<upstream> [<head> [<limite>]]]"
 
-#: builtin/log.c:2206
+#: builtin/log.c:2290
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -16528,7 +16935,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "non stampare l'URL del remoto"
 
-#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1384
+#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1392
 msgid "exec"
 msgstr "eseguibile"
 
@@ -16729,180 +17136,180 @@ msgstr "git merge --abort"
 msgid "git merge --continue"
 msgstr "git merge --continue"
 
-#: builtin/merge.c:121
+#: builtin/merge.c:120
 msgid "switch `m' requires a value"
 msgstr "lo switch 'm' richiede un valore"
 
-#: builtin/merge.c:144
+#: builtin/merge.c:143
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "l'opzione `%s' richiede un valore"
 
-#: builtin/merge.c:190
+#: builtin/merge.c:189
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Non è stato possibile trovare la strategia di merge '%s'.\n"
 
-#: builtin/merge.c:191
+#: builtin/merge.c:190
 #, c-format
 msgid "Available strategies are:"
 msgstr "Le strategie disponibili sono:"
 
-#: builtin/merge.c:196
+#: builtin/merge.c:195
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Le strategie personalizzate disponibili sono:"
 
-#: builtin/merge.c:247 builtin/pull.c:133
+#: builtin/merge.c:246 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "non visualizzare un diffstat al termine del merge"
 
-#: builtin/merge.c:250 builtin/pull.c:136
+#: builtin/merge.c:249 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "visualizza un diffstat al termine del merge"
 
-#: builtin/merge.c:251 builtin/pull.c:139
+#: builtin/merge.c:250 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(sinonimo di --stat)"
 
-#: builtin/merge.c:253 builtin/pull.c:142
+#: builtin/merge.c:252 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "aggiungi (al più <n>) voci dal registro breve al messaggio di commit del "
 "merge"
 
-#: builtin/merge.c:256 builtin/pull.c:148
+#: builtin/merge.c:255 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "crea un singolo commit anziché eseguire un merge"
 
-#: builtin/merge.c:258 builtin/pull.c:151
+#: builtin/merge.c:257 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "esegui un commit se il merge ha successo (impostazione predefinita)"
 
-#: builtin/merge.c:260 builtin/pull.c:154
+#: builtin/merge.c:259 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "modifica il messaggio prima di eseguire il commit"
 
-#: builtin/merge.c:262
+#: builtin/merge.c:261
 msgid "allow fast-forward (default)"
 msgstr "consenti fast forward (impostazione predefinita)"
 
-#: builtin/merge.c:264 builtin/pull.c:161
+#: builtin/merge.c:263 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "interrompi se il fast forward non è possibile"
 
-#: builtin/merge.c:268 builtin/pull.c:164
+#: builtin/merge.c:267 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "verifica che il commit specificato abbia una firma GPG valida"
 
-#: builtin/merge.c:269 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:527 builtin/rebase.c:1398 builtin/revert.c:114
+#: builtin/merge.c:268 builtin/notes.c:787 builtin/pull.c:168
+#: builtin/rebase.c:533 builtin/rebase.c:1406 builtin/revert.c:114
 msgid "strategy"
 msgstr "strategia"
 
-#: builtin/merge.c:270 builtin/pull.c:169
+#: builtin/merge.c:269 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "strategia di merge da usare"
 
-#: builtin/merge.c:271 builtin/pull.c:172
+#: builtin/merge.c:270 builtin/pull.c:172
 msgid "option=value"
 msgstr "opzione=valore"
 
-#: builtin/merge.c:272 builtin/pull.c:173
+#: builtin/merge.c:271 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "opzione per la strategia di merge selezionata"
 
-#: builtin/merge.c:274
+#: builtin/merge.c:273
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "messaggio di commit del merge (per un merge non fast forward)"
 
-#: builtin/merge.c:281
+#: builtin/merge.c:280
 msgid "abort the current in-progress merge"
 msgstr "interrompi il merge attualmente in corso"
 
-#: builtin/merge.c:283
+#: builtin/merge.c:282
 msgid "--abort but leave index and working tree alone"
 msgstr "esegui --abort ma mantieni immutati l'indice e l'albero di lavoro"
 
-#: builtin/merge.c:285
+#: builtin/merge.c:284
 msgid "continue the current in-progress merge"
 msgstr "continua il merge attualmente in corso"
 
-#: builtin/merge.c:287 builtin/pull.c:180
+#: builtin/merge.c:286 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "consenti di unire cronologie non correlate"
 
-#: builtin/merge.c:294
+#: builtin/merge.c:293
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "ignora gli hook pre-merge-commit e commit-msg"
 
-#: builtin/merge.c:311
+#: builtin/merge.c:310
 msgid "could not run stash."
 msgstr "non è stato possibile eseguire stash."
 
-#: builtin/merge.c:316
+#: builtin/merge.c:315
 msgid "stash failed"
 msgstr "esecuzione di stash non riuscita"
 
-#: builtin/merge.c:321
+#: builtin/merge.c:320
 #, c-format
 msgid "not a valid object: %s"
 msgstr "non è un oggetto valido: %s"
 
-#: builtin/merge.c:343 builtin/merge.c:360
+#: builtin/merge.c:342 builtin/merge.c:359
 msgid "read-tree failed"
 msgstr "read-tree non riuscito"
 
-#: builtin/merge.c:390
+#: builtin/merge.c:389
 msgid " (nothing to squash)"
 msgstr " (nulla di cui eseguire lo squash)"
 
-#: builtin/merge.c:401
+#: builtin/merge.c:400
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Commit di squash -- non aggiorno HEAD\n"
 
-#: builtin/merge.c:451
+#: builtin/merge.c:450
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Nessun messaggio di merge -- HEAD non viene aggiornato\n"
 
-#: builtin/merge.c:502
+#: builtin/merge.c:501
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "'%s' non punta ad un commit"
 
-#: builtin/merge.c:589
+#: builtin/merge.c:588
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Stringa branch.%s.mergeoptions errata: %s"
 
-#: builtin/merge.c:716
+#: builtin/merge.c:713
 msgid "Not handling anything other than two heads merge."
 msgstr "Non gestisco nulla che non sia il merge di due head."
 
-#: builtin/merge.c:730
+#: builtin/merge.c:726
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Opzione sconosciuta per merge-recursive: -X%s"
 
-#: builtin/merge.c:745
+#: builtin/merge.c:741
 #, c-format
 msgid "unable to write %s"
 msgstr "impossibile scrivere %s"
 
-#: builtin/merge.c:797
+#: builtin/merge.c:793
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "Non è stato possibile leggere da '%s'"
 
-#: builtin/merge.c:806
+#: builtin/merge.c:802
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Non eseguo il commit del merge; usa 'git commit' per completare il merge.\n"
 
-#: builtin/merge.c:812
+#: builtin/merge.c:808
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -16913,11 +17320,11 @@ msgstr ""
 "aggiornato in un topic branch.\n"
 "\n"
 
-#: builtin/merge.c:817
+#: builtin/merge.c:813
 msgid "An empty message aborts the commit.\n"
 msgstr "Un messaggio vuoto interromperà il commit.\n"
 
-#: builtin/merge.c:820
+#: builtin/merge.c:816
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -16926,74 +17333,74 @@ msgstr ""
 "Le righe che iniziano con '%c' saranno ignorate e un messaggio vuoto\n"
 "interromperà il commit.\n"
 
-#: builtin/merge.c:873
+#: builtin/merge.c:869
 msgid "Empty commit message."
 msgstr "Messaggio di commit vuoto."
 
-#: builtin/merge.c:888
+#: builtin/merge.c:884
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Splendido.\n"
 
-#: builtin/merge.c:949
+#: builtin/merge.c:945
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Merge automatico fallito; risolvi i conflitti ed esegui il commit\n"
 "del risultato.\n"
 
-#: builtin/merge.c:988
+#: builtin/merge.c:984
 msgid "No current branch."
 msgstr "Nessun branch corrente."
 
-#: builtin/merge.c:990
+#: builtin/merge.c:986
 msgid "No remote for the current branch."
 msgstr "Nessun remote per il branch corrente."
 
-#: builtin/merge.c:992
+#: builtin/merge.c:988
 msgid "No default upstream defined for the current branch."
 msgstr "Nessun upstream di default definito per il branch corrente."
 
-#: builtin/merge.c:997
+#: builtin/merge.c:993
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Nessun branch che tracci un remoto per %s da %s"
 
-#: builtin/merge.c:1054
+#: builtin/merge.c:1050
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Valore errato '%s' nell'ambiente '%s'"
 
-#: builtin/merge.c:1157
+#: builtin/merge.c:1153
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "non è qualcosa di cui possiamo eseguire il merge in %s: %s"
 
-#: builtin/merge.c:1191
+#: builtin/merge.c:1187
 msgid "not something we can merge"
 msgstr "non è qualcosa di cui possiamo eseguire il merge"
 
-#: builtin/merge.c:1295
+#: builtin/merge.c:1291
 msgid "--abort expects no arguments"
 msgstr "--abort non richiede argomenti"
 
-#: builtin/merge.c:1299
+#: builtin/merge.c:1295
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Non c'è nessun merge da interrompere (MERGE_HEAD mancante)."
 
-#: builtin/merge.c:1317
+#: builtin/merge.c:1313
 msgid "--quit expects no arguments"
 msgstr "--quit non richiede argomenti"
 
-#: builtin/merge.c:1330
+#: builtin/merge.c:1326
 msgid "--continue expects no arguments"
 msgstr "--continue non richiede argomenti"
 
-#: builtin/merge.c:1334
+#: builtin/merge.c:1330
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Non c'è nessun merge in corso (MERGE_HEAD mancante)."
 
-#: builtin/merge.c:1350
+#: builtin/merge.c:1346
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17001,7 +17408,7 @@ msgstr ""
 "Non hai concluso il merge (MERGE_HEAD esiste).\n"
 "Esegui il commit delle modifiche prima di eseguire il merge."
 
-#: builtin/merge.c:1357
+#: builtin/merge.c:1353
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17009,96 +17416,96 @@ msgstr ""
 "Non hai concluso il cherry-pick (CHERRY_PICK_HEAD esiste).\n"
 "Esegui il commit delle modifiche prima di eseguire il merge."
 
-#: builtin/merge.c:1360
+#: builtin/merge.c:1356
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Il cherry-pick non è stato concluso (CHERRY_PICK_HEAD esiste)."
 
-#: builtin/merge.c:1374
+#: builtin/merge.c:1370
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Non è possibile combinare --squash con --no-ff."
 
-#: builtin/merge.c:1376
+#: builtin/merge.c:1372
 msgid "You cannot combine --squash with --commit."
 msgstr "Non è possibile combinare --squash con --commit."
 
-#: builtin/merge.c:1392
+#: builtin/merge.c:1388
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Nessun commit specificato e merge.defaultToUpstream non impostato."
 
-#: builtin/merge.c:1409
+#: builtin/merge.c:1405
 msgid "Squash commit into empty head not supported yet"
 msgstr "Lo squash di un commit in un'head vuota non è ancora supportato"
 
-#: builtin/merge.c:1411
+#: builtin/merge.c:1407
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Un commit non fast forward non ha senso in un'head vuota"
 
-#: builtin/merge.c:1416
+#: builtin/merge.c:1412
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - non è qualcosa per cui possiamo eseguire il merge"
 
-#: builtin/merge.c:1418
+#: builtin/merge.c:1414
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Si può eseguire solo il merge di uno e un solo commit in un'head vuota"
 
-#: builtin/merge.c:1499
+#: builtin/merge.c:1495
 msgid "refusing to merge unrelated histories"
 msgstr "mi rifiuto di eseguire il merge di cronologie non correlate"
 
-#: builtin/merge.c:1508
+#: builtin/merge.c:1504
 msgid "Already up to date."
 msgstr "Già aggiornato."
 
-#: builtin/merge.c:1518
+#: builtin/merge.c:1514
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Aggiornamento di %s..%s\n"
 
-#: builtin/merge.c:1564
+#: builtin/merge.c:1560
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Provo con un merge veramente banale dentro l'indice...\n"
 
-#: builtin/merge.c:1571
+#: builtin/merge.c:1567
 #, c-format
 msgid "Nope.\n"
 msgstr "No.\n"
 
-#: builtin/merge.c:1596
+#: builtin/merge.c:1592
 msgid "Already up to date. Yeeah!"
 msgstr "Già aggiornato. Oh sì!"
 
-#: builtin/merge.c:1602
+#: builtin/merge.c:1598
 msgid "Not possible to fast-forward, aborting."
 msgstr "Fast forward non possibile, interrompo l'operazione."
 
-#: builtin/merge.c:1630 builtin/merge.c:1695
+#: builtin/merge.c:1626 builtin/merge.c:1691
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Ripristino l'albero in uno stato pulito...\n"
 
-#: builtin/merge.c:1634
+#: builtin/merge.c:1630
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Tentativo con la strategia di merge %s...\n"
 
-#: builtin/merge.c:1686
+#: builtin/merge.c:1682
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Nessuna strategia di merge ha gestito il merge.\n"
 
-#: builtin/merge.c:1688
+#: builtin/merge.c:1684
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Merge con la strategia %s fallito.\n"
 
-#: builtin/merge.c:1697
+#: builtin/merge.c:1693
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
 msgstr "Uso %s per preparare una risoluzione manuale.\n"
 
-#: builtin/merge.c:1711
+#: builtin/merge.c:1707
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -17183,68 +17590,72 @@ msgstr "forza spostamento/ridenominazione anche se la destinazione esiste"
 msgid "skip move/rename errors"
 msgstr "salta errori spostamento/ridenominazione"
 
-#: builtin/mv.c:169
+#: builtin/mv.c:170
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "la destinazione '%s' non è una directory"
 
-#: builtin/mv.c:180
+#: builtin/mv.c:181
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Controllo la ridenominazione di '%s' in '%s'\n"
 
-#: builtin/mv.c:184
+#: builtin/mv.c:185
 msgid "bad source"
 msgstr "sourgente errata"
 
-#: builtin/mv.c:187
+#: builtin/mv.c:188
 msgid "can not move directory into itself"
 msgstr "non è possibile spostare la directory in sé stessa"
 
-#: builtin/mv.c:190
+#: builtin/mv.c:191
 msgid "cannot move directory over file"
 msgstr "non è possibile spostare la directory su un file"
 
-#: builtin/mv.c:199
+#: builtin/mv.c:200
 msgid "source directory is empty"
 msgstr "la directory sorgente è vuota"
 
-#: builtin/mv.c:224
+#: builtin/mv.c:225
 msgid "not under version control"
 msgstr "non è sotto controllo di versione"
 
 #: builtin/mv.c:227
+msgid "conflicted"
+msgstr "conflitto"
+
+#: builtin/mv.c:230
 msgid "destination exists"
 msgstr "la destinazione esiste"
 
-#: builtin/mv.c:235
+#: builtin/mv.c:238
 #, c-format
 msgid "overwriting '%s'"
 msgstr "sovrascrittura di %s in corso"
 
-#: builtin/mv.c:238
+#: builtin/mv.c:241
 msgid "Cannot overwrite"
 msgstr "Impossibile sovrascrivere"
 
-#: builtin/mv.c:241
+#: builtin/mv.c:244
 msgid "multiple sources for the same target"
 msgstr "fonti multiple per la stessa destinazione"
 
-#: builtin/mv.c:243
+#: builtin/mv.c:246
 msgid "destination directory does not exist"
 msgstr "la directory di destinazione non esiste"
 
-#: builtin/mv.c:250
+#: builtin/mv.c:253
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, sorgente=%s, destinazione=%s"
 
-#: builtin/mv.c:271
+#: builtin/mv.c:274
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Rinominazione di %s in %s in corso\n"
 
-#: builtin/mv.c:277 builtin/remote.c:781 builtin/repack.c:520
+#: builtin/mv.c:280 builtin/remote.c:782 builtin/repack.c:518
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "rinomina di '%s' non riuscita"
@@ -17262,8 +17673,8 @@ msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [<opzioni>] --stdin"
 
 #: builtin/name-rev.c:524
-msgid "print only names (no SHA-1)"
-msgstr "stampa solo i nomi (non lo SHA-1)"
+msgid "print only ref-based names (no object names)"
+msgstr "stampa solo i nomi basati sui riferimenti (non i nomi oggetto)"
 
 #: builtin/name-rev.c:525
 msgid "only use tags to name the commits"
@@ -17709,141 +18120,142 @@ msgstr "riferimento note"
 msgid "use notes from <notes-ref>"
 msgstr "usa le note in <riferimento note>"
 
-#: builtin/notes.c:1034 builtin/stash.c:1608
+#: builtin/notes.c:1034 builtin/stash.c:1605
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "sottocomando sconosciuto: %s"
 
-#: builtin/pack-objects.c:53
+#: builtin/pack-objects.c:54
 msgid ""
 "git pack-objects --stdout [<options>...] [< <ref-list> | < <object-list>]"
 msgstr ""
 "git pack-objects --stdout [<opzioni>...] [< <elenco riferimenti> | < <elenco "
 "oggetti>]"
 
-#: builtin/pack-objects.c:54
+#: builtin/pack-objects.c:55
 msgid ""
 "git pack-objects [<options>...] <base-name> [< <ref-list> | < <object-list>]"
 msgstr ""
 "git pack-objects [<opzioni>...] <nome base> [< <elenco riferimenti> | < "
 "<elenco oggetti>]"
 
-#: builtin/pack-objects.c:442
+#: builtin/pack-objects.c:443
 #, c-format
 msgid "bad packed object CRC for %s"
 msgstr "CRC oggetto sottoposto a pack %s errato"
 
-#: builtin/pack-objects.c:453
+#: builtin/pack-objects.c:454
 #, c-format
 msgid "corrupt packed object for %s"
 msgstr "oggetto sottoposto a pack %s corrotto"
 
-#: builtin/pack-objects.c:584
+#: builtin/pack-objects.c:585
 #, c-format
 msgid "recursive delta detected for object %s"
 msgstr "rilevato delta ricorsivo per l'oggetto %s"
 
-#: builtin/pack-objects.c:795
+#: builtin/pack-objects.c:796
 #, c-format
 msgid "ordered %u objects, expected %<PRIu32>"
 msgstr "%u oggetti ordinati, attesi %<PRIu32>"
 
-#: builtin/pack-objects.c:1003
+#: builtin/pack-objects.c:1004
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "disabilito la scrittura delle bitmap, i pack sono divisi a causa "
 "dell'impostazione pack.packSizeLimit"
 
-#: builtin/pack-objects.c:1016
+#: builtin/pack-objects.c:1017
 msgid "Writing objects"
 msgstr "Scrittura degli oggetti in corso"
 
-#: builtin/pack-objects.c:1077 builtin/update-index.c:90
+#: builtin/pack-objects.c:1078 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "stat di %s non riuscito"
 
-#: builtin/pack-objects.c:1130
+#: builtin/pack-objects.c:1131
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "scritti %<PRIu32> oggetti quando me ne attendevo %<PRIu32>"
 
-#: builtin/pack-objects.c:1347
+#: builtin/pack-objects.c:1348
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "disabilito la scrittura delle bitmap perché alcuni oggetti non saranno "
 "sottoposti a pack"
 
-#: builtin/pack-objects.c:1774
+#: builtin/pack-objects.c:1796
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "overflow dell'offset base del delta nel pack per %s"
 
-#: builtin/pack-objects.c:1783
+#: builtin/pack-objects.c:1805
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "offset base del delta fuori dall'intervallo consentito per %s"
 
-#: builtin/pack-objects.c:2054
+#: builtin/pack-objects.c:2086
 msgid "Counting objects"
 msgstr "Conteggio degli oggetti in corso"
 
-#: builtin/pack-objects.c:2199
+#: builtin/pack-objects.c:2231
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "impossibile analizzare l'intestazione oggetto di %s"
 
-#: builtin/pack-objects.c:2269 builtin/pack-objects.c:2285
-#: builtin/pack-objects.c:2295
+#: builtin/pack-objects.c:2301 builtin/pack-objects.c:2317
+#: builtin/pack-objects.c:2327
 #, c-format
 msgid "object %s cannot be read"
 msgstr "impossibile leggere l'oggetto %s"
 
-#: builtin/pack-objects.c:2272 builtin/pack-objects.c:2299
+#: builtin/pack-objects.c:2304 builtin/pack-objects.c:2331
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr ""
 "oggetto %s: lunghezza oggetto inconsistente (%<PRIuMAX> contro %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2309
+#: builtin/pack-objects.c:2341
 msgid "suboptimal pack - out of memory"
 msgstr "pack subottimo - memoria esaurita"
 
-#: builtin/pack-objects.c:2624
+#: builtin/pack-objects.c:2656
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Compressione delta in corso, uso fino a %d thread"
 
-#: builtin/pack-objects.c:2763
+#: builtin/pack-objects.c:2795
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "impossibile eseguire il pack degli oggetti raggiungibili dal tag %s"
 
-#: builtin/pack-objects.c:2851
+#: builtin/pack-objects.c:2883
 msgid "Compressing objects"
 msgstr "Compressione oggetti in corso"
 
-#: builtin/pack-objects.c:2857
+#: builtin/pack-objects.c:2889
 msgid "inconsistency with delta count"
 msgstr "inconsistenza con il numero dei delta"
 
-#: builtin/pack-objects.c:2929
+#: builtin/pack-objects.c:2961
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
 "hash> <uri>' (got '%s')"
 msgstr ""
-"il valore di uploadpack.blobpackfileuri dev'essere nella forma '<hash oggetto"
-"> <hash pack> <URI>' (ricevuto '%s')"
+"il valore di uploadpack.blobpackfileuri dev'essere nella forma '<hash "
+"oggetto> <hash pack> <URI>' (ricevuto '%s')"
 
-#: builtin/pack-objects.c:2932
+#: builtin/pack-objects.c:2964
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
 msgstr ""
-"oggetto già configurato in un altro uploadpack.blobpackfileuri (ricevuto '%s')"
+"oggetto già configurato in un altro uploadpack.blobpackfileuri (ricevuto "
+"'%s')"
 
-#: builtin/pack-objects.c:2961
+#: builtin/pack-objects.c:2993
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -17852,7 +18264,7 @@ msgstr ""
 "atteso ID oggetto arco, ricevuti dati errati:\n"
 " %s"
 
-#: builtin/pack-objects.c:2967
+#: builtin/pack-objects.c:2999
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -17861,243 +18273,244 @@ msgstr ""
 "atteso ID oggetto, ricevuti dati errati:\n"
 " %s"
 
-#: builtin/pack-objects.c:3065
+#: builtin/pack-objects.c:3097
 msgid "invalid value for --missing"
 msgstr "valore non valido per --missing"
 
-#: builtin/pack-objects.c:3124 builtin/pack-objects.c:3232
+#: builtin/pack-objects.c:3156 builtin/pack-objects.c:3264
 msgid "cannot open pack index"
 msgstr "impossibile aprire l'indice pack"
 
-#: builtin/pack-objects.c:3155
+#: builtin/pack-objects.c:3187
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "impossibile esaminare l'oggetto sciolto %s"
 
-#: builtin/pack-objects.c:3240
+#: builtin/pack-objects.c:3272
 msgid "unable to force loose object"
 msgstr "impossibile forzare l'oggetto sciolto"
 
-#: builtin/pack-objects.c:3333
+#: builtin/pack-objects.c:3365
 #, c-format
 msgid "not a rev '%s'"
 msgstr "'%s' non è una revisione"
 
-#: builtin/pack-objects.c:3336
+#: builtin/pack-objects.c:3368
 #, c-format
 msgid "bad revision '%s'"
 msgstr "revisione '%s' errata"
 
-#: builtin/pack-objects.c:3361
+#: builtin/pack-objects.c:3393
 msgid "unable to add recent objects"
 msgstr "impossibile aggiungere gli oggetti recenti"
 
-#: builtin/pack-objects.c:3414
+#: builtin/pack-objects.c:3446
 #, c-format
 msgid "unsupported index version %s"
 msgstr "versione %s di index non supportata"
 
-#: builtin/pack-objects.c:3418
+#: builtin/pack-objects.c:3450
 #, c-format
 msgid "bad index version '%s'"
 msgstr "versione '%s' di index errata"
 
-#: builtin/pack-objects.c:3456
+#: builtin/pack-objects.c:3488
 msgid "<version>[,<offset>]"
 msgstr "<versione>[,<offset>]"
 
-#: builtin/pack-objects.c:3457
+#: builtin/pack-objects.c:3489
 msgid "write the pack index file in the specified idx format version"
 msgstr "scrivi il file indice pack usando la versione formato idx specificata"
 
-#: builtin/pack-objects.c:3460
+#: builtin/pack-objects.c:3492
 msgid "maximum size of each output pack file"
 msgstr "dimensione massima di ogni file pack in output"
 
-#: builtin/pack-objects.c:3462
+#: builtin/pack-objects.c:3494
 msgid "ignore borrowed objects from alternate object store"
 msgstr "ignora gli oggetti presi in prestito dallo store oggetti alternativo"
 
-#: builtin/pack-objects.c:3464
+#: builtin/pack-objects.c:3496
 msgid "ignore packed objects"
 msgstr "ignora gli oggetti sottoposti a pack"
 
-#: builtin/pack-objects.c:3466
+#: builtin/pack-objects.c:3498
 msgid "limit pack window by objects"
 msgstr "limita la finestra di pack al numero di oggetti specificato"
 
-#: builtin/pack-objects.c:3468
+#: builtin/pack-objects.c:3500
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 "limita la finestra di pack alla memoria specificata in aggiunta al limite "
 "sugli oggetti"
 
-#: builtin/pack-objects.c:3470
+#: builtin/pack-objects.c:3502
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr "lunghezza massima della catena di delta consentita nel pack risultante"
 
-#: builtin/pack-objects.c:3472
+#: builtin/pack-objects.c:3504
 msgid "reuse existing deltas"
 msgstr "riusa i delta esistenti"
 
-#: builtin/pack-objects.c:3474
+#: builtin/pack-objects.c:3506
 msgid "reuse existing objects"
 msgstr "riusa gli oggetti esistenti"
 
-#: builtin/pack-objects.c:3476
+#: builtin/pack-objects.c:3508
 msgid "use OFS_DELTA objects"
 msgstr "usa oggetti OFS_DELTA"
 
-#: builtin/pack-objects.c:3478
+#: builtin/pack-objects.c:3510
 msgid "use threads when searching for best delta matches"
 msgstr ""
 "usa più thread durante la ricerca delle migliori corrispondenze per i delta"
 
-#: builtin/pack-objects.c:3480
+#: builtin/pack-objects.c:3512
 msgid "do not create an empty pack output"
 msgstr "non creare un output pack vuoto"
 
-#: builtin/pack-objects.c:3482
+#: builtin/pack-objects.c:3514
 msgid "read revision arguments from standard input"
 msgstr "leggi gli argomenti revisione dallo standard input"
 
-#: builtin/pack-objects.c:3484
+#: builtin/pack-objects.c:3516
 msgid "limit the objects to those that are not yet packed"
 msgstr "limita gli oggetti a quelli non ancora sottoposti a pack"
 
-#: builtin/pack-objects.c:3487
+#: builtin/pack-objects.c:3519
 msgid "include objects reachable from any reference"
 msgstr "includi gli oggetti raggiungibili da qualunque riferimento"
 
-#: builtin/pack-objects.c:3490
+#: builtin/pack-objects.c:3522
 msgid "include objects referred by reflog entries"
 msgstr "includi gli oggetti referenziati da voci del log riferimenti"
 
-#: builtin/pack-objects.c:3493
+#: builtin/pack-objects.c:3525
 msgid "include objects referred to by the index"
 msgstr "includi gli oggetti referenziati dall'indice"
 
-#: builtin/pack-objects.c:3496
+#: builtin/pack-objects.c:3528
 msgid "output pack to stdout"
 msgstr "invia il pack in output sullo standard output"
 
-#: builtin/pack-objects.c:3498
+#: builtin/pack-objects.c:3530
 msgid "include tag objects that refer to objects to be packed"
 msgstr ""
 "includi gli oggetti tag che fanno riferimento agli oggetti da sottoporre a "
 "pack"
 
-#: builtin/pack-objects.c:3500
+#: builtin/pack-objects.c:3532
 msgid "keep unreachable objects"
 msgstr "mantieni gli oggetti non raggiungibili"
 
-#: builtin/pack-objects.c:3502
+#: builtin/pack-objects.c:3534
 msgid "pack loose unreachable objects"
 msgstr "esegui il pack degli oggetti non raggiungibili sciolti"
 
-#: builtin/pack-objects.c:3504
+#: builtin/pack-objects.c:3536
 msgid "unpack unreachable objects newer than <time>"
 msgstr "decomprimi gli oggetti non raggiungibili più recenti di <tempo>"
 
-#: builtin/pack-objects.c:3507
+#: builtin/pack-objects.c:3539
 msgid "use the sparse reachability algorithm"
 msgstr "usa l'algoritmo di raggiungibilità sparse"
 
-#: builtin/pack-objects.c:3509
+#: builtin/pack-objects.c:3541
 msgid "create thin packs"
 msgstr "crea pack thin"
 
-#: builtin/pack-objects.c:3511
+#: builtin/pack-objects.c:3543
 msgid "create packs suitable for shallow fetches"
 msgstr "crea pack adatti per fetch shallow"
 
-#: builtin/pack-objects.c:3513
+#: builtin/pack-objects.c:3545
 msgid "ignore packs that have companion .keep file"
 msgstr "ignora i pack che hanno un file .keep che li accompagna"
 
-#: builtin/pack-objects.c:3515
+#: builtin/pack-objects.c:3547
 msgid "ignore this pack"
 msgstr "ignora questo pack"
 
-#: builtin/pack-objects.c:3517
+#: builtin/pack-objects.c:3549
 msgid "pack compression level"
 msgstr "livello compressione pack"
 
-#: builtin/pack-objects.c:3519
+#: builtin/pack-objects.c:3551
 msgid "do not hide commits by grafts"
 msgstr "non nascondere i commit innestati"
 
-#: builtin/pack-objects.c:3521
+#: builtin/pack-objects.c:3553
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "usa un indice bitmap se disponibile per velocizzare il conteggio degli "
 "oggetti"
 
-#: builtin/pack-objects.c:3523
+#: builtin/pack-objects.c:3555
 msgid "write a bitmap index together with the pack index"
 msgstr "scrivi un indice bitmap insieme all'indice pack"
 
-#: builtin/pack-objects.c:3527
+#: builtin/pack-objects.c:3559
 msgid "write a bitmap index if possible"
 msgstr "scrivi un indice bitmap se possibile"
 
-#: builtin/pack-objects.c:3531
+#: builtin/pack-objects.c:3563
 msgid "handling for missing objects"
 msgstr "azione da eseguire sugli oggetti mancanti"
 
-#: builtin/pack-objects.c:3534
+#: builtin/pack-objects.c:3566
 msgid "do not pack objects in promisor packfiles"
 msgstr "non eseguire il pack degli oggetti nei file pack promettenti"
 
-#: builtin/pack-objects.c:3536
+#: builtin/pack-objects.c:3568
 msgid "respect islands during delta compression"
 msgstr "rispetta le isole durante la compressione delta"
 
-#: builtin/pack-objects.c:3538
+#: builtin/pack-objects.c:3570
 msgid "protocol"
 msgstr "protocollo"
 
-#: builtin/pack-objects.c:3539
+#: builtin/pack-objects.c:3571
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
-"escludi tutti gli uploadpack.blobpackfileuri configurati con questo protocollo"
+"escludi tutti gli uploadpack.blobpackfileuri configurati con questo "
+"protocollo"
 
-#: builtin/pack-objects.c:3568
+#: builtin/pack-objects.c:3600
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "la profondità della catena dei delta (%d) è troppo elevata, forzo %d"
 
-#: builtin/pack-objects.c:3573
+#: builtin/pack-objects.c:3605
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "il valore pack.deltaCacheLimit è troppo elevato, forzo %d"
 
-#: builtin/pack-objects.c:3627
+#: builtin/pack-objects.c:3659
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size non può essere usato per generare un pack da trasferire"
 
-#: builtin/pack-objects.c:3629
+#: builtin/pack-objects.c:3661
 msgid "minimum pack size limit is 1 MiB"
 msgstr "il limite minimo delle dimensioni dei pack è 1 MiB"
 
-#: builtin/pack-objects.c:3634
+#: builtin/pack-objects.c:3666
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin non può essere usato per generare un pack indicizzabile"
 
-#: builtin/pack-objects.c:3637
+#: builtin/pack-objects.c:3669
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable e --unpack-unreachable non sono compatibili"
 
-#: builtin/pack-objects.c:3643
+#: builtin/pack-objects.c:3675
 msgid "cannot use --filter without --stdout"
 msgstr "impossibile usare --filter senza --stdout"
 
-#: builtin/pack-objects.c:3703
+#: builtin/pack-objects.c:3735
 msgid "Enumerating objects"
 msgstr "Enumerazione degli oggetti in corso"
 
-#: builtin/pack-objects.c:3734
+#: builtin/pack-objects.c:3766
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -18164,7 +18577,7 @@ msgstr "Opzioni relative al merge"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "incorpora le modifiche eseguendo un rebase anziché un merge"
 
-#: builtin/pull.c:158 builtin/rebase.c:478 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/rebase.c:484 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "consenti fast forward"
 
@@ -18189,7 +18602,7 @@ msgstr "numero di sottomoduli recuperati in parallelo"
 msgid "Invalid value for pull.ff: %s"
 msgstr "Valore non valido per pull.ff: %s"
 
-#: builtin/pull.c:349
+#: builtin/pull.c:348
 msgid ""
 "Pulling without specifying how to reconcile divergent branches is\n"
 "discouraged. You can squelch this message by running one of the following\n"
@@ -18220,7 +18633,7 @@ msgstr ""
 "eseguire l'override del valore predefinito configurato per una singola\n"
 "invocazione.\n"
 
-#: builtin/pull.c:459
+#: builtin/pull.c:458
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -18228,14 +18641,14 @@ msgstr ""
 "Non ci sono candidati in base ai quali eseguire il rebase fra i riferimenti "
 "appena recuperati."
 
-#: builtin/pull.c:461
+#: builtin/pull.c:460
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Non ci sono candidati in base ai quali eseguire il merge fra i riferimenti "
 "appena recuperati."
 
-#: builtin/pull.c:462
+#: builtin/pull.c:461
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -18243,7 +18656,7 @@ msgstr ""
 "In generale, questo significa che hai fornito uno specificatore\n"
 "riferimento che non aveva corrispondenze nel remoto."
 
-#: builtin/pull.c:465
+#: builtin/pull.c:464
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -18255,44 +18668,44 @@ msgstr ""
 "configurato come predefinito per il branch corrente, devi\n"
 "specificare un branch sulla riga di comando."
 
-#: builtin/pull.c:470 builtin/rebase.c:1234 git-parse-remote.sh:73
+#: builtin/pull.c:469 builtin/rebase.c:1240 git-parse-remote.sh:73
 msgid "You are not currently on a branch."
 msgstr "Attualmente non sei su un branch."
 
-#: builtin/pull.c:472 builtin/pull.c:487 git-parse-remote.sh:79
+#: builtin/pull.c:471 builtin/pull.c:486 git-parse-remote.sh:79
 msgid "Please specify which branch you want to rebase against."
 msgstr "Specifica il branch in base a cui vuoi effettuare il rebase."
 
-#: builtin/pull.c:474 builtin/pull.c:489 git-parse-remote.sh:82
+#: builtin/pull.c:473 builtin/pull.c:488 git-parse-remote.sh:82
 msgid "Please specify which branch you want to merge with."
 msgstr "Specifica il branch in base a cui vuoi effettuare il merge."
 
-#: builtin/pull.c:475 builtin/pull.c:490
+#: builtin/pull.c:474 builtin/pull.c:489
 msgid "See git-pull(1) for details."
 msgstr "Vedi git-pull(1) per ulteriori dettagli."
 
-#: builtin/pull.c:477 builtin/pull.c:483 builtin/pull.c:492
-#: builtin/rebase.c:1240 git-parse-remote.sh:64
+#: builtin/pull.c:476 builtin/pull.c:482 builtin/pull.c:491
+#: builtin/rebase.c:1246 git-parse-remote.sh:64
 msgid "<remote>"
 msgstr "<remoto>"
 
-#: builtin/pull.c:477 builtin/pull.c:492 builtin/pull.c:497
+#: builtin/pull.c:476 builtin/pull.c:491 builtin/pull.c:496
 #: git-parse-remote.sh:65
 msgid "<branch>"
 msgstr "<branch>"
 
-#: builtin/pull.c:485 builtin/rebase.c:1232 git-parse-remote.sh:75
+#: builtin/pull.c:484 builtin/rebase.c:1238 git-parse-remote.sh:75
 msgid "There is no tracking information for the current branch."
 msgstr "Non ci sono informazioni di tracciamento per il branch corrente."
 
-#: builtin/pull.c:494 git-parse-remote.sh:95
+#: builtin/pull.c:493 git-parse-remote.sh:95
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
 "Se vuoi impostare le informazioni di tracciamento per questo branch puoi "
 "farlo con:"
 
-#: builtin/pull.c:499
+#: builtin/pull.c:498
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -18302,28 +18715,28 @@ msgstr ""
 "il merge con il riferimento '%s' del remoto, ma un tale\n"
 "riferimento non è stato recuperato."
 
-#: builtin/pull.c:610
+#: builtin/pull.c:609
 #, c-format
 msgid "unable to access commit %s"
 msgstr "impossibile accedere al commit %s"
 
-#: builtin/pull.c:895
+#: builtin/pull.c:894
 msgid "ignoring --verify-signatures for rebase"
 msgstr "ignoro --verify-signature per il rebase"
 
-#: builtin/pull.c:955
+#: builtin/pull.c:954
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Aggiorno un branch non nato con le modifiche aggiunte all'indice."
 
-#: builtin/pull.c:959
+#: builtin/pull.c:958
 msgid "pull with rebase"
 msgstr "pull con rebase"
 
-#: builtin/pull.c:960
+#: builtin/pull.c:959
 msgid "please commit or stash them."
 msgstr "eseguine il commit o lo stash."
 
-#: builtin/pull.c:985
+#: builtin/pull.c:984
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -18335,7 +18748,7 @@ msgstr ""
 "Eseguo il fast forward dell'albero\n"
 "di lavoro dal commit %s."
 
-#: builtin/pull.c:991
+#: builtin/pull.c:990
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -18354,15 +18767,15 @@ msgstr ""
 "$ git reset --hard\n"
 "per eseguire il ripristino."
 
-#: builtin/pull.c:1006
+#: builtin/pull.c:1005
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Impossibile eseguire il merge di più branch in un head vuoto."
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1009
 msgid "Cannot rebase onto multiple branches."
 msgstr "Impossibile eseguire il rebase su più branch."
 
-#: builtin/pull.c:1018
+#: builtin/pull.c:1017
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "impossibile eseguire il rebase se ci sono delle modifiche registrate "
@@ -18372,15 +18785,15 @@ msgstr ""
 msgid "git push [<options>] [<repository> [<refspec>...]]"
 msgstr "git push [<opzioni>] [<repository> [<specificatore riferimento>...]]"
 
-#: builtin/push.c:112
+#: builtin/push.c:111
 msgid "tag shorthand without <tag>"
 msgstr "esegui il tag della forma breve senza <tag>"
 
-#: builtin/push.c:122
+#: builtin/push.c:119
 msgid "--delete only accepts plain target ref names"
 msgstr "--delete accetta solo nomi dei ref di destinazione in chiaro"
 
-#: builtin/push.c:168
+#: builtin/push.c:164
 msgid ""
 "\n"
 "To choose either option permanently, see push.default in 'git help config'."
@@ -18389,7 +18802,7 @@ msgstr ""
 "Per scegliere permanentemente una delle due opzioni, vedi push.default in "
 "'git help config'."
 
-#: builtin/push.c:171
+#: builtin/push.c:167
 #, c-format
 msgid ""
 "The upstream branch of your current branch does not match\n"
@@ -18414,7 +18827,7 @@ msgstr ""
 "    git push %s HEAD\n"
 "%s"
 
-#: builtin/push.c:186
+#: builtin/push.c:182
 #, c-format
 msgid ""
 "You are not currently on a branch.\n"
@@ -18429,7 +18842,7 @@ msgstr ""
 "\n"
 "    git push %s HEAD:<nome del branch remoto>\n"
 
-#: builtin/push.c:200
+#: builtin/push.c:194
 #, c-format
 msgid ""
 "The current branch %s has no upstream branch.\n"
@@ -18443,13 +18856,13 @@ msgstr ""
 "\n"
 "    git push --set-upstream %s %s\n"
 
-#: builtin/push.c:208
+#: builtin/push.c:202
 #, c-format
 msgid "The current branch %s has multiple upstream branches, refusing to push."
 msgstr ""
 "Il branch corrente %s ha più branch upstream, mi rifiuto di eseguire il push."
 
-#: builtin/push.c:211
+#: builtin/push.c:205
 #, c-format
 msgid ""
 "You are pushing to remote '%s', which is not the upstream of\n"
@@ -18460,14 +18873,14 @@ msgstr ""
 "branch corrente '%s', senza dirmi di cosa devo eseguire il push\n"
 "per aggiornare quale branch remoto."
 
-#: builtin/push.c:270
+#: builtin/push.c:260
 msgid ""
 "You didn't specify any refspecs to push, and push.default is \"nothing\"."
 msgstr ""
 "Non è stato specificato alcun refspec per il push, e push.default è \"nothing"
 "\"."
 
-#: builtin/push.c:277
+#: builtin/push.c:267
 msgid ""
 "Updates were rejected because the tip of your current branch is behind\n"
 "its remote counterpart. Integrate the remote changes (e.g.\n"
@@ -18481,7 +18894,7 @@ msgstr ""
 "Vedi la 'Nota sui fast forward' in 'git push --help' per ulteriori\n"
 "dettagli."
 
-#: builtin/push.c:283
+#: builtin/push.c:273
 msgid ""
 "Updates were rejected because a pushed branch tip is behind its remote\n"
 "counterpart. Check out this branch and integrate the remote changes\n"
@@ -18496,7 +18909,7 @@ msgstr ""
 "Vedi la 'Nota sui fast forward' in 'git push --help' per ulteriori\n"
 "dettagli."
 
-#: builtin/push.c:289
+#: builtin/push.c:279
 msgid ""
 "Updates were rejected because the remote contains work that you do\n"
 "not have locally. This is usually caused by another repository pushing\n"
@@ -18512,12 +18925,12 @@ msgstr ""
 "Vedi la 'Nota sui fast forward' in 'git push --help' per ulteriori\n"
 "dettagli."
 
-#: builtin/push.c:296
+#: builtin/push.c:286
 msgid "Updates were rejected because the tag already exists in the remote."
 msgstr ""
 "Gli aggiornamenti sono stati rifiutati perché il tag esiste già nel remoto."
 
-#: builtin/push.c:299
+#: builtin/push.c:289
 msgid ""
 "You cannot update a remote ref that points at a non-commit object,\n"
 "or update a remote ref to make it point at a non-commit object,\n"
@@ -18528,100 +18941,100 @@ msgstr ""
 "puntare a un oggetto diverso da un commit senza usare l'opzione\n"
 "'--force'.\n"
 
-#: builtin/push.c:361
+#: builtin/push.c:351
 #, c-format
 msgid "Pushing to %s\n"
 msgstr "Push su %s in corso\n"
 
-#: builtin/push.c:368
+#: builtin/push.c:358
 #, c-format
 msgid "failed to push some refs to '%s'"
 msgstr "push di alcuni riferimenti su '%s' non riuscito"
 
-#: builtin/push.c:542
+#: builtin/push.c:532
 msgid "repository"
 msgstr "repository"
 
-#: builtin/push.c:543 builtin/send-pack.c:164
+#: builtin/push.c:533 builtin/send-pack.c:183
 msgid "push all refs"
 msgstr "esegui il push di tutti i riferimenti"
 
-#: builtin/push.c:544 builtin/send-pack.c:166
+#: builtin/push.c:534 builtin/send-pack.c:185
 msgid "mirror all refs"
 msgstr "esegui il mirror di tutti i riferimenti"
 
-#: builtin/push.c:546
+#: builtin/push.c:536
 msgid "delete refs"
 msgstr "elimina riferimenti"
 
-#: builtin/push.c:547
+#: builtin/push.c:537
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "esegui il push dei tag (non può essere usato con --all o --mirror)"
 
-#: builtin/push.c:550 builtin/send-pack.c:167
+#: builtin/push.c:540 builtin/send-pack.c:186
 msgid "force updates"
 msgstr "forza gli aggiornamenti"
 
-#: builtin/push.c:551 builtin/send-pack.c:179
+#: builtin/push.c:541 builtin/send-pack.c:198
 msgid "<refname>:<expect>"
 msgstr "<nome riferimento>:<valore atteso>"
 
-#: builtin/push.c:552 builtin/send-pack.c:180
+#: builtin/push.c:542 builtin/send-pack.c:199
 msgid "require old value of ref to be at this value"
 msgstr ""
 "richiedi che il vecchio valore del riferimento corrisponda a questo valore"
 
-#: builtin/push.c:555
+#: builtin/push.c:545
 msgid "control recursive pushing of submodules"
 msgstr "controlla il push ricorsivo dei sottomoduli"
 
-#: builtin/push.c:556 builtin/send-pack.c:174
+#: builtin/push.c:546 builtin/send-pack.c:193
 msgid "use thin pack"
 msgstr "usa un thin pack"
 
-#: builtin/push.c:557 builtin/push.c:558 builtin/send-pack.c:161
-#: builtin/send-pack.c:162
+#: builtin/push.c:547 builtin/push.c:548 builtin/send-pack.c:180
+#: builtin/send-pack.c:181
 msgid "receive pack program"
 msgstr "programma ricezione pack"
 
-#: builtin/push.c:559
+#: builtin/push.c:549
 msgid "set upstream for git pull/status"
 msgstr "imposta l'upstream per git pull/status"
 
-#: builtin/push.c:562
+#: builtin/push.c:552
 msgid "prune locally removed refs"
 msgstr "elimina i riferimenti rimossi localmente"
 
-#: builtin/push.c:564
+#: builtin/push.c:554
 msgid "bypass pre-push hook"
 msgstr "ignora l'hook pre-push"
 
-#: builtin/push.c:565
+#: builtin/push.c:555
 msgid "push missing but relevant tags"
 msgstr "esegui il push dei tag mancanti ma rilevanti"
 
-#: builtin/push.c:567 builtin/send-pack.c:168
+#: builtin/push.c:557 builtin/send-pack.c:187
 msgid "GPG sign the push"
 msgstr "firma il push con GPG"
 
-#: builtin/push.c:569 builtin/send-pack.c:175
+#: builtin/push.c:559 builtin/send-pack.c:194
 msgid "request atomic transaction on remote side"
 msgstr "richiedi l'atomicità della transazione al remoto"
 
-#: builtin/push.c:587
+#: builtin/push.c:577
 msgid "--delete is incompatible with --all, --mirror and --tags"
 msgstr "--delete non è compatibile con --all, --mirror e --tags"
 
-#: builtin/push.c:589
+#: builtin/push.c:579
 msgid "--delete doesn't make sense without any refs"
 msgstr "--delete non ha senso senza alcun ref"
 
-#: builtin/push.c:609
+#: builtin/push.c:599
 #, c-format
 msgid "bad repository '%s'"
 msgstr "repository '%s' errato"
 
-#: builtin/push.c:610
+#: builtin/push.c:600
 msgid ""
 "No configured push destination.\n"
 "Either specify the URL from the command-line or configure a remote "
@@ -18643,27 +19056,27 @@ msgstr ""
 "\n"
 "    git push <nome>\n"
 
-#: builtin/push.c:625
+#: builtin/push.c:615
 msgid "--all and --tags are incompatible"
 msgstr "--all e --tags non sono compatibili"
 
-#: builtin/push.c:627
+#: builtin/push.c:617
 msgid "--all can't be combined with refspecs"
 msgstr "--all non può essere combinato con degli specificatori riferimento"
 
-#: builtin/push.c:631
+#: builtin/push.c:621
 msgid "--mirror and --tags are incompatible"
 msgstr "--mirror e --tags non sono compatibili"
 
-#: builtin/push.c:633
+#: builtin/push.c:623
 msgid "--mirror can't be combined with refspecs"
 msgstr "--mirror non può essere combinato con degli specificatori riferimento"
 
-#: builtin/push.c:636
+#: builtin/push.c:626
 msgid "--all and --mirror are incompatible"
 msgstr "--all e --mirror non sono compatibili"
 
-#: builtin/push.c:640
+#: builtin/push.c:630
 msgid "push options must not have new line characters"
 msgstr "le opzioni push non devono avere caratteri di fine riga"
 
@@ -18815,194 +19228,194 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:181 builtin/rebase.c:205 builtin/rebase.c:232
+#: builtin/rebase.c:187 builtin/rebase.c:211 builtin/rebase.c:238
 #, c-format
 msgid "unusable todo list: '%s'"
 msgstr "elenco todo inutilizzabile: '%s'"
 
-#: builtin/rebase.c:298
+#: builtin/rebase.c:304
 #, c-format
 msgid "could not create temporary %s"
 msgstr "impossibile creare un %s temporaneo"
 
-#: builtin/rebase.c:304
+#: builtin/rebase.c:310
 msgid "could not mark as interactive"
 msgstr "impossibile contrassegnare come interattivo"
 
-#: builtin/rebase.c:358
+#: builtin/rebase.c:364
 msgid "could not generate todo list"
 msgstr "impossibile generare l'elenco todo"
 
-#: builtin/rebase.c:399
+#: builtin/rebase.c:405
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr ""
 "le opzioni --upstream o --onto richiedono che sia fornito un commit di base"
 
-#: builtin/rebase.c:468
+#: builtin/rebase.c:474
 msgid "git rebase--interactive [<options>]"
 msgstr "git rebase --interactive [<opzioni>]"
 
-#: builtin/rebase.c:481 builtin/rebase.c:1374
+#: builtin/rebase.c:487 builtin/rebase.c:1382
 msgid "keep commits which start empty"
 msgstr "mantieni i commit che iniziano vuoti"
 
-#: builtin/rebase.c:485 builtin/revert.c:128
+#: builtin/rebase.c:491 builtin/revert.c:128
 msgid "allow commits with empty messages"
 msgstr "consenti commit con messaggi vuoti"
 
-#: builtin/rebase.c:487
+#: builtin/rebase.c:493
 msgid "rebase merge commits"
 msgstr "esegui il rebase dei commit di merge"
 
-#: builtin/rebase.c:489
+#: builtin/rebase.c:495
 msgid "keep original branch points of cousins"
 msgstr "mantieni i punti di branch originali dei cugini"
 
-#: builtin/rebase.c:491
+#: builtin/rebase.c:497
 msgid "move commits that begin with squash!/fixup!"
 msgstr "sposta i commit che iniziano con squash!/fixup!"
 
-#: builtin/rebase.c:492
+#: builtin/rebase.c:498
 msgid "sign commits"
 msgstr "firma i commit"
 
-#: builtin/rebase.c:494 builtin/rebase.c:1314
+#: builtin/rebase.c:500 builtin/rebase.c:1321
 msgid "display a diffstat of what changed upstream"
 msgstr "visualizza un diffstat delle modifiche upstream"
 
-#: builtin/rebase.c:496
+#: builtin/rebase.c:502
 msgid "continue rebase"
 msgstr "continua il rebase"
 
-#: builtin/rebase.c:498
+#: builtin/rebase.c:504
 msgid "skip commit"
 msgstr "salta il commit"
 
-#: builtin/rebase.c:499
+#: builtin/rebase.c:505
 msgid "edit the todo list"
 msgstr "modifica l'elenco todo"
 
-#: builtin/rebase.c:501
+#: builtin/rebase.c:507
 msgid "show the current patch"
 msgstr "visualizza la patch corrente"
 
-#: builtin/rebase.c:504
+#: builtin/rebase.c:510
 msgid "shorten commit ids in the todo list"
 msgstr "abbrevia gli ID dei commit nell'elenco todo"
 
-#: builtin/rebase.c:506
+#: builtin/rebase.c:512
 msgid "expand commit ids in the todo list"
 msgstr "espandi gli ID dei commit nell'elenco todo"
 
-#: builtin/rebase.c:508
+#: builtin/rebase.c:514
 msgid "check the todo list"
 msgstr "controlla l'elenco todo"
 
-#: builtin/rebase.c:510
+#: builtin/rebase.c:516
 msgid "rearrange fixup/squash lines"
 msgstr "ridisponi le righe fixup/squash"
 
-#: builtin/rebase.c:512
+#: builtin/rebase.c:518
 msgid "insert exec commands in todo list"
 msgstr "inserisci i comandi exec nell'elenco todo"
 
-#: builtin/rebase.c:513
+#: builtin/rebase.c:519
 msgid "onto"
 msgstr "su"
 
-#: builtin/rebase.c:516
+#: builtin/rebase.c:522
 msgid "restrict-revision"
 msgstr "revisioni-limite"
 
-#: builtin/rebase.c:516
+#: builtin/rebase.c:522
 msgid "restrict revision"
 msgstr "limita la revisione"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:524
 msgid "squash-onto"
 msgstr "squash-su"
 
-#: builtin/rebase.c:519
+#: builtin/rebase.c:525
 msgid "squash onto"
 msgstr "esegui lo squash su"
 
-#: builtin/rebase.c:521
+#: builtin/rebase.c:527
 msgid "the upstream commit"
 msgstr "il commit upstream"
 
-#: builtin/rebase.c:523
+#: builtin/rebase.c:529
 msgid "head-name"
 msgstr "nome head"
 
-#: builtin/rebase.c:523
+#: builtin/rebase.c:529
 msgid "head name"
 msgstr "nome head"
 
-#: builtin/rebase.c:528
+#: builtin/rebase.c:534
 msgid "rebase strategy"
 msgstr "strategia di rebase"
 
-#: builtin/rebase.c:529
+#: builtin/rebase.c:535
 msgid "strategy-opts"
 msgstr "opzioni strategia"
 
-#: builtin/rebase.c:530
+#: builtin/rebase.c:536
 msgid "strategy options"
 msgstr "opzioni strategia"
 
-#: builtin/rebase.c:531
+#: builtin/rebase.c:537
 msgid "switch-to"
 msgstr "passa a"
 
-#: builtin/rebase.c:532
+#: builtin/rebase.c:538
 msgid "the branch or commit to checkout"
 msgstr "il branch o il commit di cui eseguire il checkout"
 
-#: builtin/rebase.c:533
+#: builtin/rebase.c:539
 msgid "onto-name"
 msgstr "nome"
 
-#: builtin/rebase.c:533
+#: builtin/rebase.c:539
 msgid "onto name"
 msgstr "sul nome"
 
-#: builtin/rebase.c:534
+#: builtin/rebase.c:540
 msgid "cmd"
 msgstr "comando"
 
-#: builtin/rebase.c:534
+#: builtin/rebase.c:540
 msgid "the command to run"
 msgstr "il comando da eseguire"
 
-#: builtin/rebase.c:537 builtin/rebase.c:1407
+#: builtin/rebase.c:543 builtin/rebase.c:1415
 msgid "automatically re-schedule any `exec` that fails"
 msgstr "schedula nuovamente le operazioni `exec` non riuscite automaticamente"
 
-#: builtin/rebase.c:553
+#: builtin/rebase.c:559
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
 msgstr "--[no-]rebase-cousins non ha effetto senza --rebase-merges"
 
-#: builtin/rebase.c:569
+#: builtin/rebase.c:575
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s richiede il backend da utilizzare per il merge"
 
-#: builtin/rebase.c:612
+#: builtin/rebase.c:618
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "impossibile ottenere 'onto': '%s'"
 
-#: builtin/rebase.c:629
+#: builtin/rebase.c:635
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "orig-head non valida: '%s'"
 
-#: builtin/rebase.c:654
+#: builtin/rebase.c:660
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "ignoro il valore non valido per allow_rerere_autoupdate: '%s'"
 
-#: builtin/rebase.c:799 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:805 git-rebase--preserve-merges.sh:81
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -19018,7 +19431,7 @@ msgstr ""
 "Per interrompere l'operazione e tornare allo stato precedente\n"
 "il \"git rebase\", esegui \"git rebase --abort\"."
 
-#: builtin/rebase.c:882
+#: builtin/rebase.c:888
 #, c-format
 msgid ""
 "\n"
@@ -19037,7 +19450,7 @@ msgstr ""
 "\n"
 "Di conseguenza, Git non può eseguirne il rebase."
 
-#: builtin/rebase.c:1208
+#: builtin/rebase.c:1214
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -19046,7 +19459,7 @@ msgstr ""
 "tipo vuoto '%s' non riconosciuto; i valori validi sono \"drop\", \"keep\" e "
 "\"ask\"."
 
-#: builtin/rebase.c:1226
+#: builtin/rebase.c:1232
 #, c-format
 msgid ""
 "%s\n"
@@ -19063,7 +19476,7 @@ msgstr ""
 "    git rebase '<branch>'\n"
 "\n"
 
-#: builtin/rebase.c:1242
+#: builtin/rebase.c:1248
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -19077,139 +19490,153 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<branch> %s\n"
 "\n"
 
-#: builtin/rebase.c:1272
+#: builtin/rebase.c:1278
 msgid "exec commands cannot contain newlines"
 msgstr "i comandi exec non possono contenere caratteri di fine riga"
 
-#: builtin/rebase.c:1276
+#: builtin/rebase.c:1282
 msgid "empty exec command"
 msgstr "comando exec vuoto"
 
-#: builtin/rebase.c:1305
+#: builtin/rebase.c:1312
 msgid "rebase onto given branch instead of upstream"
 msgstr "esegui il rebase sul branch specificato anziché su quello upstream"
 
-#: builtin/rebase.c:1307
+#: builtin/rebase.c:1314
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "usa la base del merge dell'upstream e del branch come base corrente"
 
-#: builtin/rebase.c:1309
+#: builtin/rebase.c:1316
 msgid "allow pre-rebase hook to run"
 msgstr "consenti l'esecuzione dell'hook pre-rebase"
 
-#: builtin/rebase.c:1311
+#: builtin/rebase.c:1318
 msgid "be quiet. implies --no-stat"
 msgstr "sii silenzioso. implica --no-stat"
 
-#: builtin/rebase.c:1317
+#: builtin/rebase.c:1324
 msgid "do not show diffstat of what changed upstream"
 msgstr "non visualizzare un diffstat delle modifiche upstream"
 
-#: builtin/rebase.c:1320
+#: builtin/rebase.c:1327
 msgid "add a Signed-off-by: line to each commit"
 msgstr "aggiungi una riga Signed-off-by: a ogni commit"
 
-#: builtin/rebase.c:1322 builtin/rebase.c:1326 builtin/rebase.c:1328
-msgid "passed to 'git am'"
-msgstr "passato a 'git am'"
+#: builtin/rebase.c:1330
+msgid "make committer date match author date"
+msgstr ""
+"fai corrispondere la data della persona che ha eseguito il commit alla data "
+"autore"
 
-#: builtin/rebase.c:1330 builtin/rebase.c:1332
+#: builtin/rebase.c:1332
+msgid "ignore author date and use current date"
+msgstr "ignora la data autore e usa la data corrente"
+
+#: builtin/rebase.c:1334
+msgid "synonym of --reset-author-date"
+msgstr "sinonimo di --reset-author-date"
+
+#: builtin/rebase.c:1336 builtin/rebase.c:1340
 msgid "passed to 'git apply'"
 msgstr "passato a 'git apply'"
 
-#: builtin/rebase.c:1334 builtin/rebase.c:1337
+#: builtin/rebase.c:1338
+msgid "ignore changes in whitespace"
+msgstr "ignora modifiche agli spazi bianchi"
+
+#: builtin/rebase.c:1342 builtin/rebase.c:1345
 msgid "cherry-pick all commits, even if unchanged"
 msgstr "esegui il cherry-pick di tutti i commit, anche se non modificati"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1347
 msgid "continue"
 msgstr "continua"
 
-#: builtin/rebase.c:1342
+#: builtin/rebase.c:1350
 msgid "skip current patch and continue"
 msgstr "salta la patch corrente e continua"
 
-#: builtin/rebase.c:1344
+#: builtin/rebase.c:1352
 msgid "abort and check out the original branch"
 msgstr "interrompi ed esegui il checkout del branch originario"
 
-#: builtin/rebase.c:1347
+#: builtin/rebase.c:1355
 msgid "abort but keep HEAD where it is"
 msgstr "interrompi ma mantieni l'HEAD dov'è"
 
-#: builtin/rebase.c:1348
+#: builtin/rebase.c:1356
 msgid "edit the todo list during an interactive rebase"
 msgstr "modifica l'elenco todo durante un rebase interattivo"
 
-#: builtin/rebase.c:1351
+#: builtin/rebase.c:1359
 msgid "show the patch file being applied or merged"
 msgstr ""
 "visualizza il file patch che sta per essere applicato o sottoposto a merge"
 
-#: builtin/rebase.c:1354
+#: builtin/rebase.c:1362
 msgid "use apply strategies to rebase"
 msgstr "usa le strategie di apply per eseguire il rebase"
 
-#: builtin/rebase.c:1358
+#: builtin/rebase.c:1366
 msgid "use merging strategies to rebase"
 msgstr "usa le strategie di merge per eseguire il rebase"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1370
 msgid "let the user edit the list of commits to rebase"
 msgstr ""
 "consenti all'utente di modificare l'elenco dei commit di cui eseguire il "
 "rebase"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1374
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(DEPRECATO) prova a ricreare i merge anziché ignorarli"
 
-#: builtin/rebase.c:1371
+#: builtin/rebase.c:1379
 msgid "how to handle commits that become empty"
 msgstr "come gestire i commit che diventano vuoti"
 
-#: builtin/rebase.c:1378
+#: builtin/rebase.c:1386
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "sposta i commit che iniziano con squash!/fixup! in -i"
 
-#: builtin/rebase.c:1385
+#: builtin/rebase.c:1393
 msgid "add exec lines after each commit of the editable list"
 msgstr "aggiungi righe exec dopo ogni commit della lista modificabile"
 
-#: builtin/rebase.c:1389
+#: builtin/rebase.c:1397
 msgid "allow rebasing commits with empty messages"
 msgstr "consenti il rebase di commit con messaggi vuoti"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1401
 msgid "try to rebase merges instead of skipping them"
 msgstr "prova ad eseguire il rebase dei merge anziché saltarli"
 
-#: builtin/rebase.c:1396
+#: builtin/rebase.c:1404
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr ""
 "usa 'merge-base --fork-point' per ridefinire più precisamente l'upstream"
 
-#: builtin/rebase.c:1398
+#: builtin/rebase.c:1406
 msgid "use the given merge strategy"
 msgstr "usa la strategia di merge specificata"
 
-#: builtin/rebase.c:1400 builtin/revert.c:115
+#: builtin/rebase.c:1408 builtin/revert.c:115
 msgid "option"
 msgstr "opzione"
 
-#: builtin/rebase.c:1401
+#: builtin/rebase.c:1409
 msgid "pass the argument through to the merge strategy"
 msgstr "passa l'argomento alla strategia di merge"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1412
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "esegui il rebase di tutti i commit raggiungibili fino a quelli radice"
 
-#: builtin/rebase.c:1409
+#: builtin/rebase.c:1417
 msgid "apply all changes, even those already present upstream"
 msgstr "applica tutte le modifiche, anche quelle già presenti upstream"
 
-#: builtin/rebase.c:1426
+#: builtin/rebase.c:1434
 msgid ""
 "the rebase.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -19217,41 +19644,41 @@ msgstr ""
 "il supporto per rebase.useBuiltin è stato rimosso!\n"
 "Vedi la voce relativa in 'git help config' per i dettagli."
 
-#: builtin/rebase.c:1432
+#: builtin/rebase.c:1440
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "Sembra che 'git am' sia in corso. Impossibile eseguire il rebase."
 
-#: builtin/rebase.c:1473
+#: builtin/rebase.c:1481
 msgid ""
 "git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
 msgstr "git rebase --preserve-merges è deprecato. Usa --rebase-merges."
 
-#: builtin/rebase.c:1478
+#: builtin/rebase.c:1486
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "impossibile combinare '--keep-base' con '--onto'"
 
-#: builtin/rebase.c:1480
+#: builtin/rebase.c:1488
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "impossibile combinare '--keep-base' con '--root'"
 
-#: builtin/rebase.c:1484
+#: builtin/rebase.c:1492
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "impossibile combinare '--root' con '--fork-point'"
 
-#: builtin/rebase.c:1487
+#: builtin/rebase.c:1495
 msgid "No rebase in progress?"
 msgstr "Nessun rebase in corso?"
 
-#: builtin/rebase.c:1491
+#: builtin/rebase.c:1499
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "L'azione --edit-todo può essere usata solo durante un rebase interattivo."
 
-#: builtin/rebase.c:1514
+#: builtin/rebase.c:1522
 msgid "Cannot read HEAD"
 msgstr "Impossibile leggere l'HEAD"
 
-#: builtin/rebase.c:1526
+#: builtin/rebase.c:1534
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -19260,16 +19687,16 @@ msgstr ""
 "quindi contrassegnarli come risolti usando\n"
 "git add"
 
-#: builtin/rebase.c:1545
+#: builtin/rebase.c:1553
 msgid "could not discard worktree changes"
 msgstr "impossibile scartare le modifiche all'albero di lavoro"
 
-#: builtin/rebase.c:1564
+#: builtin/rebase.c:1572
 #, c-format
 msgid "could not move back to %s"
 msgstr "impossibile ritornare a %s"
 
-#: builtin/rebase.c:1610
+#: builtin/rebase.c:1618
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -19290,137 +19717,137 @@ msgstr ""
 "ed eseguimi di nuovo. Mi fermo nel caso in cui tu abbia ancora\n"
 "salvato qualcosa di importante lì.\n"
 
-#: builtin/rebase.c:1638
+#: builtin/rebase.c:1646
 msgid "switch `C' expects a numerical value"
 msgstr "l'opzione `C` richiede un valore numerico"
 
-#: builtin/rebase.c:1680
+#: builtin/rebase.c:1688
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Modo sconosciuto: %s"
 
-#: builtin/rebase.c:1702
+#: builtin/rebase.c:1727
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy richiede --merge o --interactive"
 
-#: builtin/rebase.c:1732
+#: builtin/rebase.c:1757
 msgid "cannot combine apply options with merge options"
 msgstr "non è possibile combinare le opzioni apply con quelle merge"
 
-#: builtin/rebase.c:1745
+#: builtin/rebase.c:1770
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Backend di rebase sconosciuto: %s"
 
-#: builtin/rebase.c:1770
+#: builtin/rebase.c:1795
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec richiede --exec o --interactive"
 
-#: builtin/rebase.c:1790
+#: builtin/rebase.c:1815
 msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
 msgstr "impossibile combinare '--preserve-merges' con '--rebase-merges'"
 
-#: builtin/rebase.c:1794
+#: builtin/rebase.c:1819
 msgid ""
 "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
 "errore: impossibile combinare '--preserve-merges' con '--reschedule-failed-"
 "exec'"
 
-#: builtin/rebase.c:1818
+#: builtin/rebase.c:1843
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "upstream non valido: '%s'"
 
-#: builtin/rebase.c:1824
+#: builtin/rebase.c:1849
 msgid "Could not create new root commit"
 msgstr "Impossibile creare il nuovo commit radice"
 
-#: builtin/rebase.c:1850
+#: builtin/rebase.c:1875
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr ""
 "'%s': è necessario specificare esattamente una base per il merge con il "
 "branch"
 
-#: builtin/rebase.c:1853
+#: builtin/rebase.c:1878
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': è necessario specificare esattamente una base per il merge"
 
-#: builtin/rebase.c:1861
+#: builtin/rebase.c:1886
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' non punta a un commit valido"
 
-#: builtin/rebase.c:1887
+#: builtin/rebase.c:1912
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
 msgstr "errore fatale: branch/commit '%s' inesistente"
 
-#: builtin/rebase.c:1895 builtin/submodule--helper.c:40
-#: builtin/submodule--helper.c:1990
+#: builtin/rebase.c:1920 builtin/submodule--helper.c:40
+#: builtin/submodule--helper.c:2414
 #, c-format
 msgid "No such ref: %s"
 msgstr "Riferimento non esistente: %s"
 
-#: builtin/rebase.c:1906
+#: builtin/rebase.c:1931
 msgid "Could not resolve HEAD to a revision"
 msgstr "Impossibile risolvere HEAD come revisione"
 
-#: builtin/rebase.c:1927
+#: builtin/rebase.c:1952
 msgid "Please commit or stash them."
 msgstr "Eseguine il commit o lo stash."
 
-#: builtin/rebase.c:1963
+#: builtin/rebase.c:1988
 #, c-format
 msgid "could not switch to %s"
 msgstr "impossibile passare a %s"
 
-#: builtin/rebase.c:1974
+#: builtin/rebase.c:1999
 msgid "HEAD is up to date."
 msgstr "HEAD è aggiornato."
 
-#: builtin/rebase.c:1976
+#: builtin/rebase.c:2001
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Il branch corrente %s è aggiornato.\n"
 
-#: builtin/rebase.c:1984
+#: builtin/rebase.c:2009
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD è aggiornato, forzo il rebase."
 
-#: builtin/rebase.c:1986
+#: builtin/rebase.c:2011
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Il branch corrente %s è aggiornato, forzo il rebase.\n"
 
-#: builtin/rebase.c:1994
+#: builtin/rebase.c:2019
 msgid "The pre-rebase hook refused to rebase."
 msgstr "L'hook pre-rebase ha rifiutato di consentire il rebase."
 
-#: builtin/rebase.c:2001
+#: builtin/rebase.c:2026
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Modifiche a %s:\n"
 
-#: builtin/rebase.c:2004
+#: builtin/rebase.c:2029
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Modifiche da %s a %s:\n"
 
-#: builtin/rebase.c:2029
+#: builtin/rebase.c:2054
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Per prima cosa, ripristino l'head per riapplicare le tue modifiche su di "
 "esso...\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:2063
 msgid "Could not detach HEAD"
 msgstr "Impossibile scollegare l'HEAD"
 
-#: builtin/rebase.c:2047
+#: builtin/rebase.c:2072
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Fast forward da %s a %s eseguito.\n"
@@ -19429,7 +19856,7 @@ msgstr "Fast forward da %s a %s eseguito.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <directory Git>"
 
-#: builtin/receive-pack.c:844
+#: builtin/receive-pack.c:1224
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -19462,7 +19889,7 @@ msgstr ""
 "il comportamento predefinito, imposta la variabile di\n"
 "configurazione 'receive.denyCurrentBranch' a 'refuse'."
 
-#: builtin/receive-pack.c:864
+#: builtin/receive-pack.c:1244
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -19485,11 +19912,11 @@ msgstr ""
 "Per non visualizzare più questo messaggio, puoi impostarla a\n"
 "'refuse'."
 
-#: builtin/receive-pack.c:1970
+#: builtin/receive-pack.c:2422
 msgid "quiet"
 msgstr "non visualizzare messaggi"
 
-#: builtin/receive-pack.c:1984
+#: builtin/receive-pack.c:2436
 msgid "You must specify a directory."
 msgstr "Devi specificare una directory."
 
@@ -19688,12 +20115,12 @@ msgstr ""
 "specificare i branch da tracciare ha senso solo con i mirror da cui "
 "recuperare dati"
 
-#: builtin/remote.c:195 builtin/remote.c:696
+#: builtin/remote.c:195 builtin/remote.c:697
 #, c-format
 msgid "remote %s already exists."
 msgstr "il remoto %s esiste già."
 
-#: builtin/remote.c:199 builtin/remote.c:700
+#: builtin/remote.c:199 builtin/remote.c:701
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' non è un nome di remoto valido"
@@ -19717,12 +20144,12 @@ msgstr "(corrispondente)"
 msgid "(delete)"
 msgstr "(elimina)"
 
-#: builtin/remote.c:653
+#: builtin/remote.c:654
 #, c-format
 msgid "could not set '%s'"
 msgstr "impossibile impostare '%s'"
 
-#: builtin/remote.c:658
+#: builtin/remote.c:659
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -19733,19 +20160,19 @@ msgstr ""
 "\t%s:%d\n"
 "ora dà il nome al remoto inesistente '%s'"
 
-#: builtin/remote.c:689 builtin/remote.c:832 builtin/remote.c:940
+#: builtin/remote.c:690 builtin/remote.c:833 builtin/remote.c:941
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Remoto non esistente: '%s'"
 
-#: builtin/remote.c:706
+#: builtin/remote.c:707
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr ""
 "Non è stato possibile ridenominare la sezione di configurazione da '%s' in "
 "'%s'"
 
-#: builtin/remote.c:726
+#: builtin/remote.c:727
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -19756,17 +20183,17 @@ msgstr ""
 "\t%s\n"
 "\tAggiorna la configurazione manualmente se necessario."
 
-#: builtin/remote.c:766
+#: builtin/remote.c:767
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "eliminazione di '%s' non riuscita"
 
-#: builtin/remote.c:800
+#: builtin/remote.c:801
 #, c-format
 msgid "creating '%s' failed"
 msgstr "creazione di '%s' non riuscita"
 
-#: builtin/remote.c:876
+#: builtin/remote.c:877
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -19782,120 +20209,120 @@ msgstr[1] ""
 "eliminati;\n"
 "per eliminarli, usa:"
 
-#: builtin/remote.c:890
+#: builtin/remote.c:891
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Impossibile rimuovere la sezione di configurazione '%s'"
 
-#: builtin/remote.c:993
+#: builtin/remote.c:994
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " nuovo (il prossimo fetch lo salverà in remotes/%s)"
 
-#: builtin/remote.c:996
+#: builtin/remote.c:997
 msgid " tracked"
 msgstr " tracciato"
 
-#: builtin/remote.c:998
+#: builtin/remote.c:999
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " vecchio (usa 'git remote prune' per rimuoverlo)"
 
-#: builtin/remote.c:1000
+#: builtin/remote.c:1001
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1041
+#: builtin/remote.c:1042
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr ""
 "valore branch.%s.merge non valido; impossibile eseguire il rebase su più di "
 "un branch"
 
-#: builtin/remote.c:1050
+#: builtin/remote.c:1051
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "rebase interattivo sul remoto %s"
 
-#: builtin/remote.c:1052
+#: builtin/remote.c:1053
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "rebase interattivo (con merge) sul remoto %s"
 
-#: builtin/remote.c:1055
+#: builtin/remote.c:1056
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "rebase sul remoto %s"
 
-#: builtin/remote.c:1059
+#: builtin/remote.c:1060
 #, c-format
 msgid " merges with remote %s"
 msgstr " merge con il remote %s"
 
-#: builtin/remote.c:1062
+#: builtin/remote.c:1063
 #, c-format
 msgid "merges with remote %s"
 msgstr "merge con il remote %s"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1066
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    e con il remoto %s\n"
 
-#: builtin/remote.c:1108
+#: builtin/remote.c:1109
 msgid "create"
 msgstr "crea"
 
-#: builtin/remote.c:1111
+#: builtin/remote.c:1112
 msgid "delete"
 msgstr "elimina"
 
-#: builtin/remote.c:1115
+#: builtin/remote.c:1116
 msgid "up to date"
 msgstr "aggiornato"
 
-#: builtin/remote.c:1118
+#: builtin/remote.c:1119
 msgid "fast-forwardable"
 msgstr "fast forward possibile"
 
-#: builtin/remote.c:1121
+#: builtin/remote.c:1122
 msgid "local out of date"
 msgstr "locale non aggiornato"
 
-#: builtin/remote.c:1128
+#: builtin/remote.c:1129
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s esegue un aggiornamento forzato su %-*s (%s)"
 
-#: builtin/remote.c:1131
+#: builtin/remote.c:1132
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s esegue il push su %-*s (%s)"
 
-#: builtin/remote.c:1135
+#: builtin/remote.c:1136
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s esegue un aggiornamento forzato su %s"
 
-#: builtin/remote.c:1138
+#: builtin/remote.c:1139
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s esegue il push su %s"
 
-#: builtin/remote.c:1206
+#: builtin/remote.c:1207
 msgid "do not query remotes"
 msgstr "non interrogare i remoti"
 
-#: builtin/remote.c:1233
+#: builtin/remote.c:1234
 #, c-format
 msgid "* remote %s"
 msgstr "* remoto %s"
 
-#: builtin/remote.c:1234
+#: builtin/remote.c:1235
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL recupero: %s"
 
-#: builtin/remote.c:1235 builtin/remote.c:1251 builtin/remote.c:1390
+#: builtin/remote.c:1236 builtin/remote.c:1252 builtin/remote.c:1391
 msgid "(no URL)"
 msgstr "(nessun URL)"
 
@@ -19903,177 +20330,177 @@ msgstr "(nessun URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1249 builtin/remote.c:1251
+#: builtin/remote.c:1250 builtin/remote.c:1252
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "      URL push: %s"
 
-#: builtin/remote.c:1253 builtin/remote.c:1255 builtin/remote.c:1257
+#: builtin/remote.c:1254 builtin/remote.c:1256 builtin/remote.c:1258
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  branch HEAD: %s"
 
-#: builtin/remote.c:1253
+#: builtin/remote.c:1254
 msgid "(not queried)"
 msgstr "(non interrogato)"
 
-#: builtin/remote.c:1255
+#: builtin/remote.c:1256
 msgid "(unknown)"
 msgstr "(sconosciuto)"
 
-#: builtin/remote.c:1259
+#: builtin/remote.c:1260
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr ""
 "  branch HEAD (l'HEAD remoto è ambiguo, potrebbe essere uno dei seguenti):\n"
 
-#: builtin/remote.c:1271
+#: builtin/remote.c:1272
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Branch remoto:%s"
 msgstr[1] "  Branch remoti:%s"
 
-#: builtin/remote.c:1274 builtin/remote.c:1300
+#: builtin/remote.c:1275 builtin/remote.c:1301
 msgid " (status not queried)"
 msgstr " (stato non richiesto)"
 
-#: builtin/remote.c:1283
+#: builtin/remote.c:1284
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Branch locale configurato per 'git pull':"
 msgstr[1] "  Branch locali configurati per 'git pull':"
 
-#: builtin/remote.c:1291
+#: builtin/remote.c:1292
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  I riferimenti locali saranno copiati da 'git push'"
 
-#: builtin/remote.c:1297
+#: builtin/remote.c:1298
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Ref locale configurato per 'git push'%s:"
 msgstr[1] "  Ref locali configurati per 'git push'%s:"
 
-#: builtin/remote.c:1318
+#: builtin/remote.c:1319
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "imposta refs/remotes/<nome>/HEAD in base al remoto"
 
-#: builtin/remote.c:1320
+#: builtin/remote.c:1321
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "elimina refs/remotes/<nome>/HEAD"
 
-#: builtin/remote.c:1335
+#: builtin/remote.c:1336
 msgid "Cannot determine remote HEAD"
 msgstr "Impossibile determinare l'HEAD remoto"
 
-#: builtin/remote.c:1337
+#: builtin/remote.c:1338
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr "Branch HEAD remoti multipli. Scegline uno esplicitamente con:"
 
-#: builtin/remote.c:1347
+#: builtin/remote.c:1348
 #, c-format
 msgid "Could not delete %s"
 msgstr "Non è stato possibile eliminare %s"
 
-#: builtin/remote.c:1355
+#: builtin/remote.c:1356
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "Non è un ref valido: %s"
 
-#: builtin/remote.c:1357
+#: builtin/remote.c:1358
 #, c-format
 msgid "Could not setup %s"
 msgstr "Non è stato possibile configurare %s"
 
-#: builtin/remote.c:1375
+#: builtin/remote.c:1376
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s diventerà pendente!"
 
-#: builtin/remote.c:1376
+#: builtin/remote.c:1377
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s è diventato pendente!"
 
-#: builtin/remote.c:1386
+#: builtin/remote.c:1387
 #, c-format
 msgid "Pruning %s"
 msgstr "Eliminazione di %s in corso"
 
-#: builtin/remote.c:1387
+#: builtin/remote.c:1388
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1403
+#: builtin/remote.c:1404
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [sarebbe eliminato] %s"
 
-#: builtin/remote.c:1406
+#: builtin/remote.c:1407
 #, c-format
 msgid " * [pruned] %s"
 msgstr " * [eliminato] %s"
 
-#: builtin/remote.c:1451
+#: builtin/remote.c:1452
 msgid "prune remotes after fetching"
 msgstr "elimina remoti dopo il fetch"
 
-#: builtin/remote.c:1514 builtin/remote.c:1568 builtin/remote.c:1636
+#: builtin/remote.c:1515 builtin/remote.c:1569 builtin/remote.c:1637
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Remote '%s' non esistente"
 
-#: builtin/remote.c:1530
+#: builtin/remote.c:1531
 msgid "add branch"
 msgstr "aggiungi branch"
 
-#: builtin/remote.c:1537
+#: builtin/remote.c:1538
 msgid "no remote specified"
 msgstr "nessun remote specificato"
 
-#: builtin/remote.c:1554
+#: builtin/remote.c:1555
 msgid "query push URLs rather than fetch URLs"
 msgstr "interroga gli URL per il push anziché gli URL per il fetch"
 
-#: builtin/remote.c:1556
+#: builtin/remote.c:1557
 msgid "return all URLs"
 msgstr "restituisci tutti gli URL"
 
-#: builtin/remote.c:1584
+#: builtin/remote.c:1585
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "nessun URL configurato per il remoto '%s'"
 
-#: builtin/remote.c:1610
+#: builtin/remote.c:1611
 msgid "manipulate push URLs"
 msgstr "manipola gli URL per il push"
 
-#: builtin/remote.c:1612
+#: builtin/remote.c:1613
 msgid "add URL"
 msgstr "aggiungi URL"
 
-#: builtin/remote.c:1614
+#: builtin/remote.c:1615
 msgid "delete URLs"
 msgstr "elimina URL"
 
-#: builtin/remote.c:1621
+#: builtin/remote.c:1622
 msgid "--add --delete doesn't make sense"
 msgstr "--add --delete non ha senso"
 
-#: builtin/remote.c:1660
+#: builtin/remote.c:1661
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "Pattern URL vecchio non valido: %s"
 
-#: builtin/remote.c:1668
+#: builtin/remote.c:1669
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Nessuna URL trovata: %s"
 
-#: builtin/remote.c:1670
+#: builtin/remote.c:1671
 msgid "Will not delete all non-push URLs"
 msgstr "Non eliminerò tutti gli URL non push"
 
@@ -20090,118 +20517,118 @@ msgstr ""
 "Usa --no-write-bitmap-index o disabilita l'opzione di configurazione\n"
 "pack.writebitmaps."
 
-#: builtin/repack.c:193
+#: builtin/repack.c:197
 msgid "could not start pack-objects to repack promisor objects"
 msgstr ""
 "impossibile avviare pack-objects per eseguire il repack degli oggetti "
 "promettenti"
 
-#: builtin/repack.c:232 builtin/repack.c:418
+#: builtin/repack.c:236 builtin/repack.c:421
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Da pack-objects mi attendevo solo righe con gli ID completi "
 "esadecimali degli oggetti."
 
-#: builtin/repack.c:256
+#: builtin/repack.c:260
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "impossibile portare a termine pack-objects per eseguire il repack degli "
 "oggetti promettenti"
 
-#: builtin/repack.c:294
+#: builtin/repack.c:297
 msgid "pack everything in a single pack"
 msgstr "esegui il pack di tutto in un singolo pack"
 
-#: builtin/repack.c:296
+#: builtin/repack.c:299
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "come -a e rendi sciolti gli oggetti non raggiungibili"
 
-#: builtin/repack.c:299
+#: builtin/repack.c:302
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "rimuovi i pack ridondanti ed esegui git-prune-packed"
 
-#: builtin/repack.c:301
+#: builtin/repack.c:304
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "fornisci l'opzione --no-reuse-delta a git-pack-objects"
 
-#: builtin/repack.c:303
+#: builtin/repack.c:306
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "fornisci l'opzione --no-reuse-object a git-pack-objects"
 
-#: builtin/repack.c:305
+#: builtin/repack.c:308
 msgid "do not run git-update-server-info"
 msgstr "non eseguire git-update-server-info"
 
-#: builtin/repack.c:308
+#: builtin/repack.c:311
 msgid "pass --local to git-pack-objects"
 msgstr "fornisci l'opzione --local a git-pack-objects"
 
-#: builtin/repack.c:310
+#: builtin/repack.c:313
 msgid "write bitmap index"
 msgstr "scrivi l'indice bitmap"
 
-#: builtin/repack.c:312
+#: builtin/repack.c:315
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "fornisci l'opzione --delta-islands a git-pack-objects"
 
-#: builtin/repack.c:313
+#: builtin/repack.c:316
 msgid "approxidate"
 msgstr "data approssimativa"
 
-#: builtin/repack.c:314
+#: builtin/repack.c:317
 msgid "with -A, do not loosen objects older than this"
 msgstr "con -A, non rendere sciolti gli oggetti meno recenti di questa data"
 
-#: builtin/repack.c:316
+#: builtin/repack.c:319
 msgid "with -a, repack unreachable objects"
 msgstr "con -a, esegui il repack degli oggetti non raggiungibili"
 
-#: builtin/repack.c:318
+#: builtin/repack.c:321
 msgid "size of the window used for delta compression"
 msgstr "dimensione della finestra usata per la compressione delta"
 
-#: builtin/repack.c:319 builtin/repack.c:325
+#: builtin/repack.c:322 builtin/repack.c:328
 msgid "bytes"
 msgstr "byte"
 
-#: builtin/repack.c:320
+#: builtin/repack.c:323
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "come sopra, ma limita le dimensioni della memoria invece del numero di voci"
 
-#: builtin/repack.c:322
+#: builtin/repack.c:325
 msgid "limits the maximum delta depth"
 msgstr "limita la profondità massima dei delta"
 
-#: builtin/repack.c:324
+#: builtin/repack.c:327
 msgid "limits the maximum number of threads"
 msgstr "limita il numero massimo di thread"
 
-#: builtin/repack.c:326
+#: builtin/repack.c:329
 msgid "maximum size of each packfile"
 msgstr "dimensione massima di ogni file pack"
 
-#: builtin/repack.c:328
+#: builtin/repack.c:331
 msgid "repack objects in packs marked with .keep"
 msgstr "esegui il repack degli oggetti nei pack contrassegnati con .keep"
 
-#: builtin/repack.c:330
+#: builtin/repack.c:333
 msgid "do not repack this pack"
 msgstr "non eseguire il repack di questo pack"
 
-#: builtin/repack.c:340
+#: builtin/repack.c:343
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "impossibile eliminare i pack in un repository 'oggetti preziosi'"
 
-#: builtin/repack.c:344
+#: builtin/repack.c:347
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable e -A non sono compatibili"
 
-#: builtin/repack.c:427
+#: builtin/repack.c:430
 msgid "Nothing new to pack."
 msgstr "Non ci sono oggetti nuovi di cui eseguire il pack."
 
-#: builtin/repack.c:488
+#: builtin/repack.c:486
 #, c-format
 msgid ""
 "WARNING: Some packs in use have been renamed by\n"
@@ -20221,7 +20648,7 @@ msgstr ""
 "AVVISO: non è riuscito. Ridenominali manualmente\n"
 "AVVISO: entro %s:\n"
 
-#: builtin/repack.c:536
+#: builtin/repack.c:534
 #, c-format
 msgid "failed to remove '%s'"
 msgstr "eliminazione di '%s' non riuscita"
@@ -20878,55 +21305,77 @@ msgstr ""
 "[<riferimento>...]\n"
 "  --all e uno specificatore <riferimento> sono mutualmente esclusivi."
 
-#: builtin/send-pack.c:163
+#: builtin/send-pack.c:182
 msgid "remote name"
 msgstr "nome remoto"
 
-#: builtin/send-pack.c:176
+#: builtin/send-pack.c:195
 msgid "use stateless RPC protocol"
 msgstr "usa protocollo RPC senza stato"
 
-#: builtin/send-pack.c:177
+#: builtin/send-pack.c:196
 msgid "read refs from stdin"
 msgstr "leggi i riferimento dallo standard input"
 
-#: builtin/send-pack.c:178
+#: builtin/send-pack.c:197
 msgid "print status from remote helper"
 msgstr "stampa lo stato dell'helper remoto"
 
-#: builtin/shortlog.c:14
+#: builtin/shortlog.c:15
 msgid "git shortlog [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git shortlog [<opzioni>] [<intervallo revisioni>] [[--] <percorso>...]"
 
-#: builtin/shortlog.c:15
+#: builtin/shortlog.c:16
 msgid "git log --pretty=short | git shortlog [<options>]"
 msgstr "git log --pretty=short | git shortlog [<opzioni>]"
 
-#: builtin/shortlog.c:264
+#: builtin/shortlog.c:134
+msgid "using multiple --group options with stdin is not supported"
+msgstr ""
+"l'utilizzo di opzioni --group multiple con lo standard input non è supportato"
+
+#: builtin/shortlog.c:144
+msgid "using --group=trailer with stdin is not supported"
+msgstr "l'utilizzo di --group=trailer con lo standard input non è supportato"
+
+#: builtin/shortlog.c:388
+#, c-format
+msgid "unknown group type: %s"
+msgstr "tipo gruppo sconosciuto: %s"
+
+#: builtin/shortlog.c:416
 msgid "Group by committer rather than author"
 msgstr "Raggruppa per persona che ha eseguito il commit anziché per autore"
 
-#: builtin/shortlog.c:266
+#: builtin/shortlog.c:419
 msgid "sort output according to the number of commits per author"
 msgstr "ordina l'output in base al numero di commit per autore"
 
-#: builtin/shortlog.c:268
+#: builtin/shortlog.c:421
 msgid "Suppress commit descriptions, only provides commit count"
 msgstr "Ometti le descrizioni dei commit, fornisci solo il numero dei commit"
 
-#: builtin/shortlog.c:270
+#: builtin/shortlog.c:423
 msgid "Show the email address of each author"
 msgstr "Visualizza l'indirizzo e-mail di ogni autore"
 
-#: builtin/shortlog.c:271
+#: builtin/shortlog.c:424
 msgid "<w>[,<i1>[,<i2>]]"
 msgstr "<w>[,<i1>[,<i2>]]"
 
-#: builtin/shortlog.c:272
+#: builtin/shortlog.c:425
 msgid "Linewrap output"
 msgstr "Output a capo automatico"
 
-#: builtin/shortlog.c:301
+#: builtin/shortlog.c:427
+msgid "field"
+msgstr "campo"
+
+#: builtin/shortlog.c:428
+msgid "Group by field"
+msgstr "Raggruppa per campo"
+
+#: builtin/shortlog.c:456
 msgid "too many arguments given outside repository"
 msgstr "troppi argomenti forniti oltre al repository"
 
@@ -21128,61 +21577,73 @@ msgstr ""
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
 msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <opzioni>"
 
-#: builtin/sparse-checkout.c:64
+#: builtin/sparse-checkout.c:50
+msgid "git sparse-checkout list"
+msgstr "git sparse-checkout list"
+
+#: builtin/sparse-checkout.c:76
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "questo albero di lavoro non è sparse (il file sparse-checkout potrebbe non "
 "esistere)"
 
-#: builtin/sparse-checkout.c:216
+#: builtin/sparse-checkout.c:228
 msgid "failed to create directory for sparse-checkout file"
 msgstr "creazione della directory per il file sparse-checkout non riuscita"
 
-#: builtin/sparse-checkout.c:257
+#: builtin/sparse-checkout.c:269
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "impossibile aggiornare il formato repository per abilitare worktreeConfig"
 
-#: builtin/sparse-checkout.c:259
+#: builtin/sparse-checkout.c:271
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "impostazione dell'opzione extensions.worktreeConfig non riuscita"
 
-#: builtin/sparse-checkout.c:276
+#: builtin/sparse-checkout.c:288
 msgid "git sparse-checkout init [--cone]"
 msgstr "git sparse-checkout init [--cone]"
 
-#: builtin/sparse-checkout.c:295
+#: builtin/sparse-checkout.c:307
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "inizializza il checkout sparse in modalità cone"
 
-#: builtin/sparse-checkout.c:332
+#: builtin/sparse-checkout.c:344
 #, c-format
 msgid "failed to open '%s'"
 msgstr "apertura di '%s' non riuscita"
 
-#: builtin/sparse-checkout.c:389
+#: builtin/sparse-checkout.c:401
 #, c-format
 msgid "could not normalize path %s"
 msgstr "impossibile normalizzare il percorso '%s'"
 
-#: builtin/sparse-checkout.c:401
+#: builtin/sparse-checkout.c:413
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | <pattern>)"
 
-#: builtin/sparse-checkout.c:426
+#: builtin/sparse-checkout.c:438
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "impossibile rimuovere le virgolette dalla stringa in stile C '%s'"
 
-#: builtin/sparse-checkout.c:480 builtin/sparse-checkout.c:504
+#: builtin/sparse-checkout.c:492 builtin/sparse-checkout.c:516
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "impossibile caricare i pattern sparse-checkout esistenti"
 
-#: builtin/sparse-checkout.c:549
+#: builtin/sparse-checkout.c:561
 msgid "read patterns from standard in"
 msgstr "leggi i pattern dallo standard input"
 
-#: builtin/sparse-checkout.c:586
+#: builtin/sparse-checkout.c:576
+msgid "git sparse-checkout reapply"
+msgstr "git sparse-checkout reapply"
+
+#: builtin/sparse-checkout.c:595
+msgid "git sparse-checkout disable"
+msgstr "git sparse-checkout disable"
+
+#: builtin/sparse-checkout.c:623
 msgid "error while refreshing working directory"
 msgstr "errore durante l'aggiornamento della directory di lavoro"
 
@@ -21338,7 +21799,7 @@ msgstr "Nome del branch non specificato"
 msgid "Cannot update %s with %s"
 msgstr "Impossibile aggiornare %s con %s"
 
-#: builtin/stash.c:818 builtin/stash.c:1475 builtin/stash.c:1540
+#: builtin/stash.c:818 builtin/stash.c:1472 builtin/stash.c:1537
 msgid "stash message"
 msgstr "messaggio di stash"
 
@@ -21346,81 +21807,81 @@ msgstr "messaggio di stash"
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" richiede un argomento <commit>"
 
-#: builtin/stash.c:1046
+#: builtin/stash.c:1043
 msgid "No changes selected"
 msgstr "Nessuna modifica selezionata"
 
-#: builtin/stash.c:1146
+#: builtin/stash.c:1143
 msgid "You do not have the initial commit yet"
 msgstr "Non hai ancora un commit iniziale"
 
-#: builtin/stash.c:1173
+#: builtin/stash.c:1170
 msgid "Cannot save the current index state"
 msgstr "Impossibile salvare lo stato corrente di index"
 
-#: builtin/stash.c:1182
+#: builtin/stash.c:1179
 msgid "Cannot save the untracked files"
 msgstr "Impossibile salvare i file non tracciati"
 
-#: builtin/stash.c:1193 builtin/stash.c:1202
+#: builtin/stash.c:1190 builtin/stash.c:1199
 msgid "Cannot save the current worktree state"
 msgstr "Impossibile salvare lo stato corrente dell'albero di lavoro"
 
-#: builtin/stash.c:1230
+#: builtin/stash.c:1227
 msgid "Cannot record working tree state"
 msgstr "Impossibile registrare lo stato dell'albero di lavoro"
 
-#: builtin/stash.c:1279
+#: builtin/stash.c:1276
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Impossibile usare --patch e --include-untracked o --all allo stesso tempo"
 
-#: builtin/stash.c:1295
+#: builtin/stash.c:1292
 msgid "Did you forget to 'git add'?"
 msgstr "Ti sei scordato di eseguire 'git add'?"
 
-#: builtin/stash.c:1310
+#: builtin/stash.c:1307
 msgid "No local changes to save"
 msgstr "Nessuna modifica locale da salvare"
 
-#: builtin/stash.c:1317
+#: builtin/stash.c:1314
 msgid "Cannot initialize stash"
 msgstr "Impossibile inizializzare stash"
 
-#: builtin/stash.c:1332
+#: builtin/stash.c:1329
 msgid "Cannot save the current status"
 msgstr "Impossibile salvare lo stato attuale"
 
-#: builtin/stash.c:1337
+#: builtin/stash.c:1334
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Directory di lavoro e stato indice salvati: %s"
 
-#: builtin/stash.c:1427
+#: builtin/stash.c:1424
 msgid "Cannot remove worktree changes"
 msgstr "Impossibile rimuovere le modifiche all'albero di lavoro"
 
-#: builtin/stash.c:1466 builtin/stash.c:1531
+#: builtin/stash.c:1463 builtin/stash.c:1528
 msgid "keep index"
 msgstr "mantieni l'indice"
 
-#: builtin/stash.c:1468 builtin/stash.c:1533
+#: builtin/stash.c:1465 builtin/stash.c:1530
 msgid "stash in patch mode"
 msgstr "esegui lo stash in modalità patch"
 
-#: builtin/stash.c:1469 builtin/stash.c:1534
+#: builtin/stash.c:1466 builtin/stash.c:1531
 msgid "quiet mode"
 msgstr "modalità silenziosa"
 
-#: builtin/stash.c:1471 builtin/stash.c:1536
+#: builtin/stash.c:1468 builtin/stash.c:1533
 msgid "include untracked files in stash"
 msgstr "includi i file non tracciati nello stash"
 
-#: builtin/stash.c:1473 builtin/stash.c:1538
+#: builtin/stash.c:1470 builtin/stash.c:1535
 msgid "include ignore files"
 msgstr "includi i file ignorati"
 
-#: builtin/stash.c:1573
+#: builtin/stash.c:1570
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -21444,7 +21905,7 @@ msgstr "salta e rimuovi tutte le righe che iniziano con un carattere commento"
 msgid "prepend comment character and space to each line"
 msgstr "anteponi il carattere commento e uno spazio a ogni riga"
 
-#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:1999
+#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:2423
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Atteso nome riferimento completo, ricevuto %s"
@@ -21458,7 +21919,7 @@ msgstr "submodule--helper print-default-remote non richiede argomenti"
 msgid "cannot strip one component off url '%s'"
 msgstr "impossibile rimuovere un componente dall'URL '%s'"
 
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1395
+#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1819
 msgid "alternative anchor for relative paths"
 msgstr "ancoraggio alternativo per i percorsi relativi"
 
@@ -21466,8 +21927,8 @@ msgstr "ancoraggio alternativo per i percorsi relativi"
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<percorso>] [<percorso>...]"
 
-#: builtin/submodule--helper.c:472 builtin/submodule--helper.c:630
-#: builtin/submodule--helper.c:653
+#: builtin/submodule--helper.c:472 builtin/submodule--helper.c:629
+#: builtin/submodule--helper.c:652
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Nessun URL trovato in .gitmodules per il percorso del sottomodulo '%s'"
@@ -21501,7 +21962,7 @@ msgstr ""
 msgid "Suppress output of entering each submodule command"
 msgstr "Non visualizzare l'output dei comandi eseguiti in ogni sottomodulo"
 
-#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:1063
+#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:1487
 msgid "Recurse into nested submodules"
 msgstr "Esegui ricorsivamente sui sottomoduli innestati"
 
@@ -21518,56 +21979,56 @@ msgstr ""
 "impossibile trovare la configurazione '%s'. Assumo che questo repository sia "
 "il proprio repository autoritativo upstream."
 
-#: builtin/submodule--helper.c:667
+#: builtin/submodule--helper.c:666
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr "Registrazione dell'URL per il percorso sottomodulo '%s' non riuscita"
 
-#: builtin/submodule--helper.c:671
+#: builtin/submodule--helper.c:670
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Sottomodulo '%s' (%s) registrato per il percorso '%s'\n"
 
-#: builtin/submodule--helper.c:681
+#: builtin/submodule--helper.c:680
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr ""
 "avviso: suggerita modalità comando aggiornamento per il sottomodulo '%s'\n"
 
-#: builtin/submodule--helper.c:688
+#: builtin/submodule--helper.c:687
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr ""
 "Registrazione della modalità aggiornamento per il percorso sottomodulo '%s'"
 
-#: builtin/submodule--helper.c:710
+#: builtin/submodule--helper.c:709
 msgid "Suppress output for initializing a submodule"
 msgstr "Non visualizzare l'output dell'inizializzazione del sottomodulo"
 
-#: builtin/submodule--helper.c:715
+#: builtin/submodule--helper.c:714
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<opzioni>] [<percorso>]"
 
-#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
+#: builtin/submodule--helper.c:787 builtin/submodule--helper.c:922
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "mapping sottomodulo per il percorso '%s' non trovato in .gitmodules"
 
-#: builtin/submodule--helper.c:837
+#: builtin/submodule--helper.c:835
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "impossibile risolvere il riferimento HEAD nel sottomodulo '%s'"
 
-#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1033
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1457
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "ricorsione nel sottomodulo '%s' non riuscita"
 
-#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1199
+#: builtin/submodule--helper.c:886 builtin/submodule--helper.c:1623
 msgid "Suppress submodule status output"
 msgstr "Non visualizzare l'output dello stato del sottomodulo"
 
-#: builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:887
 msgid ""
 "Use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -21575,49 +22036,107 @@ msgstr ""
 "Usa il commit salvato nell'indice anziché quello salvato nell'HEAD del "
 "sottomodulo"
 
-#: builtin/submodule--helper.c:890
+#: builtin/submodule--helper.c:888
 msgid "recurse into nested submodules"
 msgstr "esegui ricorsivamente sui sottomoduli innestati"
 
-#: builtin/submodule--helper.c:895
+#: builtin/submodule--helper.c:893
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr ""
 "git submodule status [--quiet] [--cached] [--recursive] [<percorso>...]"
 
-#: builtin/submodule--helper.c:919
+#: builtin/submodule--helper.c:917
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <percorso>"
 
-#: builtin/submodule--helper.c:983
+#: builtin/submodule--helper.c:989
+#, c-format
+msgid "* %s %s(blob)->%s(submodule)"
+msgstr "* %s %s(blob)->%s(sottomodulo)"
+
+#: builtin/submodule--helper.c:992
+#, c-format
+msgid "* %s %s(submodule)->%s(blob)"
+msgstr "* %s %s(sottomodulo)->%s(blob)"
+
+#: builtin/submodule--helper.c:1005
+#, c-format
+msgid "%s"
+msgstr "%s"
+
+#: builtin/submodule--helper.c:1055
+#, c-format
+msgid "couldn't hash object from '%s'"
+msgstr "impossibile calcolare l'hash dell'oggetto da '%s'"
+
+#: builtin/submodule--helper.c:1059
+#, c-format
+msgid "unexpected mode %o\n"
+msgstr "modalità %o inattesa\n"
+
+#: builtin/submodule--helper.c:1300
+msgid "use the commit stored in the index instead of the submodule HEAD"
+msgstr ""
+"usa il commit salvato nell'indice anziché quello salvato nell'HEAD del"
+" sottomodulo"
+
+#: builtin/submodule--helper.c:1302
+msgid "to compare the commit in the index with that in the submodule HEAD"
+msgstr ""
+"per confrontare il commit salvato nell'indice con quello salvato nell'HEAD"
+" del sottomodulo"
+
+#: builtin/submodule--helper.c:1304
+msgid "skip submodules with 'ignore_config' value set to 'all'"
+msgstr ""
+"ignora i sottomoduli il cui valore 'ignore_config' è impostato ad 'all'"
+
+#: builtin/submodule--helper.c:1306
+msgid "limit the summary size"
+msgstr "limita le dimensioni del riassunto"
+
+#: builtin/submodule--helper.c:1311
+msgid "git submodule--helper summary [<options>] [commit] [--] [<path>]"
+msgstr "git submodule--helper summary [<opzioni>] [commit] [--] [<percorso>]"
+
+#: builtin/submodule--helper.c:1335
+msgid "could not fetch a revision for HEAD"
+msgstr "impossibile recuperare una revisione per HEAD"
+
+#: builtin/submodule--helper.c:1340
+msgid "--cached and --files are mutually exclusive"
+msgstr "le opzioni --cached e --files sono mutualmente esclusive"
+
+#: builtin/submodule--helper.c:1407
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Sincronizzazione URL sottomodulo per '%s' in corso\n"
 
-#: builtin/submodule--helper.c:989
+#: builtin/submodule--helper.c:1413
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "registrazione dell'URL per il percorso sottomodulo '%s' non riuscita"
 
-#: builtin/submodule--helper.c:1003
+#: builtin/submodule--helper.c:1427
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "recupero del remoto predefinito per il sottomodulo '%s' non riuscito"
 
-#: builtin/submodule--helper.c:1014
+#: builtin/submodule--helper.c:1438
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "aggiornamento del remoto per il sottomodulo '%s' non riuscito"
 
-#: builtin/submodule--helper.c:1061
+#: builtin/submodule--helper.c:1485
 msgid "Suppress output of synchronizing submodule url"
 msgstr ""
 "Non visualizzare l'output della sincronizzazione dell'URL del sottomodulo"
 
-#: builtin/submodule--helper.c:1068
+#: builtin/submodule--helper.c:1492
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<percorso>]"
 
-#: builtin/submodule--helper.c:1122
+#: builtin/submodule--helper.c:1546
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -21626,7 +22145,7 @@ msgstr ""
 "L'albero di lavoro del sottomodulo ('%s') contiene una directory .git (usa "
 "'rm -rf' se vuoi veramente rimuoverla, inclusa l'intera sua cronologia)"
 
-#: builtin/submodule--helper.c:1134
+#: builtin/submodule--helper.c:1558
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -21635,47 +22154,47 @@ msgstr ""
 "L'albero di lavoro del sottomodulo ('%s') contiene modifiche locali; usa '-"
 "f' per scartarle"
 
-#: builtin/submodule--helper.c:1142
+#: builtin/submodule--helper.c:1566
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Directory '%s' ripulita\n"
 
-#: builtin/submodule--helper.c:1144
+#: builtin/submodule--helper.c:1568
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Impossibile rimuovere l'albero di lavoro del sottomodulo '%s'\n"
 
-#: builtin/submodule--helper.c:1155
+#: builtin/submodule--helper.c:1579
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "impossibile creare la directory vuota del sottomodulo %s"
 
-#: builtin/submodule--helper.c:1171
+#: builtin/submodule--helper.c:1595
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Rimossa registrazione sottomodulo '%s' (%s) per il percorso '%s'\n"
 
-#: builtin/submodule--helper.c:1200
+#: builtin/submodule--helper.c:1624
 msgid "Remove submodule working trees even if they contain local changes"
 msgstr ""
 "Rimuovi gli alberi di lavoro dei sottomoduli anche se contengono modifiche "
 "locali"
 
-#: builtin/submodule--helper.c:1201
+#: builtin/submodule--helper.c:1625
 msgid "Unregister all submodules"
 msgstr "Annulla la registrazione di tutti i sottomoduli"
 
-#: builtin/submodule--helper.c:1206
+#: builtin/submodule--helper.c:1630
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<percorso>...]]"
 
-#: builtin/submodule--helper.c:1220
+#: builtin/submodule--helper.c:1644
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Usa '--all' se vuoi veramente deinizializzare tutti i sottomoduli"
 
-#: builtin/submodule--helper.c:1289
+#: builtin/submodule--helper.c:1713
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -21690,46 +22209,46 @@ msgstr ""
 "clone\n"
 "con l'opzione '--reference-if-able' anziché '--reference'."
 
-#: builtin/submodule--helper.c:1328 builtin/submodule--helper.c:1331
+#: builtin/submodule--helper.c:1752 builtin/submodule--helper.c:1755
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "non è possibile aggiungere un alternato per il sottomodulo '%s': %s"
 
-#: builtin/submodule--helper.c:1367
+#: builtin/submodule--helper.c:1791
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Valore '%s' per submodule.alternateErrorStrategy non riconosciuto"
 
-#: builtin/submodule--helper.c:1374
+#: builtin/submodule--helper.c:1798
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Valore '%s' per submodule.alternateLocation non riconosciuto"
 
-#: builtin/submodule--helper.c:1398
+#: builtin/submodule--helper.c:1822
 msgid "where the new submodule will be cloned to"
 msgstr "percorso in cui sarà clonato il nuovo sottomodulo"
 
-#: builtin/submodule--helper.c:1401
+#: builtin/submodule--helper.c:1825
 msgid "name of the new submodule"
 msgstr "nome del nuovo sottomodulo"
 
-#: builtin/submodule--helper.c:1404
+#: builtin/submodule--helper.c:1828
 msgid "url where to clone the submodule from"
 msgstr "URL da cui clonare il sottomodulo"
 
-#: builtin/submodule--helper.c:1412
+#: builtin/submodule--helper.c:1836
 msgid "depth for shallow clones"
 msgstr "profondità per i cloni shallow"
 
-#: builtin/submodule--helper.c:1415 builtin/submodule--helper.c:1924
+#: builtin/submodule--helper.c:1839 builtin/submodule--helper.c:2348
 msgid "force cloning progress"
 msgstr "forza l'indicazione d'avanzamento della clonazione"
 
-#: builtin/submodule--helper.c:1417 builtin/submodule--helper.c:1926
+#: builtin/submodule--helper.c:1841 builtin/submodule--helper.c:2350
 msgid "disallow cloning into non-empty directory"
 msgstr "disabilita il clone in una directory non vuota"
 
-#: builtin/submodule--helper.c:1424
+#: builtin/submodule--helper.c:1848
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -21739,109 +22258,109 @@ msgstr ""
 "<repository>] [--name <nome>] [--depth <profondità>] [--single-branch] --url "
 "<URL> --path <percorso>"
 
-#: builtin/submodule--helper.c:1449
+#: builtin/submodule--helper.c:1873
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "mi rifiuto di creare/usare '%s' nella directory Git di un altro sottomodulo"
 
-#: builtin/submodule--helper.c:1460
+#: builtin/submodule--helper.c:1884
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "clone di '%s' nel percorso del sottomodulo ('%s') non riuscito"
 
-#: builtin/submodule--helper.c:1464
+#: builtin/submodule--helper.c:1888
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "directory non vuota: '%s'"
 
-#: builtin/submodule--helper.c:1476
+#: builtin/submodule--helper.c:1900
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "impossibile recuperare la directory del sottomodulo per '%s'"
 
-#: builtin/submodule--helper.c:1512
+#: builtin/submodule--helper.c:1936
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr ""
 "Modalità aggiornamento '%s' non valida per il percorso del sottomodulo ('%s')"
 
-#: builtin/submodule--helper.c:1516
+#: builtin/submodule--helper.c:1940
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "È stata configurata una modalità aggiornamento '%s' non valida per il "
 "percorso del sottomodulo ('%s')"
 
-#: builtin/submodule--helper.c:1617
+#: builtin/submodule--helper.c:2041
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Percorso del sottomodulo ('%s') non inizializzato"
 
-#: builtin/submodule--helper.c:1621
+#: builtin/submodule--helper.c:2045
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Potresti voler usare 'update --init'."
 
-#: builtin/submodule--helper.c:1651
+#: builtin/submodule--helper.c:2075
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Ignoro il sottomodulo %s non sottoposto a merge"
 
-#: builtin/submodule--helper.c:1680
+#: builtin/submodule--helper.c:2104
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Ignoro il sottomodulo '%s'"
 
-#: builtin/submodule--helper.c:1830
+#: builtin/submodule--helper.c:2254
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Clone di '%s' non riuscito. Nuovo tentativo programmato"
 
-#: builtin/submodule--helper.c:1841
+#: builtin/submodule--helper.c:2265
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr ""
 "Clone di '%s' non riuscito per la seconda volta, interrompo l'operazione"
 
-#: builtin/submodule--helper.c:1903 builtin/submodule--helper.c:2149
+#: builtin/submodule--helper.c:2327 builtin/submodule--helper.c:2573
 msgid "path into the working tree"
 msgstr "percorso nell'albero di lavoro"
 
-#: builtin/submodule--helper.c:1906
+#: builtin/submodule--helper.c:2330
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr ""
 "percorso nell'albero di lavoro attraverso i confini dei sottomoduli innestati"
 
-#: builtin/submodule--helper.c:1910
+#: builtin/submodule--helper.c:2334
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout o none"
 
-#: builtin/submodule--helper.c:1916
+#: builtin/submodule--helper.c:2340
 msgid "Create a shallow clone truncated to the specified number of revisions"
 msgstr "Crea un clone shallow limitato al numero di revisioni specificato"
 
-#: builtin/submodule--helper.c:1919
+#: builtin/submodule--helper.c:2343
 msgid "parallel jobs"
 msgstr "processi da eseguire in parallelo"
 
-#: builtin/submodule--helper.c:1921
+#: builtin/submodule--helper.c:2345
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "determina se il clone iniziale sarà shallow come raccomandato"
 
-#: builtin/submodule--helper.c:1922
+#: builtin/submodule--helper.c:2346
 msgid "don't print cloning progress"
 msgstr "non stampare l'indicazione di avanzamento della clonazione"
 
-#: builtin/submodule--helper.c:1933
+#: builtin/submodule--helper.c:2357
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr ""
 "git submodule--helper update-clone [--prefix=<percorso>] [<percorso>...]"
 
-#: builtin/submodule--helper.c:1946
+#: builtin/submodule--helper.c:2370
 msgid "bad value for update parameter"
 msgstr "valore parametro aggiornamento errato"
 
-#: builtin/submodule--helper.c:1994
+#: builtin/submodule--helper.c:2418
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -21850,86 +22369,86 @@ msgstr ""
 "Il branch del sottomodulo (%s) è configurato in modo da ereditare il branch "
 "dal progetto al livello superiore, ma questo non è su alcun branch"
 
-#: builtin/submodule--helper.c:2117
+#: builtin/submodule--helper.c:2541
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "impossibile recuperare un handle repository per il sottomodulo '%s'"
 
-#: builtin/submodule--helper.c:2150
+#: builtin/submodule--helper.c:2574
 msgid "recurse into submodules"
 msgstr "esegui ricorsivamente sui sottomoduli"
 
-#: builtin/submodule--helper.c:2156
+#: builtin/submodule--helper.c:2580
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<opzioni>] [<percorso>...]"
 
-#: builtin/submodule--helper.c:2212
+#: builtin/submodule--helper.c:2636
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "controlla se è sicuro scrivere sul file .gitmodules"
 
-#: builtin/submodule--helper.c:2215
+#: builtin/submodule--helper.c:2639
 msgid "unset the config in the .gitmodules file"
 msgstr "rimuovi la configurazione nel file .gitmodules"
 
-#: builtin/submodule--helper.c:2220
+#: builtin/submodule--helper.c:2644
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <nome> [<valore>]"
 
-#: builtin/submodule--helper.c:2221
+#: builtin/submodule--helper.c:2645
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <nome>"
 
-#: builtin/submodule--helper.c:2222
+#: builtin/submodule--helper.c:2646
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2241 git-submodule.sh:176
+#: builtin/submodule--helper.c:2665 git-submodule.sh:151
 #, sh-format
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "assicurati che il file .gitmodules sia nell'albero di lavoro"
 
-#: builtin/submodule--helper.c:2257
+#: builtin/submodule--helper.c:2681
 msgid "Suppress output for setting url of a submodule"
 msgstr "Non visualizzare l'output dell'impostazione dell'URL del sottomodulo"
 
-#: builtin/submodule--helper.c:2261
+#: builtin/submodule--helper.c:2685
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <percorso> <nuovo URL>"
 
-#: builtin/submodule--helper.c:2294
+#: builtin/submodule--helper.c:2718
 msgid "set the default tracking branch to master"
 msgstr "imposta il branch tracciato predefinito a master"
 
-#: builtin/submodule--helper.c:2296
+#: builtin/submodule--helper.c:2720
 msgid "set the default tracking branch"
 msgstr "imposta il branch tracciato predefinito"
 
-#: builtin/submodule--helper.c:2300
+#: builtin/submodule--helper.c:2724
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-d|--default) <percorso>"
 
-#: builtin/submodule--helper.c:2301
+#: builtin/submodule--helper.c:2725
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
-"git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <"
-"percorso>"
+"git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> "
+"<percorso>"
 
-#: builtin/submodule--helper.c:2308
+#: builtin/submodule--helper.c:2732
 msgid "--branch or --default required"
 msgstr "è richiesto specificare --branch o --default"
 
-#: builtin/submodule--helper.c:2311
+#: builtin/submodule--helper.c:2735
 msgid "--branch and --default are mutually exclusive"
 msgstr "le opzioni --branch e --default sono mutualmente esclusive"
 
-#: builtin/submodule--helper.c:2367 git.c:436 git.c:683
+#: builtin/submodule--helper.c:2792 git.c:438 git.c:691
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s non supporta --super-prefix"
 
-#: builtin/submodule--helper.c:2373
+#: builtin/submodule--helper.c:2798
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' non è un sottocomando submodule--helper valido"
@@ -21980,11 +22499,13 @@ msgstr "git tag -d <nome tag>..."
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
-"\t\t[--format=<format>] [--[no-]merged [<commit>]] [<pattern>...]"
+"\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"[<pattern>...]"
 msgstr ""
 "git tag -l [-n[<numero>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <oggetto>]\n"
-"\t\t[--format=<formato>] [--[no-]merged [<commit>]] [<pattern>...]"
+"\t\t[--format=<formato>] [--merged <commit>] [--no-merged <commit>] "
+"[<pattern>...]"
 
 #: builtin/tag.c:30
 msgid "git tag -v [--format=<format>] <tagname>..."
@@ -22536,15 +23057,15 @@ msgstr "stampa i contenuti del commit"
 msgid "print raw gpg status output"
 msgstr "stampa l'output grezzo dello stato di GPG"
 
-#: builtin/verify-pack.c:55
+#: builtin/verify-pack.c:59
 msgid "git verify-pack [-v | --verbose] [-s | --stat-only] <pack>..."
 msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] <pack>..."
 
-#: builtin/verify-pack.c:65
+#: builtin/verify-pack.c:70
 msgid "verbose"
 msgstr "dettagliato"
 
-#: builtin/verify-pack.c:67
+#: builtin/verify-pack.c:72
 msgid "show statistics only"
 msgstr "visualizza solo le statistiche"
 
@@ -22584,7 +23105,7 @@ msgstr "git worktree remove [<opzioni>] <albero di lavoro>"
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <percorso>"
 
-#: builtin/worktree.c:60 builtin/worktree.c:972
+#: builtin/worktree.c:60 builtin/worktree.c:970
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "eliminazione di '%s' non riuscita"
@@ -22645,8 +23166,8 @@ msgid ""
 "use '%s -f -f' to override, or 'unlock' and 'prune' or 'remove' to clear"
 msgstr ""
 "'%s' è un albero di lavoro mancante ma bloccato;\n"
-"usa '%s -f -f' per eseguire l'override, o 'unlock' e 'prune' o 'remove' per"
-" rimuoverlo"
+"usa '%s -f -f' per eseguire l'override, o 'unlock' e 'prune' o 'remove' per "
+"rimuoverlo"
 
 #: builtin/worktree.c:309
 #, c-format
@@ -22730,7 +23251,7 @@ msgid "reason for locking"
 msgstr "motivo di blocco"
 
 #: builtin/worktree.c:767 builtin/worktree.c:800 builtin/worktree.c:874
-#: builtin/worktree.c:1000
+#: builtin/worktree.c:998
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' non è un albero di lavoro"
@@ -22764,7 +23285,7 @@ msgstr ""
 msgid "force move even if worktree is dirty or locked"
 msgstr "forza lo spostamento anche se l'albero di lavoro è sporco o bloccato"
 
-#: builtin/worktree.c:876 builtin/worktree.c:1002
+#: builtin/worktree.c:876 builtin/worktree.c:1000
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' è un albero di lavoro principale"
@@ -22803,27 +23324,27 @@ msgstr "validazione non riuscita, impossibile spostare l'albero di lavoro: %s"
 msgid "failed to move '%s' to '%s'"
 msgstr "spostamento di '%s' in '%s' non riuscito"
 
-#: builtin/worktree.c:952
+#: builtin/worktree.c:950
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "esecuzione di 'git status' su '%s' non riuscita"
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:954
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' contiene file modificati o non tracciati, usa --force per eliminarlo"
 
-#: builtin/worktree.c:961
+#: builtin/worktree.c:959
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "esecuzione di 'git status' su '%s' non riuscita, codice %d"
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:982
 msgid "force removal even if worktree is dirty or locked"
 msgstr "forza la rimozione anche se l'albero di lavoro è sporco o bloccato"
 
-#: builtin/worktree.c:1007
+#: builtin/worktree.c:1005
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -22833,7 +23354,7 @@ msgstr ""
 "usa 'remove -f -f' per eseguirne l'override o sbloccalo prima di eseguire "
 "l'operazione"
 
-#: builtin/worktree.c:1009
+#: builtin/worktree.c:1007
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -22842,10 +23363,20 @@ msgstr ""
 "usa 'remove -f -f' per eseguirne l'override o sbloccalo prima di eseguire "
 "l'operazione"
 
-#: builtin/worktree.c:1012
+#: builtin/worktree.c:1010
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "validazione non riuscita, impossibile rimuovere l'albero di lavoro: %s"
+
+#: builtin/worktree.c:1034
+#, c-format
+msgid "repair: %s: %s"
+msgstr "ripara: %s: %s"
+
+#: builtin/worktree.c:1037
+#, c-format
+msgid "error: %s: %s"
+msgstr "errore: %s: %s"
 
 #: builtin/write-tree.c:15
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
@@ -22863,166 +23394,21 @@ msgstr "scrivi l'oggetto albero per una sottodirectory <prefisso>"
 msgid "only useful for debugging"
 msgstr "utile solo per il debug"
 
-#: bugreport.c:15
-msgid "git version:\n"
-msgstr "versione di git:\n"
-
-#: bugreport.c:21
-#, c-format
-msgid "uname() failed with error '%s' (%d)\n"
-msgstr "uname() non riuscita: errore '%s' (%d)\n"
-
-#: bugreport.c:31
-msgid "compiler info: "
-msgstr "informazioni sul compilatore: "
-
-#: bugreport.c:34
-msgid "libc info: "
-msgstr "informazioni su libc: "
-
-#: bugreport.c:80
-msgid "not run from a git repository - no hooks to show\n"
-msgstr ""
-"comando non eseguito da un repository Git - nessun hook da visualizzare\n"
-
-#: bugreport.c:90
-msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
-msgstr "git bugreport [-o|--output-directory <file>] [-s|--suffix <formato>]"
-
-#: bugreport.c:97
-msgid ""
-"Thank you for filling out a Git bug report!\n"
-"Please answer the following questions to help us understand your issue.\n"
-"\n"
-"What did you do before the bug happened? (Steps to reproduce your issue)\n"
-"\n"
-"What did you expect to happen? (Expected behavior)\n"
-"\n"
-"What happened instead? (Actual behavior)\n"
-"\n"
-"What's different between what you expected and what actually happened?\n"
-"\n"
-"Anything else you want to add:\n"
-"\n"
-"Please review the rest of the bug report below.\n"
-"You can delete any lines you don't wish to share.\n"
-msgstr ""
-"Grazie per voler compilare una segnalazione d'errore per Git!\n"
-"Rispondi alle seguenti domande per consentirci di capire il problema.\n"
-"\n"
-"Cos'hai fatto prima che si verificasse l'errore? (Passaggi per riprodurre "
-"il\n"
-"problema)\n"
-"\n"
-"Cosa ti aspettavi che succedesse? (Comportamento atteso)\n"
-"\n"
-"Cosa è successo invece? (Comportamento reale)\n"
-"\n"
-"Cosa c'è di diverso fra quello che ti aspettavi e ciò che in realtà è\n"
-"successo?\n"
-"\n"
-"Altre note che desideri aggiungere:\n"
-"\n"
-"Rivedi il resto della segnalazione d'errore qui sotto.\n"
-"Puoi eliminare le righe che non desideri condividere.\n"
-
-#: bugreport.c:136
-msgid "specify a destination for the bugreport file"
-msgstr ""
-"specifica una destinazione per il file contenente la segnalazione d'errore"
-
-#: bugreport.c:138
-msgid "specify a strftime format suffix for the filename"
-msgstr "specifica un suffisso in formato strftime per il nome del file"
-
-#: bugreport.c:162
-#, c-format
-msgid "could not create leading directories for '%s'"
-msgstr "impossibile creare le prime directory per '%s'"
-
-#: bugreport.c:169
-msgid "System Info"
-msgstr "Informazioni di sistema"
-
-#: bugreport.c:172
-msgid "Enabled Hooks"
-msgstr "Hook abilitati"
-
-#: bugreport.c:180
-#, c-format
-msgid "couldn't create a new file at '%s'"
-msgstr "impossibile creare un nuovo file in '%s'"
-
-#: bugreport.c:184
-#, c-format
-msgid "unable to write to %s"
-msgstr "impossibile scrivere su %s"
-
-#: bugreport.c:194
-#, c-format
-msgid "Created new report at '%s'.\n"
-msgstr "Nuovo report creato in '%s'.\n"
-
-#: fast-import.c:3100
-#, c-format
-msgid "Missing from marks for submodule '%s'"
-msgstr "Contrassegni Da mancanti per il sottomodulo '%s'"
-
-#: fast-import.c:3102
-#, c-format
-msgid "Missing to marks for submodule '%s'"
-msgstr "Contrassegni A mancanti per il sottomodulo '%s'"
-
-#: fast-import.c:3237
-#, c-format
-msgid "Expected 'mark' command, got %s"
-msgstr "Atteso comando 'mark', ricevuto %s"
-
-#: fast-import.c:3242
-#, c-format
-msgid "Expected 'to' command, got %s"
-msgstr "Atteso comando 'to', ricevuto %s"
-
-#: fast-import.c:3334
-msgid "Expected format name:filename for submodule rewrite option"
-msgstr ""
-"Per l'opzione riscrittura sottomodulo ci si attendeva un formato nome:"
-"nomefile"
-
-#: fast-import.c:3388
-#, c-format
-msgid "feature '%s' forbidden in input without --allow-unsafe-features"
-msgstr "funzionalità '%s' vietata nell'input senza --allow-unsafe-features"
-
-#: http-fetch.c:111
+#: http-fetch.c:114
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "l'argomento di --packfile dev'essere un hash valido (ricevuto '%s')"
 
-#: credential-cache--daemon.c:223
-#, c-format
-msgid ""
-"The permissions on your socket directory are too loose; other\n"
-"users may be able to read your cached credentials. Consider running:\n"
-"\n"
-"\tchmod 0700 %s"
-msgstr ""
-"I permessi sulla directory del socket sono troppo laschi; altri\n"
-"utenti potrebbero essere in grado di leggere le credenziali nella\n"
-"cache. Valuta di eseguire:\n"
-"\n"
-"\tchmod 0700 %s"
+#: http-fetch.c:122
+msgid "not a git repository"
+msgstr "non è un repository Git"
 
-#: credential-cache--daemon.c:272
-msgid "print debugging messages to stderr"
-msgstr "stampa i messaggi di debug sullo standard error"
-
-#: t/helper/test-reach.c:152
+#: t/helper/test-reach.c:154
 #, c-format
 msgid "commit %s is not marked reachable"
 msgstr "il commit %s non è contrassegnato come raggiungibile"
 
-#: t/helper/test-reach.c:162
+#: t/helper/test-reach.c:164
 msgid "too many commits marked reachable"
 msgstr "troppi commit contrassegnati come raggiungibili"
 
@@ -23100,12 +23486,12 @@ msgstr "nessuna directory specificata per -C\n"
 msgid "unknown option: %s\n"
 msgstr "opzione sconosciuta: %s\n"
 
-#: git.c:362
+#: git.c:364
 #, c-format
 msgid "while expanding alias '%s': '%s'"
 msgstr "durante l'espansione dell'alias '%s': '%s'"
 
-#: git.c:371
+#: git.c:373
 #, c-format
 msgid ""
 "alias '%s' changes environment variables.\n"
@@ -23114,39 +23500,39 @@ msgstr ""
 "l'alias '%s' modifica le variabili d'ambiente.\n"
 "Puoi usare '!git' nell'alias per farlo"
 
-#: git.c:378
+#: git.c:380
 #, c-format
 msgid "empty alias for %s"
 msgstr "alias vuoto per %s"
 
-#: git.c:381
+#: git.c:383
 #, c-format
 msgid "recursive alias: %s"
 msgstr "alias ricorsivo: %s"
 
-#: git.c:463
+#: git.c:465
 msgid "write failure on standard output"
 msgstr "errore di scrittura sullo standard output"
 
-#: git.c:465
+#: git.c:467
 msgid "unknown write failure on standard output"
 msgstr "errore di scrittura sconosciuto sullo standard output"
 
-#: git.c:467
+#: git.c:469
 msgid "close failed on standard output"
 msgstr "chiusura dello standard output non riuscita"
 
-#: git.c:792
+#: git.c:800
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "rilevato ciclo alias: l'espansione di '%s' non termina:%s"
 
-#: git.c:842
+#: git.c:850
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "impossibile gestire %s come comando incorporato"
 
-#: git.c:855
+#: git.c:863
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -23155,12 +23541,12 @@ msgstr ""
 "uso: %s\n"
 "\n"
 
-#: git.c:875
+#: git.c:883
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "espansione dell'alias '%s' non riuscita; '%s' non è un comando Git\n"
 
-#: git.c:887
+#: git.c:895
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "esecuzione del comando '%s' non riuscita: %s\n"
@@ -23214,142 +23600,142 @@ msgstr ""
 "  richiesta: %s\n"
 "   redirect: %s"
 
-#: remote-curl.c:168
+#: remote-curl.c:174
 #, c-format
 msgid "invalid quoting in push-option value: '%s'"
 msgstr "virgolette non valide nel valore push-option: '%s'"
 
-#: remote-curl.c:295
+#: remote-curl.c:298
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr "%sinfo/refs non valido: è un repository Git?"
 
-#: remote-curl.c:396
+#: remote-curl.c:399
 msgid "invalid server response; expected service, got flush packet"
 msgstr ""
 "risposta del server non valida; atteso servizio, ricevuto pacchetto flush"
 
-#: remote-curl.c:427
+#: remote-curl.c:430
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr "risposta del server non valida; ricevuto '%s'"
 
-#: remote-curl.c:487
+#: remote-curl.c:490
 #, c-format
 msgid "repository '%s' not found"
 msgstr "repository '%s' non trovato"
 
-#: remote-curl.c:491
+#: remote-curl.c:494
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr "Autenticazione non riuscita per '%s'"
 
-#: remote-curl.c:495
+#: remote-curl.c:498
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "impossibile accedere a '%s': %s"
 
-#: remote-curl.c:501
+#: remote-curl.c:504
 #, c-format
 msgid "redirecting to %s"
 msgstr "redirezione a %s in corso"
 
-#: remote-curl.c:630
+#: remote-curl.c:633
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr ""
 "non dovrebbe esserci un pacchetto fine file se non si è accomodanti con "
 "questi ultimi"
 
-#: remote-curl.c:642
+#: remote-curl.c:645
 msgid "remote server sent stateless separator"
 msgstr "il server remoto ha inviato un separatore senza stato"
 
-#: remote-curl.c:712
+#: remote-curl.c:715
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
 "impossibile ritornare a un punto precedente dei dati POST RPC - prova ad "
 "aumentare il valore di http.postBuffer"
 
-#: remote-curl.c:742
+#: remote-curl.c:745
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr "remote-curl: carattere lunghezza riga non valido: %.4s"
 
-#: remote-curl.c:744
+#: remote-curl.c:747
 msgid "remote-curl: unexpected response end packet"
 msgstr "remote-curl: pacchetto fine risposta non atteso"
 
-#: remote-curl.c:820
+#: remote-curl.c:823
 #, c-format
 msgid "RPC failed; %s"
 msgstr "RPC non riuscita; %s"
 
-#: remote-curl.c:860
+#: remote-curl.c:863
 msgid "cannot handle pushes this big"
 msgstr "impossibile gestire push così grandi"
 
-#: remote-curl.c:975
+#: remote-curl.c:978
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr ""
 "impossibile eseguire il deflate della richiesta; errore deflate zlib %d"
 
-#: remote-curl.c:979
+#: remote-curl.c:982
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr "impossibile eseguire il deflate della richiesta; errore fine zlib %d"
 
-#: remote-curl.c:1029
+#: remote-curl.c:1032
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr "sono stati ricevuti %d byte dell'intestazione sulla lunghezza"
 
-#: remote-curl.c:1031
+#: remote-curl.c:1034
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr "sono ancora attesi %d byte del corpo"
 
-#: remote-curl.c:1120
+#: remote-curl.c:1123
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "il trasporto http stupido non supporta le funzionalità shallow"
 
-#: remote-curl.c:1135
+#: remote-curl.c:1138
 msgid "fetch failed."
 msgstr "recupero non riuscito."
 
-#: remote-curl.c:1183
+#: remote-curl.c:1184
 msgid "cannot fetch by sha1 over smart http"
 msgstr ""
 "impossibile recuperare i dati in base allo SHA1 con il trasporto HTTP "
 "intelligente"
 
-#: remote-curl.c:1227 remote-curl.c:1233
+#: remote-curl.c:1228 remote-curl.c:1234
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "errore protocollo: atteso SHA/riferimento, ricevuto '%s'"
 
-#: remote-curl.c:1245 remote-curl.c:1360
+#: remote-curl.c:1246 remote-curl.c:1361
 #, c-format
 msgid "http transport does not support %s"
 msgstr "il trasporto HTTP non supporta %s"
 
-#: remote-curl.c:1281
+#: remote-curl.c:1282
 msgid "git-http-push failed"
 msgstr "git-http-push non riuscito"
 
-#: remote-curl.c:1466
+#: remote-curl.c:1467
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: uso: git remote-curl <remoto> [<URL>]"
 
-#: remote-curl.c:1498
+#: remote-curl.c:1499
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: errore durante la lettura del flusso dei comandi da Git"
 
-#: remote-curl.c:1505
+#: remote-curl.c:1506
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: tentato un fetch senza un repository locale"
 
-#: remote-curl.c:1546
+#: remote-curl.c:1547
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: ricevuto comando sconosciuto '%s' da Git"
@@ -23362,11 +23748,11 @@ msgstr "nessuna informazione sul compilatore disponibile\n"
 msgid "no libc information available\n"
 msgstr "nessuna informazione su libc disponibile\n"
 
-#: list-objects-filter-options.h:85
+#: list-objects-filter-options.h:91
 msgid "args"
 msgstr "argomenti"
 
-#: list-objects-filter-options.h:86
+#: list-objects-filter-options.h:92
 msgid "object filtering"
 msgstr "filtraggio oggetti"
 
@@ -23387,8 +23773,8 @@ msgid "be more quiet"
 msgstr "visualizza meno dettagli"
 
 #: parse-options.h:317
-msgid "use <n> digits to display SHA-1s"
-msgstr "usa <n> cifre per mostrare gli hash SHA-1"
+msgid "use <n> digits to display object names"
+msgstr "usa <n> cifre per mostrare i nomi oggetto"
 
 #: parse-options.h:336
 msgid "how to strip spaces and #comments from message"
@@ -23405,11 +23791,11 @@ msgstr ""
 "con --pathspec-from-file gli elementi specificatori percorso sono separati "
 "da un carattere NUL"
 
-#: ref-filter.h:101
+#: ref-filter.h:96
 msgid "key"
 msgstr "chiave"
 
-#: ref-filter.h:101
+#: ref-filter.h:96
 msgid "field name to sort on"
 msgstr "nome campo in base a cui ordinare"
 
@@ -23733,439 +24119,440 @@ msgid "Simple UNIX mbox splitter program"
 msgstr "Un semplice programma per suddividere i file UNIX mbox"
 
 #: command-list.h:122
+msgid "Run tasks to optimize Git repository data"
+msgstr "Esegui delle attività per ottimizzare i dati dei repository Git"
+
+#: command-list.h:123
 msgid "Join two or more development histories together"
 msgstr "Unisce due o più cronologie di sviluppo"
 
-#: command-list.h:123
+#: command-list.h:124
 msgid "Find as good common ancestors as possible for a merge"
 msgstr "Trova il maggior numero possibile di antenati comuni per un merge"
 
-#: command-list.h:124
+#: command-list.h:125
 msgid "Run a three-way file merge"
 msgstr "Esegue un merge a tre vie su file"
 
-#: command-list.h:125
+#: command-list.h:126
 msgid "Run a merge for files needing merging"
 msgstr "Esegue un merge per i file che lo richiedono"
 
-#: command-list.h:126
+#: command-list.h:127
 msgid "The standard helper program to use with git-merge-index"
 msgstr "Il programma helper standard da usare con git-merge-index"
 
-#: command-list.h:127
+#: command-list.h:128
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 "Esegue gli strumenti di risoluzione conflitti di merge per risolvere i "
 "conflitti di merge"
 
-#: command-list.h:128
+#: command-list.h:129
 msgid "Show three-way merge without touching index"
 msgstr "Visualizza un merge a tre vie senza modificare l'indice"
 
-#: command-list.h:129
+#: command-list.h:130
 msgid "Write and verify multi-pack-indexes"
 msgstr "Scrive e verifica indici multi-pack"
 
-#: command-list.h:130
+#: command-list.h:131
 msgid "Creates a tag object"
 msgstr "Crea un oggetto tag"
 
-#: command-list.h:131
+#: command-list.h:132
 msgid "Build a tree-object from ls-tree formatted text"
 msgstr "Genera un oggetto albero da testo in formato ls-tree"
 
-#: command-list.h:132
+#: command-list.h:133
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr "Sposta o rinomina un file, una directory o un collegamento simbolico"
 
-#: command-list.h:133
+#: command-list.h:134
 msgid "Find symbolic names for given revs"
 msgstr "Trova i nomi simbolici per le revisioni date"
 
-#: command-list.h:134
+#: command-list.h:135
 msgid "Add or inspect object notes"
 msgstr "Aggiunge o esamina le note agli oggetti"
 
-#: command-list.h:135
+#: command-list.h:136
 msgid "Import from and submit to Perforce repositories"
 msgstr "Importa dati da, o invia dati a, repository Perforce"
 
-#: command-list.h:136
+#: command-list.h:137
 msgid "Create a packed archive of objects"
 msgstr "Crea un archivio di oggetti sottoposto a pack"
 
-#: command-list.h:137
+#: command-list.h:138
 msgid "Find redundant pack files"
 msgstr "Trova file pack ridondanti"
 
-#: command-list.h:138
+#: command-list.h:139
 msgid "Pack heads and tags for efficient repository access"
 msgstr "Esegue il pack di head e tag per un accesso efficiente al repository"
 
-#: command-list.h:139
+#: command-list.h:140
 msgid "Routines to help parsing remote repository access parameters"
 msgstr ""
 "Routine che aiutano ad analizzare i parametri di accesso ai repository remoti"
 
-#: command-list.h:140
+#: command-list.h:141
 msgid "Compute unique ID for a patch"
 msgstr "Calcola l'ID univoco per una patch"
 
-#: command-list.h:141
+#: command-list.h:142
 msgid "Prune all unreachable objects from the object database"
 msgstr "Elimina tutti gli oggetti non raggiungibili dal database oggetti"
 
-#: command-list.h:142
+#: command-list.h:143
 msgid "Remove extra objects that are already in pack files"
 msgstr "Rimuove gli oggetti aggiuntivi già presenti nei file pack"
 
-#: command-list.h:143
+#: command-list.h:144
 msgid "Fetch from and integrate with another repository or a local branch"
 msgstr ""
 "Esegue il fetch e l'integrazione con un altro repository o un branch locale"
 
-#: command-list.h:144
+#: command-list.h:145
 msgid "Update remote refs along with associated objects"
 msgstr "Aggiorna i riferimenti remoti insieme agli oggetti associati"
 
-#: command-list.h:145
+#: command-list.h:146
 msgid "Applies a quilt patchset onto the current branch"
 msgstr "Applica un insieme di patch quilt sul branch corrente"
 
-#: command-list.h:146
+#: command-list.h:147
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
 msgstr "Compara due intervalli di commit (ad es. due versioni di un branch)"
 
-#: command-list.h:147
+#: command-list.h:148
 msgid "Reads tree information into the index"
 msgstr "Legge le informazioni su un albero dall'indice"
 
-#: command-list.h:148
+#: command-list.h:149
 msgid "Reapply commits on top of another base tip"
 msgstr "Riapplica dei commit dopo l'ultimo commit di un branch"
 
-#: command-list.h:149
+#: command-list.h:150
 msgid "Receive what is pushed into the repository"
 msgstr "Riceve quanto sottoposto a push nel repository"
 
-#: command-list.h:150
+#: command-list.h:151
 msgid "Manage reflog information"
 msgstr "Gestisce le informazioni del registro dei riferimenti"
 
-#: command-list.h:151
+#: command-list.h:152
 msgid "Manage set of tracked repositories"
 msgstr "Gestisce l'insieme dei repository tracciati"
 
-#: command-list.h:152
+#: command-list.h:153
 msgid "Pack unpacked objects in a repository"
 msgstr "Esegue il pack degli oggetti non sottoposti a pack in un repository"
 
-#: command-list.h:153
+#: command-list.h:154
 msgid "Create, list, delete refs to replace objects"
 msgstr "Crea, elenca, elimina i riferimenti per sostituire oggetti"
 
-#: command-list.h:154
+#: command-list.h:155
 msgid "Generates a summary of pending changes"
 msgstr "Genera un riassunto delle modifiche in sospeso"
 
-#: command-list.h:155
+#: command-list.h:156
 msgid "Reuse recorded resolution of conflicted merges"
 msgstr "Riusa la risoluzione registrata dei merge che hanno generato conflitti"
 
-#: command-list.h:156
+#: command-list.h:157
 msgid "Reset current HEAD to the specified state"
 msgstr "Ripristina l'HEAD corrente allo stato specificato"
 
-#: command-list.h:157
+#: command-list.h:158
 msgid "Restore working tree files"
 msgstr "Ripristina i file nell'albero di lavoro"
 
-#: command-list.h:158
+#: command-list.h:159
 msgid "Revert some existing commits"
 msgstr "Esegue il revert di alcuni commit esistenti"
 
-#: command-list.h:159
+#: command-list.h:160
 msgid "Lists commit objects in reverse chronological order"
 msgstr "Elenca gli oggetti commit in ordine cronologico inverso"
 
-#: command-list.h:160
+#: command-list.h:161
 msgid "Pick out and massage parameters"
 msgstr "Sceglie e altera i parametri"
 
-#: command-list.h:161
+#: command-list.h:162
 msgid "Remove files from the working tree and from the index"
 msgstr "Rimuove file dall'albero di lavoro e dall'indice"
 
-#: command-list.h:162
+#: command-list.h:163
 msgid "Send a collection of patches as emails"
 msgstr "Invia un insieme di patch come e-mail"
 
-#: command-list.h:163
+#: command-list.h:164
 msgid "Push objects over Git protocol to another repository"
 msgstr ""
 "Esegue il push di oggetti su un altro repository tramite il protocollo Git"
 
-#: command-list.h:164
+#: command-list.h:165
 msgid "Restricted login shell for Git-only SSH access"
 msgstr "Shell di login limitata per concedere accesso SSH solo per Git"
 
-#: command-list.h:165
+#: command-list.h:166
 msgid "Summarize 'git log' output"
 msgstr "Riassume l'output di 'git log'"
 
-#: command-list.h:166
+#: command-list.h:167
 msgid "Show various types of objects"
 msgstr "Visualizza vari tipi di oggetti"
 
-#: command-list.h:167
+#: command-list.h:168
 msgid "Show branches and their commits"
 msgstr "Visualizza i branch e i loro commit"
 
-#: command-list.h:168
+#: command-list.h:169
 msgid "Show packed archive index"
 msgstr "Visualizza l'indice di un archivio sottoposto a pack"
 
-#: command-list.h:169
+#: command-list.h:170
 msgid "List references in a local repository"
 msgstr "Elenca i riferimenti in un repository locale"
 
-#: command-list.h:170
+#: command-list.h:171
 msgid "Git's i18n setup code for shell scripts"
 msgstr ""
 "Codice di inizializzazione dell'internazionalizzazione di Git per gli script "
 "shell"
 
-#: command-list.h:171
+#: command-list.h:172
 msgid "Common Git shell script setup code"
 msgstr "Codice comune di inizializzazione di Git per gli script shell"
 
-#: command-list.h:172
+#: command-list.h:173
 msgid "Initialize and modify the sparse-checkout"
 msgstr "Inizializza e modifica sparse-checkout"
 
-#: command-list.h:173
+#: command-list.h:174
 msgid "Stash the changes in a dirty working directory away"
 msgstr "Mette da parte le modifiche in una directory di lavoro sporca"
 
-#: command-list.h:174
+#: command-list.h:175
 msgid "Add file contents to the staging area"
 msgstr "Aggiunge i contenuti dei file all'area di staging"
 
-#: command-list.h:175
+#: command-list.h:176
 msgid "Show the working tree status"
 msgstr "Visualizza lo stato dell'albero di lavoro"
 
-#: command-list.h:176
+#: command-list.h:177
 msgid "Remove unnecessary whitespace"
 msgstr "Rimuove spazi bianchi non necessari"
 
-#: command-list.h:177
+#: command-list.h:178
 msgid "Initialize, update or inspect submodules"
 msgstr "Inizializza, aggiorna o esamina sottomoduli"
 
-#: command-list.h:178
+#: command-list.h:179
 msgid "Bidirectional operation between a Subversion repository and Git"
 msgstr "Operatività bidirezionale tra un repository Subversion e Git"
 
-#: command-list.h:179
+#: command-list.h:180
 msgid "Switch branches"
 msgstr "Passa da un branch a un altro"
 
-#: command-list.h:180
+#: command-list.h:181
 msgid "Read, modify and delete symbolic refs"
 msgstr "Legge, modifica ed elimina riferimenti simbolici"
 
-#: command-list.h:181
+#: command-list.h:182
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr "Crea, elenca, elimina o verifica un oggetto tag firmato con GPG"
 
-#: command-list.h:182
+#: command-list.h:183
 msgid "Creates a temporary file with a blob's contents"
 msgstr "Crea un file temporaneo con i contenuti di un blob"
 
-#: command-list.h:183
+#: command-list.h:184
 msgid "Unpack objects from a packed archive"
 msgstr "Decomprime gli oggetti da un archivio sottoposto a pack"
 
-#: command-list.h:184
+#: command-list.h:185
 msgid "Register file contents in the working tree to the index"
 msgstr "Registra i contenuti dei file dell'albero di lavoro nell'indice"
 
-#: command-list.h:185
+#: command-list.h:186
 msgid "Update the object name stored in a ref safely"
 msgstr "Aggiorna in modo sicuro il nome oggetto salvato in un riferimento"
 
-#: command-list.h:186
+#: command-list.h:187
 msgid "Update auxiliary info file to help dumb servers"
 msgstr "Aggiorna il file informazioni aggiuntive per aiutare i server stupidi"
 
-#: command-list.h:187
+#: command-list.h:188
 msgid "Send archive back to git-archive"
 msgstr "Reinvia l'archivio a git-archive"
 
-#: command-list.h:188
+#: command-list.h:189
 msgid "Send objects packed back to git-fetch-pack"
 msgstr "Reinvia gli oggetti sottoposti a pack a git-fetch-pack"
 
-#: command-list.h:189
+#: command-list.h:190
 msgid "Show a Git logical variable"
 msgstr "Visualizza una variabile logica di Git"
 
-#: command-list.h:190
+#: command-list.h:191
 msgid "Check the GPG signature of commits"
 msgstr "Verifica la firma GPG dei commit"
 
-#: command-list.h:191
+#: command-list.h:192
 msgid "Validate packed Git archive files"
 msgstr "Convalida i file archivio sottoposti a pack di Git"
 
-#: command-list.h:192
+#: command-list.h:193
 msgid "Check the GPG signature of tags"
 msgstr "Verifica la firma GPG dei tag"
 
-#: command-list.h:193
+#: command-list.h:194
 msgid "Git web interface (web frontend to Git repositories)"
 msgstr "Interfaccia Web per Git (frontend Web ai repository Git)"
 
-#: command-list.h:194
+#: command-list.h:195
 msgid "Show logs with difference each commit introduces"
 msgstr ""
 "Visualizza i registri insieme alle differenze introdotte da ciascun commit"
 
-#: command-list.h:195
+#: command-list.h:196
 msgid "Manage multiple working trees"
 msgstr "Gestisce alberi di lavoro multipli"
 
-#: command-list.h:196
+#: command-list.h:197
 msgid "Create a tree object from the current index"
 msgstr "Crea un oggetto albero dall'indice corrente"
 
-#: command-list.h:197
+#: command-list.h:198
 msgid "Defining attributes per path"
 msgstr "Definizione di attributi per percorso"
 
-#: command-list.h:198
+#: command-list.h:199
 msgid "Git command-line interface and conventions"
 msgstr "Interfaccia a riga di comando di Git e convenzioni"
 
-#: command-list.h:199
+#: command-list.h:200
 msgid "A Git core tutorial for developers"
 msgstr "Un tutorial Git di base per gli sviluppatori"
 
-#: command-list.h:200
+#: command-list.h:201
+msgid "Providing usernames and passwords to Git"
+msgstr "Fornire nomi utente e password a Git"
+
+#: command-list.h:202
 msgid "Git for CVS users"
 msgstr "Git per utenti CVS"
 
-#: command-list.h:201
+#: command-list.h:203
 msgid "Tweaking diff output"
 msgstr "Messa a punto dell'output di diff"
 
-#: command-list.h:202
+#: command-list.h:204
 msgid "A useful minimum set of commands for Everyday Git"
 msgstr "Un insieme di comandi utile e minimale per l'uso quotidiano di Git"
 
-#: command-list.h:203
+#: command-list.h:205
 msgid "Frequently asked questions about using Git"
 msgstr "Domande frequenti sull'utilizzo di Git"
 
-#: command-list.h:204
+#: command-list.h:206
 msgid "A Git Glossary"
 msgstr "Un glossario di Git"
 
-#: command-list.h:205
+#: command-list.h:207
 msgid "Hooks used by Git"
 msgstr "Hook usati da Git"
 
-#: command-list.h:206
+#: command-list.h:208
 msgid "Specifies intentionally untracked files to ignore"
 msgstr "Specifica i file intenzionalmente non tracciati da ignorare"
 
-#: command-list.h:207
+#: command-list.h:209
 msgid "Defining submodule properties"
 msgstr "Definizione proprietà sottomodulo"
 
-#: command-list.h:208
+#: command-list.h:210
 msgid "Git namespaces"
 msgstr "Spazi dei nomi Git"
 
-#: command-list.h:209
+#: command-list.h:211
+msgid "Helper programs to interact with remote repositories"
+msgstr "Programmi helper per interagire con repository remoti"
+
+#: command-list.h:212
 msgid "Git Repository Layout"
 msgstr "Struttura repository Git"
 
-#: command-list.h:210
+#: command-list.h:213
 msgid "Specifying revisions and ranges for Git"
 msgstr "Come specificare revisioni e intervalli in Git"
 
-#: command-list.h:211
+#: command-list.h:214
 msgid "Mounting one repository inside another"
 msgstr "Monto un repository dentro un altro"
 
-#: command-list.h:212
+#: command-list.h:215
 msgid "A tutorial introduction to Git: part two"
 msgstr "Un tutorial introduttivo per Git: seconda parte"
 
-#: command-list.h:213
+#: command-list.h:216
 msgid "A tutorial introduction to Git"
 msgstr "Un tutorial introduttivo per Git"
 
-#: command-list.h:214
+#: command-list.h:217
 msgid "An overview of recommended workflows with Git"
 msgstr "Una panoramica dei flussi di lavoro raccomandati in Git"
 
-#: git-bisect.sh:54
-msgid "You need to start by \"git bisect start\""
-msgstr "Devi iniziare con \"git bisect start\""
-
-#. TRANSLATORS: Make sure to include [Y] and [n] in your
-#. translation. The program will only accept English input
-#. at this point.
-#: git-bisect.sh:60
-msgid "Do you want me to do it for you [Y/n]? "
-msgstr "Vuoi che me ne occupi io [Y/n]? "
-
-#: git-bisect.sh:101
+#: git-bisect.sh:79
 #, sh-format
 msgid "Bad rev input: $arg"
 msgstr "Revisione fornita non valida: $arg"
 
-#: git-bisect.sh:121
+#: git-bisect.sh:99
 #, sh-format
 msgid "Bad rev input: $bisected_head"
 msgstr "Revisione fornita non valida: $bisected_head"
 
-#: git-bisect.sh:130
+#: git-bisect.sh:108
 #, sh-format
 msgid "Bad rev input: $rev"
 msgstr "Revisione fornita non valida: $rev"
 
-#: git-bisect.sh:139
+#: git-bisect.sh:117
 #, sh-format
 msgid "'git bisect $TERM_BAD' can take only one argument."
 msgstr "'git bisect $TERM_BAD' richiede un solo argomento."
 
-#: git-bisect.sh:209
+#: git-bisect.sh:149
 msgid "No logfile given"
 msgstr "Nessun file di log specificato"
 
-#: git-bisect.sh:210
+#: git-bisect.sh:150
 #, sh-format
 msgid "cannot read $file for replaying"
 msgstr "impossibile leggere $file per rieseguire i comandi contenuti"
 
-#: git-bisect.sh:233
+#: git-bisect.sh:173
 msgid "?? what are you talking about?"
 msgstr "?? di cosa stai parlando?"
 
-#: git-bisect.sh:243
+#: git-bisect.sh:183
 msgid "bisect run failed: no command provided."
 msgstr "esecuzione di bisect non riuscita: nessun comando fornito."
 
-#: git-bisect.sh:248
+#: git-bisect.sh:188
 #, sh-format
 msgid "running $command"
 msgstr "esecuzione di $command in corso"
 
-#: git-bisect.sh:255
+#: git-bisect.sh:195
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -24174,11 +24561,11 @@ msgstr ""
 "esecuzione di bisect non riuscita:\n"
 "il codice di uscita $res da '$command' è < 0 oppure >= 128"
 
-#: git-bisect.sh:281
+#: git-bisect.sh:221
 msgid "bisect run cannot continue any more"
 msgstr "l'esecuzione di bisect non può più proseguire"
 
-#: git-bisect.sh:287
+#: git-bisect.sh:227
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -24187,11 +24574,11 @@ msgstr ""
 "esecuzione di bisect non riuscita:\n"
 "'bisect_state $state' è uscito con il codice di errore $res"
 
-#: git-bisect.sh:294
+#: git-bisect.sh:234
 msgid "bisect run success"
 msgstr "esecuzione di bisect completata con successo"
 
-#: git-bisect.sh:302
+#: git-bisect.sh:242
 msgid "We are not bisecting."
 msgstr "Non stiamo eseguendo una bisezione."
 
@@ -24235,50 +24622,50 @@ msgstr "Provo un merge semplice con $pretty_name"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Il merge semplice non ha funzionato, provo il merge automatico."
 
-#: git-submodule.sh:205
+#: git-submodule.sh:180
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
 "Il percorso relativo può essere usato solo dal primo livello dell'albero di "
 "lavoro"
 
-#: git-submodule.sh:215
+#: git-submodule.sh:190
 #, sh-format
 msgid "repo URL: '$repo' must be absolute or begin with ./|../"
 msgstr "URL repository:: '$repo' deve essere assoluto o iniziare con ./|../"
 
-#: git-submodule.sh:234
+#: git-submodule.sh:209
 #, sh-format
 msgid "'$sm_path' already exists in the index"
 msgstr "'$sm_path' esiste già nell'indice"
 
-#: git-submodule.sh:237
+#: git-submodule.sh:212
 #, sh-format
 msgid "'$sm_path' already exists in the index and is not a submodule"
 msgstr "'$sm_path' esiste già nell'indice e non è un sottomodulo"
 
-#: git-submodule.sh:244
+#: git-submodule.sh:219
 #, sh-format
 msgid "'$sm_path' does not have a commit checked out"
 msgstr "'$sm_path' non ha un commit di cui è stato eseguito il checkout"
 
-#: git-submodule.sh:275
+#: git-submodule.sh:250
 #, sh-format
 msgid "Adding existing repo at '$sm_path' to the index"
 msgstr "Aggiunta del repository esistente in '$sm_path' all'indice"
 
-#: git-submodule.sh:277
+#: git-submodule.sh:252
 #, sh-format
 msgid "'$sm_path' already exists and is not a valid git repo"
 msgstr "'$sm_path' esiste già e non è un repository Git valido"
 
-#: git-submodule.sh:285
+#: git-submodule.sh:260
 #, sh-format
 msgid "A git directory for '$sm_name' is found locally with remote(s):"
 msgstr ""
 "È stata trovata localmente una directory Git per '$sm_name' con i seguenti "
 "remoti:"
 
-#: git-submodule.sh:287
+#: git-submodule.sh:262
 #, sh-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -24295,39 +24682,39 @@ msgstr ""
 "altro\n"
 "nome con l'opzione '--name'."
 
-#: git-submodule.sh:293
+#: git-submodule.sh:268
 #, sh-format
 msgid "Reactivating local git directory for submodule '$sm_name'."
 msgstr "Riattivo la directory Git locale per il sottomodulo '$sm_name'."
 
-#: git-submodule.sh:305
+#: git-submodule.sh:280
 #, sh-format
 msgid "Unable to checkout submodule '$sm_path'"
 msgstr "Impossibile eseguire il checkout del sottomodulo '$sm_path'"
 
-#: git-submodule.sh:310
+#: git-submodule.sh:285
 #, sh-format
 msgid "Failed to add submodule '$sm_path'"
 msgstr "Aggiunta del sottomodulo '$sm_path' non riuscita"
 
-#: git-submodule.sh:319
+#: git-submodule.sh:294
 #, sh-format
 msgid "Failed to register submodule '$sm_path'"
 msgstr "Registrazione del sottomodulo '$sm_path' non riuscita"
 
-#: git-submodule.sh:592
+#: git-submodule.sh:567
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr ""
 "Impossibile trovare la revisione corrente nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:602
+#: git-submodule.sh:577
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "Impossibile eseguire il fetch nel percorso del sottomodulo '$sm_path'"
 
-#: git-submodule.sh:607
+#: git-submodule.sh:582
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -24336,7 +24723,7 @@ msgstr ""
 "Impossibile trovare la revisione corrente per ${remote_name}/${branch} nel "
 "percorso del sottomodulo '$sm_path'"
 
-#: git-submodule.sh:625
+#: git-submodule.sh:600
 #, sh-format
 msgid ""
 "Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
@@ -24345,7 +24732,7 @@ msgstr ""
 "Impossibile eseguire il fetch nel percorso del sottomodulo '$displaypath'; "
 "provo a recuperare direttamente $sha1:"
 
-#: git-submodule.sh:631
+#: git-submodule.sh:606
 #, sh-format
 msgid ""
 "Fetched in submodule path '$displaypath', but it did not contain $sha1. "
@@ -24354,83 +24741,58 @@ msgstr ""
 "Fetch eseguito nel percorso del sottomodulo '$displaypath', ma non conteneva "
 "$sha1. Fetch diretto di tale commit non riuscito."
 
-#: git-submodule.sh:638
+#: git-submodule.sh:613
 #, sh-format
 msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
 msgstr ""
 "Impossibile eseguire il checkout di '$sha1' nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:639
+#: git-submodule.sh:614
 #, sh-format
 msgid "Submodule path '$displaypath': checked out '$sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': eseguito checkout di '$sha1'"
 
-#: git-submodule.sh:643
+#: git-submodule.sh:618
 #, sh-format
 msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
 msgstr ""
 "Impossibile eseguire il rebase di '$sha1' nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:644
+#: git-submodule.sh:619
 #, sh-format
 msgid "Submodule path '$displaypath': rebased into '$sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': eseguito rebase su '$sha1'"
 
-#: git-submodule.sh:649
+#: git-submodule.sh:624
 #, sh-format
 msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
 msgstr ""
 "Impossibile eseguire il merge di '$sha1' nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:650
+#: git-submodule.sh:625
 #, sh-format
 msgid "Submodule path '$displaypath': merged in '$sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': eseguito merge in '$sha1'"
 
-#: git-submodule.sh:655
+#: git-submodule.sh:630
 #, sh-format
 msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
 msgstr ""
 "Esecuzione di '$command $sha1' non riuscita nel percorso del sottomodulo "
 "'$displaypath'"
 
-#: git-submodule.sh:656
+#: git-submodule.sh:631
 #, sh-format
 msgid "Submodule path '$displaypath': '$command $sha1'"
 msgstr "Percorso del sottomodulo '$displaypath': '$command $sha1'"
 
-#: git-submodule.sh:687
+#: git-submodule.sh:662
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr "Ricorsione nel percorso del sottomodulo '$displaypath' non riuscita"
-
-#: git-submodule.sh:852
-msgid "The --cached option cannot be used with the --files option"
-msgstr "L'opzione --cached non può essere usata con l'opzione --files"
-
-#: git-submodule.sh:904
-#, sh-format
-msgid "unexpected mode $mod_dst"
-msgstr "modalità $mod_dst inattesa"
-
-#: git-submodule.sh:924
-#, sh-format
-msgid "  Warn: $display_name doesn't contain commit $sha1_src"
-msgstr "  Attenzione: $display_name non contiene il commit $sha1_src"
-
-#: git-submodule.sh:927
-#, sh-format
-msgid "  Warn: $display_name doesn't contain commit $sha1_dst"
-msgstr "  Attenzione: $display_name non contiene il commit $sha1_dst"
-
-#: git-submodule.sh:930
-#, sh-format
-msgid "  Warn: $display_name doesn't contain commits $sha1_src and $sha1_dst"
-msgstr ""
-"  Attenzione: $display_name non contiene i commit $sha1_src e $sha1_dst"
 
 #: git-parse-remote.sh:89
 #, sh-format
@@ -24461,7 +24823,7 @@ msgstr ""
 msgid "Rebasing ($new_count/$total)"
 msgstr "Rebase in corso ($new_count/$total)"
 
-#: git-rebase--preserve-merges.sh:207
+#: git-rebase--preserve-merges.sh:197
 msgid ""
 "\n"
 "Commands:\n"
@@ -24503,7 +24865,7 @@ msgstr ""
 "Queste righe possono essere riordinate; saranno eseguite dalla prima "
 "all'ultima.\n"
 
-#: git-rebase--preserve-merges.sh:270
+#: git-rebase--preserve-merges.sh:260
 #, sh-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -24522,85 +24884,85 @@ msgstr ""
 "\n"
 "\tgit rebase --continue"
 
-#: git-rebase--preserve-merges.sh:295
+#: git-rebase--preserve-merges.sh:285
 #, sh-format
 msgid "$sha1: not a commit that can be picked"
 msgstr "$sha1: non è un commit che possa essere scelto"
 
-#: git-rebase--preserve-merges.sh:334
+#: git-rebase--preserve-merges.sh:324
 #, sh-format
 msgid "Invalid commit name: $sha1"
 msgstr "Nome commit non valido: $sha1"
 
-#: git-rebase--preserve-merges.sh:364
+#: git-rebase--preserve-merges.sh:354
 msgid "Cannot write current commit's replacement sha1"
 msgstr ""
 "Impossibile scrivere lo SHA1 del commit che dovrebbe sostituire quello "
 "corrente"
 
-#: git-rebase--preserve-merges.sh:415
+#: git-rebase--preserve-merges.sh:405
 #, sh-format
 msgid "Fast-forward to $sha1"
 msgstr "Fast forward a $sha1"
 
-#: git-rebase--preserve-merges.sh:417
+#: git-rebase--preserve-merges.sh:407
 #, sh-format
 msgid "Cannot fast-forward to $sha1"
 msgstr "Impossibile eseguire il fast forward a $sha1"
 
-#: git-rebase--preserve-merges.sh:426
+#: git-rebase--preserve-merges.sh:416
 #, sh-format
 msgid "Cannot move HEAD to $first_parent"
 msgstr "Impossibile spostare l'HEAD a $first_parent"
 
-#: git-rebase--preserve-merges.sh:431
+#: git-rebase--preserve-merges.sh:421
 #, sh-format
 msgid "Refusing to squash a merge: $sha1"
 msgstr "Mi rifiuto di eseguire lo squash di un merge: $sha1"
 
-#: git-rebase--preserve-merges.sh:449
+#: git-rebase--preserve-merges.sh:439
 #, sh-format
 msgid "Error redoing merge $sha1"
 msgstr "Errore durante la riesecuzione del merge di $sha1"
 
-#: git-rebase--preserve-merges.sh:458
+#: git-rebase--preserve-merges.sh:448
 #, sh-format
 msgid "Could not pick $sha1"
 msgstr "Impossibile scegliere $sha1"
 
-#: git-rebase--preserve-merges.sh:467
+#: git-rebase--preserve-merges.sh:457
 #, sh-format
 msgid "This is the commit message #${n}:"
 msgstr "Questo è il messaggio di commit numero ${n}:"
 
-#: git-rebase--preserve-merges.sh:472
+#: git-rebase--preserve-merges.sh:462
 #, sh-format
 msgid "The commit message #${n} will be skipped:"
 msgstr "Il messaggio di commit numero ${n} sarà saltato:"
 
-#: git-rebase--preserve-merges.sh:483
+#: git-rebase--preserve-merges.sh:473
 #, sh-format
 msgid "This is a combination of $count commit."
 msgid_plural "This is a combination of $count commits."
 msgstr[0] "Questa è una combinazione di $count commit."
 msgstr[1] "Questa è una combinazione di $count commit."
 
-#: git-rebase--preserve-merges.sh:492
+#: git-rebase--preserve-merges.sh:482
 #, sh-format
 msgid "Cannot write $fixup_msg"
 msgstr "Impossibile scrivere $fixup_msg"
 
-#: git-rebase--preserve-merges.sh:495
+#: git-rebase--preserve-merges.sh:485
 msgid "This is a combination of 2 commits."
 msgstr "Questa è una combinazione di 2 commit."
 
-#: git-rebase--preserve-merges.sh:536 git-rebase--preserve-merges.sh:579
-#: git-rebase--preserve-merges.sh:582
+#: git-rebase--preserve-merges.sh:526 git-rebase--preserve-merges.sh:569
+#: git-rebase--preserve-merges.sh:572
 #, sh-format
 msgid "Could not apply $sha1... $rest"
 msgstr "Impossibile applicare $sha1... $rest"
 
-#: git-rebase--preserve-merges.sh:611
+#: git-rebase--preserve-merges.sh:601
 #, sh-format
 msgid ""
 "Could not amend commit after successfully picking $sha1... $rest\n"
@@ -24615,31 +24977,31 @@ msgstr ""
 "potrebbe essere necessario risolvere il problema evidenziato per essere in\n"
 "grado di modificare il messaggio di commit."
 
-#: git-rebase--preserve-merges.sh:626
+#: git-rebase--preserve-merges.sh:616
 #, sh-format
 msgid "Stopped at $sha1_abbrev... $rest"
 msgstr "Fermato a $sha1_abbrev... $rest"
 
-#: git-rebase--preserve-merges.sh:641
+#: git-rebase--preserve-merges.sh:631
 #, sh-format
 msgid "Cannot '$squash_style' without a previous commit"
 msgstr "Impossibile eseguire '$squash_style' senza un commit precedente"
 
-#: git-rebase--preserve-merges.sh:683
+#: git-rebase--preserve-merges.sh:673
 #, sh-format
 msgid "Executing: $rest"
 msgstr "Eseguo $rest"
 
-#: git-rebase--preserve-merges.sh:691
+#: git-rebase--preserve-merges.sh:681
 #, sh-format
 msgid "Execution failed: $rest"
 msgstr "Esecuzione non riuscita: $rest"
 
-#: git-rebase--preserve-merges.sh:693
+#: git-rebase--preserve-merges.sh:683
 msgid "and made changes to the index and/or the working tree"
 msgstr "e sono state apportate modifiche all'indice e/o all'albero di lavoro"
 
-#: git-rebase--preserve-merges.sh:695
+#: git-rebase--preserve-merges.sh:685
 msgid ""
 "You can fix the problem, and then run\n"
 "\n"
@@ -24650,7 +25012,7 @@ msgstr ""
 "\tgit rebase --continue"
 
 #. TRANSLATORS: after these lines is a command to be issued by the user
-#: git-rebase--preserve-merges.sh:708
+#: git-rebase--preserve-merges.sh:698
 #, sh-format
 msgid ""
 "Execution succeeded: $rest\n"
@@ -24665,25 +25027,25 @@ msgstr ""
 "\n"
 "\tgit rebase --continue"
 
-#: git-rebase--preserve-merges.sh:719
+#: git-rebase--preserve-merges.sh:709
 #, sh-format
 msgid "Unknown command: $command $sha1 $rest"
 msgstr "Comando sconosciuto: $command $sha1 $rest"
 
-#: git-rebase--preserve-merges.sh:720
+#: git-rebase--preserve-merges.sh:710
 msgid "Please fix this using 'git rebase --edit-todo'."
 msgstr "Correggi la situazione usando 'git rebase --edit-todo'."
 
-#: git-rebase--preserve-merges.sh:755
+#: git-rebase--preserve-merges.sh:745
 #, sh-format
 msgid "Successfully rebased and updated $head_name."
 msgstr "Rebase e aggiornamento di $head_name eseguiti con successo."
 
-#: git-rebase--preserve-merges.sh:812
+#: git-rebase--preserve-merges.sh:802
 msgid "Could not remove CHERRY_PICK_HEAD"
 msgstr "impossibile rimuovere CHERRY_PICK_HEAD"
 
-#: git-rebase--preserve-merges.sh:817
+#: git-rebase--preserve-merges.sh:807
 #, sh-format
 msgid ""
 "You have staged changes in your working tree.\n"
@@ -24714,13 +25076,13 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: git-rebase--preserve-merges.sh:834
+#: git-rebase--preserve-merges.sh:824
 msgid "Error trying to find the author identity to amend commit"
 msgstr ""
 "Errore durante la ricerca dell'identità dell'autore per la modifica del "
 "commit"
 
-#: git-rebase--preserve-merges.sh:839
+#: git-rebase--preserve-merges.sh:829
 msgid ""
 "You have uncommitted changes in your working tree. Please commit them\n"
 "first and then run 'git rebase --continue' again."
@@ -24729,44 +25091,44 @@ msgstr ""
 "di lavoro. Eseguine prima il commit e quindi esegui nuovamente 'git rebase\n"
 "--continue'."
 
-#: git-rebase--preserve-merges.sh:844 git-rebase--preserve-merges.sh:848
+#: git-rebase--preserve-merges.sh:834 git-rebase--preserve-merges.sh:838
 msgid "Could not commit staged changes."
 msgstr "Impossibile eseguire il commit delle modifiche in staging."
 
-#: git-rebase--preserve-merges.sh:879 git-rebase--preserve-merges.sh:965
+#: git-rebase--preserve-merges.sh:869 git-rebase--preserve-merges.sh:955
 msgid "Could not execute editor"
 msgstr "Impossibile eseguire l'editor"
 
-#: git-rebase--preserve-merges.sh:900
+#: git-rebase--preserve-merges.sh:890
 #, sh-format
 msgid "Could not checkout $switch_to"
 msgstr "Impossibile eseguire il checkout di $switch_to"
 
-#: git-rebase--preserve-merges.sh:907
+#: git-rebase--preserve-merges.sh:897
 msgid "No HEAD?"
 msgstr "Nessun'HEAD?"
 
-#: git-rebase--preserve-merges.sh:908
+#: git-rebase--preserve-merges.sh:898
 #, sh-format
 msgid "Could not create temporary $state_dir"
 msgstr "Impossibile creare la directory temporanea $state_dir"
 
-#: git-rebase--preserve-merges.sh:911
+#: git-rebase--preserve-merges.sh:901
 msgid "Could not mark as interactive"
 msgstr "Impossibile contrassegnare come interattivo"
 
-#: git-rebase--preserve-merges.sh:943
+#: git-rebase--preserve-merges.sh:933
 #, sh-format
 msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
 msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
 msgstr[0] "Rebase di $shortrevisions su $shortonto ($todocount comando)"
 msgstr[1] "Rebase di $shortrevisions su $shortonto ($todocount comandi)"
 
-#: git-rebase--preserve-merges.sh:955
+#: git-rebase--preserve-merges.sh:945
 msgid "Note that empty commits are commented out"
 msgstr "Nota che i commit vuoti sono commentati"
 
-#: git-rebase--preserve-merges.sh:997 git-rebase--preserve-merges.sh:1002
+#: git-rebase--preserve-merges.sh:987 git-rebase--preserve-merges.sh:992
 msgid "Could not init rewritten commits"
 msgstr "Impossibile inizializzare i commit riscritti"
 
@@ -24854,7 +25216,7 @@ msgid_plural "touched %d paths\n"
 msgstr[0] "eseguito touch su %d percorso\n"
 msgstr[1] "eseguito touch su %d percorsi\n"
 
-#: git-add--interactive.perl:1055
+#: git-add--interactive.perl:1058
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for staging."
@@ -24862,7 +25224,7 @@ msgstr ""
 "Se la patch viene applicata senza problemi, l'hunk modificato sarà\n"
 "contrassegnato immediatamente per l'aggiunta all'area di staging."
 
-#: git-add--interactive.perl:1058
+#: git-add--interactive.perl:1061
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for stashing."
@@ -24870,7 +25232,7 @@ msgstr ""
 "Se la patch viene applicata senza problemi, l'hunk modificato sarà\n"
 "contrassegnato immediatamente per lo stash."
 
-#: git-add--interactive.perl:1061
+#: git-add--interactive.perl:1064
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for unstaging."
@@ -24878,8 +25240,8 @@ msgstr ""
 "Se la patch viene applicata senza problemi, l'hunk modificato sarà\n"
 "contrassegnato immediatamente per la rimozione dall'area di staging."
 
-#: git-add--interactive.perl:1064 git-add--interactive.perl:1073
-#: git-add--interactive.perl:1079
+#: git-add--interactive.perl:1067 git-add--interactive.perl:1076
+#: git-add--interactive.perl:1082
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for applying."
@@ -24887,8 +25249,8 @@ msgstr ""
 "Se la patch viene applicata senza problemi, l'hunk modificato sarà\n"
 "contrassegnato immediatamente per l'applicazione."
 
-#: git-add--interactive.perl:1067 git-add--interactive.perl:1070
-#: git-add--interactive.perl:1076
+#: git-add--interactive.perl:1070 git-add--interactive.perl:1073
+#: git-add--interactive.perl:1079
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for discarding."
@@ -24896,12 +25258,12 @@ msgstr ""
 "Se la patch viene applicata senza problemi, l'hunk modificato sarà\n"
 "contrassegnato immediatamente per la rimozione."
 
-#: git-add--interactive.perl:1113
+#: git-add--interactive.perl:1116
 #, perl-format
 msgid "failed to open hunk edit file for writing: %s"
 msgstr "apertura del file di modifica hunk in scrittura non riuscita: %s"
 
-#: git-add--interactive.perl:1120
+#: git-add--interactive.perl:1123
 #, perl-format
 msgid ""
 "---\n"
@@ -24914,12 +25276,12 @@ msgstr ""
 "Per rimuovere '%s' righe, eliminale.\n"
 "Le righe che iniziano con %s saranno rimosse.\n"
 
-#: git-add--interactive.perl:1142
+#: git-add--interactive.perl:1145
 #, perl-format
 msgid "failed to open hunk edit file for reading: %s"
 msgstr "apertura del file di modifica hunk in lettura non riuscita: %s"
 
-#: git-add--interactive.perl:1250
+#: git-add--interactive.perl:1253
 msgid ""
 "y - stage this hunk\n"
 "n - do not stage this hunk\n"
@@ -24936,7 +25298,7 @@ msgstr ""
 "d - non aggiungere né quest'hunk né quelli successivi nel file all'area di "
 "staging"
 
-#: git-add--interactive.perl:1256
+#: git-add--interactive.perl:1259
 msgid ""
 "y - stash this hunk\n"
 "n - do not stash this hunk\n"
@@ -24950,7 +25312,7 @@ msgstr ""
 "a - esegui lo stash di quest'hunk e di tutti quelli successivi nel file\n"
 "d - non eseguire lo stash né di quest'hunk né di quelli successivi nel file"
 
-#: git-add--interactive.perl:1262
+#: git-add--interactive.perl:1265
 msgid ""
 "y - unstage this hunk\n"
 "n - do not unstage this hunk\n"
@@ -24967,7 +25329,7 @@ msgstr ""
 "d - non rimuovere né quest'hunk né quelli successivi nel file dall'area di "
 "staging"
 
-#: git-add--interactive.perl:1268
+#: git-add--interactive.perl:1271
 msgid ""
 "y - apply this hunk to index\n"
 "n - do not apply this hunk to index\n"
@@ -24981,7 +25343,7 @@ msgstr ""
 "a - applica quest'hunk e tutti quelli successivi nel file\n"
 "d - non applicare né quest'hunk né quelli successivi nel file"
 
-#: git-add--interactive.perl:1274 git-add--interactive.perl:1292
+#: git-add--interactive.perl:1277 git-add--interactive.perl:1295
 msgid ""
 "y - discard this hunk from worktree\n"
 "n - do not discard this hunk from worktree\n"
@@ -24995,7 +25357,7 @@ msgstr ""
 "a - rimuovi quest'hunk e tutti quelli successivi nel file\n"
 "d - non rimuovere né quest'hunk né quelli successivi nel file"
 
-#: git-add--interactive.perl:1280
+#: git-add--interactive.perl:1283
 msgid ""
 "y - discard this hunk from index and worktree\n"
 "n - do not discard this hunk from index and worktree\n"
@@ -25009,7 +25371,7 @@ msgstr ""
 "a - rimuovi quest'hunk e tutti quelli successivi nel file\n"
 "d - non rimuovere né quest'hunk né quelli successivi nel file"
 
-#: git-add--interactive.perl:1286
+#: git-add--interactive.perl:1289
 msgid ""
 "y - apply this hunk to index and worktree\n"
 "n - do not apply this hunk to index and worktree\n"
@@ -25023,7 +25385,7 @@ msgstr ""
 "a - applica quest'hunk e tutti quelli successivi nel file\n"
 "d - non applicare né quest'hunk né quelli successivi nel file"
 
-#: git-add--interactive.perl:1298
+#: git-add--interactive.perl:1301
 msgid ""
 "y - apply this hunk to worktree\n"
 "n - do not apply this hunk to worktree\n"
@@ -25037,7 +25399,7 @@ msgstr ""
 "a - applica quest'hunk e tutti quelli successivi nel file\n"
 "d - non applicare né quest'hunk né quelli successivi nel file"
 
-#: git-add--interactive.perl:1313
+#: git-add--interactive.perl:1316
 msgid ""
 "g - select a hunk to go to\n"
 "/ - search for a hunk matching the given regex\n"
@@ -25061,90 +25423,90 @@ msgstr ""
 "e - modifica manualmente l'hunk corrente\n"
 "? - stampa una guida\n"
 
-#: git-add--interactive.perl:1344
+#: git-add--interactive.perl:1347
 msgid "The selected hunks do not apply to the index!\n"
 msgstr "Gli hunk selezionati non si applicano senza problemi all'indice!\n"
 
-#: git-add--interactive.perl:1359
+#: git-add--interactive.perl:1362
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "ignoro ciò che non è stato sottoposto a merge: %s\n"
 
-#: git-add--interactive.perl:1478
+#: git-add--interactive.perl:1481
 #, perl-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicare la modifica modo all'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1479
+#: git-add--interactive.perl:1482
 #, perl-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicare l'eliminazione all'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1480
+#: git-add--interactive.perl:1483
 #, perl-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicare l'aggiunta all'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1481
+#: git-add--interactive.perl:1484
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicare quest'hunk all'albero di lavoro [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1587
+#: git-add--interactive.perl:1601
 msgid "No other hunks to goto\n"
 msgstr "Nessun altro hunk a cui andare\n"
 
-#: git-add--interactive.perl:1605
+#: git-add--interactive.perl:1619
 #, perl-format
 msgid "Invalid number: '%s'\n"
 msgstr "Numero non valido: '%s'\n"
 
-#: git-add--interactive.perl:1610
+#: git-add--interactive.perl:1624
 #, perl-format
 msgid "Sorry, only %d hunk available.\n"
 msgid_plural "Sorry, only %d hunks available.\n"
 msgstr[0] "Mi dispiace, è disponibile solo %d hunk.\n"
 msgstr[1] "Mi dispiace, sono disponibili solo %d hunk.\n"
 
-#: git-add--interactive.perl:1636
+#: git-add--interactive.perl:1659
 msgid "No other hunks to search\n"
 msgstr "Nessun altro hunk in cui ricercare\n"
 
-#: git-add--interactive.perl:1653
+#: git-add--interactive.perl:1676
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
 msgstr "Espressione regolare di ricerca %s malformata: %s\n"
 
-#: git-add--interactive.perl:1663
+#: git-add--interactive.perl:1686
 msgid "No hunk matches the given pattern\n"
 msgstr "Nessun hunk corrisponde al pattern fornito\n"
 
-#: git-add--interactive.perl:1675 git-add--interactive.perl:1697
+#: git-add--interactive.perl:1698 git-add--interactive.perl:1720
 msgid "No previous hunk\n"
 msgstr "Nessun hunk precedente\n"
 
-#: git-add--interactive.perl:1684 git-add--interactive.perl:1703
+#: git-add--interactive.perl:1707 git-add--interactive.perl:1726
 msgid "No next hunk\n"
 msgstr "Nessun hunk successivo\n"
 
-#: git-add--interactive.perl:1709
+#: git-add--interactive.perl:1732
 msgid "Sorry, cannot split this hunk\n"
 msgstr "Mi dispiace, non posso suddividere quest'hunk\n"
 
-#: git-add--interactive.perl:1715
+#: git-add--interactive.perl:1738
 #, perl-format
 msgid "Split into %d hunk.\n"
 msgid_plural "Split into %d hunks.\n"
 msgstr[0] "Suddiviso in %d hunk.\n"
 msgstr[1] "Suddiviso in %d hunk.\n"
 
-#: git-add--interactive.perl:1725
+#: git-add--interactive.perl:1748
 msgid "Sorry, cannot edit this hunk\n"
 msgstr "Mi dispiace, non posso modificare quest'hunk\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
-#: git-add--interactive.perl:1790
+#: git-add--interactive.perl:1813
 msgid ""
 "status        - show paths with changes\n"
 "update        - add working tree state to the staged set of changes\n"
@@ -25164,19 +25526,19 @@ msgstr ""
 "add untracked - aggiunge i contenuti dei file non tracciati all'insieme di\n"
 "                modifiche nell'area di staging\n"
 
-#: git-add--interactive.perl:1807 git-add--interactive.perl:1812
-#: git-add--interactive.perl:1815 git-add--interactive.perl:1822
-#: git-add--interactive.perl:1825 git-add--interactive.perl:1832
-#: git-add--interactive.perl:1836 git-add--interactive.perl:1842
+#: git-add--interactive.perl:1830 git-add--interactive.perl:1835
+#: git-add--interactive.perl:1838 git-add--interactive.perl:1845
+#: git-add--interactive.perl:1848 git-add--interactive.perl:1855
+#: git-add--interactive.perl:1859 git-add--interactive.perl:1865
 msgid "missing --"
 msgstr "-- mancante"
 
-#: git-add--interactive.perl:1838
+#: git-add--interactive.perl:1861
 #, perl-format
 msgid "unknown --patch mode: %s"
 msgstr "modalità --patch sconosciuta: %s"
 
-#: git-add--interactive.perl:1844 git-add--interactive.perl:1850
+#: git-add--interactive.perl:1867 git-add--interactive.perl:1873
 #, perl-format
 msgid "invalid argument %s, expecting --"
 msgstr "argomento %s non valido, atteso --"
@@ -25195,27 +25557,38 @@ msgstr "l'offset del fuso orario locale è maggiore o uguale a 24 ore\n"
 msgid "the editor exited uncleanly, aborting everything"
 msgstr "l'editor non è terminato regolarmente, interrompo tutte le operazioni"
 
-#: git-send-email.perl:310
+#: git-send-email.perl:312
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr ""
 "'%s' contiene una versione intermedia dell'e-mail che stavi componendo.\n"
 
-#: git-send-email.perl:315
+#: git-send-email.perl:317
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr "'%s.final' contiene l'e-mail composta.\n"
 
-#: git-send-email.perl:408
+#: git-send-email.perl:410
 msgid "--dump-aliases incompatible with other options\n"
 msgstr "--dump-aliases non è compatibile con altre opzioni\n"
 
-#: git-send-email.perl:481 git-send-email.perl:683
+#: git-send-email.perl:484
+msgid ""
+"fatal: found configuration options for 'sendmail'\n"
+"git-send-email is configured with the sendemail.* options - note the 'e'.\n"
+"Set sendemail.forbidSendmailVariables to false to disable this check.\n"
+msgstr ""
+"errore fatale: sono state trovate opzioni di configurazione per 'sendmail'\n"
+"git-send-email è configurato con le opzioni sendemail.* - nota la 'e'.\n"
+"Imposta sendemail.forbidSendmailVariables a false per disabilitare questo"
+" controllo.\n"
+
+#: git-send-email.perl:489 git-send-email.perl:691
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr "Impossibile eseguire git format-patch al di fuori di un repository\n"
 
-#: git-send-email.perl:484
+#: git-send-email.perl:492
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
@@ -25223,37 +25596,37 @@ msgstr ""
 "`batch-size` e `relogin` devono essere specificati insieme (sulla riga di "
 "comando o tramite un'opzione di configurazione)\n"
 
-#: git-send-email.perl:497
+#: git-send-email.perl:505
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr "Campo --suppress-cc sconosciuto: '%s'\n"
 
-#: git-send-email.perl:528
+#: git-send-email.perl:536
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr "Impostazione --confirm sconosciuta: '%s'\n"
 
-#: git-send-email.perl:556
+#: git-send-email.perl:564
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr "attenzione: non sono supportati alias sendmail con virgolette: %s\n"
 
-#: git-send-email.perl:558
+#: git-send-email.perl:566
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr "attenzione: `:include:` non supportato: %s\n"
 
-#: git-send-email.perl:560
+#: git-send-email.perl:568
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr "attenzione: redirezioni `/file` o `|pipe` non supportate: %s\n"
 
-#: git-send-email.perl:565
+#: git-send-email.perl:573
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr "attenzione: riga sendmail non riconosciuta: %s\n"
 
-#: git-send-email.perl:649
+#: git-send-email.perl:657
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -25270,12 +25643,12 @@ msgstr ""
 "    * ...fornendo l'opzione --format-patch se ti riferisci\n"
 "      a un intervallo.\n"
 
-#: git-send-email.perl:670
+#: git-send-email.perl:678
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr "opendir di %s non riuscita: %s"
 
-#: git-send-email.perl:694
+#: git-send-email.perl:702
 #, perl-format
 msgid ""
 "fatal: %s: %s\n"
@@ -25284,7 +25657,7 @@ msgstr ""
 "errore fatale: %s: %s\n"
 "attenzione: non è stata inviata alcuna patch\n"
 
-#: git-send-email.perl:705
+#: git-send-email.perl:713
 msgid ""
 "\n"
 "No patch files specified!\n"
@@ -25294,17 +25667,17 @@ msgstr ""
 "Nessun file patch specificato!\n"
 "\n"
 
-#: git-send-email.perl:718
+#: git-send-email.perl:726
 #, perl-format
 msgid "No subject line in %s?"
 msgstr "Riga oggetto assente in %s?"
 
-#: git-send-email.perl:728
+#: git-send-email.perl:736
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr "Apertura di %s in scrittura non riuscita: %s"
 
-#: git-send-email.perl:739
+#: git-send-email.perl:747
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -25318,27 +25691,27 @@ msgstr ""
 "\n"
 "Rimuovi il corpo se non vuoi inviare un sommario.\n"
 
-#: git-send-email.perl:763
+#: git-send-email.perl:771
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr "Apertura di %s non riuscita: %s"
 
-#: git-send-email.perl:780
+#: git-send-email.perl:788
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr "Apertura di %s.final non riuscita: %s"
 
-#: git-send-email.perl:823
+#: git-send-email.perl:831
 msgid "Summary email is empty, skipping it\n"
 msgstr "E-mail riassuntiva vuota, la ometto\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:858
+#: git-send-email.perl:866
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr "Usare <%s> [y/N]? "
 
-#: git-send-email.perl:913
+#: git-send-email.perl:921
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
@@ -25346,11 +25719,11 @@ msgstr ""
 "I seguenti file sono codificati a 8 bit ma non dichiarano un Content-"
 "Transfer-Encoding.\n"
 
-#: git-send-email.perl:918
+#: git-send-email.perl:926
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr "Che codifica a 8 bit devo dichiarare [UTF-8]? "
 
-#: git-send-email.perl:926
+#: git-send-email.perl:934
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -25363,24 +25736,24 @@ msgstr ""
 "ha come oggetto nel modello '*** SUBJECT HERE ***'. Fornisci l'opzione --"
 "force se vuoi veramente procedere con l'invio.\n"
 
-#: git-send-email.perl:945
+#: git-send-email.perl:953
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr ""
 "A chi dovranno essere inviate le e-mail (se devono essere inviate a "
 "qualcuno)?"
 
-#: git-send-email.perl:963
+#: git-send-email.perl:971
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr "errore fatale: l'alias '%s' si espande in se stesso\n"
 
-#: git-send-email.perl:975
+#: git-send-email.perl:983
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
 "Message-ID da usare nell'intestazione In-Reply-To per la prima e-mail (se "
 "dev'essere usato)? "
 
-#: git-send-email.perl:1033 git-send-email.perl:1041
+#: git-send-email.perl:1041 git-send-email.perl:1049
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr "errore: impossibile estrarre un indirizzo valido da %s\n"
@@ -25388,17 +25761,17 @@ msgstr "errore: impossibile estrarre un indirizzo valido da %s\n"
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1045
+#: git-send-email.perl:1053
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr ""
 "Cosa devo fare con quest'indirizzo? (Esci [q]|scarta [d]|modifica [e]): "
 
-#: git-send-email.perl:1362
+#: git-send-email.perl:1370
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr "Il percorso CA \"%s\" non esiste"
 
-#: git-send-email.perl:1445
+#: git-send-email.perl:1453
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -25427,134 +25800,229 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1460
+#: git-send-email.perl:1468
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr ""
 "Inviare quest'e-mail? (Sì [y]|[n]o|modifica [e]|esci [q]|invia tutte [a]): "
 
-#: git-send-email.perl:1463
+#: git-send-email.perl:1471
 msgid "Send this email reply required"
 msgstr "È richiesta una risposta alla richiesta di invio e-mail"
 
-#: git-send-email.perl:1491
+#: git-send-email.perl:1499
 msgid "The required SMTP server is not properly defined."
 msgstr "Il server SMTP richiesto non è definito in modo adeguato."
 
-#: git-send-email.perl:1538
+#: git-send-email.perl:1546
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr "Il server non supporta STARTTLS! %s"
 
-#: git-send-email.perl:1543 git-send-email.perl:1547
+#: git-send-email.perl:1551 git-send-email.perl:1555
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr "STARTTLS non riuscito! %s"
 
-#: git-send-email.perl:1556
+#: git-send-email.perl:1564
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 "Impossibile inizializzare SMTP in modo adeguato. Controlla la configurazione "
 "e usa --smtp-debug."
 
-#: git-send-email.perl:1574
+#: git-send-email.perl:1582
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr "Invio di %s non riuscito\n"
 
-#: git-send-email.perl:1577
+#: git-send-email.perl:1585
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr "Test invio %s riuscito\n"
 
-#: git-send-email.perl:1577
+#: git-send-email.perl:1585
 #, perl-format
 msgid "Sent %s\n"
 msgstr "%s inviato\n"
 
-#: git-send-email.perl:1579
+#: git-send-email.perl:1587
 msgid "Dry-OK. Log says:\n"
 msgstr "Esecuzione di prova riuscita. Il registro è il seguente:\n"
 
-#: git-send-email.perl:1579
+#: git-send-email.perl:1587
 msgid "OK. Log says:\n"
 msgstr "Operazione riuscita. Il registro è il seguente:\n"
 
-#: git-send-email.perl:1591
+#: git-send-email.perl:1599
 msgid "Result: "
 msgstr "Risultato: "
 
-#: git-send-email.perl:1594
+#: git-send-email.perl:1602
 msgid "Result: OK\n"
 msgstr "Risultato: OK\n"
 
-#: git-send-email.perl:1612
+#: git-send-email.perl:1620
 #, perl-format
 msgid "can't open file %s"
 msgstr "impossibile aprire il file %s"
 
-#: git-send-email.perl:1659 git-send-email.perl:1679
+#: git-send-email.perl:1667 git-send-email.perl:1687
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr "(mbox) Aggiungo cc: %s dalla riga '%s'\n"
 
-#: git-send-email.perl:1665
+#: git-send-email.perl:1673
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr "(mbox) Aggiungo to: %s dalla riga '%s'\n"
 
-#: git-send-email.perl:1722
+#: git-send-email.perl:1730
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr "(non mbox) Aggiungo cc: %s dalla riga '%s'\n"
 
-#: git-send-email.perl:1757
+#: git-send-email.perl:1765
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(corpo) Aggiungo cc: %s dalla riga '%s'\n"
 
-#: git-send-email.perl:1868
+#: git-send-email.perl:1876
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Impossibile eseguire '%s'"
 
-#: git-send-email.perl:1875
+#: git-send-email.perl:1883
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Aggiungo %s: %s da: '%s'\n"
 
-#: git-send-email.perl:1879
+#: git-send-email.perl:1887
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) chiusura della pipe a '%s' non riuscita"
 
-#: git-send-email.perl:1909
+#: git-send-email.perl:1917
 msgid "cannot send message as 7bit"
 msgstr "impossibile inviare il messaggio con codifica a 7 bit"
 
-#: git-send-email.perl:1917
+#: git-send-email.perl:1925
 msgid "invalid transfer encoding"
 msgstr "codifica di trasferimento non valida"
 
-#: git-send-email.perl:1958 git-send-email.perl:2010 git-send-email.perl:2020
+#: git-send-email.perl:1966 git-send-email.perl:2018 git-send-email.perl:2028
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "impossibile aprire %s: %s\n"
 
-#: git-send-email.perl:1961
+#: git-send-email.perl:1969
 #, perl-format
 msgid "%s: patch contains a line longer than 998 characters"
 msgstr "%s: la patch contiene una riga più lunga di 998 caratteri"
 
-#: git-send-email.perl:1978
+#: git-send-email.perl:1986
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Salto %s con il suffisso di backup '%s'.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:1982
+#: git-send-email.perl:1990
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Inviare %s? [y|N]: "
+
+#~ msgid "unknown hash algorithm length"
+#~ msgstr "lunghezza algoritmo hash sconosciuta"
+
+#~ msgid ""
+#~ "commit-graph chunk lookup table entry missing; file may be incomplete"
+#~ msgstr ""
+#~ "voce blocco grafo dei commit mancante nella tabella di ricerca; il file "
+#~ "potrebbe non essere completo"
+
+#~ msgid "Writing changed paths Bloom filters index"
+#~ msgstr ""
+#~ "Scrittura dell'indice dei filtri di Bloom per i percorsi modificati in "
+#~ "corso"
+
+#, c-format
+#~ msgid "hash version %u does not match"
+#~ msgstr "la versione dell'hash %u non corrisponde"
+
+#~ msgid "Remote with no URL"
+#~ msgstr "Remoto senza URL"
+
+#, c-format
+#~ msgid "%%(subject) does not take arguments"
+#~ msgstr "%%(subject) non accetta argomenti"
+
+#, c-format
+#~ msgid "positive value expected objectname:short=%s"
+#~ msgstr "atteso valore positivo in objectname:short=%s"
+
+#, c-format
+#~ msgid "unrecognized %%(objectname) argument: %s"
+#~ msgstr "argomento %%(objectname) non riconosciuto: %s"
+
+#, c-format
+#~ msgid "option `%s' is incompatible with --merged"
+#~ msgstr "l'opzione `%s' non è compatibile con --merged"
+
+#, c-format
+#~ msgid "option `%s' is incompatible with --no-merged"
+#~ msgstr "l'opzione `%s' non è compatibile con --no-merged"
+
+#, c-format
+#~ msgid "could not open '%s' for writing: %s"
+#~ msgstr "impossibile aprire '%s' in scrittura: %s"
+
+#, c-format
+#~ msgid "could not read ref '%s'"
+#~ msgstr "impossibile leggere il riferimento '%s'"
+
+#, c-format
+#~ msgid "ref '%s' already exists"
+#~ msgstr "il riferimento '%s' esiste già"
+
+#, c-format
+#~ msgid "unexpected object ID when writing '%s'"
+#~ msgstr "ID oggetto inatteso durante la scrittura di '%s'"
+
+#, c-format
+#~ msgid "unexpected object ID when deleting '%s'"
+#~ msgstr "ID oggetto inatteso durante l'eliminazione di '%s'"
+
+#, c-format
+#~ msgid "The hash algorithm %s is not supported in this build."
+#~ msgstr "L'algoritmo hash %s non è supportato in questa compilazione."
+
+#~ msgid "could not open the file BISECT_TERMS"
+#~ msgstr "impossibile aprire il file BISECT_TERMS"
+
+#~ msgid "update BISECT_HEAD instead of checking out the current commit"
+#~ msgstr ""
+#~ "aggiorna BISECT_HEAD anziché eseguire il checkout del commit corrente"
+
+#~ msgid "print only names (no SHA-1)"
+#~ msgstr "stampa solo i nomi (non lo SHA-1)"
+
+#~ msgid "passed to 'git am'"
+#~ msgstr "passato a 'git am'"
+
+#~ msgid "The --cached option cannot be used with the --files option"
+#~ msgstr "L'opzione --cached non può essere usata con l'opzione --files"
+
+#, sh-format
+#~ msgid "  Warn: $display_name doesn't contain commit $sha1_src"
+#~ msgstr "  Attenzione: $display_name non contiene il commit $sha1_src"
+
+#, sh-format
+#~ msgid "  Warn: $display_name doesn't contain commit $sha1_dst"
+#~ msgstr "  Attenzione: $display_name non contiene il commit $sha1_dst"
+
+#, sh-format
+#~ msgid ""
+#~ "  Warn: $display_name doesn't contain commits $sha1_src and $sha1_dst"
+#~ msgstr ""
+#~ "  Attenzione: $display_name non contiene i commit $sha1_src e $sha1_dst"
 
 #, c-format
 #~ msgid "Finding commits for commit graph from %d ref"
@@ -25762,9 +26230,6 @@ msgstr "Inviare %s? [y|N]: "
 #~ msgid "malformed ident line"
 #~ msgstr "riga ident malformata"
 
-#~ msgid "corrupted author without date information"
-#~ msgstr "informazioni sull'autore corrotte (senza data)"
-
 #, c-format
 #~ msgid "could not parse '%.*s'"
 #~ msgstr "impossibile analizzare '%.*s'"
@@ -25801,20 +26266,6 @@ msgstr "Inviare %s? [y|N]: "
 
 #~ msgid "no HEAD?"
 #~ msgstr "nessun'HEAD?"
-
-#~ msgid "make committer date match author date"
-#~ msgstr ""
-#~ "fai corrispondere la data della persona che ha eseguito il commit alla "
-#~ "data autore"
-
-#~ msgid "ignore author date and use current date"
-#~ msgstr "ignora la data autore e usa la data corrente"
-
-#~ msgid "synonym of --reset-author-date"
-#~ msgstr "sinonimo di --reset-author-date"
-
-#~ msgid "ignore changes in whitespace"
-#~ msgstr "ignora modifiche agli spazi bianchi"
 
 #~ msgid "preserve empty commits during rebase"
 #~ msgstr "mantieni i commit vuoti durante il rebase"
@@ -25979,9 +26430,6 @@ msgstr "Inviare %s? [y|N]: "
 
 #~ msgid "unrecognized verb: %s"
 #~ msgstr "verbo non riconosciuto: %s"
-
-#~ msgid "hash version %X does not match version %X"
-#~ msgstr "la versione dell'hash %X non corrisponde alla versione %X"
 
 #~ msgid "option '%s' requires a value"
 #~ msgstr "l'opzione '%s' richiede un valore"


### PR DESCRIPTION
This PR updates the Italian translation for Git 2.29.0, round 1.