### PR TITLE
l10n: it.po: update the Italian translation for Git 2.29.0 round 2

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2020-10-06 09:14+0800\n"
-"PO-Revision-Date: 2020-10-07 21:44+0200\n"
+"POT-Creation-Date: 2020-10-10 09:32+0800\n"
+"PO-Revision-Date: 2020-10-10 09:31+0200\n"
 "Last-Translator: Alessandro Menti <alessandro.menti@alessandromenti.it>\n"
 "Language-Team: Italian <>\n"
 "Language: it\n"
@@ -4322,42 +4322,42 @@ msgstr "Comandi di basso livello / Sincronizzazione repository"
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Comandi di basso livello / Funzioni helper interne"
 
-#: help.c:298
+#: help.c:300
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "comandi git disponibili in '%s'"
 
-#: help.c:305
+#: help.c:307
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "comandi git disponibili altrove nel tuo $PATH"
 
-#: help.c:314
+#: help.c:316
 msgid "These are common Git commands used in various situations:"
 msgstr "Questi sono i comandi Git comuni usati in varie situazioni:"
 
-#: help.c:363 git.c:99
+#: help.c:365 git.c:99
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "tipo elenco comandi non supportato: '%s'"
 
-#: help.c:403
+#: help.c:405
 msgid "The Git concept guides are:"
 msgstr "Le guide Git concettuali sono:"
 
-#: help.c:427
+#: help.c:429
 msgid "See 'git help <command>' to read about a specific subcommand"
 msgstr ""
 "Vedi 'git help <comando>' per saperne di più su un sottocomando specifico"
 
-#: help.c:432
+#: help.c:434
 msgid "External commands"
 msgstr "Comandi esterni"
 
-#: help.c:447
+#: help.c:449
 msgid "Command aliases"
 msgstr "Alias comandi"
 
-#: help.c:511
+#: help.c:513
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4366,31 +4366,31 @@ msgstr ""
 "'%s' sembra essere un comando git, ma non è stato\n"
 "possibile eseguirlo. Forse git-%s è corrotto?"
 
-#: help.c:570
+#: help.c:572
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Oh oh. Il tuo sistema non riporta alcun comando Git."
 
-#: help.c:592
+#: help.c:594
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr "ATTENZIONE: hai chiamato un comando Git '%s' inesistente."
 
-#: help.c:597
+#: help.c:599
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Continuo assumendo che intendessi '%s'."
 
-#: help.c:602
+#: help.c:604
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Continuo fra %0.1f secondi assumendo che intendessi '%s'."
 
-#: help.c:610
+#: help.c:612
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: '%s' non è un comando git. Vedi 'git --help'."
 
-#: help.c:614
+#: help.c:616
 msgid ""
 "\n"
 "The most similar command is"
@@ -4404,16 +4404,16 @@ msgstr[1] ""
 "\n"
 "I comandi maggiormente simili sono"
 
-#: help.c:654
+#: help.c:656
 msgid "git version [<options>]"
 msgstr "git version [<opzioni>]"
 
-#: help.c:709
+#: help.c:711
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:713
+#: help.c:715
 msgid ""
 "\n"
 "Did you mean this?"
@@ -5581,8 +5581,8 @@ msgstr "promisor-remote: impossibile scrivere sul sottoprocesso di fetch"
 #: promisor-remote.c:41
 msgid "promisor-remote: could not close stdin to fetch subprocess"
 msgstr ""
-"promisor-remote: impossibile chiudere lo standard input del sottoprocesso di"
-" fetch"
+"promisor-remote: impossibile chiudere lo standard input del sottoprocesso di "
+"fetch"
 
 #: promisor-remote.c:53
 #, c-format
@@ -7800,8 +7800,8 @@ msgstr "trovate estensioni repository sconosciute:"
 #: setup.c:681
 msgid "repo version is 0, but v1-only extensions found:"
 msgstr ""
-"la versione del repository è 0, ma sono state trovate estensioni proprie solo"
-" della versione 1:"
+"la versione del repository è 0, ma sono state trovate estensioni proprie "
+"solo della versione 1:"
 
 #: setup.c:700
 #, c-format
@@ -8134,7 +8134,7 @@ msgstr "%s non è un oggetto valido"
 msgid "%s is not a valid '%s' object"
 msgstr "%s non è un oggetto '%s' valido"
 
-#: sha1-file.c:2288 builtin/index-pack.c:197
+#: sha1-file.c:2288 builtin/index-pack.c:192
 #, c-format
 msgid "unable to open %s"
 msgstr "impossibile aprire %s"
@@ -10569,9 +10569,9 @@ msgid ""
 "=<term>] [--no-checkout] [--first-parent] [<bad> [<good>...]] [--] "
 "[<paths>...]"
 msgstr ""
-"git bisect--helper --bisect-start [--term-{new,bad}=<termine>"
-" --term-{old,good}=<termine>] [--no-checkout] [--first-parent] [<non"
-" funzionante> [<funzionante>...]] [--] [<percorsi>...]"
+"git bisect--helper --bisect-start [--term-{new,bad}=<termine> --term-{old,"
+"good}=<termine>] [--no-checkout] [--first-parent] [<non funzionante> "
+"[<funzionante>...]] [--] [<percorsi>...]"
 
 #: builtin/bisect--helper.c:33
 msgid "git bisect--helper --bisect-next"
@@ -10813,8 +10813,8 @@ msgstr "trova il prossimo commit della bisezione"
 #: builtin/bisect--helper.c:888
 msgid "verify the next bisection state then checkout the next bisection commit"
 msgstr ""
-"verifica il prossimo stato della bisezione, quindi esegui il checkout del"
-" prossimo commit della bisezione"
+"verifica il prossimo stato della bisezione, quindi esegui il checkout del "
+"prossimo commit della bisezione"
 
 #: builtin/bisect--helper.c:890
 msgid "start the bisection if it has not yet been started"
@@ -10903,8 +10903,8 @@ msgstr ""
 #: builtin/blame.c:868
 msgid "Do not show object names of boundary commits (Default: off)"
 msgstr ""
-"Non visualizzare i nomi degli oggetti dei commit limite (impostazione"
-" predefinita: off)"
+"Non visualizzare i nomi degli oggetti dei commit limite (impostazione "
+"predefinita: off)"
 
 #: builtin/blame.c:869
 msgid "Do not treat root commits as boundaries (Default: off)"
@@ -12956,33 +12956,6 @@ msgstr "Il branch remoto %s non è stato trovato nell'upstream %s"
 msgid "You appear to have cloned an empty repository."
 msgstr "Sembra che tu abbia clonato un repository vuoto."
 
-#: builtin/credential-cache.c:154
-msgid "credential-cache unavailable; no unix socket support"
-msgstr "credential-cache non disponibile; supporto socket UNIX non presente"
-
-#: builtin/credential-cache--daemon.c:226
-#, c-format
-msgid ""
-"The permissions on your socket directory are too loose; other\n"
-"users may be able to read your cached credentials. Consider running:\n"
-"\n"
-"\tchmod 0700 %s"
-msgstr ""
-"I permessi sulla directory del socket sono troppo laschi; altri\n"
-"utenti potrebbero essere in grado di leggere le credenziali nella\n"
-"cache. Valuta di eseguire:\n"
-"\n"
-"\tchmod 0700 %s"
-
-#: builtin/credential-cache--daemon.c:275
-msgid "print debugging messages to stderr"
-msgstr "stampa i messaggi di debug sullo standard error"
-
-#: builtin/credential-cache--daemon.c:315
-msgid "credential-cache--daemon unavailable; no unix socket support"
-msgstr ""
-"credential-cache--daemon non disponibile; supporto socket UNIX non presente"
-
 #: builtin/column.c:10
 msgid "git column [<options>]"
 msgstr "git column [<opzioni>]"
@@ -14079,6 +14052,33 @@ msgstr "git count-objects [-v] [-H | --human-readable]"
 #: builtin/count-objects.c:100
 msgid "print sizes in human readable format"
 msgstr "stampa le dimensioni in un formato leggibile"
+
+#: builtin/credential-cache--daemon.c:226
+#, c-format
+msgid ""
+"The permissions on your socket directory are too loose; other\n"
+"users may be able to read your cached credentials. Consider running:\n"
+"\n"
+"\tchmod 0700 %s"
+msgstr ""
+"I permessi sulla directory del socket sono troppo laschi; altri\n"
+"utenti potrebbero essere in grado di leggere le credenziali nella\n"
+"cache. Valuta di eseguire:\n"
+"\n"
+"\tchmod 0700 %s"
+
+#: builtin/credential-cache--daemon.c:275
+msgid "print debugging messages to stderr"
+msgstr "stampa i messaggi di debug sullo standard error"
+
+#: builtin/credential-cache--daemon.c:315
+msgid "credential-cache--daemon unavailable; no unix socket support"
+msgstr ""
+"credential-cache--daemon non disponibile; supporto socket UNIX non presente"
+
+#: builtin/credential-cache.c:154
+msgid "credential-cache unavailable; no unix socket support"
+msgstr "credential-cache non disponibile; supporto socket UNIX non presente"
 
 #: builtin/describe.c:26
 msgid "git describe [<options>] [<commit-ish>...]"
@@ -15193,7 +15193,7 @@ msgstr "Controllo directory oggetti in corso"
 msgid "Checking %s link"
 msgstr "Controllo collegamento %s"
 
-#: builtin/fsck.c:696 builtin/index-pack.c:871
+#: builtin/fsck.c:696 builtin/index-pack.c:865
 #, c-format
 msgid "invalid %s"
 msgstr "%s non valido"
@@ -15278,7 +15278,7 @@ msgstr "visualizza l'avanzamento"
 msgid "show verbose names for reachable objects"
 msgstr "visualizza nomi dettagliati per gli oggetti raggiungibili"
 
-#: builtin/fsck.c:847 builtin/index-pack.c:267
+#: builtin/fsck.c:847 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Controllo oggetti in corso"
 
@@ -15469,7 +15469,7 @@ msgstr "specificato numero non valido di thread (%d) per %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:287 builtin/index-pack.c:1581 builtin/index-pack.c:1771
+#: builtin/grep.c:287 builtin/index-pack.c:1576 builtin/index-pack.c:1766
 #: builtin/pack-objects.c:2936
 #, c-format
 msgid "no threads support, ignoring %s"
@@ -15708,7 +15708,7 @@ msgstr "combinazione di opzioni non valida, ignoro --threads"
 msgid "no threads support, ignoring --threads"
 msgstr "non vi è supporto per i thread, ignoro --threads"
 
-#: builtin/grep.c:1088 builtin/index-pack.c:1578 builtin/pack-objects.c:2933
+#: builtin/grep.c:1088 builtin/index-pack.c:1573 builtin/pack-objects.c:2933
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "specificato numero non valido di thread (%d)"
@@ -15877,299 +15877,299 @@ msgstr "uso: %s%s"
 msgid "'git help config' for more information"
 msgstr "Vedi 'git help config' per maggiori informazioni"
 
-#: builtin/index-pack.c:227
+#: builtin/index-pack.c:221
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "tipo oggetto non corrispondente in %s"
 
-#: builtin/index-pack.c:247
+#: builtin/index-pack.c:241
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "non si è ricevuto l'oggetto atteso %s"
 
-#: builtin/index-pack.c:250
+#: builtin/index-pack.c:244
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "oggetto %s: atteso tipo %s, trovato %s"
 
-#: builtin/index-pack.c:300
+#: builtin/index-pack.c:294
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "impossibile riempire %d byte"
 msgstr[1] "impossibile riempire %d byte"
 
-#: builtin/index-pack.c:310
+#: builtin/index-pack.c:304
 msgid "early EOF"
 msgstr "EOF prematuro"
 
-#: builtin/index-pack.c:311
+#: builtin/index-pack.c:305
 msgid "read error on input"
 msgstr "errore di lettura in input"
 
-#: builtin/index-pack.c:323
+#: builtin/index-pack.c:317
 msgid "used more bytes than were available"
 msgstr "usati più byte di quelli disponibili"
 
-#: builtin/index-pack.c:330 builtin/pack-objects.c:619
+#: builtin/index-pack.c:324 builtin/pack-objects.c:619
 msgid "pack too large for current definition of off_t"
 msgstr "pack troppo largo per la definizione corrente di off_t"
 
-#: builtin/index-pack.c:333 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "il pack supera la dimensione massima consentita"
 
-#: builtin/index-pack.c:348 builtin/repack.c:254
+#: builtin/index-pack.c:342 builtin/repack.c:254
 #, c-format
 msgid "unable to create '%s'"
 msgstr "impossibile creare '%s'"
 
-#: builtin/index-pack.c:354
+#: builtin/index-pack.c:348
 #, c-format
 msgid "cannot open packfile '%s'"
 msgstr "impossibile aprire il file pack '%s'"
 
-#: builtin/index-pack.c:368
+#: builtin/index-pack.c:362
 msgid "pack signature mismatch"
 msgstr "la firma del pack non coincide"
 
-#: builtin/index-pack.c:370
+#: builtin/index-pack.c:364
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "versione pack %<PRIu32> non supportata"
 
-#: builtin/index-pack.c:388
+#: builtin/index-pack.c:382
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "il pack ha un oggetto danneggiato all'offset %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:494
+#: builtin/index-pack.c:488
 #, c-format
 msgid "inflate returned %d"
 msgstr "inflate ha restituito il codice %d"
 
-#: builtin/index-pack.c:543
+#: builtin/index-pack.c:537
 msgid "offset value overflow for delta base object"
 msgstr "overflow del valore dell'offset base del delta"
 
-#: builtin/index-pack.c:551
+#: builtin/index-pack.c:545
 msgid "delta base offset is out of bound"
 msgstr "l'offset base del delta è fuori dall'intervallo consentito"
 
-#: builtin/index-pack.c:559
+#: builtin/index-pack.c:553
 #, c-format
 msgid "unknown object type %d"
 msgstr "tipo oggetto %d sconosciuto"
 
-#: builtin/index-pack.c:590
+#: builtin/index-pack.c:584
 msgid "cannot pread pack file"
 msgstr "impossibile eseguire pread sul file pack"
 
-#: builtin/index-pack.c:592
+#: builtin/index-pack.c:586
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "fine del file pack prematura, %<PRIuMAX> byte mancante"
 msgstr[1] "fine del file pack prematura, %<PRIuMAX> byte mancanti"
 
-#: builtin/index-pack.c:618
+#: builtin/index-pack.c:612
 msgid "serious inflate inconsistency"
 msgstr "inconsistenza grave di inflate"
 
-#: builtin/index-pack.c:763 builtin/index-pack.c:769 builtin/index-pack.c:793
-#: builtin/index-pack.c:832 builtin/index-pack.c:841
+#: builtin/index-pack.c:757 builtin/index-pack.c:763 builtin/index-pack.c:787
+#: builtin/index-pack.c:826 builtin/index-pack.c:835
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "TROVATA COLLISIONE SHA1 CON %s !"
 
-#: builtin/index-pack.c:766 builtin/pack-objects.c:171
+#: builtin/index-pack.c:760 builtin/pack-objects.c:171
 #: builtin/pack-objects.c:231 builtin/pack-objects.c:326
 #, c-format
 msgid "unable to read %s"
 msgstr "impossibile leggere %s"
 
-#: builtin/index-pack.c:830
+#: builtin/index-pack.c:824
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "impossibile leggere le informazioni sull'oggetto esistente: %s"
 
-#: builtin/index-pack.c:838
+#: builtin/index-pack.c:832
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "non è possibile leggere l'oggetto %s esistente"
 
-#: builtin/index-pack.c:852
+#: builtin/index-pack.c:846
 #, c-format
 msgid "invalid blob object %s"
 msgstr "oggetto blob %s non valido"
 
-#: builtin/index-pack.c:855 builtin/index-pack.c:874
+#: builtin/index-pack.c:849 builtin/index-pack.c:868
 msgid "fsck error in packed object"
 msgstr "errore fsck nell'oggetto sottoposto a pack"
 
-#: builtin/index-pack.c:876
+#: builtin/index-pack.c:870
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Non tutti gli oggetti figlio di %s sono raggiungibili"
 
-#: builtin/index-pack.c:940 builtin/index-pack.c:987
+#: builtin/index-pack.c:931 builtin/index-pack.c:978
 msgid "failed to apply delta"
 msgstr "applicazione del delta non riuscita"
 
-#: builtin/index-pack.c:1166
+#: builtin/index-pack.c:1161
 msgid "Receiving objects"
 msgstr "Ricezione degli oggetti"
 
-#: builtin/index-pack.c:1166
+#: builtin/index-pack.c:1161
 msgid "Indexing objects"
 msgstr "Indicizzazione degli oggetti"
 
-#: builtin/index-pack.c:1200
+#: builtin/index-pack.c:1195
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "il pack è corrotto (SHA1 non corrisponde)"
 
-#: builtin/index-pack.c:1205
+#: builtin/index-pack.c:1200
 msgid "cannot fstat packfile"
 msgstr "impossibile eseguire fstat sul file pack"
 
-#: builtin/index-pack.c:1208
+#: builtin/index-pack.c:1203
 msgid "pack has junk at the end"
 msgstr "il pack ha dati inutili alla fine"
 
-#: builtin/index-pack.c:1220
+#: builtin/index-pack.c:1215
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "confusione oltre ogni follia in parse_pack_objects()"
 
-#: builtin/index-pack.c:1243
+#: builtin/index-pack.c:1238
 msgid "Resolving deltas"
 msgstr "Risoluzione dei delta"
 
-#: builtin/index-pack.c:1254 builtin/pack-objects.c:2697
+#: builtin/index-pack.c:1249 builtin/pack-objects.c:2697
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "impossibile creare il thread: %s"
 
-#: builtin/index-pack.c:1287
+#: builtin/index-pack.c:1282
 msgid "confusion beyond insanity"
 msgstr "confusione oltre ogni follia"
 
-#: builtin/index-pack.c:1293
+#: builtin/index-pack.c:1288
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "completato con %d oggetto locale"
 msgstr[1] "completato con %d oggetti locali"
 
-#: builtin/index-pack.c:1305
+#: builtin/index-pack.c:1300
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Checksum in coda inatteso per %s (disco corrotto?)"
 
-#: builtin/index-pack.c:1309
+#: builtin/index-pack.c:1304
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "pack ha %d delta irrisolto"
 msgstr[1] "pack ha %d delta irrisolti"
 
-#: builtin/index-pack.c:1333
+#: builtin/index-pack.c:1328
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "impossibile eseguire deflate sull'oggetto aggiunto alla fine (%d)"
 
-#: builtin/index-pack.c:1429
+#: builtin/index-pack.c:1424
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "l'oggetto locale %s è corrotto"
 
-#: builtin/index-pack.c:1449
+#: builtin/index-pack.c:1444
 #, c-format
 msgid "packfile name '%s' does not end with '.pack'"
 msgstr "il nome del file pack '%s' non termina con '.pack'"
 
-#: builtin/index-pack.c:1474
+#: builtin/index-pack.c:1469
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "impossibile scrivere il file %s '%s'"
 
-#: builtin/index-pack.c:1482
+#: builtin/index-pack.c:1477
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "impossibile chiudere il file %s scritto '%s'"
 
-#: builtin/index-pack.c:1506
+#: builtin/index-pack.c:1501
 msgid "error while closing pack file"
 msgstr "errore nella chiusura del file pack"
 
-#: builtin/index-pack.c:1520
+#: builtin/index-pack.c:1515
 msgid "cannot store pack file"
 msgstr "impossibile archiviare il file pack"
 
-#: builtin/index-pack.c:1528
+#: builtin/index-pack.c:1523
 msgid "cannot store index file"
 msgstr "impossibile archiviare index file"
 
-#: builtin/index-pack.c:1572 builtin/pack-objects.c:2944
+#: builtin/index-pack.c:1567 builtin/pack-objects.c:2944
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "pack.indexversion=%<PRIu32> non valida"
 
-#: builtin/index-pack.c:1636
+#: builtin/index-pack.c:1631
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Impossibile aprire il file pack '%s' esistente"
 
-#: builtin/index-pack.c:1638
+#: builtin/index-pack.c:1633
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Impossibile aprire il file pack idx esistente per '%s'"
 
-#: builtin/index-pack.c:1686
+#: builtin/index-pack.c:1681
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "non delta: %d oggetto"
 msgstr[1] "non delta: %d oggetti"
 
-#: builtin/index-pack.c:1693
+#: builtin/index-pack.c:1688
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "lunghezza della catena = %d: %lu oggetto"
 msgstr[1] "lunghezza della catena = %d: %lu oggetti"
 
-#: builtin/index-pack.c:1733
+#: builtin/index-pack.c:1728
 msgid "Cannot come back to cwd"
 msgstr "impossibile tornare alla directory di lavoro corrente"
 
-#: builtin/index-pack.c:1782 builtin/index-pack.c:1785
-#: builtin/index-pack.c:1801 builtin/index-pack.c:1805
+#: builtin/index-pack.c:1777 builtin/index-pack.c:1780
+#: builtin/index-pack.c:1796 builtin/index-pack.c:1800
 #, c-format
 msgid "bad %s"
 msgstr "%s errato"
 
-#: builtin/index-pack.c:1811 builtin/init-db.c:391 builtin/init-db.c:623
+#: builtin/index-pack.c:1806 builtin/init-db.c:391 builtin/init-db.c:623
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algoritmo hash '%s' sconosciuto"
 
-#: builtin/index-pack.c:1826
+#: builtin/index-pack.c:1821
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin non può essere usato senza --stdin"
 
-#: builtin/index-pack.c:1828
+#: builtin/index-pack.c:1823
 msgid "--stdin requires a git repository"
 msgstr "--stdin richiede un repository Git"
 
-#: builtin/index-pack.c:1830
+#: builtin/index-pack.c:1825
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format non può essere usato con --stdin"
 
-#: builtin/index-pack.c:1836
+#: builtin/index-pack.c:1831
 msgid "--verify with no packfile name given"
 msgstr "--verify senza un nome del file pack specificato"
 
-#: builtin/index-pack.c:1897 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1892 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "errore fsck negli oggetti sottoposti a pack"
 
@@ -22077,14 +22077,14 @@ msgstr "modalità %o inattesa\n"
 #: builtin/submodule--helper.c:1300
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr ""
-"usa il commit salvato nell'indice anziché quello salvato nell'HEAD del"
-" sottomodulo"
+"usa il commit salvato nell'indice anziché quello salvato nell'HEAD del "
+"sottomodulo"
 
 #: builtin/submodule--helper.c:1302
 msgid "to compare the commit in the index with that in the submodule HEAD"
 msgstr ""
-"per confrontare il commit salvato nell'indice con quello salvato nell'HEAD"
-" del sottomodulo"
+"per confrontare il commit salvato nell'indice con quello salvato nell'HEAD "
+"del sottomodulo"
 
 #: builtin/submodule--helper.c:1304
 msgid "skip submodules with 'ignore_config' value set to 'all'"
@@ -22096,8 +22096,8 @@ msgid "limit the summary size"
 msgstr "limita le dimensioni del riassunto"
 
 #: builtin/submodule--helper.c:1311
-msgid "git submodule--helper summary [<options>] [commit] [--] [<path>]"
-msgstr "git submodule--helper summary [<opzioni>] [commit] [--] [<percorso>]"
+msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
+msgstr "git submodule--helper summary [<opzioni>] [<commit>] [--] [<percorso>]"
 
 #: builtin/submodule--helper.c:1335
 msgid "could not fetch a revision for HEAD"
@@ -22443,7 +22443,7 @@ msgstr "è richiesto specificare --branch o --default"
 msgid "--branch and --default are mutually exclusive"
 msgstr "le opzioni --branch e --default sono mutualmente esclusive"
 
-#: builtin/submodule--helper.c:2792 git.c:438 git.c:691
+#: builtin/submodule--helper.c:2792 git.c:438 git.c:710
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s non supporta --super-prefix"
@@ -23522,17 +23522,17 @@ msgstr "errore di scrittura sconosciuto sullo standard output"
 msgid "close failed on standard output"
 msgstr "chiusura dello standard output non riuscita"
 
-#: git.c:800
+#: git.c:819
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "rilevato ciclo alias: l'espansione di '%s' non termina:%s"
 
-#: git.c:850
+#: git.c:869
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "impossibile gestire %s come comando incorporato"
 
-#: git.c:863
+#: git.c:882
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -23541,12 +23541,12 @@ msgstr ""
 "uso: %s\n"
 "\n"
 
-#: git.c:883
+#: git.c:902
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "espansione dell'alias '%s' non riuscita; '%s' non è un comando Git\n"
 
-#: git.c:895
+#: git.c:914
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "esecuzione del comando '%s' non riuscita: %s\n"
@@ -25581,8 +25581,8 @@ msgid ""
 msgstr ""
 "errore fatale: sono state trovate opzioni di configurazione per 'sendmail'\n"
 "git-send-email è configurato con le opzioni sendemail.* - nota la 'e'.\n"
-"Imposta sendemail.forbidSendmailVariables a false per disabilitare questo"
-" controllo.\n"
+"Imposta sendemail.forbidSendmailVariables a false per disabilitare questo "
+"controllo.\n"
 
 #: git-send-email.perl:489 git-send-email.perl:691
 msgid "Cannot run git format-patch from outside a repository\n"


### PR DESCRIPTION
This PR updates the Italian translation for Git 2.29.0, round 2.