### PR TITLE
l10n: id: po-id for 2.32.0 (round 1)

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-03-04 22:41+0800\n"
-"PO-Revision-Date: 2021-02-20 18:07+0700\n"
+"POT-Creation-Date: 2021-05-17 16:02+0800\n"
+"PO-Revision-Date: 2021-05-17 18:32+0700\n"
 "Last-Translator: Bagas Sanjaya <bagasdotme@gmail.com>\n"
 "Language-Team: Indonesian\n"
 "Language: id\n"
@@ -20,238 +20,240 @@ msgstr ""
 #: add-interactive.c:376
 #, c-format
 msgid "Huh (%s)?"
-msgstr ""
+msgstr "Huh (%s)"
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:65 sequencer.c:3292
-#: sequencer.c:3743 sequencer.c:3898 builtin/rebase.c:1538
-#: builtin/rebase.c:1963
+#: add-interactive.c:529 add-interactive.c:830 reset.c:65 sequencer.c:3493
+#: sequencer.c:3944 sequencer.c:4099 builtin/rebase.c:1528
+#: builtin/rebase.c:1953
 msgid "could not read index"
-msgstr ""
+msgstr "tidak dapat membaca indeks"
 
 #: add-interactive.c:584 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
-msgstr ""
+msgstr "biner"
 
 #: add-interactive.c:642 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
-msgstr ""
+msgstr "tidak ada"
 
 #: add-interactive.c:643 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
-msgstr ""
+msgstr "tak berubah"
 
 #: add-interactive.c:680 git-add--interactive.perl:641
 msgid "Update"
-msgstr ""
+msgstr "Perbarui"
 
 #: add-interactive.c:697 add-interactive.c:885
 #, c-format
 msgid "could not stage '%s'"
-msgstr ""
+msgstr "tidak dapat menggelar '%s'"
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3486
+#: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3687
 msgid "could not write index"
-msgstr ""
+msgstr "tidak dapat menulis indeks"
 
 #: add-interactive.c:706 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d jalur diperbarui\n"
+msgstr[1] "%d jalur diperbarui\n"
 
 #: add-interactive.c:724 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
-msgstr ""
+msgstr "catatan: %s sekarang tak terlacak.\n"
 
-#: add-interactive.c:729 apply.c:4125 builtin/checkout.c:295
+#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:298
 #: builtin/reset.c:145
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
-msgstr ""
+msgstr "make_cache_entry gagal untuk jalur '%s'"
 
 #: add-interactive.c:759 git-add--interactive.perl:653
 msgid "Revert"
-msgstr ""
+msgstr "Kembalikan"
 
 #: add-interactive.c:775
 msgid "Could not parse HEAD^{tree}"
-msgstr ""
+msgstr "Tidak dapat menguraikan HEAD^{tree}"
 
 #: add-interactive.c:813 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d jalur dikembalikan\n"
+msgstr[1] "%d jalur dikembalikan\n"
 
 #: add-interactive.c:864 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
-msgstr ""
+msgstr "Tidak ada berkas tak terlacak.\n"
 
 #: add-interactive.c:868 git-add--interactive.perl:687
 msgid "Add untracked"
-msgstr ""
+msgstr "Tambahkan tak terlacak"
 
 #: add-interactive.c:895 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d jalur ditambahkan\n"
+msgstr[1] "%d jalur ditambahkan\n"
 
 #: add-interactive.c:925
 #, c-format
 msgid "ignoring unmerged: %s"
-msgstr ""
+msgstr "mengabaikan tak tergabung: %s"
 
 #: add-interactive.c:937 add-patch.c:1751 git-add--interactive.perl:1369
 #, c-format
 msgid "Only binary files changed.\n"
-msgstr ""
+msgstr "Hanya berkas biner yang berubah.\n"
 
 #: add-interactive.c:939 add-patch.c:1749 git-add--interactive.perl:1371
 #, c-format
 msgid "No changes.\n"
-msgstr ""
+msgstr "Tidak ada perubahan.\n"
 
 #: add-interactive.c:943 git-add--interactive.perl:1379
 msgid "Patch update"
-msgstr ""
+msgstr "Pembaruan tambalan"
 
 #: add-interactive.c:982 git-add--interactive.perl:1792
 msgid "Review diff"
-msgstr ""
+msgstr "Tinjau diff"
 
 #: add-interactive.c:1010
 msgid "show paths with changes"
-msgstr ""
+msgstr "perlihatkan jalur dengan perubahan"
 
 #: add-interactive.c:1012
 msgid "add working tree state to the staged set of changes"
-msgstr ""
+msgstr "tambahkan keadaan pohon kerja ke set perubahan yang tergelar"
 
 #: add-interactive.c:1014
 msgid "revert staged set of changes back to the HEAD version"
-msgstr ""
+msgstr "kembalikan set perubahan yang tergelar kembali ke versi HEAD"
 
 #: add-interactive.c:1016
 msgid "pick hunks and update selectively"
-msgstr ""
+msgstr "ambil hunk dan perbarui secara selektif"
 
 #: add-interactive.c:1018
 msgid "view diff between HEAD and index"
-msgstr ""
+msgstr "lihat diff antara HEAD dan indeks"
 
 #: add-interactive.c:1020
 msgid "add contents of untracked files to the staged set of changes"
-msgstr ""
+msgstr "tambahkan isi berkas tak terlacak ke set perubahan yang tergelar"
 
 #: add-interactive.c:1028 add-interactive.c:1077
 msgid "Prompt help:"
-msgstr ""
+msgstr "Permintaan bantuan:"
 
 #: add-interactive.c:1030
 msgid "select a single item"
-msgstr ""
+msgstr "pilih satu item"
 
 #: add-interactive.c:1032
 msgid "select a range of items"
-msgstr ""
+msgstr "pilih kisaran item"
 
 #: add-interactive.c:1034
 msgid "select multiple ranges"
-msgstr ""
+msgstr "pilih banyak kisaran"
 
 #: add-interactive.c:1036 add-interactive.c:1081
 msgid "select item based on unique prefix"
-msgstr ""
+msgstr "pilih item berdasarkan prefiks unik"
 
 #: add-interactive.c:1038
 msgid "unselect specified items"
-msgstr ""
+msgstr "batal pilih item yang disebutkan"
 
 #: add-interactive.c:1040
 msgid "choose all items"
-msgstr ""
+msgstr "pilih semua item"
 
 #: add-interactive.c:1042
 msgid "(empty) finish selecting"
-msgstr ""
+msgstr "(kosong) sudah memilih"
 
 #: add-interactive.c:1079
 msgid "select a numbered item"
-msgstr ""
+msgstr "pilih item bernomor"
 
 #: add-interactive.c:1083
 msgid "(empty) select nothing"
-msgstr ""
+msgstr "(empty) tidak pilih apapun"
 
 #: add-interactive.c:1091 builtin/clean.c:816 git-add--interactive.perl:1896
 msgid "*** Commands ***"
-msgstr ""
+msgstr "*** Perintah ***"
 
 #: add-interactive.c:1092 builtin/clean.c:817 git-add--interactive.perl:1893
 msgid "What now"
-msgstr ""
+msgstr "Apa sekarang"
 
 #: add-interactive.c:1144 git-add--interactive.perl:213
 msgid "staged"
-msgstr ""
+msgstr "tergelar"
 
 #: add-interactive.c:1144 git-add--interactive.perl:213
 msgid "unstaged"
-msgstr ""
+msgstr "tak tergelar"
 
-#: add-interactive.c:1144 apply.c:4987 apply.c:4990 builtin/am.c:2257
-#: builtin/am.c:2260 builtin/bugreport.c:134 builtin/clone.c:124
-#: builtin/fetch.c:150 builtin/merge.c:285 builtin/pull.c:190
-#: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1818
-#: builtin/submodule--helper.c:1821 builtin/submodule--helper.c:2326
-#: builtin/submodule--helper.c:2329 builtin/submodule--helper.c:2572
+#: add-interactive.c:1144 apply.c:4994 apply.c:4997 builtin/am.c:2308
+#: builtin/am.c:2311 builtin/bugreport.c:135 builtin/clone.c:128
+#: builtin/fetch.c:152 builtin/merge.c:285 builtin/pull.c:190
+#: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1819
+#: builtin/submodule--helper.c:1822 builtin/submodule--helper.c:2327
+#: builtin/submodule--helper.c:2330 builtin/submodule--helper.c:2573
 #: git-add--interactive.perl:213
 msgid "path"
-msgstr ""
+msgstr "jalur"
 
 #: add-interactive.c:1151
 msgid "could not refresh index"
-msgstr ""
+msgstr "tidak dapat menyegarkan indeks"
 
 #: add-interactive.c:1165 builtin/clean.c:781 git-add--interactive.perl:1803
 #, c-format
 msgid "Bye.\n"
-msgstr ""
+msgstr "Sampai jumpa.\n"
 
 #: add-patch.c:34 git-add--interactive.perl:1431
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Gelar perubahan mode [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:35 git-add--interactive.perl:1432
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Gelar penghapusan [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:36 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Gelar penambahan [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:37 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Gelar hunk ini [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:39
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "staging."
 msgstr ""
+"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
+"untuk digelar."
 
 #: add-patch.c:42
 msgid ""
@@ -261,32 +263,39 @@ msgid ""
 "a - stage this hunk and all later hunks in the file\n"
 "d - do not stage this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - gelar hunk ini\n"
+"n - jangan gelar hunk ini\n"
+"q - keluar; jangan gelar hunk ini atau yang sisanya\n"
+"a - gelar hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan gelar hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:56 git-add--interactive.perl:1437
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Stase perubahan mode [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:57 git-add--interactive.perl:1438
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Stase penghapusan [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:58 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Stase penambahan [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:59 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Stase hunk ini [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:61
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
 msgstr ""
+"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
+"untuk distase."
 
 #: add-patch.c:64
 msgid ""
@@ -296,32 +305,39 @@ msgid ""
 "a - stash this hunk and all later hunks in the file\n"
 "d - do not stash this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - stase hunk ini\n"
+"n - jangan stase hunk ini\n"
+"q - keluar; jangan stase hunk ini atau yang sisanya\n"
+"a - stase hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan stase hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:80 git-add--interactive.perl:1443
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Batal gelar perubahan mode [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:81 git-add--interactive.perl:1444
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Batal gelar penghapusan [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:82 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Batal gelar penambahan [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:83 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Batal gelar hunk ini [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:85
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
 msgstr ""
+"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
+"untuk dibatalgelarkan."
 
 #: add-patch.c:88
 msgid ""
@@ -331,32 +347,39 @@ msgid ""
 "a - unstage this hunk and all later hunks in the file\n"
 "d - do not unstage this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - batal gelar hunk ini\n"
+"n - jangan batal gelar hunk ini\n"
+"q - keluar; jangan batal gelar hunk ini atau yang sisanya\n"
+"a - batal gelar hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan batal gelar hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:103 git-add--interactive.perl:1449
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan perubahan mode ke indeks [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:104 git-add--interactive.perl:1450
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan penghapusan ke indeks [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:105 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan penambahan ke indeks [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:106 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan hunk ini ke indeks [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:108 add-patch.c:176 add-patch.c:221
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "applying."
 msgstr ""
+"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
+"untuk diterapkan."
 
 #: add-patch.c:111
 msgid ""
@@ -366,36 +389,43 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - terapkan hunk ini ke indeks\n"
+"n - jangan terapkan hunk ini ke indeks\n"
+"q - keluar; jangan terapkan hunk ini atau yang sisanya\n"
+"a - terapkan hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan terapkan hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:126 git-add--interactive.perl:1455
 #: git-add--interactive.perl:1473
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang perubahan mode dari pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:127 git-add--interactive.perl:1456
 #: git-add--interactive.perl:1474
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang penghapusan dari pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:128 git-add--interactive.perl:1457
 #: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang penambahan dari pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:129 git-add--interactive.perl:1458
 #: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang hunk ini dari pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:131 add-patch.c:154 add-patch.c:199
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "discarding."
 msgstr ""
+"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
+"untuk dibuang."
 
 #: add-patch.c:134 add-patch.c:202
 msgid ""
@@ -405,26 +435,31 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - buang hunk ini dari pohon kerja\n"
+"n - jangan buang hunk ini dari pohon kerja\n"
+"q - keluar; jangan buang hunk ini atau yang sisanya\n"
+"a - buang hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan buang hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1461
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang perubahan mode dari indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1462
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang penghapusan dari indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang penambahan dari indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Buang hunk ini dari indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:157
 msgid ""
@@ -434,26 +469,31 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - buang hunk ini dari indeks dan pohon kerja\n"
+"n - jangan buang hunk ini dari indeks dan pohon kerja\n"
+"q - keluar; jangan buang hunk ini atau yang sisanya\n"
+"a - buang hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan buang hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1467
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan perubahan mode ke indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1468
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan penghapusan ke indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan penambahan ke indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Terapkan hunk ini ke indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:179
 msgid ""
@@ -463,6 +503,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - terapkan hunk ini ke indeks dan pohon kerja\n"
+"n - jangan terapkan hunk ini ke indeks dan pohon kerja\n"
+"q - keluar; jangan terapkan hunk ini atau yang sisanya\n"
+"a - terapkan hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan terapkan hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:224
 msgid ""
@@ -472,39 +517,46 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - terapkan hunk ini ke pohon kerja\n"
+"n - jangan terapkan hunk ini ke pohon kerja\n"
+"q - keluar; jangan terapkan hunk ini atau yang sisanya\n"
+"a - terapkan hunk ini dan semua hunk selanjutnya dalam berkas\n"
+"d - jangan terapkan hunk ini atau hunk selanjutnya dalam berkas\n"
 
 #: add-patch.c:342
 #, c-format
 msgid "could not parse hunk header '%.*s'"
-msgstr ""
+msgstr "tidak dapat menguraikan kepala hunk '%.*s'"
 
 #: add-patch.c:361 add-patch.c:365
 #, c-format
 msgid "could not parse colored hunk header '%.*s'"
-msgstr ""
+msgstr "tidak dapat menguraikan kepala hunk berwarna '%.*s'"
 
 #: add-patch.c:419
 msgid "could not parse diff"
-msgstr ""
+msgstr "tidak dapat menguraikan diff"
 
 #: add-patch.c:438
 msgid "could not parse colored diff"
-msgstr ""
+msgstr "tidak dapat menguraikan diff berwarna"
 
 #: add-patch.c:452
 #, c-format
 msgid "failed to run '%s'"
-msgstr ""
+msgstr "gagal menjalankan '%s'"
 
 #: add-patch.c:611
 msgid "mismatched output from interactive.diffFilter"
-msgstr ""
+msgstr "keluaran tak cocok dari interactive.diffFilter"
 
 #: add-patch.c:612
 msgid ""
 "Your filter must maintain a one-to-one correspondence\n"
 "between its input and output lines."
 msgstr ""
+"Saringan Anda haru menjaga korespondensi satu-satu antara masukannya\n"
+"dan baris keluaran."
 
 #: add-patch.c:790
 #, c-format
@@ -512,6 +564,8 @@ msgid ""
 "expected context line #%d in\n"
 "%.*s"
 msgstr ""
+"baris konteks #%d diharapkan dalam\n"
+"%.*s"
 
 #: add-patch.c:805
 #, c-format
@@ -521,10 +575,14 @@ msgid ""
 "\tdoes not end with:\n"
 "%.*s"
 msgstr ""
+"hunk tidak tumpang tindih:\n"
+"%.*s\n"
+"tidak berakhir dengan:\n"
+"%.*s"
 
 #: add-patch.c:1081 git-add--interactive.perl:1115
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
-msgstr ""
+msgstr "Mode sunting hunk manual -- lihat dibawah untuk panduan cepat.\n"
 
 #: add-patch.c:1085
 #, c-format
@@ -534,6 +592,10 @@ msgid ""
 "To remove '%c' lines, delete them.\n"
 "Lines starting with %c will be removed.\n"
 msgstr ""
+"---\n"
+"Untuk menghapus baris '%c', buatlah menjadi baris ' ' (konteks).\n"
+"Untuk menghapus baris '%c', hapuslah itu.\n"
+"Baris yang diawali dengan %c akan dihapus.\n"
 
 #. TRANSLATORS: 'it' refers to the patch mentioned in the previous messages.
 #: add-patch.c:1099 git-add--interactive.perl:1129
@@ -542,14 +604,17 @@ msgid ""
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
 "aborted and the hunk is left unchanged.\n"
 msgstr ""
+"Jika itu tidak diterapkan dengan bersih, Anda akan diberikan kesempatan\n"
+"untuk menyunting lagi. Jika semua baris dalam hunk dihapus, suntingan\n"
+"dibatalkan dan hunk tetap tidak berubah.\n"
 
 #: add-patch.c:1132
 msgid "could not parse hunk header"
-msgstr ""
+msgstr "tidak dapat menguraikan kepala hunk"
 
 #: add-patch.c:1177
 msgid "'git apply --cached' failed"
-msgstr ""
+msgstr "'git apply --cached' gagal"
 
 #. TRANSLATORS: do not translate [y/n]
 #. The program will only accept that input at this point.
@@ -567,18 +632,20 @@ msgstr ""
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
+"Hunk Anda tak diterapkan. Sunting lagi (bilang \"n\" untuk \"tidak\" buang!) "
+"[y/n]?"
 
 #: add-patch.c:1289
 msgid "The selected hunks do not apply to the index!"
-msgstr ""
+msgstr "Hunk yang dipilih tidak diterapkan ke indeks!"
 
 #: add-patch.c:1290 git-add--interactive.perl:1346
 msgid "Apply them to the worktree anyway? "
-msgstr ""
+msgstr "Tetap terapkan itu ke pohon kerja? "
 
 #: add-patch.c:1297 git-add--interactive.perl:1349
 msgid "Nothing was applied.\n"
-msgstr ""
+msgstr "Tidak ada yang diterapkan.\n"
 
 #: add-patch.c:1354
 msgid ""
@@ -592,133 +659,155 @@ msgid ""
 "e - manually edit the current hunk\n"
 "? - print help\n"
 msgstr ""
+"j - biarkan hunk ini ragu, lihat hunk ragu berikutnya\n"
+"J - biarkan hunk ini ragu, lihat hunk berikutnya\n"
+"k - biarkan hunk ini ragu, lihat hunk ragu sebelumnya\n"
+"K - biarkan hunk ini ragu, lihat hunk sebelumnya\n"
+"g - pilih satu hunk untuk dikunjungi\n"
+"/ - cari satu hunk yang cocok dengan regex yang diberikan\n"
+"s - belah hunk saat ini ke dalam hunk yang lebih kecil\n"
+"e - sunting hunk saat ini secara manual\n"
+"? - cetak bantuan\n"
 
 #: add-patch.c:1516 add-patch.c:1526
 msgid "No previous hunk"
-msgstr ""
+msgstr "Tidak ada hunk sebelumnya"
 
 #: add-patch.c:1521 add-patch.c:1531
 msgid "No next hunk"
-msgstr ""
+msgstr "Tidak ada hunk selanjutnya"
 
 #: add-patch.c:1537
 msgid "No other hunks to goto"
-msgstr ""
+msgstr "Tidak ada hunk lainnya untuk dikunjungi"
 
 #: add-patch.c:1548 git-add--interactive.perl:1606
 msgid "go to which hunk (<ret> to see more)? "
-msgstr ""
+msgstr "pergi ke hunk yang mana (<ret> untuk lihat lebih)? "
 
 #: add-patch.c:1549 git-add--interactive.perl:1608
 msgid "go to which hunk? "
-msgstr ""
+msgstr "pergi ke hunk yang mana?"
 
 #: add-patch.c:1560
 #, c-format
 msgid "Invalid number: '%s'"
-msgstr ""
+msgstr "Angka tidak valid: '%s'"
 
 #: add-patch.c:1565
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Maaf, hanya %d hunk yang tersedia."
+msgstr[1] "Maaf, hanya %d hunk yang tersedia."
 
 #: add-patch.c:1574
 msgid "No other hunks to search"
-msgstr ""
+msgstr "Tidak ada hunk lainnya untuk dicari"
 
 #: add-patch.c:1580 git-add--interactive.perl:1661
 msgid "search for regex? "
-msgstr ""
+msgstr "cari untuk regex? "
 
 #: add-patch.c:1595
 #, c-format
 msgid "Malformed search regexp %s: %s"
-msgstr ""
+msgstr "regexp pencarian %s cacat: %s"
 
 #: add-patch.c:1612
 msgid "No hunk matches the given pattern"
-msgstr ""
+msgstr "Tidak ada hunk yang cocok dengan pola yang diberikan"
 
 #: add-patch.c:1619
 msgid "Sorry, cannot split this hunk"
-msgstr ""
+msgstr "Maaf, tidak dapat membelah hunk ini"
 
 #: add-patch.c:1623
 #, c-format
 msgid "Split into %d hunks."
-msgstr ""
+msgstr "Terbelah ke dalam %d hunk."
 
 #: add-patch.c:1627
 msgid "Sorry, cannot edit this hunk"
-msgstr ""
+msgstr "Maaf, tidak dapat menyunting hunk ini"
 
 #: add-patch.c:1679
 msgid "'git apply' failed"
-msgstr ""
+msgstr "'git apply' gagal"
 
-#: advice.c:143
+#: advice.c:145
 #, c-format
 msgid ""
 "\n"
 "Disable this message with \"git config advice.%s false\""
 msgstr ""
 
-#: advice.c:159
+#: advice.c:161
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr ""
 
-#: advice.c:250
+#: advice.c:252
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:252
+#: advice.c:254
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:254
+#: advice.c:256
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:256
+#: advice.c:258
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:258
+#: advice.c:260
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:260
+#: advice.c:262
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr ""
 
-#: advice.c:268
+#: advice.c:270
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
 msgstr ""
 
-#: advice.c:276
+#: advice.c:278
 msgid "Exiting because of an unresolved conflict."
 msgstr ""
 
-#: advice.c:281 builtin/merge.c:1370
+#: advice.c:283 builtin/merge.c:1374
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr ""
 
-#: advice.c:283
+#: advice.c:285
 msgid "Please, commit your changes before merging."
 msgstr ""
 
-#: advice.c:284
+#: advice.c:286
 msgid "Exiting because of unfinished merge."
 msgstr ""
 
-#: advice.c:290
+#: advice.c:296
+#, c-format
+msgid ""
+"The following pathspecs didn't match any eligible path, but they do match "
+"index\n"
+"entries outside the current sparse checkout:\n"
+msgstr ""
+
+#: advice.c:303
+msgid ""
+"Disable or modify the sparsity rules if you intend to update such entries."
+msgstr ""
+
+#: advice.c:310
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -749,82 +838,78 @@ msgstr ""
 msgid "unclosed quote"
 msgstr ""
 
-#: apply.c:69
+#: apply.c:70
 #, c-format
 msgid "unrecognized whitespace option '%s'"
 msgstr ""
 
-#: apply.c:85
+#: apply.c:86
 #, c-format
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr ""
 
-#: apply.c:135
+#: apply.c:136
 msgid "--reject and --3way cannot be used together."
 msgstr ""
 
-#: apply.c:137
-msgid "--cached and --3way cannot be used together."
-msgstr ""
-
-#: apply.c:140
+#: apply.c:139
 msgid "--3way outside a repository"
 msgstr ""
 
-#: apply.c:151
+#: apply.c:150
 msgid "--index outside a repository"
 msgstr ""
 
-#: apply.c:154
+#: apply.c:153
 msgid "--cached outside a repository"
 msgstr ""
 
-#: apply.c:801
+#: apply.c:800
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
 msgstr ""
 
-#: apply.c:810
+#: apply.c:809
 #, c-format
 msgid "regexec returned %d for input: %s"
 msgstr ""
 
-#: apply.c:884
+#: apply.c:883
 #, c-format
 msgid "unable to find filename in patch at line %d"
 msgstr ""
 
-#: apply.c:922
+#: apply.c:921
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
 msgstr ""
 
-#: apply.c:928
+#: apply.c:927
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
 
-#: apply.c:929
+#: apply.c:928
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr ""
 
-#: apply.c:934
+#: apply.c:933
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null on line %d"
 msgstr ""
 
-#: apply.c:963
+#: apply.c:962
 #, c-format
 msgid "invalid mode on line %d: %s"
 msgstr ""
 
-#: apply.c:1282
+#: apply.c:1281
 #, c-format
 msgid "inconsistent header lines %d and %d"
 msgstr ""
 
-#: apply.c:1372
+#: apply.c:1371
 #, c-format
 msgid ""
 "git diff header lacks filename information when removing %d leading pathname "
@@ -835,524 +920,530 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: apply.c:1385
+#: apply.c:1384
 #, c-format
 msgid "git diff header lacks filename information (line %d)"
 msgstr ""
 
-#: apply.c:1481
+#: apply.c:1480
 #, c-format
 msgid "recount: unexpected line: %.*s"
 msgstr ""
 
-#: apply.c:1550
+#: apply.c:1549
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
 msgstr ""
 
-#: apply.c:1753
+#: apply.c:1752
 msgid "new file depends on old contents"
 msgstr ""
 
-#: apply.c:1755
+#: apply.c:1754
 msgid "deleted file still has contents"
 msgstr ""
 
-#: apply.c:1789
+#: apply.c:1788
 #, c-format
 msgid "corrupt patch at line %d"
 msgstr ""
 
-#: apply.c:1826
+#: apply.c:1825
 #, c-format
 msgid "new file %s depends on old contents"
 msgstr ""
 
-#: apply.c:1828
+#: apply.c:1827
 #, c-format
 msgid "deleted file %s still has contents"
 msgstr ""
 
-#: apply.c:1831
+#: apply.c:1830
 #, c-format
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr ""
 
-#: apply.c:1978
+#: apply.c:1977
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr ""
 
-#: apply.c:2015
+#: apply.c:2014
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr ""
 
-#: apply.c:2177
+#: apply.c:2176
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr ""
 
-#: apply.c:2263
+#: apply.c:2262
 #, c-format
 msgid "unable to read symlink %s"
 msgstr ""
 
-#: apply.c:2267
+#: apply.c:2266
 #, c-format
 msgid "unable to open or read %s"
 msgstr ""
 
-#: apply.c:2936
+#: apply.c:2935
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr ""
 
-#: apply.c:3057
+#: apply.c:3056
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: apply.c:3069
+#: apply.c:3068
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr ""
 
-#: apply.c:3075
+#: apply.c:3074
 #, c-format
 msgid ""
 "while searching for:\n"
 "%.*s"
 msgstr ""
 
-#: apply.c:3097
+#: apply.c:3096
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr ""
 
-#: apply.c:3105
+#: apply.c:3104
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
 
-#: apply.c:3152
+#: apply.c:3151
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr ""
 
-#: apply.c:3163
+#: apply.c:3162
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
 msgstr ""
 
-#: apply.c:3171
+#: apply.c:3170
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr ""
 
-#: apply.c:3189
+#: apply.c:3188
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr ""
 
-#: apply.c:3202
+#: apply.c:3201
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr ""
 
-#: apply.c:3209
+#: apply.c:3208
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 
-#: apply.c:3230
+#: apply.c:3229
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr ""
 
-#: apply.c:3353
+#: apply.c:3352
 #, c-format
 msgid "cannot checkout %s"
 msgstr ""
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:86 pack-revindex.c:213
+#: apply.c:3404 apply.c:3415 apply.c:3461 midx.c:98 pack-revindex.c:214
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr ""
 
-#: apply.c:3413
+#: apply.c:3412
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr ""
 
-#: apply.c:3442 apply.c:3685
+#: apply.c:3441 apply.c:3687
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr ""
 
-#: apply.c:3528 apply.c:3700
+#: apply.c:3527 apply.c:3702
 #, c-format
 msgid "%s: does not exist in index"
 msgstr ""
 
-#: apply.c:3537 apply.c:3708 apply.c:3952
+#: apply.c:3536 apply.c:3710 apply.c:3954
 #, c-format
 msgid "%s: does not match index"
 msgstr ""
 
-#: apply.c:3572
-msgid "repository lacks the necessary blob to fall back on 3-way merge."
+#: apply.c:3571
+msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
 
-#: apply.c:3575
+#: apply.c:3574
 #, c-format
-msgid "Falling back to three-way merge...\n"
+msgid "Performing three-way merge...\n"
 msgstr ""
 
-#: apply.c:3591 apply.c:3595
+#: apply.c:3590 apply.c:3594
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr ""
 
-#: apply.c:3607
+#: apply.c:3606
 #, c-format
-msgid "Failed to fall back on three-way merge...\n"
+msgid "Failed to perform three-way merge...\n"
 msgstr ""
 
-#: apply.c:3621
+#: apply.c:3620
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr ""
 
-#: apply.c:3626
+#: apply.c:3625
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr ""
 
-#: apply.c:3652
-msgid "removal patch leaves file contents"
+#: apply.c:3642
+#, c-format
+msgid "Falling back to direct application...\n"
 msgstr ""
 
-#: apply.c:3725
-#, c-format
-msgid "%s: wrong type"
+#: apply.c:3654
+msgid "removal patch leaves file contents"
 msgstr ""
 
 #: apply.c:3727
 #, c-format
+msgid "%s: wrong type"
+msgstr ""
+
+#: apply.c:3729
+#, c-format
 msgid "%s has type %o, expected %o"
 msgstr ""
 
-#: apply.c:3892 apply.c:3894 read-cache.c:832 read-cache.c:858
-#: read-cache.c:1313
+#: apply.c:3894 apply.c:3896 read-cache.c:861 read-cache.c:890
+#: read-cache.c:1351
 #, c-format
 msgid "invalid path '%s'"
 msgstr ""
 
-#: apply.c:3950
+#: apply.c:3952
 #, c-format
 msgid "%s: already exists in index"
 msgstr ""
 
-#: apply.c:3954
+#: apply.c:3956
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr ""
 
-#: apply.c:3974
+#: apply.c:3976
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr ""
 
-#: apply.c:3979
+#: apply.c:3981
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr ""
 
-#: apply.c:3999
+#: apply.c:4001
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr ""
 
-#: apply.c:4003
+#: apply.c:4005
 #, c-format
 msgid "%s: patch does not apply"
 msgstr ""
 
-#: apply.c:4018
+#: apply.c:4020
 #, c-format
 msgid "Checking patch %s..."
 msgstr ""
 
-#: apply.c:4110
+#: apply.c:4112
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr ""
 
-#: apply.c:4117
+#: apply.c:4119
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr ""
 
-#: apply.c:4120
+#: apply.c:4122
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr ""
 
-#: apply.c:4129
+#: apply.c:4131
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr ""
 
-#: apply.c:4139
+#: apply.c:4141
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr ""
 
-#: apply.c:4277
+#: apply.c:4279
 #, c-format
 msgid "unable to remove %s from index"
 msgstr ""
 
-#: apply.c:4311
+#: apply.c:4313
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr ""
 
-#: apply.c:4317
+#: apply.c:4319
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr ""
 
-#: apply.c:4325
+#: apply.c:4327
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
 
-#: apply.c:4331 apply.c:4476
+#: apply.c:4333 apply.c:4478
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr ""
 
-#: apply.c:4374 builtin/bisect--helper.c:523
+#: apply.c:4376 builtin/bisect--helper.c:523
 #, c-format
 msgid "failed to write to '%s'"
 msgstr ""
 
-#: apply.c:4378
+#: apply.c:4380
 #, c-format
 msgid "closing file '%s'"
 msgstr ""
 
-#: apply.c:4448
+#: apply.c:4450
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr ""
 
-#: apply.c:4546
+#: apply.c:4548
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr ""
 
-#: apply.c:4554
+#: apply.c:4556
 msgid "internal error"
 msgstr ""
 
-#: apply.c:4557
+#: apply.c:4559
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] ""
 msgstr[1] ""
 
-#: apply.c:4568
+#: apply.c:4570
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr ""
 
-#: apply.c:4576 builtin/fetch.c:933 builtin/fetch.c:1334
+#: apply.c:4578 builtin/fetch.c:993 builtin/fetch.c:1394
 #, c-format
 msgid "cannot open %s"
 msgstr ""
 
-#: apply.c:4590
+#: apply.c:4592
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr ""
 
-#: apply.c:4594
+#: apply.c:4596
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr ""
 
-#: apply.c:4718
+#: apply.c:4725
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr ""
 
-#: apply.c:4726
+#: apply.c:4733
 msgid "unrecognized input"
 msgstr ""
 
-#: apply.c:4746
+#: apply.c:4753
 msgid "unable to read index file"
 msgstr ""
 
-#: apply.c:4903
+#: apply.c:4910
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr ""
 
-#: apply.c:4930
+#: apply.c:4937
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: apply.c:4936 apply.c:4951
+#: apply.c:4943 apply.c:4958
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: apply.c:4944
+#: apply.c:4951
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] ""
 msgstr[1] ""
 
-#: apply.c:4960 builtin/add.c:626 builtin/mv.c:304 builtin/rm.c:406
+#: apply.c:4967 builtin/add.c:679 builtin/mv.c:304 builtin/rm.c:423
 msgid "Unable to write new index file"
 msgstr ""
 
-#: apply.c:4988
+#: apply.c:4995
 msgid "don't apply changes matching the given path"
 msgstr ""
 
-#: apply.c:4991
+#: apply.c:4998
 msgid "apply changes matching the given path"
 msgstr ""
 
-#: apply.c:4993 builtin/am.c:2266
+#: apply.c:5000 builtin/am.c:2317
 msgid "num"
 msgstr ""
 
-#: apply.c:4994
+#: apply.c:5001
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 
-#: apply.c:4997
+#: apply.c:5004
 msgid "ignore additions made by the patch"
 msgstr ""
 
-#: apply.c:4999
+#: apply.c:5006
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 
-#: apply.c:5003
+#: apply.c:5010
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 
-#: apply.c:5005
+#: apply.c:5012
 msgid "instead of applying the patch, output a summary for the input"
 msgstr ""
 
-#: apply.c:5007
+#: apply.c:5014
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
 
-#: apply.c:5009
+#: apply.c:5016
 msgid "make sure the patch is applicable to the current index"
 msgstr ""
 
-#: apply.c:5011
+#: apply.c:5018
 msgid "mark new files with `git add --intent-to-add`"
 msgstr ""
 
-#: apply.c:5013
+#: apply.c:5020
 msgid "apply a patch without touching the working tree"
 msgstr ""
 
-#: apply.c:5015
+#: apply.c:5022
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 
-#: apply.c:5018
+#: apply.c:5025
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr ""
 
-#: apply.c:5020
-msgid "attempt three-way merge if a patch does not apply"
-msgstr ""
-
-#: apply.c:5022
-msgid "build a temporary index based on embedded index information"
-msgstr ""
-
-#: apply.c:5025 builtin/checkout-index.c:195 builtin/ls-files.c:540
-msgid "paths are separated with NUL character"
-msgstr ""
-
 #: apply.c:5027
-msgid "ensure at least <n> lines of context match"
-msgstr ""
-
-#: apply.c:5028 builtin/am.c:2245 builtin/interpret-trailers.c:98
-#: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
-#: builtin/pack-objects.c:3577 builtin/rebase.c:1352
-msgid "action"
+msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 
 #: apply.c:5029
+msgid "build a temporary index based on embedded index information"
+msgstr ""
+
+#: apply.c:5032 builtin/checkout-index.c:196 builtin/ls-files.c:617
+msgid "paths are separated with NUL character"
+msgstr ""
+
+#: apply.c:5034
+msgid "ensure at least <n> lines of context match"
+msgstr ""
+
+#: apply.c:5035 builtin/am.c:2293 builtin/am.c:2296
+#: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3831
+#: builtin/rebase.c:1347
+msgid "action"
+msgstr ""
+
+#: apply.c:5036
 msgid "detect new or modified lines that have whitespace errors"
 msgstr ""
 
-#: apply.c:5032 apply.c:5035
+#: apply.c:5039 apply.c:5042
 msgid "ignore changes in whitespace when finding context"
 msgstr ""
 
-#: apply.c:5038
+#: apply.c:5045
 msgid "apply the patch in reverse"
 msgstr ""
 
-#: apply.c:5040
+#: apply.c:5047
 msgid "don't expect at least one line of context"
 msgstr ""
 
-#: apply.c:5042
+#: apply.c:5049
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr ""
 
-#: apply.c:5044
+#: apply.c:5051
 msgid "allow overlapping hunks"
 msgstr ""
 
-#: apply.c:5045 builtin/add.c:337 builtin/check-ignore.c:22
-#: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:757
-#: builtin/log.c:2286 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5052 builtin/add.c:364 builtin/check-ignore.c:22
+#: builtin/commit.c:1474 builtin/count-objects.c:98 builtin/fsck.c:755
+#: builtin/log.c:2295 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr ""
 
-#: apply.c:5047
+#: apply.c:5054
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr ""
 
-#: apply.c:5050
+#: apply.c:5057
 msgid "do not trust the line counts in the hunk headers"
 msgstr ""
 
-#: apply.c:5052 builtin/am.c:2254
+#: apply.c:5059 builtin/am.c:2305
 msgid "root"
 msgstr ""
 
-#: apply.c:5053
+#: apply.c:5060
 msgid "prepend <root> to all filenames"
 msgstr ""
 
@@ -1402,171 +1493,173 @@ msgstr ""
 
 #: archive.c:14
 msgid "git archive [<options>] <tree-ish> [<path>...]"
-msgstr ""
+msgstr "git archive [<opsi>] <mirip pohon> [<jalur>...]"
 
 #: archive.c:15
 msgid "git archive --list"
-msgstr ""
+msgstr "git archive --list"
 
 #: archive.c:16
 msgid ""
 "git archive --remote <repo> [--exec <cmd>] [<options>] <tree-ish> [<path>...]"
 msgstr ""
+"git archive --remote <repo> [--exec <perintah>] [<opsi>] <mirip pohon> "
+"[<jalur>...]"
 
 #: archive.c:17
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
-msgstr ""
+msgstr "git archive --remote <repo> [--exec <perintah>] --list"
 
-#: archive.c:192
+#: archive.c:188
 #, c-format
 msgid "cannot read %s"
-msgstr ""
+msgstr "Tidak dapat membaca %s"
 
-#: archive.c:345 sequencer.c:459 sequencer.c:1744 sequencer.c:2894
-#: sequencer.c:3335 sequencer.c:3444 builtin/am.c:249 builtin/commit.c:786
-#: builtin/merge.c:1139
+#: archive.c:342 sequencer.c:460 sequencer.c:1915 sequencer.c:3095
+#: sequencer.c:3536 sequencer.c:3645 builtin/am.c:261 builtin/commit.c:833
+#: builtin/merge.c:1143
 #, c-format
 msgid "could not read '%s'"
-msgstr ""
+msgstr "tidak dapat membaca '%s'"
 
-#: archive.c:430 builtin/add.c:189 builtin/add.c:602 builtin/rm.c:315
+#: archive.c:427 builtin/add.c:205 builtin/add.c:646 builtin/rm.c:328
 #, c-format
 msgid "pathspec '%s' did not match any files"
-msgstr ""
+msgstr "spek jalur '%s' tidak cocok dengan berkas apapun"
 
-#: archive.c:454
+#: archive.c:451
 #, c-format
 msgid "no such ref: %.*s"
-msgstr ""
+msgstr "tidak ada referensi seperti: %.*s"
 
-#: archive.c:460
+#: archive.c:457
 #, c-format
 msgid "not a valid object name: %s"
-msgstr ""
+msgstr "bukan nama objek valid: %s"
 
-#: archive.c:473
+#: archive.c:470
 #, c-format
 msgid "not a tree object: %s"
-msgstr ""
+msgstr "bukan objek pohon: %s"
 
-#: archive.c:485
+#: archive.c:482
 msgid "current working directory is untracked"
-msgstr ""
+msgstr "direktori kerja saat ini tak terlacak"
 
-#: archive.c:526
+#: archive.c:523
 #, c-format
 msgid "File not found: %s"
-msgstr ""
+msgstr "Berkas tidak ditemukan: %s"
 
-#: archive.c:528
+#: archive.c:525
 #, c-format
 msgid "Not a regular file: %s"
-msgstr ""
+msgstr "Bukan berkas reguler: %s"
 
-#: archive.c:555
+#: archive.c:552
 msgid "fmt"
-msgstr ""
+msgstr "fmt"
 
-#: archive.c:555
+#: archive.c:552
 msgid "archive format"
-msgstr ""
+msgstr "format arsip"
 
-#: archive.c:556 builtin/log.c:1764
+#: archive.c:553 builtin/log.c:1772
 msgid "prefix"
-msgstr ""
+msgstr "prefiks"
 
-#: archive.c:557
+#: archive.c:554
 msgid "prepend prefix to each pathname in the archive"
-msgstr ""
+msgstr "tambahkan prefiks di depan setiap nama jalur dalam arsip"
 
-#: archive.c:558 archive.c:561 builtin/blame.c:884 builtin/blame.c:888
+#: archive.c:555 archive.c:558 builtin/blame.c:884 builtin/blame.c:888
 #: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
 #: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:920 builtin/hash-object.c:105
-#: builtin/ls-files.c:576 builtin/ls-files.c:579 builtin/notes.c:412
-#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:190
+#: builtin/fast-export.c:1213 builtin/grep.c:922 builtin/hash-object.c:105
+#: builtin/ls-files.c:653 builtin/ls-files.c:656 builtin/notes.c:412
+#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:191
 msgid "file"
-msgstr ""
+msgstr "berkas"
 
-#: archive.c:559
+#: archive.c:556
 msgid "add untracked file to archive"
-msgstr ""
+msgstr "tambahkan berkas tak terlacak ke arsip"
 
-#: archive.c:562 builtin/archive.c:90
+#: archive.c:559 builtin/archive.c:90
 msgid "write the archive to this file"
-msgstr ""
+msgstr "tulis arsip ke berkas ini"
+
+#: archive.c:561
+msgid "read .gitattributes in working directory"
+msgstr "baca .gitattributes dalam direktori kerja"
+
+#: archive.c:562
+msgid "report archived files on stderr"
+msgstr "laporkan berkas terarsip ke error standar"
 
 #: archive.c:564
-msgid "read .gitattributes in working directory"
-msgstr ""
-
-#: archive.c:565
-msgid "report archived files on stderr"
-msgstr ""
+msgid "set compression level"
+msgstr "setel level kompresi"
 
 #: archive.c:567
-msgid "set compression level"
-msgstr ""
-
-#: archive.c:570
 msgid "list supported archive formats"
-msgstr ""
+msgstr "daftar format arsip yang didukung"
 
-#: archive.c:572 builtin/archive.c:91 builtin/clone.c:114 builtin/clone.c:117
-#: builtin/submodule--helper.c:1830 builtin/submodule--helper.c:2335
+#: archive.c:569 builtin/archive.c:91 builtin/clone.c:118 builtin/clone.c:121
+#: builtin/submodule--helper.c:1831 builtin/submodule--helper.c:2336
 msgid "repo"
-msgstr ""
+msgstr "repositori"
 
-#: archive.c:573 builtin/archive.c:92
+#: archive.c:570 builtin/archive.c:92
 msgid "retrieve the archive from remote repository <repo>"
-msgstr ""
+msgstr "ambil arsip dari repositori remote <repo>"
 
-#: archive.c:574 builtin/archive.c:93 builtin/difftool.c:714
+#: archive.c:571 builtin/archive.c:93 builtin/difftool.c:718
 #: builtin/notes.c:498
 msgid "command"
-msgstr ""
+msgstr "perintah"
 
-#: archive.c:575 builtin/archive.c:94
+#: archive.c:572 builtin/archive.c:94
 msgid "path to the remote git-upload-archive command"
-msgstr ""
+msgstr "jalur ke perintah git-upload-archive remote"
 
-#: archive.c:582
+#: archive.c:579
 msgid "Unexpected option --remote"
-msgstr ""
+msgstr "Opsi --remote tak diharapkan"
 
-#: archive.c:584
+#: archive.c:581
 msgid "Option --exec can only be used together with --remote"
-msgstr ""
+msgstr "Opsi --exec hanya dapat digunakan bersamaan dengan --remote"
 
-#: archive.c:586
+#: archive.c:583
 msgid "Unexpected option --output"
-msgstr ""
+msgstr "Opsi --output tak diharapkan"
 
-#: archive.c:588
+#: archive.c:585
 msgid "Options --add-file and --remote cannot be used together"
-msgstr ""
+msgstr "Opsi --add-file dan --remote tidak dapat digunakan bersamaan"
 
-#: archive.c:610
+#: archive.c:607
 #, c-format
 msgid "Unknown archive format '%s'"
-msgstr ""
+msgstr "Format arsip tidak dikenal '%s'"
 
-#: archive.c:619
+#: archive.c:616
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
-msgstr ""
+msgstr "Argumen tidak didukung untuk format '%s': -%d"
 
 #: attr.c:202
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr ""
 
-#: attr.c:359
+#: attr.c:363
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr ""
 
-#: attr.c:399
+#: attr.c:403
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1634,7 +1727,7 @@ msgstr ""
 msgid "a %s revision is needed"
 msgstr ""
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:287
+#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:298
 #, c-format
 msgid "could not create file '%s'"
 msgstr ""
@@ -1677,37 +1770,37 @@ msgid_plural "Bisecting: %d revisions left to test after this %s\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: blame.c:2777
+#: blame.c:2776
 msgid "--contents and --reverse do not blend well."
 msgstr ""
 
-#: blame.c:2791
+#: blame.c:2790
 msgid "cannot use --contents with final commit object name"
 msgstr ""
 
-#: blame.c:2812
+#: blame.c:2811
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2206 remote.c:2041 sequencer.c:2146
-#: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
-#: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
-#: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
-#: builtin/shortlog.c:255
+#: blame.c:2820 bundle.c:213 ref-filter.c:2207 remote.c:2041 sequencer.c:2333
+#: sequencer.c:4866 submodule.c:857 builtin/commit.c:1106 builtin/log.c:411
+#: builtin/log.c:1018 builtin/log.c:1626 builtin/log.c:2054 builtin/log.c:2344
+#: builtin/merge.c:428 builtin/pack-objects.c:3183 builtin/pack-objects.c:3646
+#: builtin/pack-objects.c:3661 builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "persiapan jalan revisi gagal"
 
-#: blame.c:2839
+#: blame.c:2838
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
 
-#: blame.c:2850
+#: blame.c:2849
 #, c-format
 msgid "no such path %s in %s"
 msgstr ""
 
-#: blame.c:2861
+#: blame.c:2860
 #, c-format
 msgid "cannot read blob %s for path %s"
 msgstr ""
@@ -1826,12 +1919,12 @@ msgstr ""
 msgid "Not a valid branch point: '%s'."
 msgstr ""
 
-#: branch.c:365
+#: branch.c:366
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr ""
 
-#: branch.c:388
+#: branch.c:389
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr ""
@@ -1856,8 +1949,8 @@ msgstr ""
 msgid "unrecognized header: %s%s (%d)"
 msgstr ""
 
-#: bundle.c:136 rerere.c:464 rerere.c:674 sequencer.c:2398 sequencer.c:3184
-#: builtin/commit.c:814
+#: bundle.c:136 rerere.c:464 rerere.c:674 sequencer.c:2593 sequencer.c:3385
+#: builtin/commit.c:861
 #, c-format
 msgid "could not open '%s'"
 msgstr ""
@@ -1915,7 +2008,7 @@ msgstr ""
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr ""
 
-#: bundle.c:510 builtin/log.c:210 builtin/log.c:1926 builtin/shortlog.c:396
+#: bundle.c:510 builtin/log.c:210 builtin/log.c:1935 builtin/shortlog.c:396
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr ""
@@ -1957,252 +2050,252 @@ msgstr ""
 msgid "invalid color value: %.*s"
 msgstr ""
 
-#: commit-graph.c:197 midx.c:46
+#: commit-graph.c:204 midx.c:47
 msgid "invalid hash version"
 msgstr ""
 
-#: commit-graph.c:255
+#: commit-graph.c:262
 msgid "commit-graph file is too small"
-msgstr ""
-
-#: commit-graph.c:348
-#, c-format
-msgid "commit-graph signature %X does not match signature %X"
 msgstr ""
 
 #: commit-graph.c:355
 #, c-format
-msgid "commit-graph version %X does not match version %X"
+msgid "commit-graph signature %X does not match signature %X"
 msgstr ""
 
 #: commit-graph.c:362
 #, c-format
+msgid "commit-graph version %X does not match version %X"
+msgstr ""
+
+#: commit-graph.c:369
+#, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr ""
 
-#: commit-graph.c:379
+#: commit-graph.c:386
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr ""
 
-#: commit-graph.c:472
+#: commit-graph.c:482
 msgid "commit-graph has no base graphs chunk"
 msgstr ""
 
-#: commit-graph.c:482
+#: commit-graph.c:492
 msgid "commit-graph chain does not match"
 msgstr ""
 
-#: commit-graph.c:530
+#: commit-graph.c:540
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr ""
 
-#: commit-graph.c:554
+#: commit-graph.c:564
 msgid "unable to find all commit-graph files"
 msgstr ""
 
-#: commit-graph.c:735 commit-graph.c:772
+#: commit-graph.c:745 commit-graph.c:782
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:756
+#: commit-graph.c:766
 #, c-format
 msgid "could not find commit %s"
 msgstr ""
 
-#: commit-graph.c:789
+#: commit-graph.c:799
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 
-#: commit-graph.c:1065 builtin/am.c:1292
+#: commit-graph.c:1075 builtin/am.c:1340
 #, c-format
 msgid "unable to parse commit %s"
 msgstr ""
 
-#: commit-graph.c:1327 builtin/pack-objects.c:2872
+#: commit-graph.c:1337 builtin/pack-objects.c:2897
 #, c-format
 msgid "unable to get type of object %s"
 msgstr ""
 
-#: commit-graph.c:1358
+#: commit-graph.c:1368
 msgid "Loading known commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1375
+#: commit-graph.c:1385
 msgid "Expanding reachable commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1395
+#: commit-graph.c:1405
 msgid "Clearing commit marks in commit graph"
 msgstr ""
 
-#: commit-graph.c:1414
+#: commit-graph.c:1424
 msgid "Computing commit graph topological levels"
 msgstr ""
 
-#: commit-graph.c:1467
+#: commit-graph.c:1477
 msgid "Computing commit graph generation numbers"
 msgstr ""
 
-#: commit-graph.c:1548
+#: commit-graph.c:1558
 msgid "Computing commit changed paths Bloom filters"
 msgstr ""
 
-#: commit-graph.c:1625
+#: commit-graph.c:1635
 msgid "Collecting referenced commits"
 msgstr ""
 
-#: commit-graph.c:1650
+#: commit-graph.c:1660
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:1663
+#: commit-graph.c:1673
 #, c-format
 msgid "error adding pack %s"
 msgstr ""
 
-#: commit-graph.c:1667
+#: commit-graph.c:1677
 #, c-format
 msgid "error opening index for %s"
 msgstr ""
 
-#: commit-graph.c:1704
+#: commit-graph.c:1714
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 
-#: commit-graph.c:1722
+#: commit-graph.c:1732
 msgid "Finding extra edges in commit graph"
 msgstr ""
 
-#: commit-graph.c:1771
+#: commit-graph.c:1781
 msgid "failed to write correct number of base graph ids"
 msgstr ""
 
-#: commit-graph.c:1802 midx.c:794
+#: commit-graph.c:1812 midx.c:906
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr ""
 
-#: commit-graph.c:1815
+#: commit-graph.c:1825
 msgid "unable to create temporary graph layer"
 msgstr ""
 
-#: commit-graph.c:1820
+#: commit-graph.c:1830
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr ""
 
-#: commit-graph.c:1879
+#: commit-graph.c:1887
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:1915
+#: commit-graph.c:1923
 msgid "unable to open commit-graph chain file"
 msgstr ""
 
-#: commit-graph.c:1931
+#: commit-graph.c:1939
 msgid "failed to rename base commit-graph file"
 msgstr ""
 
-#: commit-graph.c:1951
+#: commit-graph.c:1959
 msgid "failed to rename temporary commit-graph file"
 msgstr ""
 
-#: commit-graph.c:2084
+#: commit-graph.c:2092
 msgid "Scanning merged commits"
 msgstr ""
 
-#: commit-graph.c:2128
+#: commit-graph.c:2136
 msgid "Merging commit-graph"
 msgstr ""
 
-#: commit-graph.c:2235
+#: commit-graph.c:2244
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 
-#: commit-graph.c:2342
+#: commit-graph.c:2351
 msgid "too many commits to write graph"
 msgstr ""
 
-#: commit-graph.c:2440
+#: commit-graph.c:2450
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:2450
+#: commit-graph.c:2460
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr ""
 
-#: commit-graph.c:2460 commit-graph.c:2475
+#: commit-graph.c:2470 commit-graph.c:2485
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 
-#: commit-graph.c:2467
+#: commit-graph.c:2477
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr ""
 
-#: commit-graph.c:2485
+#: commit-graph.c:2495
 msgid "Verifying commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:2500
+#: commit-graph.c:2510
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 
-#: commit-graph.c:2507
+#: commit-graph.c:2517
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2517
+#: commit-graph.c:2527
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 
-#: commit-graph.c:2526
+#: commit-graph.c:2536
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2540
+#: commit-graph.c:2550
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 
-#: commit-graph.c:2545
+#: commit-graph.c:2555
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2549
+#: commit-graph.c:2559
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2566
+#: commit-graph.c:2576
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 
-#: commit-graph.c:2572
+#: commit-graph.c:2582
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 
-#: commit.c:52 sequencer.c:2887 builtin/am.c:359 builtin/am.c:403
-#: builtin/am.c:1371 builtin/am.c:2018 builtin/replace.c:457
+#: commit.c:52 sequencer.c:3088 builtin/am.c:371 builtin/am.c:416
+#: builtin/am.c:421 builtin/am.c:1419 builtin/am.c:2066 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr ""
@@ -2224,27 +2317,27 @@ msgid ""
 "\"git config advice.graftFileDeprecated false\""
 msgstr ""
 
-#: commit.c:1223
+#: commit.c:1237
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 
-#: commit.c:1227
+#: commit.c:1241
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr ""
 
-#: commit.c:1230
+#: commit.c:1244
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr ""
 
-#: commit.c:1233
+#: commit.c:1247
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr ""
 
-#: commit.c:1487
+#: commit.c:1501
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2264,336 +2357,345 @@ msgid ""
 "\t%s\n"
 "This might be due to circular includes."
 msgstr ""
+"melebihi kedalaman include maksimum (%d) ketika memasukkan\n"
+"\t%s\n"
+"dari\n"
+"\t%s\n"
+"Ini mungkin disebabkan oleh include sirkular."
 
 #: config.c:142
 #, c-format
 msgid "could not expand include path '%s'"
-msgstr ""
+msgstr "tidak dapat menjabarkan jalur include '%s'"
 
 #: config.c:153
 msgid "relative config includes must come from files"
-msgstr ""
+msgstr "include konfigurasi relatif harus dari berkas"
 
 #: config.c:199
 msgid "relative config include conditionals must come from files"
-msgstr ""
+msgstr "kondisional include konfigurasi relative harus dari berkas"
 
 #: config.c:396
+#, c-format
 msgid "invalid config format: %s"
-msgstr ""
+msgstr "format konfigurasi tidak valid: %s"
 
 #: config.c:400
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
-msgstr ""
+msgstr "nama variabel lingkungan untuk konfigurasi hilang '%.*s'"
 
 #: config.c:405
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
-msgstr ""
+msgstr "variabel lingkungan '%s' untuk konfigurasi '%.*s'"
 
 #: config.c:442
 #, c-format
 msgid "key does not contain a section: %s"
-msgstr ""
+msgstr "kunci tidak berisi bagian: %s"
 
 #: config.c:448
 #, c-format
 msgid "key does not contain variable name: %s"
-msgstr ""
+msgstr "kunci tidak berisi nama variabel: %s"
 
-#: config.c:472 sequencer.c:2588
+#: config.c:472 sequencer.c:2785
 #, c-format
 msgid "invalid key: %s"
-msgstr ""
+msgstr "kunci tidak valid: %s"
 
 #: config.c:478
 #, c-format
 msgid "invalid key (newline): %s"
-msgstr ""
+msgstr "kunci tidak valid (barisbaru): %s"
 
 #: config.c:511
 msgid "empty config key"
-msgstr ""
+msgstr "kunci konfigurasi kosong"
 
 #: config.c:529 config.c:541
 #, c-format
 msgid "bogus config parameter: %s"
-msgstr ""
+msgstr "parameter konfigurasi gadungan: %s"
 
 #: config.c:555 config.c:572 config.c:579 config.c:588
 #, c-format
 msgid "bogus format in %s"
-msgstr ""
+msgstr "format gadungan dalam %s"
 
 #: config.c:622
 #, c-format
 msgid "bogus count in %s"
-msgstr ""
+msgstr "hitungan gadungan dalam %s"
 
 #: config.c:626
 #, c-format
 msgid "too many entries in %s"
-msgstr ""
+msgstr "terlalu banyak entri di %s"
 
 #: config.c:636
 #, c-format
 msgid "missing config key %s"
-msgstr ""
+msgstr "kunci konfigurasi %s hilang"
 
 #: config.c:644
 #, c-format
 msgid "missing config value %s"
-msgstr ""
+msgstr "nilai konfigurasi %s hilang"
 
 #: config.c:995
 #, c-format
 msgid "bad config line %d in blob %s"
-msgstr ""
+msgstr "baris konfigurasi %d jelek dalam blob %s"
 
 #: config.c:999
 #, c-format
 msgid "bad config line %d in file %s"
-msgstr ""
+msgstr "baris konfigurasi %d jelek dalam berkas %s"
 
 #: config.c:1003
 #, c-format
 msgid "bad config line %d in standard input"
-msgstr ""
+msgstr "baris konfigurasi %d jelek pada masukan standar"
 
 #: config.c:1007
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
-msgstr ""
+msgstr "baris konfigurasi %d jelek dalam blob submodul %s"
 
 #: config.c:1011
 #, c-format
 msgid "bad config line %d in command line %s"
-msgstr ""
+msgstr "baris konfigurasi %d jelek pada baris perintah %s"
 
 #: config.c:1015
 #, c-format
 msgid "bad config line %d in %s"
-msgstr ""
+msgstr "baris konfigurasi %d jelek dalam %s"
 
 #: config.c:1152
 msgid "out of range"
-msgstr ""
+msgstr "di luar rentang"
 
 #: config.c:1152
 msgid "invalid unit"
-msgstr ""
+msgstr "satuan tidak valid"
 
 #: config.c:1153
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
-msgstr ""
+msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s': %s"
 
 #: config.c:1163
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
-msgstr ""
+msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam blob %s: %s"
 
 #: config.c:1166
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
-msgstr ""
+msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam berkas %s: %s"
 
 #: config.c:1169
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr ""
+"nilai konfigurasi numerik '%s' jelek untuk '%s' pada masukan standar: %s"
 
 #: config.c:1172
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr ""
+"nilai konfigurasi numerik '%s' jelek untuk '%s' dalam blob submodul %s: %s"
 
 #: config.c:1175
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr ""
+"nilai konfigurasi numerik '%s' jelek untuk '%s' pada baris perintah %s: %s"
 
 #: config.c:1178
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
-msgstr ""
+msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam %s: %s"
 
-#: config.c:1194
+#: config.c:1257
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
-msgstr ""
+msgstr "nilai konfigurasi boolean '%s' jelek untuk '%s'"
 
-#: config.c:1289
+#: config.c:1275
 #, c-format
 msgid "failed to expand user dir in: '%s'"
-msgstr ""
+msgstr "gagal menjabarkan direktori pengguna di: '%s'"
 
-#: config.c:1298
+#: config.c:1284
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
-msgstr ""
+msgstr "'%s' untuk '%s' bukan stempel waktu valid"
 
-#: config.c:1391
+#: config.c:1377
 #, c-format
 msgid "abbrev length out of range: %d"
-msgstr ""
+msgstr "panjang singkatan di luar rentang: %d"
 
-#: config.c:1405 config.c:1416
+#: config.c:1391 config.c:1402
 #, c-format
 msgid "bad zlib compression level %d"
-msgstr ""
+msgstr "level kompresi zlib jelek %d"
 
-#: config.c:1508
+#: config.c:1494
 msgid "core.commentChar should only be one character"
-msgstr ""
+msgstr "core.commentChar harusnya hanya satu karakter"
 
-#: config.c:1541
+#: config.c:1527
 #, c-format
 msgid "invalid mode for object creation: %s"
-msgstr ""
+msgstr "mode tidak valid untuk pembuatan objek: %s"
 
-#: config.c:1613
+#: config.c:1599
 #, c-format
 msgid "malformed value for %s"
-msgstr ""
+msgstr "nilai rusak untuk %s"
 
-#: config.c:1639
+#: config.c:1625
 #, c-format
 msgid "malformed value for %s: %s"
-msgstr ""
+msgstr "nilai rusak untuk %s: %s"
 
-#: config.c:1640
+#: config.c:1626
 msgid "must be one of nothing, matching, simple, upstream or current"
-msgstr ""
+msgstr "harus salah satu dari nothing, matching, simple, upstream atau current"
 
-#: config.c:1701 builtin/pack-objects.c:3666
+#: config.c:1687 builtin/pack-objects.c:3924
 #, c-format
 msgid "bad pack compression level %d"
-msgstr ""
+msgstr "level kompresi pak jelek %d"
 
-#: config.c:1823
+#: config.c:1809
 #, c-format
 msgid "unable to load config blob object '%s'"
-msgstr ""
+msgstr "tidak dapat memuat objek blob konfigurasi '%s'"
 
-#: config.c:1826
+#: config.c:1812
 #, c-format
 msgid "reference '%s' does not point to a blob"
-msgstr ""
+msgstr "referensi '%s' tidak menunjuk pada sebuah blob"
 
-#: config.c:1843
+#: config.c:1829
 #, c-format
 msgid "unable to resolve config blob '%s'"
-msgstr ""
+msgstr "tidak dapat menguraikan blob konfigurasi '%s'"
 
 #: config.c:1873
 #, c-format
 msgid "failed to parse %s"
-msgstr ""
+msgstr "gagal menguraikan %s"
 
-#: config.c:1927
+#: config.c:1929
 msgid "unable to parse command-line config"
-msgstr ""
+msgstr "gagal menguraikan konfigurasi baris perintah"
 
-#: config.c:2290
+#: config.c:2293
 msgid "unknown error occurred while reading the configuration files"
-msgstr ""
+msgstr "error tidak diketahui ketika membaca berkas konfigurasi"
 
-#: config.c:2464
+#: config.c:2467
 #, c-format
 msgid "Invalid %s: '%s'"
-msgstr ""
+msgstr "%s tidak valid: '%s'"
 
-#: config.c:2509
+#: config.c:2512
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
-msgstr ""
+msgstr "nilai splitIndex.maxPercentChange '%d' harusnya diantara 0 dan 100"
 
-#: config.c:2555
+#: config.c:2558
 #, c-format
 msgid "unable to parse '%s' from command-line config"
-msgstr ""
+msgstr "tidak dapat menguraikan '%s' dari konfigurasi baris perintah"
 
-#: config.c:2557
+#: config.c:2560
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
-msgstr ""
+msgstr "variabel konfigurasi '%s' jelek dalam berkas '%s' pada baris %d"
 
-#: config.c:2641
+#: config.c:2644
 #, c-format
 msgid "invalid section name '%s'"
-msgstr ""
+msgstr "nama bagian '%s' tidak valid"
 
-#: config.c:2673
+#: config.c:2676
 #, c-format
 msgid "%s has multiple values"
-msgstr ""
+msgstr "%s punya banyak nilai"
 
-#: config.c:2702
+#: config.c:2705
 #, c-format
 msgid "failed to write new configuration file %s"
-msgstr ""
+msgstr "gagal menulis berkas konfigurasi baru %s"
 
-#: config.c:2954 config.c:3280
+#: config.c:2957 config.c:3283
 #, c-format
 msgid "could not lock config file %s"
-msgstr ""
+msgstr "tidak dapat mengunci berkas konfigurasi %s"
 
-#: config.c:2965
+#: config.c:2968
 #, c-format
 msgid "opening %s"
-msgstr ""
+msgstr "membuka %s"
 
-#: config.c:3002 builtin/config.c:361
+#: config.c:3005 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
-msgstr ""
+msgstr "pola tidak valid: %s"
 
-#: config.c:3027
+#: config.c:3030
 #, c-format
 msgid "invalid config file %s"
-msgstr ""
+msgstr "berkas konfigurasi %s tidak valid"
 
-#: config.c:3040 config.c:3293
+#: config.c:3043 config.c:3296
 #, c-format
 msgid "fstat on %s failed"
-msgstr ""
+msgstr "fstat pada %s gagal"
 
-#: config.c:3051
+#: config.c:3054
 #, c-format
 msgid "unable to mmap '%s'"
-msgstr ""
+msgstr "tidak dapat me-mmap '%s'"
 
-#: config.c:3060 config.c:3298
+#: config.c:3063 config.c:3301
 #, c-format
 msgid "chmod on %s failed"
-msgstr ""
+msgstr "chmod pada %s gagal"
 
-#: config.c:3145 config.c:3395
+#: config.c:3148 config.c:3398
 #, c-format
 msgid "could not write config file %s"
-msgstr ""
+msgstr "tidak dapat menulis berkas konfigurasi %s"
 
-#: config.c:3179
+#: config.c:3182
 #, c-format
 msgid "could not set '%s' to '%s'"
-msgstr ""
+msgstr "tidak dapat menyetel '%s' ke '%s'"
 
-#: config.c:3181 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3184 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
 #, c-format
 msgid "could not unset '%s'"
-msgstr ""
+msgstr "tidak dapat mem-batal setel '%s'"
 
-#: config.c:3271
+#: config.c:3274
 #, c-format
 msgid "invalid section name: %s"
-msgstr ""
+msgstr "nama bagian tidak valid: %s"
 
-#: config.c:3438
+#: config.c:3441
 #, c-format
 msgid "missing value for '%s'"
-msgstr ""
+msgstr "nilai hilang untuk '%s'"
 
 #: connect.c:61
 msgid "the remote end hung up upon initial contact"
@@ -2759,7 +2861,7 @@ msgstr ""
 msgid "unable to fork"
 msgstr ""
 
-#: connected.c:108 builtin/fsck.c:191 builtin/prune.c:45
+#: connected.c:108 builtin/fsck.c:188 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr ""
 
@@ -2775,119 +2877,119 @@ msgstr ""
 msgid "failed to close rev-list's stdin"
 msgstr ""
 
-#: convert.c:194
+#: convert.c:183
 #, c-format
 msgid "illegal crlf_action %d"
 msgstr ""
 
-#: convert.c:207
+#: convert.c:196
 #, c-format
 msgid "CRLF would be replaced by LF in %s"
 msgstr ""
 
-#: convert.c:209
+#: convert.c:198
 #, c-format
 msgid ""
 "CRLF will be replaced by LF in %s.\n"
 "The file will have its original line endings in your working directory"
 msgstr ""
 
-#: convert.c:217
+#: convert.c:206
 #, c-format
 msgid "LF would be replaced by CRLF in %s"
 msgstr ""
 
-#: convert.c:219
+#: convert.c:208
 #, c-format
 msgid ""
 "LF will be replaced by CRLF in %s.\n"
 "The file will have its original line endings in your working directory"
 msgstr ""
 
-#: convert.c:284
+#: convert.c:273
 #, c-format
 msgid "BOM is prohibited in '%s' if encoded as %s"
 msgstr ""
 
-#: convert.c:291
+#: convert.c:280
 #, c-format
 msgid ""
 "The file '%s' contains a byte order mark (BOM). Please use UTF-%.*s as "
 "working-tree-encoding."
 msgstr ""
 
-#: convert.c:304
+#: convert.c:293
 #, c-format
 msgid "BOM is required in '%s' if encoded as %s"
 msgstr ""
 
-#: convert.c:306
+#: convert.c:295
 #, c-format
 msgid ""
 "The file '%s' is missing a byte order mark (BOM). Please use UTF-%sBE or UTF-"
 "%sLE (depending on the byte order) as working-tree-encoding."
 msgstr ""
 
-#: convert.c:419 convert.c:490
+#: convert.c:408 convert.c:479
 #, c-format
 msgid "failed to encode '%s' from %s to %s"
 msgstr ""
 
-#: convert.c:462
+#: convert.c:451
 #, c-format
 msgid "encoding '%s' from %s to %s and back is not the same"
 msgstr ""
 
-#: convert.c:665
+#: convert.c:654
 #, c-format
 msgid "cannot fork to run external filter '%s'"
 msgstr ""
 
-#: convert.c:685
+#: convert.c:674
 #, c-format
 msgid "cannot feed the input to external filter '%s'"
 msgstr ""
 
-#: convert.c:692
+#: convert.c:681
 #, c-format
 msgid "external filter '%s' failed %d"
 msgstr ""
 
-#: convert.c:727 convert.c:730
+#: convert.c:716 convert.c:719
 #, c-format
 msgid "read from external filter '%s' failed"
 msgstr ""
 
-#: convert.c:733 convert.c:788
+#: convert.c:722 convert.c:777
 #, c-format
 msgid "external filter '%s' failed"
 msgstr ""
 
-#: convert.c:837
+#: convert.c:826
 msgid "unexpected filter type"
 msgstr ""
 
-#: convert.c:848
+#: convert.c:837
 msgid "path name too long for external filter"
 msgstr ""
 
-#: convert.c:940
+#: convert.c:934
 #, c-format
 msgid ""
 "external filter '%s' is not available anymore although not all paths have "
 "been filtered"
 msgstr ""
 
-#: convert.c:1240
+#: convert.c:1234
 msgid "true/false are no valid working-tree-encodings"
 msgstr ""
 
-#: convert.c:1428 convert.c:1462
+#: convert.c:1414 convert.c:1447
 #, c-format
 msgid "%s: clean filter '%s' failed"
 msgstr ""
 
-#: convert.c:1508
+#: convert.c:1490
 #, c-format
 msgid "%s: smudge filter %s failed"
 msgstr ""
@@ -3012,28 +3114,28 @@ msgstr ""
 msgid "Marked %d islands, done.\n"
 msgstr ""
 
-#: diff-merges.c:70
+#: diff-merges.c:80
 #, c-format
 msgid "unknown value for --diff-merges: %s"
 msgstr ""
 
-#: diff-lib.c:534
+#: diff-lib.c:538
 msgid "--merge-base does not work with ranges"
 msgstr ""
 
-#: diff-lib.c:536
+#: diff-lib.c:540
 msgid "--merge-base only works with commits"
 msgstr ""
 
-#: diff-lib.c:553
+#: diff-lib.c:557
 msgid "unable to get HEAD"
 msgstr ""
 
-#: diff-lib.c:560
+#: diff-lib.c:564
 msgid "no merge base found"
 msgstr ""
 
-#: diff-lib.c:562
+#: diff-lib.c:566
 msgid "multiple merge bases found"
 msgstr ""
 
@@ -3050,18 +3152,20 @@ msgstr ""
 #: diff.c:156
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
-msgstr ""
+msgstr "  Gagal mengurai persentase potongan dirstat '%s'\n"
 
 #: diff.c:161
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
-msgstr ""
+msgstr "  Parameter dirstat tidak ditketahui '%s'\n"
 
 #: diff.c:297
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
 msgstr ""
+"Setelan warna berpindah harus salah satu dari 'no', 'default', 'blocks', "
+"'dimmed-zebra', 'plain'"
 
 #: diff.c:325
 #, c-format
@@ -3069,17 +3173,22 @@ msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
 "'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-change'"
 msgstr ""
+"mode color-moved-ws tidak dikenal '%s', nilai yang mungkin yaitu 'ignore-"
+"space-change', 'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-"
+"change'"
 
 #: diff.c:333
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
 msgstr ""
+"color-moved-ws: allow-indentation-change tidak dapat digabungkan dengan mode "
+"spasi yang lainnya"
 
 #: diff.c:410
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
-msgstr ""
+msgstr "Nilai tidak dikenal untuk variabel konfigurasi 'diff.submodule': '%s'"
 
 #: diff.c:470
 #, c-format
@@ -3087,556 +3196,583 @@ msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
 "%s"
 msgstr ""
+"Ditemukan error dalam variable konfigurasi 'diff.dirstat':\n"
+"%s"
 
-#: diff.c:4276
+#: diff.c:4278
 #, c-format
 msgid "external diff died, stopping at %s"
-msgstr ""
+msgstr "diff eksternal mati, berhenti pada %s"
 
-#: diff.c:4628
+#: diff.c:4630
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
-msgstr ""
+msgstr "--name-only, --name-status, --check dan -s saling eksklusif"
 
-#: diff.c:4631
+#: diff.c:4633
 msgid "-G, -S and --find-object are mutually exclusive"
-msgstr ""
+msgstr "-G, -S dan --find-object saling eksklusif"
 
-#: diff.c:4710
+#: diff.c:4712
 msgid "--follow requires exactly one pathspec"
-msgstr ""
+msgstr "--follow butuh tepatnya satu spek jalur"
 
-#: diff.c:4758
+#: diff.c:4760
 #, c-format
 msgid "invalid --stat value: %s"
-msgstr ""
+msgstr "nilai --stat tidak valid: %s"
 
-#: diff.c:4763 diff.c:4768 diff.c:4773 diff.c:4778 diff.c:5306
+#: diff.c:4765 diff.c:4770 diff.c:4775 diff.c:4780 diff.c:5308
 #: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
 #, c-format
 msgid "%s expects a numerical value"
-msgstr ""
+msgstr "%s harap nilai numerik"
 
-#: diff.c:4795
+#: diff.c:4797
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
 "%s"
 msgstr ""
+"Gagal menguraikan parameter opsi --dirstat/-X:\n"
+"%s"
 
-#: diff.c:4880
+#: diff.c:4882
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
-msgstr ""
+msgstr "kelas perubahan '%c' tidak dikenal dalam --diff-filter=%s"
 
-#: diff.c:4904
+#: diff.c:4906
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
-msgstr ""
+msgstr "nilai tidak dikenal setelah ws-error-highlight=%.*s"
 
-#: diff.c:4918
+#: diff.c:4920
 #, c-format
 msgid "unable to resolve '%s'"
-msgstr ""
+msgstr "tidak dapat menguraikan '%s'"
 
-#: diff.c:4968 diff.c:4974
+#: diff.c:4970 diff.c:4976
 #, c-format
 msgid "%s expects <n>/<m> form"
-msgstr ""
+msgstr "%s butuh bentuk <n>/<m>"
 
-#: diff.c:4986
+#: diff.c:4988
 #, c-format
 msgid "%s expects a character, got '%s'"
-msgstr ""
+msgstr "%s butuh sebuah karakter, dapat '%s'"
 
-#: diff.c:5007
+#: diff.c:5009
 #, c-format
 msgid "bad --color-moved argument: %s"
-msgstr ""
+msgstr "argumen --color-moved jelek: %s"
 
-#: diff.c:5026
+#: diff.c:5028
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
-msgstr ""
+msgstr "mode tidak valid '%s' dalam --color-moved-ws"
 
-#: diff.c:5066
+#: diff.c:5068
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 msgstr ""
+"opsi diff-algorithm terima \"myers\", \"minimal\", \"patience\" dan "
+"\"histogram\""
 
-#: diff.c:5102 diff.c:5122
+#: diff.c:5104 diff.c:5124
 #, c-format
 msgid "invalid argument to %s"
-msgstr ""
+msgstr "argumen tidak valid ke %s"
 
-#: diff.c:5226
+#: diff.c:5228
 #, c-format
 msgid "invalid regex given to -I: '%s'"
-msgstr ""
+msgstr "regex tidak valid diberikan ke -I: '%s'"
 
-#: diff.c:5275
+#: diff.c:5277
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
-msgstr ""
+msgstr "gagal menguraikan parameter opsi --submodule: '%s'"
 
-#: diff.c:5331
+#: diff.c:5333
 #, c-format
 msgid "bad --word-diff argument: %s"
-msgstr ""
+msgstr "argumen --word-diff jelek: %s"
 
-#: diff.c:5367
+#: diff.c:5369
 msgid "Diff output format options"
-msgstr ""
+msgstr "Opsi format keluaran diff"
 
-#: diff.c:5369 diff.c:5375
+#: diff.c:5371 diff.c:5377
 msgid "generate patch"
-msgstr ""
+msgstr "buat tambalan"
 
-#: diff.c:5372 builtin/log.c:179
+#: diff.c:5374 builtin/log.c:179
 msgid "suppress diff output"
-msgstr ""
+msgstr "sembunyikan keluaran diff"
 
-#: diff.c:5377 diff.c:5491 diff.c:5498
+#: diff.c:5379 diff.c:5493 diff.c:5500
 msgid "<n>"
-msgstr ""
+msgstr "<n>"
 
-#: diff.c:5378 diff.c:5381
+#: diff.c:5380 diff.c:5383
 msgid "generate diffs with <n> lines context"
-msgstr ""
+msgstr "buat diff dengan <n> baris konteks"
 
-#: diff.c:5383
+#: diff.c:5385
 msgid "generate the diff in raw format"
-msgstr ""
+msgstr "buat diff dalam format mentah"
 
-#: diff.c:5386
+#: diff.c:5388
 msgid "synonym for '-p --raw'"
-msgstr ""
+msgstr "sinonim untuk '-p --raw'"
 
-#: diff.c:5390
+#: diff.c:5392
 msgid "synonym for '-p --stat'"
-msgstr ""
+msgstr "sinonim untuk '-p --stat'"
 
-#: diff.c:5394
+#: diff.c:5396
 msgid "machine friendly --stat"
-msgstr ""
+msgstr "--stat yang ramah mesin"
 
-#: diff.c:5397
+#: diff.c:5399
 msgid "output only the last line of --stat"
-msgstr ""
+msgstr "keluarkan hanya baris terakhir --stat"
 
-#: diff.c:5399 diff.c:5407
+#: diff.c:5401 diff.c:5409
 msgid "<param1,param2>..."
-msgstr ""
+msgstr "<parameter 1,parameter 2>..."
 
-#: diff.c:5400
+#: diff.c:5402
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
+"keluarkan distribusi jumlah perubahan relatif untuk setiap subdirektori"
 
-#: diff.c:5404
+#: diff.c:5406
 msgid "synonym for --dirstat=cumulative"
-msgstr ""
+msgstr "sinonim untuk --dirstat=cumulative"
 
-#: diff.c:5408
+#: diff.c:5410
 msgid "synonym for --dirstat=files,param1,param2..."
-msgstr ""
+msgstr "sinonim untuk --dirstat=files,param1,param2..."
 
-#: diff.c:5412
+#: diff.c:5414
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
+"peringatkan bila perubahan memasukkan penanda konflik atau kesalahan spasi"
 
-#: diff.c:5415
+#: diff.c:5417
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
+"ringkasan singkat seperti pembuatan, penggantian nama dan perubahan mode"
 
-#: diff.c:5418
+#: diff.c:5420
 msgid "show only names of changed files"
-msgstr ""
-
-#: diff.c:5421
-msgid "show only names and status of changed files"
-msgstr ""
+msgstr "perlihatkan hanya nama berkas yang berubah"
 
 #: diff.c:5423
+msgid "show only names and status of changed files"
+msgstr "perlihatkan hanya nama dan status berkas yang berubah"
+
+#: diff.c:5425
 msgid "<width>[,<name-width>[,<count>]]"
-msgstr ""
+msgstr "<lebar>[,<nama lebar>[,<hitungan>]]"
 
-#: diff.c:5424
+#: diff.c:5426
 msgid "generate diffstat"
-msgstr ""
+msgstr "buat diffstat"
 
-#: diff.c:5426 diff.c:5429 diff.c:5432
+#: diff.c:5428 diff.c:5431 diff.c:5434
 msgid "<width>"
-msgstr ""
+msgstr "<lebar>"
 
-#: diff.c:5427
+#: diff.c:5429
 msgid "generate diffstat with a given width"
-msgstr ""
+msgstr "buat diffstat dengan lebar yang diberikan"
 
-#: diff.c:5430
+#: diff.c:5432
 msgid "generate diffstat with a given name width"
-msgstr ""
-
-#: diff.c:5433
-msgid "generate diffstat with a given graph width"
-msgstr ""
+msgstr "buat diffstat dengan nama lebar yang diberikan"
 
 #: diff.c:5435
+msgid "generate diffstat with a given graph width"
+msgstr "buat diffstat dengan lebar grafik yang diberikan"
+
+#: diff.c:5437
 msgid "<count>"
-msgstr ""
+msgstr "<hitungan>"
 
-#: diff.c:5436
+#: diff.c:5438
 msgid "generate diffstat with limited lines"
-msgstr ""
+msgstr "buat diffstat dengan baris yang terbatas"
 
-#: diff.c:5439
+#: diff.c:5441
 msgid "generate compact summary in diffstat"
-msgstr ""
+msgstr "buat ringkasan singkat dalam diffstat"
 
-#: diff.c:5442
+#: diff.c:5444
 msgid "output a binary diff that can be applied"
-msgstr ""
-
-#: diff.c:5445
-msgid "show full pre- and post-image object names on the \"index\" lines"
-msgstr ""
+msgstr "keluarkan diff biner yang dapat diterapkan"
 
 #: diff.c:5447
-msgid "show colored diff"
-msgstr ""
-
-#: diff.c:5448
-msgid "<kind>"
-msgstr ""
+msgid "show full pre- and post-image object names on the \"index\" lines"
+msgstr "perlihatkan objek pra- dan pasca-citra penuh pada baris \"index\""
 
 #: diff.c:5449
+msgid "show colored diff"
+msgstr "perlihatkan diff berwarna"
+
+#: diff.c:5450
+msgid "<kind>"
+msgstr "<tipe>"
+
+#: diff.c:5451
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
 msgstr ""
+"soroti kesalahan spasi dalam baris 'context', 'old' atau 'new' dalam diff"
 
-#: diff.c:5452
+#: diff.c:5454
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
 msgstr ""
+"jangan tengkar jalur nama dan gunakan NUL sebagai pembatas bidang keluaran "
+"pada --raw atau --numstat"
 
-#: diff.c:5455 diff.c:5458 diff.c:5461 diff.c:5570
+#: diff.c:5457 diff.c:5460 diff.c:5463 diff.c:5572
 msgid "<prefix>"
-msgstr ""
+msgstr "<prefiks>"
 
-#: diff.c:5456
+#: diff.c:5458
 msgid "show the given source prefix instead of \"a/\""
-msgstr ""
+msgstr "perlihatkan prefiks sumber yang diberikan daripada \"a/\""
 
-#: diff.c:5459
+#: diff.c:5461
 msgid "show the given destination prefix instead of \"b/\""
-msgstr ""
+msgstr "perlihatkan prefiks tujuan daripada \"b/\""
 
-#: diff.c:5462
+#: diff.c:5464
 msgid "prepend an additional prefix to every line of output"
-msgstr ""
+msgstr "tambah depan prefiks tambahan pada setiap baris keluaran"
 
-#: diff.c:5465
+#: diff.c:5467
 msgid "do not show any source or destination prefix"
-msgstr ""
+msgstr "jangan perlihatkan prefiks sumber atau tujuan apapun"
 
-#: diff.c:5468
+#: diff.c:5470
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
+"perlihatkan konteks diantara hunk diff hingga jumlah baris yang disebutkan"
 
-#: diff.c:5472 diff.c:5477 diff.c:5482
+#: diff.c:5474 diff.c:5479 diff.c:5484
 msgid "<char>"
-msgstr ""
+msgstr "<karakter>"
 
-#: diff.c:5473
+#: diff.c:5475
 msgid "specify the character to indicate a new line instead of '+'"
-msgstr ""
+msgstr "sebutkan karakter yang menandai baris baru daripada '+'"
 
-#: diff.c:5478
+#: diff.c:5480
 msgid "specify the character to indicate an old line instead of '-'"
-msgstr ""
+msgstr "sebutkan karakter yang menandai baris lama daripada '-'"
 
-#: diff.c:5483
+#: diff.c:5485
 msgid "specify the character to indicate a context instead of ' '"
-msgstr ""
-
-#: diff.c:5486
-msgid "Diff rename options"
-msgstr ""
-
-#: diff.c:5487
-msgid "<n>[/<m>]"
-msgstr ""
+msgstr "sebutkan karakter yang menandai konteks daripada ' '"
 
 #: diff.c:5488
+msgid "Diff rename options"
+msgstr "Opsi penamaan ulang diff"
+
+#: diff.c:5489
+msgid "<n>[/<m>]"
+msgstr "<n>[/<m>]"
+
+#: diff.c:5490
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
+"pisahkan perubahan penulisan ulang penuh kedalam pasangan penghapusan dan "
+"pembuatan"
 
-#: diff.c:5492
+#: diff.c:5494
 msgid "detect renames"
-msgstr ""
+msgstr "deteksi penamaan ulang"
 
-#: diff.c:5496
+#: diff.c:5498
 msgid "omit the preimage for deletes"
-msgstr ""
+msgstr "lewati pracitra untuk penghapusan"
 
-#: diff.c:5499
+#: diff.c:5501
 msgid "detect copies"
-msgstr ""
-
-#: diff.c:5503
-msgid "use unmodified files as source to find copies"
-msgstr ""
+msgstr "deteksi penyalinan"
 
 #: diff.c:5505
-msgid "disable rename detection"
+msgid "use unmodified files as source to find copies"
 msgstr ""
+"gunakan berkas tak termodifikasi sebagai sumber untuk menemukan salinan"
 
-#: diff.c:5508
-msgid "use empty blobs as rename source"
-msgstr ""
+#: diff.c:5507
+msgid "disable rename detection"
+msgstr "nonaktifkan deteksi penamaan ulang"
 
 #: diff.c:5510
-msgid "continue listing the history of a file beyond renames"
-msgstr ""
+msgid "use empty blobs as rename source"
+msgstr "gunakan blob kosong sebagai sumber penamaan ulang"
 
-#: diff.c:5513
+#: diff.c:5512
+msgid "continue listing the history of a file beyond renames"
+msgstr "lanjutkan daftarkan riwayat berkas di luar penamaan ulang"
+
+#: diff.c:5515
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
 msgstr ""
-
-#: diff.c:5515
-msgid "Diff algorithm options"
-msgstr ""
+"cegah pendeteksian penamaan ulang/penyalinan jika jumlah target penamaan "
+"ulang/penyalinan melebihi batas yang diberikan"
 
 #: diff.c:5517
+msgid "Diff algorithm options"
+msgstr "Opsi algoritma diff"
+
+#: diff.c:5519
 msgid "produce the smallest possible diff"
-msgstr ""
+msgstr "hasilkan diff yang paling kecil yang dimungkinkan"
 
-#: diff.c:5520
+#: diff.c:5522
 msgid "ignore whitespace when comparing lines"
-msgstr ""
+msgstr "abaikan spasi saat membandingkan baris"
 
-#: diff.c:5523
+#: diff.c:5525
 msgid "ignore changes in amount of whitespace"
-msgstr ""
+msgstr "abaikan perubahan dalam jumlah spasi"
 
-#: diff.c:5526
+#: diff.c:5528
 msgid "ignore changes in whitespace at EOL"
-msgstr ""
+msgstr "abaikan perubahan spasi pada EOL"
 
-#: diff.c:5529
+#: diff.c:5531
 msgid "ignore carrier-return at the end of line"
-msgstr ""
+msgstr "abaikan kembalian-kurir pada akhir baris"
 
-#: diff.c:5532
+#: diff.c:5534
 msgid "ignore changes whose lines are all blank"
-msgstr ""
+msgstr "abaikan perubahan yang semua baris kosong"
 
-#: diff.c:5534 diff.c:5556 diff.c:5559 diff.c:5604
+#: diff.c:5536 diff.c:5558 diff.c:5561 diff.c:5606
 msgid "<regex>"
-msgstr ""
+msgstr "<regex>"
 
-#: diff.c:5535
+#: diff.c:5537
 msgid "ignore changes whose all lines match <regex>"
-msgstr ""
+msgstr "abaikan perubahan yang semua baris cocok dengan <regex>"
 
-#: diff.c:5538
+#: diff.c:5540
 msgid "heuristic to shift diff hunk boundaries for easy reading"
-msgstr ""
+msgstr "heuristik untuk geser perbatasan hunk diff untuk pembacaan yang mudah"
 
-#: diff.c:5541
+#: diff.c:5543
 msgid "generate diff using the \"patience diff\" algorithm"
-msgstr ""
-
-#: diff.c:5545
-msgid "generate diff using the \"histogram diff\" algorithm"
-msgstr ""
+msgstr "buat diff menggunakan algoritma \"diff sabar\""
 
 #: diff.c:5547
-msgid "<algorithm>"
-msgstr ""
+msgid "generate diff using the \"histogram diff\" algorithm"
+msgstr "buat diff menggunakan algoritma \"diff histogram\""
 
-#: diff.c:5548
-msgid "choose a diff algorithm"
-msgstr ""
+#: diff.c:5549
+msgid "<algorithm>"
+msgstr "<algoritma>"
 
 #: diff.c:5550
+msgid "choose a diff algorithm"
+msgstr "pilih algoritma diff"
+
+#: diff.c:5552
 msgid "<text>"
-msgstr ""
+msgstr "<teks>"
 
-#: diff.c:5551
+#: diff.c:5553
 msgid "generate diff using the \"anchored diff\" algorithm"
-msgstr ""
+msgstr "buat diff menggunakan algoritma \"diff terlabuh\""
 
-#: diff.c:5553 diff.c:5562 diff.c:5565
+#: diff.c:5555 diff.c:5564 diff.c:5567
 msgid "<mode>"
-msgstr ""
+msgstr "<mode>"
 
-#: diff.c:5554
+#: diff.c:5556
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
+"perlihatkan diff kata, menggunakan <mode> untuk batasi kata yang berubah"
 
-#: diff.c:5557
+#: diff.c:5559
 msgid "use <regex> to decide what a word is"
-msgstr ""
+msgstr "gunakan <regex> untuk menentukan apa itu kata"
 
-#: diff.c:5560
+#: diff.c:5562
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
-msgstr ""
+msgstr "sama dengan --word-diff=color --word-diff-regex=<regex>"
 
-#: diff.c:5563
+#: diff.c:5565
 msgid "moved lines of code are colored differently"
-msgstr ""
+msgstr "baris kode yang berpindah diwarnai berbeda"
 
-#: diff.c:5566
+#: diff.c:5568
 msgid "how white spaces are ignored in --color-moved"
-msgstr ""
-
-#: diff.c:5569
-msgid "Other diff options"
-msgstr ""
+msgstr "bagaimana spasi diabaikan di --color-moved"
 
 #: diff.c:5571
+msgid "Other diff options"
+msgstr "Opsi diff yang lainnya"
+
+#: diff.c:5573
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
-
-#: diff.c:5575
-msgid "treat all files as text"
-msgstr ""
+"ketika dijalankan dari subdirektori, kecualikan perubahan diluar dan "
+"perlihatkan jalur relatif"
 
 #: diff.c:5577
-msgid "swap two inputs, reverse the diff"
-msgstr ""
+msgid "treat all files as text"
+msgstr "perlakukan semua berkas sebagai teks"
 
 #: diff.c:5579
-msgid "exit with 1 if there were differences, 0 otherwise"
-msgstr ""
+msgid "swap two inputs, reverse the diff"
+msgstr "tukar dua masukkan, balikkan diff"
 
 #: diff.c:5581
-msgid "disable all output of the program"
-msgstr ""
+msgid "exit with 1 if there were differences, 0 otherwise"
+msgstr "keluar dengan 1 jika ada perbedaan, selain itu 0"
 
 #: diff.c:5583
-msgid "allow an external diff helper to be executed"
-msgstr ""
+msgid "disable all output of the program"
+msgstr "nonaktifkan semua keluaran program"
 
 #: diff.c:5585
-msgid "run external text conversion filters when comparing binary files"
-msgstr ""
+msgid "allow an external diff helper to be executed"
+msgstr "perbolehkan pembantu diff eksternal untuk dieksekusi"
 
 #: diff.c:5587
+msgid "run external text conversion filters when comparing binary files"
+msgstr ""
+"jalankan saringan konversi teks eksternal ketika membandingkan berkas biner"
+
+#: diff.c:5589
 msgid "<when>"
-msgstr ""
+msgstr "<kapan>"
 
-#: diff.c:5588
+#: diff.c:5590
 msgid "ignore changes to submodules in the diff generation"
-msgstr ""
+msgstr "abaikan perubahan submodul dalam pembuatan diff"
 
-#: diff.c:5591
+#: diff.c:5593
 msgid "<format>"
-msgstr ""
+msgstr "<format>"
 
-#: diff.c:5592
+#: diff.c:5594
 msgid "specify how differences in submodules are shown"
-msgstr ""
+msgstr "sebutkan bagaimana perbedaan dalam submodul diperlihatkan"
 
-#: diff.c:5596
+#: diff.c:5598
 msgid "hide 'git add -N' entries from the index"
-msgstr ""
-
-#: diff.c:5599
-msgid "treat 'git add -N' entries as real in the index"
-msgstr ""
+msgstr "sembunyikan entri 'git add -N' dari indeks"
 
 #: diff.c:5601
-msgid "<string>"
-msgstr ""
+msgid "treat 'git add -N' entries as real in the index"
+msgstr "perlakukan entri 'git add -N' sebagai nyata dalam indeks"
 
-#: diff.c:5602
+#: diff.c:5603
+msgid "<string>"
+msgstr "<untai>"
+
+#: diff.c:5604
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
-msgstr ""
+msgstr "cari perbedaan yang mengubah jumlah kemunculan untai yang disebutkan"
 
-#: diff.c:5605
+#: diff.c:5607
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
-msgstr ""
+msgstr "cari perbedaan yang mengubah jumlah kemunculan regex yang disebutkan"
 
-#: diff.c:5608
+#: diff.c:5610
 msgid "show all changes in the changeset with -S or -G"
-msgstr ""
+msgstr "perlihatkan semua perubahan dalam set perubahan dengan -S atau -G"
 
-#: diff.c:5611
+#: diff.c:5613
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
-
-#: diff.c:5614
-msgid "control the order in which files appear in the output"
-msgstr ""
-
-#: diff.c:5615 diff.c:5618
-msgid "<path>"
-msgstr ""
+"perlakukan <string> di -S sebagai ekspresi reguler POSIX yang diperluas"
 
 #: diff.c:5616
-msgid "show the change in the specified path first"
-msgstr ""
+msgid "control the order in which files appear in the output"
+msgstr "kontrol urutan berkas yang muncul dalam keluaran"
 
-#: diff.c:5619
-msgid "skip the output to the specified path"
-msgstr ""
+#: diff.c:5617 diff.c:5620
+msgid "<path>"
+msgstr "<jalur>"
+
+#: diff.c:5618
+msgid "show the change in the specified path first"
+msgstr "perlihatkan perubahan dalam jalur yang disebutkan terlebih dahulu"
 
 #: diff.c:5621
-msgid "<object-id>"
-msgstr ""
+msgid "skip the output to the specified path"
+msgstr "lewati keluaran ke jalur yang disebutkan"
 
-#: diff.c:5622
+#: diff.c:5623
+msgid "<object-id>"
+msgstr "<id objek>"
+
+#: diff.c:5624
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
-msgstr ""
+msgstr "cari perubahan yang mengubah jumlah kemunculan objek yang disebutkan"
 
-#: diff.c:5624
+#: diff.c:5626
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
-msgstr ""
-
-#: diff.c:5625
-msgid "select files by diff type"
-msgstr ""
+msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
 #: diff.c:5627
+msgid "select files by diff type"
+msgstr "pilih berkas oleh tipe diff"
+
+#: diff.c:5629
 msgid "<file>"
-msgstr ""
+msgstr "<berkas>"
 
-#: diff.c:5628
+#: diff.c:5630
 msgid "Output to a specific file"
-msgstr ""
+msgstr "Keluarkan ke berkas yang disebutkan"
 
-#: diff.c:6285
+#: diff.c:6287
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
+"deteksi penamaan ulang tak eksak dilewati karena terlalu banyak berkas."
 
-#: diff.c:6288
+#: diff.c:6290
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
+"hanya ditemukan salinan dari jalur yang berubah karena terlalu banyak berkas."
 
-#: diff.c:6291
+#: diff.c:6293
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
 msgstr ""
+"mungkin Anda ingin menyetel variabel %s Anda ke setidaknya %d dan coba lagi "
+"perintah."
 
 #: diffcore-order.c:24
 #, c-format
 msgid "failed to read orderfile '%s'"
 msgstr ""
 
-#: diffcore-rename.c:786
+#: diffcore-rename.c:1418
 msgid "Performing inexact rename detection"
 msgstr ""
 
@@ -3669,35 +3805,35 @@ msgstr ""
 msgid "disabling cone pattern matching"
 msgstr ""
 
-#: dir.c:1198
+#: dir.c:1206
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr ""
 
-#: dir.c:2305
+#: dir.c:2314
 #, c-format
 msgid "could not open directory '%s'"
 msgstr ""
 
-#: dir.c:2605
+#: dir.c:2614
 msgid "failed to get kernel name and information"
 msgstr ""
 
-#: dir.c:2729
+#: dir.c:2738
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 
-#: dir.c:3534
+#: dir.c:3543
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr ""
 
-#: dir.c:3579 dir.c:3584
+#: dir.c:3590 dir.c:3595
 #, c-format
 msgid "could not create directories for %s"
 msgstr ""
 
-#: dir.c:3613
+#: dir.c:3624
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr ""
@@ -3707,11 +3843,11 @@ msgstr ""
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr ""
 
-#: entry.c:177
+#: entry.c:179
 msgid "Filtering content"
 msgstr ""
 
-#: entry.c:478
+#: entry.c:500
 #, c-format
 msgid "could not stat file '%s'"
 msgstr ""
@@ -3731,249 +3867,257 @@ msgstr ""
 msgid "too many args to run %s"
 msgstr ""
 
-#: fetch-pack.c:177
+#: fetch-pack.c:182
 msgid "git fetch-pack: expected shallow list"
 msgstr ""
 
-#: fetch-pack.c:180
+#: fetch-pack.c:185
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr ""
 
-#: fetch-pack.c:191
+#: fetch-pack.c:196
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr ""
 
-#: fetch-pack.c:211
+#: fetch-pack.c:216
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr ""
 
-#: fetch-pack.c:222
+#: fetch-pack.c:227
 msgid "unable to write to remote"
 msgstr ""
 
-#: fetch-pack.c:283
+#: fetch-pack.c:288
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr ""
 
-#: fetch-pack.c:378 fetch-pack.c:1457
+#: fetch-pack.c:383 fetch-pack.c:1423
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr ""
 
-#: fetch-pack.c:384 fetch-pack.c:1463
+#: fetch-pack.c:389 fetch-pack.c:1429
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr ""
 
-#: fetch-pack.c:386 fetch-pack.c:1465
+#: fetch-pack.c:391 fetch-pack.c:1431
 #, c-format
 msgid "object not found: %s"
 msgstr ""
 
-#: fetch-pack.c:389 fetch-pack.c:1468
+#: fetch-pack.c:394 fetch-pack.c:1434
 #, c-format
 msgid "error in object: %s"
 msgstr ""
 
-#: fetch-pack.c:391 fetch-pack.c:1470
+#: fetch-pack.c:396 fetch-pack.c:1436
 #, c-format
 msgid "no shallow found: %s"
 msgstr ""
 
-#: fetch-pack.c:394 fetch-pack.c:1474
+#: fetch-pack.c:399 fetch-pack.c:1440
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr ""
 
-#: fetch-pack.c:434
+#: fetch-pack.c:439
 #, c-format
 msgid "got %s %d %s"
 msgstr ""
 
-#: fetch-pack.c:451
+#: fetch-pack.c:456
 #, c-format
 msgid "invalid commit %s"
 msgstr ""
 
-#: fetch-pack.c:482
+#: fetch-pack.c:487
 msgid "giving up"
 msgstr ""
 
-#: fetch-pack.c:495 progress.c:339
+#: fetch-pack.c:500 progress.c:339
 msgid "done"
 msgstr ""
 
-#: fetch-pack.c:507
+#: fetch-pack.c:512
 #, c-format
 msgid "got %s (%d) %s"
 msgstr ""
 
-#: fetch-pack.c:543
+#: fetch-pack.c:548
 #, c-format
 msgid "Marking %s as complete"
 msgstr ""
 
-#: fetch-pack.c:758
+#: fetch-pack.c:763
 #, c-format
 msgid "already have %s (%s)"
 msgstr ""
 
-#: fetch-pack.c:844
+#: fetch-pack.c:849
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr ""
 
-#: fetch-pack.c:852
+#: fetch-pack.c:857
 msgid "protocol error: bad pack header"
 msgstr ""
 
-#: fetch-pack.c:946
+#: fetch-pack.c:951
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr ""
 
-#: fetch-pack.c:952
+#: fetch-pack.c:957
 msgid "fetch-pack: invalid index-pack output"
 msgstr ""
 
-#: fetch-pack.c:969
+#: fetch-pack.c:974
 #, c-format
 msgid "%s failed"
 msgstr ""
 
-#: fetch-pack.c:971
+#: fetch-pack.c:976
 msgid "error in sideband demultiplexer"
 msgstr ""
 
-#: fetch-pack.c:1031
+#: fetch-pack.c:1019
 #, c-format
 msgid "Server version is %.*s"
 msgstr ""
 
-#: fetch-pack.c:1039 fetch-pack.c:1045 fetch-pack.c:1048 fetch-pack.c:1054
-#: fetch-pack.c:1058 fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070
-#: fetch-pack.c:1074 fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086
-#: fetch-pack.c:1092 fetch-pack.c:1098 fetch-pack.c:1103 fetch-pack.c:1108
+#: fetch-pack.c:1027 fetch-pack.c:1033 fetch-pack.c:1036 fetch-pack.c:1042
+#: fetch-pack.c:1046 fetch-pack.c:1050 fetch-pack.c:1054 fetch-pack.c:1058
+#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
+#: fetch-pack.c:1080 fetch-pack.c:1086 fetch-pack.c:1091 fetch-pack.c:1096
 #, c-format
 msgid "Server supports %s"
 msgstr ""
 
-#: fetch-pack.c:1041
+#: fetch-pack.c:1029
 msgid "Server does not support shallow clients"
 msgstr ""
 
-#: fetch-pack.c:1101
+#: fetch-pack.c:1089
 msgid "Server does not support --shallow-since"
 msgstr ""
 
-#: fetch-pack.c:1106
+#: fetch-pack.c:1094
 msgid "Server does not support --shallow-exclude"
 msgstr ""
 
-#: fetch-pack.c:1110
+#: fetch-pack.c:1098
 msgid "Server does not support --deepen"
 msgstr ""
 
-#: fetch-pack.c:1112
+#: fetch-pack.c:1100
 msgid "Server does not support this repository's object format"
 msgstr ""
 
-#: fetch-pack.c:1125
+#: fetch-pack.c:1113
 msgid "no common commits"
 msgstr ""
 
-#: fetch-pack.c:1138 fetch-pack.c:1682
+#: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
+msgid "source repository is shallow, reject to clone."
+msgstr ""
+
+#: fetch-pack.c:1128 fetch-pack.c:1651
 msgid "git fetch-pack: fetch failed."
 msgstr ""
 
-#: fetch-pack.c:1265
+#: fetch-pack.c:1242
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr ""
 
-#: fetch-pack.c:1269
+#: fetch-pack.c:1246
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr ""
 
-#: fetch-pack.c:1289
+#: fetch-pack.c:1279
 msgid "Server does not support shallow requests"
 msgstr ""
 
-#: fetch-pack.c:1296
+#: fetch-pack.c:1286
 msgid "Server supports filter"
 msgstr ""
 
-#: fetch-pack.c:1335
+#: fetch-pack.c:1329 fetch-pack.c:2034
 msgid "unable to write request to remote"
 msgstr ""
 
-#: fetch-pack.c:1353
+#: fetch-pack.c:1347
 #, c-format
 msgid "error reading section header '%s'"
 msgstr ""
 
-#: fetch-pack.c:1359
+#: fetch-pack.c:1353
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr ""
 
-#: fetch-pack.c:1420
+#: fetch-pack.c:1387
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr ""
 
-#: fetch-pack.c:1425
+#: fetch-pack.c:1392
 #, c-format
 msgid "error processing acks: %d"
 msgstr ""
 
-#: fetch-pack.c:1435
+#: fetch-pack.c:1402
 msgid "expected packfile to be sent after 'ready'"
 msgstr ""
 
-#: fetch-pack.c:1437
+#: fetch-pack.c:1404
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 
-#: fetch-pack.c:1479
+#: fetch-pack.c:1445
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr ""
 
-#: fetch-pack.c:1526
+#: fetch-pack.c:1494
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr ""
 
-#: fetch-pack.c:1531
+#: fetch-pack.c:1499
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr ""
 
-#: fetch-pack.c:1536
+#: fetch-pack.c:1504
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr ""
 
-#: fetch-pack.c:1566
+#: fetch-pack.c:1534
 msgid "git fetch-pack: expected response end packet"
 msgstr ""
 
-#: fetch-pack.c:1960
+#: fetch-pack.c:1930
 msgid "no matching remote head"
 msgstr ""
 
-#: fetch-pack.c:1983 builtin/clone.c:693
+#: fetch-pack.c:1953 builtin/clone.c:697
 msgid "remote did not send all necessary objects"
 msgstr ""
 
-#: fetch-pack.c:2010
+#: fetch-pack.c:2056
+msgid "unexpected 'ready' from remote"
+msgstr ""
+
+#: fetch-pack.c:2079
 #, c-format
 msgid "no such remote ref %s"
 msgstr ""
 
-#: fetch-pack.c:2013
+#: fetch-pack.c:2082
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr ""
@@ -3996,24 +4140,24 @@ msgstr ""
 msgid "ignore invalid color '%.*s' in log.graphColors"
 msgstr ""
 
-#: grep.c:543
+#: grep.c:531
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
 msgstr ""
 
-#: grep.c:1906
+#: grep.c:1893
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr ""
 
-#: grep.c:1923 setup.c:176 builtin/clone.c:412 builtin/diff.c:90
-#: builtin/rm.c:135
+#: grep.c:1910 setup.c:176 builtin/clone.c:416 builtin/diff.c:90
+#: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr ""
 
-#: grep.c:1934
+#: grep.c:1921
 #, c-format
 msgid "'%s': short read"
 msgstr ""
@@ -4215,47 +4359,52 @@ msgstr ""
 msgid "name consists only of disallowed characters: %s"
 msgstr ""
 
-#: ident.c:454 builtin/commit.c:634
+#: ident.c:454 builtin/commit.c:647
 #, c-format
 msgid "invalid date format: %s"
 msgstr ""
 
-#: list-objects-filter-options.c:81
+#: list-objects-filter-options.c:83
 msgid "expected 'tree:<depth>'"
 msgstr ""
 
-#: list-objects-filter-options.c:96
+#: list-objects-filter-options.c:98
 msgid "sparse:path filters support has been dropped"
 msgstr ""
 
-#: list-objects-filter-options.c:109
+#: list-objects-filter-options.c:105
+#, c-format
+msgid "'%s' for 'object:type=<type>' isnot a valid object type"
+msgstr ""
+
+#: list-objects-filter-options.c:124
 #, c-format
 msgid "invalid filter-spec '%s'"
 msgstr ""
 
-#: list-objects-filter-options.c:125
+#: list-objects-filter-options.c:140
 #, c-format
 msgid "must escape char in sub-filter-spec: '%c'"
 msgstr ""
 
-#: list-objects-filter-options.c:167
+#: list-objects-filter-options.c:182
 msgid "expected something after combine:"
 msgstr ""
 
-#: list-objects-filter-options.c:249
+#: list-objects-filter-options.c:264
 msgid "multiple filter-specs cannot be combined"
 msgstr ""
 
-#: list-objects-filter-options.c:361
+#: list-objects-filter-options.c:376
 msgid "unable to upgrade repository format to support partial clone"
 msgstr ""
 
-#: list-objects-filter.c:492
+#: list-objects-filter.c:532
 #, c-format
 msgid "unable to access sparse blob in '%s'"
 msgstr ""
 
-#: list-objects-filter.c:495
+#: list-objects-filter.c:535
 #, c-format
 msgid "unable to parse sparse filter data in %s"
 msgstr ""
@@ -4270,7 +4419,7 @@ msgstr ""
 msgid "entry '%s' in tree %s has blob mode, but is not a blob"
 msgstr ""
 
-#: list-objects.c:375
+#: list-objects.c:395
 #, c-format
 msgid "unable to load root tree for commit %s"
 msgstr ""
@@ -4301,38 +4450,48 @@ msgstr ""
 msgid "expected flush after ls-refs arguments"
 msgstr ""
 
-#: merge-ort.c:888 merge-recursive.c:1191
+#: mailinfo.c:1050
+msgid "quoted CRLF detected"
+msgstr ""
+
+#: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
+#, c-format
+msgid "bad action '%s' for '%s'"
+msgstr ""
+
+#: merge-ort.c:1116 merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr ""
 
-#: merge-ort.c:897 merge-recursive.c:1198
+#: merge-ort.c:1125 merge-recursive.c:1212
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr ""
 
-#: merge-ort.c:906 merge-recursive.c:1205
+#: merge-ort.c:1134 merge-recursive.c:1219
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 
-#: merge-ort.c:916 merge-ort.c:923
+#: merge-ort.c:1144 merge-ort.c:1151
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr ""
 
-#: merge-ort.c:944
+#: merge-ort.c:1172
+#, c-format
 msgid "Failed to merge submodule %s"
 msgstr ""
 
-#: merge-ort.c:951
+#: merge-ort.c:1179
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
 "%s\n"
 msgstr ""
 
-#: merge-ort.c:955 merge-recursive.c:1259
+#: merge-ort.c:1183 merge-recursive.c:1273
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4343,42 +4502,42 @@ msgid ""
 "which will accept this suggestion.\n"
 msgstr ""
 
-#: merge-ort.c:968
+#: merge-ort.c:1196
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
 
-#: merge-ort.c:1127 merge-recursive.c:1341
+#: merge-ort.c:1415 merge-recursive.c:1362
 msgid "Failed to execute internal merge"
 msgstr ""
 
-#: merge-ort.c:1132 merge-recursive.c:1346
+#: merge-ort.c:1420 merge-recursive.c:1367
 #, c-format
 msgid "Unable to add %s to database"
 msgstr ""
 
-#: merge-ort.c:1139 merge-recursive.c:1378
+#: merge-ort.c:1427 merge-recursive.c:1400
 #, c-format
 msgid "Auto-merging %s"
 msgstr ""
 
-#: merge-ort.c:1278 merge-recursive.c:2100
+#: merge-ort.c:1566 merge-recursive.c:2122
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
 "implicit directory rename(s) putting the following path(s) there: %s."
 msgstr ""
 
-#: merge-ort.c:1288 merge-recursive.c:2110
+#: merge-ort.c:1576 merge-recursive.c:2132
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
 "implicit directory renames tried to put these paths there: %s"
 msgstr ""
 
-#: merge-ort.c:1471
+#: merge-ort.c:1634
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4386,47 +4545,47 @@ msgid ""
 "majority of the files."
 msgstr ""
 
-#: merge-ort.c:1637 merge-recursive.c:2447
+#: merge-ort.c:1788 merge-recursive.c:2468
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
 "renamed."
 msgstr ""
 
-#: merge-ort.c:1781 merge-recursive.c:3215
+#: merge-ort.c:1932 merge-recursive.c:3244
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
 "moving it to %s."
 msgstr ""
 
-#: merge-ort.c:1788 merge-recursive.c:3222
+#: merge-ort.c:1939 merge-recursive.c:3251
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
 "%s; moving it to %s."
 msgstr ""
 
-#: merge-ort.c:1801 merge-recursive.c:3218
+#: merge-ort.c:1952 merge-recursive.c:3247
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
 "in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
 
-#: merge-ort.c:1809 merge-recursive.c:3225
+#: merge-ort.c:1960 merge-recursive.c:3254
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
 "was renamed in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
 
-#: merge-ort.c:1952
+#: merge-ort.c:2103
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 
-#: merge-ort.c:2047
+#: merge-ort.c:2198
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4434,76 +4593,91 @@ msgid ""
 "markers."
 msgstr ""
 
-#: merge-ort.c:2066 merge-ort.c:2090
+#: merge-ort.c:2217 merge-ort.c:2241
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 
-#: merge-ort.c:2735
+#: merge-ort.c:2550 merge-recursive.c:3002
+#, c-format
+msgid "cannot read object %s"
+msgstr ""
+
+#: merge-ort.c:2553 merge-recursive.c:3005
+#, c-format
+msgid "object %s is not a blob"
+msgstr ""
+
+#: merge-ort.c:2981
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
 msgstr ""
 
-#: merge-ort.c:2808
+#: merge-ort.c:3055
 #, c-format
 msgid ""
-"CONFLICT (distinct types): %s had different types on each side; renamed %s "
+"CONFLICT (distinct types): %s had different types on each side; renamed both "
 "of them so each can be recorded somewhere."
 msgstr ""
 
-#: merge-ort.c:2812
-msgid "both"
+#: merge-ort.c:3062
+#, c-format
+msgid ""
+"CONFLICT (distinct types): %s had different types on each side; renamed one "
+"of them so each can be recorded somewhere."
 msgstr ""
 
-#: merge-ort.c:2812
-msgid "one"
-msgstr ""
-
-#: merge-ort.c:2907 merge-recursive.c:3052
+#: merge-ort.c:3162 merge-recursive.c:3081
 msgid "content"
 msgstr ""
 
-#: merge-ort.c:2909 merge-recursive.c:3056
+#: merge-ort.c:3164 merge-recursive.c:3085
 msgid "add/add"
 msgstr ""
 
-#: merge-ort.c:2911 merge-recursive.c:3101
+#: merge-ort.c:3166 merge-recursive.c:3130
 msgid "submodule"
 msgstr ""
 
-#: merge-ort.c:2913 merge-recursive.c:3102
+#: merge-ort.c:3168 merge-recursive.c:3131
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr ""
 
-#: merge-ort.c:2938
+#: merge-ort.c:3198
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
 "of %s left in tree."
 msgstr ""
 
+#: merge-ort.c:3433
+#, c-format
+msgid ""
+"Note: %s not up to date and in way of checking out conflicted version; old "
+"copy renamed to %s"
+msgstr ""
+
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:3406
+#: merge-ort.c:3730
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3661
+#: merge-ort-wrappers.c:13 merge-recursive.c:3699
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "  %s"
 msgstr ""
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3436
-#, c-format
-msgid "Already up to date!"
-msgstr ""
+#: merge-ort-wrappers.c:33 merge-recursive.c:3465 builtin/merge.c:402
+msgid "Already up to date."
+msgstr "Sudah terbaru."
 
 #: merge-recursive.c:356
 msgid "(bad commit)\n"
@@ -4519,162 +4693,162 @@ msgstr ""
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
 
-#: merge-recursive.c:874
+#: merge-recursive.c:876
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr ""
 
-#: merge-recursive.c:885
+#: merge-recursive.c:887
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr ""
 
-#: merge-recursive.c:899 merge-recursive.c:918
+#: merge-recursive.c:901 merge-recursive.c:920
 msgid ": perhaps a D/F conflict?"
 msgstr ""
 
-#: merge-recursive.c:908
+#: merge-recursive.c:910
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr ""
 
-#: merge-recursive.c:949 builtin/cat-file.c:41
+#: merge-recursive.c:951 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr ""
 
-#: merge-recursive.c:954
+#: merge-recursive.c:956
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr ""
 
-#: merge-recursive.c:979
+#: merge-recursive.c:981
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr ""
 
-#: merge-recursive.c:990
+#: merge-recursive.c:992
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr ""
 
-#: merge-recursive.c:995
+#: merge-recursive.c:997
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr ""
 
-#: merge-recursive.c:1213 merge-recursive.c:1225
+#: merge-recursive.c:1227 merge-recursive.c:1239
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr ""
 
-#: merge-recursive.c:1216 merge-recursive.c:1228
+#: merge-recursive.c:1230 merge-recursive.c:1242
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr ""
 
-#: merge-recursive.c:1251
+#: merge-recursive.c:1265
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 
-#: merge-recursive.c:1255
+#: merge-recursive.c:1269
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr ""
 
-#: merge-recursive.c:1256
+#: merge-recursive.c:1270
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr ""
 
-#: merge-recursive.c:1268
+#: merge-recursive.c:1282
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr ""
 
-#: merge-recursive.c:1402
+#: merge-recursive.c:1424
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
 
-#: merge-recursive.c:1474
+#: merge-recursive.c:1496
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
 "in tree."
 msgstr ""
 
-#: merge-recursive.c:1479
+#: merge-recursive.c:1501
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
 "left in tree."
 msgstr ""
 
-#: merge-recursive.c:1486
+#: merge-recursive.c:1508
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
 "in tree at %s."
 msgstr ""
 
-#: merge-recursive.c:1491
+#: merge-recursive.c:1513
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
 "left in tree at %s."
 msgstr ""
 
-#: merge-recursive.c:1526
+#: merge-recursive.c:1548
 msgid "rename"
 msgstr ""
 
-#: merge-recursive.c:1526
+#: merge-recursive.c:1548
 msgid "renamed"
 msgstr ""
 
-#: merge-recursive.c:1577 merge-recursive.c:2484 merge-recursive.c:3129
+#: merge-recursive.c:1599 merge-recursive.c:2505 merge-recursive.c:3158
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr ""
 
-#: merge-recursive.c:1587
+#: merge-recursive.c:1609
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 
-#: merge-recursive.c:1645
+#: merge-recursive.c:1667
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 
-#: merge-recursive.c:1676
+#: merge-recursive.c:1698
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr ""
 
-#: merge-recursive.c:1681
+#: merge-recursive.c:1703
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
 
-#: merge-recursive.c:1708
+#: merge-recursive.c:1730
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
 "\"->\"%s\" in \"%s\"%s"
 msgstr ""
 
-#: merge-recursive.c:1713
+#: merge-recursive.c:1735
 msgid " (left unresolved)"
 msgstr ""
 
-#: merge-recursive.c:1805
+#: merge-recursive.c:1827
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 
-#: merge-recursive.c:2068
+#: merge-recursive.c:2090
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -4682,96 +4856,86 @@ msgid ""
 "getting a majority of the files."
 msgstr ""
 
-#: merge-recursive.c:2202
+#: merge-recursive.c:2224
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
 ">%s in %s"
 msgstr ""
 
-#: merge-recursive.c:2973
-#, c-format
-msgid "cannot read object %s"
-msgstr ""
-
-#: merge-recursive.c:2976
-#, c-format
-msgid "object %s is not a blob"
-msgstr ""
-
-#: merge-recursive.c:3040
+#: merge-recursive.c:3069
 msgid "modify"
 msgstr ""
 
-#: merge-recursive.c:3040
+#: merge-recursive.c:3069
 msgid "modified"
 msgstr ""
 
-#: merge-recursive.c:3079
+#: merge-recursive.c:3108
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr ""
 
-#: merge-recursive.c:3132
+#: merge-recursive.c:3161
 #, c-format
 msgid "Adding as %s instead"
 msgstr ""
 
-#: merge-recursive.c:3339
+#: merge-recursive.c:3368
 #, c-format
 msgid "Removing %s"
 msgstr ""
 
-#: merge-recursive.c:3362
+#: merge-recursive.c:3391
 msgid "file/directory"
 msgstr ""
 
-#: merge-recursive.c:3367
+#: merge-recursive.c:3396
 msgid "directory/file"
 msgstr ""
 
-#: merge-recursive.c:3374
+#: merge-recursive.c:3403
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 
-#: merge-recursive.c:3383
+#: merge-recursive.c:3412
 #, c-format
 msgid "Adding %s"
 msgstr ""
 
-#: merge-recursive.c:3392
+#: merge-recursive.c:3421
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr ""
 
-#: merge-recursive.c:3445
+#: merge-recursive.c:3474
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr ""
 
-#: merge-recursive.c:3539
+#: merge-recursive.c:3568
 msgid "Merging:"
 msgstr ""
 
-#: merge-recursive.c:3552
+#: merge-recursive.c:3581
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: merge-recursive.c:3602
+#: merge-recursive.c:3631
 msgid "merge returned no commit"
 msgstr ""
 
-#: merge-recursive.c:3758
+#: merge-recursive.c:3796
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr ""
 
-#: merge-recursive.c:3776 builtin/merge.c:712 builtin/merge.c:896
-#: builtin/stash.c:471
+#: merge-recursive.c:3814 builtin/merge.c:716 builtin/merge.c:900
+#: builtin/stash.c:473
 msgid "Unable to write index."
 msgstr ""
 
@@ -4779,176 +4943,195 @@ msgstr ""
 msgid "failed to read the cache"
 msgstr ""
 
-#: merge.c:109 rerere.c:704 builtin/am.c:1883 builtin/am.c:1917
-#: builtin/checkout.c:575 builtin/checkout.c:828 builtin/clone.c:817
-#: builtin/stash.c:265
+#: merge.c:109 rerere.c:704 builtin/am.c:1931 builtin/am.c:1965
+#: builtin/checkout.c:595 builtin/checkout.c:849 builtin/clone.c:821
+#: builtin/stash.c:267
 msgid "unable to write new index file"
 msgstr ""
 
-#: midx.c:62
+#: midx.c:74
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr ""
 
-#: midx.c:93
+#: midx.c:105
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr ""
 
-#: midx.c:109
+#: midx.c:121
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 
-#: midx.c:114
+#: midx.c:126
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr ""
 
-#: midx.c:119
+#: midx.c:131
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 
-#: midx.c:136
+#: midx.c:148
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr ""
 
-#: midx.c:138
+#: midx.c:150
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr ""
 
-#: midx.c:140
+#: midx.c:152
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr ""
 
-#: midx.c:142
+#: midx.c:154
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr ""
 
-#: midx.c:158
+#: midx.c:170
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 
-#: midx.c:202
+#: midx.c:214
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr ""
 
-#: midx.c:252
+#: midx.c:264
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 
-#: midx.c:467
+#: midx.c:490
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr ""
 
-#: midx.c:473
+#: midx.c:496
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr ""
 
-#: midx.c:533
+#: midx.c:564
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr ""
 
-#: midx.c:821
+#: midx.c:880 builtin/index-pack.c:1535
+msgid "cannot store reverse index file"
+msgstr "tidak dapat menyimpan berkas indeks balik"
+
+#: midx.c:933
 msgid "Adding packfiles to multi-pack-index"
 msgstr ""
 
-#: midx.c:855
+#: midx.c:979
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr ""
 
-#: midx.c:904
+#: midx.c:1024
+#, c-format
+msgid "unknown preferred pack: '%s'"
+msgstr ""
+
+#: midx.c:1029
+#, c-format
+msgid "preferred pack '%s' is expired"
+msgstr ""
+
+#: midx.c:1045
 msgid "no pack files to index."
 msgstr ""
 
-#: midx.c:965
+#: midx.c:1125 builtin/clean.c:37
+#, c-format
+msgid "failed to remove %s"
+msgstr "gagal menghapus %s"
+
+#: midx.c:1156
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr ""
 
-#: midx.c:1021
+#: midx.c:1214
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr ""
 
-#: midx.c:1029
+#: midx.c:1222
 msgid "Looking for referenced packfiles"
 msgstr ""
 
-#: midx.c:1044
+#: midx.c:1237
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 
-#: midx.c:1049
+#: midx.c:1242
 msgid "the midx contains no oid"
 msgstr ""
 
-#: midx.c:1058
+#: midx.c:1251
 msgid "Verifying OID order in multi-pack-index"
 msgstr ""
 
-#: midx.c:1067
+#: midx.c:1260
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr ""
 
-#: midx.c:1087
+#: midx.c:1280
 msgid "Sorting objects by packfile"
 msgstr ""
 
-#: midx.c:1094
+#: midx.c:1287
 msgid "Verifying object offsets"
 msgstr ""
 
-#: midx.c:1110
+#: midx.c:1303
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr ""
 
-#: midx.c:1116
+#: midx.c:1309
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr ""
 
-#: midx.c:1125
+#: midx.c:1318
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr ""
 
-#: midx.c:1150
+#: midx.c:1343
 msgid "Counting referenced objects"
 msgstr ""
 
-#: midx.c:1160
+#: midx.c:1353
 msgid "Finding and deleting unreferenced packfiles"
 msgstr ""
 
-#: midx.c:1351
+#: midx.c:1544
 msgid "could not start pack-objects"
 msgstr ""
 
-#: midx.c:1371
+#: midx.c:1564
 msgid "could not finish pack-objects"
 msgstr ""
 
-#: name-hash.c:538
+#: name-hash.c:542
 #, c-format
 msgid "unable to create lazy_dir thread: %s"
 msgstr ""
 
-#: name-hash.c:560
+#: name-hash.c:564
 #, c-format
 msgid "unable to create lazy_name thread: %s"
 msgstr ""
 
-#: name-hash.c:566
+#: name-hash.c:570
 #, c-format
 msgid "unable to join lazy_name thread: %s"
 msgstr ""
@@ -4989,256 +5172,256 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr ""
 
-#: object-file.c:480
+#: object-file.c:526
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 
-#: object-file.c:531
+#: object-file.c:577
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr ""
 
-#: object-file.c:603
+#: object-file.c:649
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr ""
 
-#: object-file.c:610
+#: object-file.c:656
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr ""
 
-#: object-file.c:653
+#: object-file.c:699
 msgid "unable to fdopen alternates lockfile"
 msgstr ""
 
-#: object-file.c:671
+#: object-file.c:717
 msgid "unable to read alternates file"
 msgstr ""
 
-#: object-file.c:678
+#: object-file.c:724
 msgid "unable to move new alternates file into place"
 msgstr ""
 
-#: object-file.c:713
+#: object-file.c:759
 #, c-format
 msgid "path '%s' does not exist"
 msgstr ""
 
-#: object-file.c:734
+#: object-file.c:780
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 
-#: object-file.c:740
+#: object-file.c:786
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr ""
 
-#: object-file.c:746
+#: object-file.c:792
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr ""
 
-#: object-file.c:754
+#: object-file.c:800
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr ""
 
-#: object-file.c:814
+#: object-file.c:860
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr ""
 
-#: object-file.c:964
+#: object-file.c:1010
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr ""
 
-#: object-file.c:985
+#: object-file.c:1031
 msgid "mmap failed"
 msgstr ""
 
-#: object-file.c:1149
+#: object-file.c:1195
 #, c-format
 msgid "object file %s is empty"
 msgstr ""
 
-#: object-file.c:1284 object-file.c:2477
+#: object-file.c:1330 object-file.c:2524
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr ""
 
-#: object-file.c:1286 object-file.c:2481
+#: object-file.c:1332 object-file.c:2528
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr ""
 
-#: object-file.c:1328
+#: object-file.c:1374
 msgid "invalid object type"
 msgstr ""
 
-#: object-file.c:1412
+#: object-file.c:1458
 #, c-format
 msgid "unable to unpack %s header with --allow-unknown-type"
 msgstr ""
 
-#: object-file.c:1415
+#: object-file.c:1461
 #, c-format
 msgid "unable to unpack %s header"
 msgstr ""
 
-#: object-file.c:1421
+#: object-file.c:1467
 #, c-format
 msgid "unable to parse %s header with --allow-unknown-type"
 msgstr ""
 
-#: object-file.c:1424
+#: object-file.c:1470
 #, c-format
 msgid "unable to parse %s header"
 msgstr ""
 
-#: object-file.c:1651
+#: object-file.c:1697
 #, c-format
 msgid "failed to read object %s"
 msgstr ""
 
-#: object-file.c:1655
+#: object-file.c:1701
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr ""
 
-#: object-file.c:1659
+#: object-file.c:1705
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr ""
 
-#: object-file.c:1663
+#: object-file.c:1709
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr ""
 
-#: object-file.c:1768
+#: object-file.c:1814
 #, c-format
 msgid "unable to write file %s"
 msgstr ""
 
-#: object-file.c:1775
+#: object-file.c:1821
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr ""
 
-#: object-file.c:1782
+#: object-file.c:1828
 msgid "file write error"
 msgstr ""
 
-#: object-file.c:1802
+#: object-file.c:1848
 msgid "error when closing loose object file"
 msgstr ""
 
-#: object-file.c:1867
+#: object-file.c:1913
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 
-#: object-file.c:1869
+#: object-file.c:1915
 msgid "unable to create temporary file"
 msgstr ""
 
-#: object-file.c:1893
+#: object-file.c:1939
 msgid "unable to write loose object file"
 msgstr ""
 
-#: object-file.c:1899
+#: object-file.c:1945
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr ""
 
-#: object-file.c:1903
+#: object-file.c:1949
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr ""
 
-#: object-file.c:1907
+#: object-file.c:1953
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr ""
 
-#: object-file.c:1917 builtin/pack-objects.c:1097
+#: object-file.c:1963 builtin/pack-objects.c:1097
 #, c-format
 msgid "failed utime() on %s"
 msgstr ""
 
-#: object-file.c:1994
+#: object-file.c:2040
 #, c-format
 msgid "cannot read object for %s"
 msgstr ""
 
-#: object-file.c:2045
+#: object-file.c:2091
 msgid "corrupt commit"
 msgstr ""
 
-#: object-file.c:2053
+#: object-file.c:2099
 msgid "corrupt tag"
 msgstr ""
 
-#: object-file.c:2153
+#: object-file.c:2199
 #, c-format
 msgid "read error while indexing %s"
 msgstr ""
 
-#: object-file.c:2156
+#: object-file.c:2202
 #, c-format
 msgid "short read while indexing %s"
 msgstr ""
 
-#: object-file.c:2229 object-file.c:2239
+#: object-file.c:2275 object-file.c:2285
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr ""
 
-#: object-file.c:2245
+#: object-file.c:2291
 #, c-format
 msgid "%s: unsupported file type"
 msgstr ""
 
-#: object-file.c:2269
+#: object-file.c:2315
 #, c-format
 msgid "%s is not a valid object"
 msgstr ""
 
-#: object-file.c:2271
+#: object-file.c:2317
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr ""
 
-#: object-file.c:2298 builtin/index-pack.c:192
+#: object-file.c:2344 builtin/index-pack.c:192
 #, c-format
 msgid "unable to open %s"
 msgstr "tidak dapat membuka %s"
 
-#: object-file.c:2488 object-file.c:2541
+#: object-file.c:2535 object-file.c:2588
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr ""
 
-#: object-file.c:2512
+#: object-file.c:2559
 #, c-format
 msgid "unable to mmap %s"
 msgstr ""
 
-#: object-file.c:2517
+#: object-file.c:2564
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr ""
 
-#: object-file.c:2523
+#: object-file.c:2570
 #, c-format
 msgid "unable to parse header of %s"
 msgstr ""
 
-#: object-file.c:2534
+#: object-file.c:2581
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr ""
@@ -5335,69 +5518,71 @@ msgstr ""
 msgid "object %s is a %s, not a %s"
 msgstr ""
 
-#: object.c:233
+#: object.c:232
 #, c-format
 msgid "object %s has unknown type id %d"
 msgstr ""
 
-#: object.c:246
+#: object.c:245
 #, c-format
 msgid "unable to parse object: %s"
 msgstr ""
 
-#: object.c:266 object.c:278
+#: object.c:265 object.c:277
 #, c-format
 msgid "hash mismatch %s"
 msgstr ""
 
-#: pack-bitmap.c:843 pack-bitmap.c:849 builtin/pack-objects.c:2226
+#: pack-bitmap.c:844 pack-bitmap.c:850 builtin/pack-objects.c:2251
 #, c-format
 msgid "unable to get size of %s"
 msgstr ""
 
-#: pack-bitmap.c:1489 builtin/rev-list.c:92
+#: pack-bitmap.c:1547 builtin/rev-list.c:92
+#, c-format
 msgid "unable to get disk usage of %s"
 msgstr ""
 
-#: pack-revindex.c:220
+#: pack-revindex.c:221
 #, c-format
 msgid "reverse-index file %s is too small"
 msgstr ""
 
-#: pack-revindex.c:225
+#: pack-revindex.c:226
 #, c-format
 msgid "reverse-index file %s is corrupt"
 msgstr ""
 
-#: pack-revindex.c:233
+#: pack-revindex.c:234
 #, c-format
 msgid "reverse-index file %s has unknown signature"
 msgstr ""
 
-#: pack-revindex.c:237
+#: pack-revindex.c:238
 #, c-format
 msgid "reverse-index file %s has unsupported version %<PRIu32>"
 msgstr ""
 
-#: pack-revindex.c:242
+#: pack-revindex.c:243
 #, c-format
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
 msgstr ""
 
-#: pack-write.c:236
+#: pack-write.c:250
 msgid "cannot both write and verify reverse index"
 msgstr ""
 
-#: pack-write.c:257
+#: pack-write.c:271
+#, c-format
 msgid "could not stat: %s"
 msgstr ""
 
-#: pack-write.c:269
+#: pack-write.c:283
 #, c-format
 msgid "failed to make %s readable"
 msgstr ""
 
-#: pack-write.c:508
+#: pack-write.c:522
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr ""
@@ -5406,12 +5591,12 @@ msgstr ""
 msgid "offset before end of packfile (broken .idx?)"
 msgstr ""
 
-#: packfile.c:1934
+#: packfile.c:1937
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 
-#: packfile.c:1938
+#: packfile.c:1941
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
@@ -5476,31 +5661,31 @@ msgstr ""
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr ""
 
-#: parse-options.c:666 parse-options.c:971
+#: parse-options.c:668 parse-options.c:988
 #, c-format
 msgid "alias of --%s"
 msgstr ""
 
-#: parse-options.c:862
+#: parse-options.c:879
 #, c-format
 msgid "unknown option `%s'"
 msgstr ""
 
-#: parse-options.c:864
+#: parse-options.c:881
 #, c-format
 msgid "unknown switch `%c'"
 msgstr ""
 
-#: parse-options.c:866
+#: parse-options.c:883
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr ""
 
-#: parse-options.c:890
+#: parse-options.c:907
 msgid "..."
 msgstr ""
 
-#: parse-options.c:909
+#: parse-options.c:926
 #, c-format
 msgid "usage: %s"
 msgstr ""
@@ -5508,17 +5693,17 @@ msgstr ""
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:915
+#: parse-options.c:932
 #, c-format
 msgid "   or: %s"
 msgstr ""
 
-#: parse-options.c:918
+#: parse-options.c:935
 #, c-format
 msgid "    %s"
 msgstr ""
 
-#: parse-options.c:957
+#: parse-options.c:974
 msgid "-NUM"
 msgstr ""
 
@@ -5527,78 +5712,78 @@ msgstr ""
 msgid "Could not make %s writable by group"
 msgstr ""
 
-#: pathspec.c:130
+#: pathspec.c:151
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr ""
 
-#: pathspec.c:148
+#: pathspec.c:169
 msgid "Only one 'attr:' specification is allowed."
 msgstr ""
 
-#: pathspec.c:151
+#: pathspec.c:172
 msgid "attr spec must not be empty"
 msgstr ""
 
-#: pathspec.c:194
+#: pathspec.c:215
 #, c-format
 msgid "invalid attribute name %s"
 msgstr ""
 
-#: pathspec.c:259
+#: pathspec.c:280
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr ""
 
-#: pathspec.c:266
+#: pathspec.c:287
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
 msgstr ""
 
-#: pathspec.c:306
+#: pathspec.c:327
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr ""
 
-#: pathspec.c:327
+#: pathspec.c:348
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr ""
 
-#: pathspec.c:332
+#: pathspec.c:353
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr ""
 
-#: pathspec.c:370
+#: pathspec.c:391
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr ""
 
-#: pathspec.c:429
+#: pathspec.c:450
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr ""
 
-#: pathspec.c:445
+#: pathspec.c:466
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
 msgstr ""
 
-#: pathspec.c:521
+#: pathspec.c:542
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr ""
 
-#: pathspec.c:531
+#: pathspec.c:552
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr ""
 
-#: pathspec.c:598
+#: pathspec.c:619
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr ""
 
-#: pathspec.c:643
+#: pathspec.c:664
 #, c-format
 msgid "line is badly quoted: %s"
 msgstr ""
@@ -5619,7 +5804,7 @@ msgstr ""
 msgid "flush packet write failed"
 msgstr ""
 
-#: pkt-line.c:153 pkt-line.c:239
+#: pkt-line.c:153 pkt-line.c:265
 msgid "protocol error: impossibly long line"
 msgstr ""
 
@@ -5627,33 +5812,34 @@ msgstr ""
 msgid "packet write with format failed"
 msgstr ""
 
-#: pkt-line.c:203
+#: pkt-line.c:204
 msgid "packet write failed - data exceeds max packet size"
 msgstr ""
 
-#: pkt-line.c:210 pkt-line.c:217
-msgid "packet write failed"
+#: pkt-line.c:222
+#, c-format
+msgid "packet write failed: %s"
 msgstr ""
 
-#: pkt-line.c:302
+#: pkt-line.c:328 pkt-line.c:329
 msgid "read error"
 msgstr ""
 
-#: pkt-line.c:310
+#: pkt-line.c:339 pkt-line.c:340
 msgid "the remote end hung up unexpectedly"
 msgstr ""
 
-#: pkt-line.c:338
+#: pkt-line.c:369 pkt-line.c:371
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr ""
 
-#: pkt-line.c:352 pkt-line.c:357
+#: pkt-line.c:386 pkt-line.c:388 pkt-line.c:394 pkt-line.c:396
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr ""
 
-#: pkt-line.c:373 sideband.c:165
+#: pkt-line.c:413 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr ""
@@ -5667,7 +5853,7 @@ msgstr ""
 msgid "unable to create threaded lstat: %s"
 msgstr ""
 
-#: pretty.c:984
+#: pretty.c:988
 msgid "unable to parse --pretty format"
 msgstr ""
 
@@ -5688,6 +5874,10 @@ msgstr ""
 msgid "promisor remote name cannot begin with '/': %s"
 msgstr ""
 
+#: protocol-caps.c:103
+msgid "object-info: expected flush after arguments"
+msgstr ""
+
 #: prune-packed.c:35
 msgid "Removing duplicate objects"
 msgstr ""
@@ -5700,7 +5890,7 @@ msgstr ""
 msgid "could not read `log` output"
 msgstr ""
 
-#: range-diff.c:101 sequencer.c:5318
+#: range-diff.c:101 sequencer.c:5551
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr ""
@@ -5730,196 +5920,200 @@ msgstr ""
 msgid "could not parse log for '%s'"
 msgstr ""
 
-#: read-cache.c:682
+#: read-cache.c:708
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr ""
 
-#: read-cache.c:698
+#: read-cache.c:724
 msgid "cannot create an empty blob in the object database"
 msgstr ""
 
-#: read-cache.c:720
+#: read-cache.c:746
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 
-#: read-cache.c:725
+#: read-cache.c:751
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr ""
 
-#: read-cache.c:777
+#: read-cache.c:803
 #, c-format
 msgid "unable to index file '%s'"
 msgstr ""
 
-#: read-cache.c:796
+#: read-cache.c:822
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr ""
 
-#: read-cache.c:807
+#: read-cache.c:833
 #, c-format
 msgid "unable to stat '%s'"
 msgstr ""
 
-#: read-cache.c:1318
+#: read-cache.c:1356
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr ""
 
-#: read-cache.c:1532
+#: read-cache.c:1571
 msgid "Refresh index"
 msgstr ""
 
-#: read-cache.c:1657
+#: read-cache.c:1700
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1667
+#: read-cache.c:1710
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1723
+#: read-cache.c:1766
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr ""
 
-#: read-cache.c:1726
+#: read-cache.c:1769
 #, c-format
 msgid "bad index version %d"
 msgstr ""
 
-#: read-cache.c:1735
+#: read-cache.c:1778
 msgid "bad index file sha1 signature"
 msgstr ""
 
-#: read-cache.c:1765
+#: read-cache.c:1812
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr ""
 
-#: read-cache.c:1767
+#: read-cache.c:1814
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr ""
 
-#: read-cache.c:1804
+#: read-cache.c:1851
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr ""
 
-#: read-cache.c:1820
+#: read-cache.c:1867
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr ""
 
-#: read-cache.c:1877
+#: read-cache.c:1924
 msgid "unordered stage entries in index"
 msgstr ""
 
-#: read-cache.c:1880
+#: read-cache.c:1927
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr ""
 
-#: read-cache.c:1883
+#: read-cache.c:1930
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr ""
 
-#: read-cache.c:1989 read-cache.c:2280 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
-#: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
-#: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
-#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:290
+#: read-cache.c:2036 read-cache.c:2333 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1635 builtin/add.c:575 builtin/check-ignore.c:183
+#: builtin/checkout.c:522 builtin/checkout.c:711 builtin/clean.c:991
+#: builtin/commit.c:377 builtin/diff-tree.c:122 builtin/grep.c:505
+#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:291
 #: builtin/submodule--helper.c:332
 msgid "index file corrupt"
 msgstr ""
 
-#: read-cache.c:2133
+#: read-cache.c:2180
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2146
+#: read-cache.c:2193
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2179
+#: read-cache.c:2226
 #, c-format
 msgid "%s: index file open failed"
 msgstr ""
 
-#: read-cache.c:2183
+#: read-cache.c:2230
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr ""
 
-#: read-cache.c:2187
+#: read-cache.c:2234
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr ""
 
-#: read-cache.c:2191
+#: read-cache.c:2238
 #, c-format
 msgid "%s: unable to map index file"
 msgstr ""
 
-#: read-cache.c:2233
+#: read-cache.c:2280
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2260
+#: read-cache.c:2307
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2292
+#: read-cache.c:2345
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr ""
 
-#: read-cache.c:2339
+#: read-cache.c:2392
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr ""
 
-#: read-cache.c:3035 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
+#: read-cache.c:3095 strbuf.c:1173 wrapper.c:633 builtin/merge.c:1145
 #, c-format
 msgid "could not close '%s'"
 msgstr ""
 
-#: read-cache.c:3138 sequencer.c:2487 sequencer.c:4239
+#: read-cache.c:3138
+msgid "failed to convert to a sparse-index"
+msgstr ""
+
+#: read-cache.c:3209 sequencer.c:2684 sequencer.c:4441
 #, c-format
 msgid "could not stat '%s'"
 msgstr ""
 
-#: read-cache.c:3151
+#: read-cache.c:3222
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr ""
 
-#: read-cache.c:3163
+#: read-cache.c:3234
 #, c-format
 msgid "unable to unlink: %s"
 msgstr ""
 
-#: read-cache.c:3188
+#: read-cache.c:3263
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr ""
 
-#: read-cache.c:3337
+#: read-cache.c:3412
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr ""
@@ -5945,7 +6139,10 @@ msgid ""
 "r, reword <commit> = use commit, but edit the commit message\n"
 "e, edit <commit> = use commit, but stop for amending\n"
 "s, squash <commit> = use commit, but meld into previous commit\n"
-"f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
+"f, fixup [-C | -c] <commit> = like \"squash\" but keep only the previous\n"
+"                   commit's log message, unless -C is used, in which case\n"
+"                   keep only this commit's message; -c is same as -C but\n"
+"                   opens the editor\n"
 "x, exec <command> = run command (the rest of the line) using shell\n"
 "b, break = stop here (continue rebase later with 'git rebase --continue')\n"
 "d, drop <commit> = remove commit\n"
@@ -5954,31 +6151,31 @@ msgid ""
 "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
 ".       create a merge commit using the original merge commit's\n"
 ".       message (or the oneline, if no original merge commit was\n"
-".       specified). Use -c <commit> to reword the commit message.\n"
+".       specified); use -c <commit> to reword the commit message\n"
 "\n"
 "These lines can be re-ordered; they are executed from top to bottom.\n"
 msgstr ""
 
-#: rebase-interactive.c:63
+#: rebase-interactive.c:66
 #, c-format
 msgid "Rebase %s onto %s (%d command)"
 msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: rebase-interactive.c:72 git-rebase--preserve-merges.sh:218
+#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:218
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
 msgstr ""
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:222
+#: rebase-interactive.c:78 git-rebase--preserve-merges.sh:222
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
 msgstr ""
 
-#: rebase-interactive.c:81 git-rebase--preserve-merges.sh:861
+#: rebase-interactive.c:84 git-rebase--preserve-merges.sh:861
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -5987,33 +6184,33 @@ msgid ""
 "\n"
 msgstr ""
 
-#: rebase-interactive.c:86 git-rebase--preserve-merges.sh:938
+#: rebase-interactive.c:89 git-rebase--preserve-merges.sh:938
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
 "\n"
 msgstr ""
 
-#: rebase-interactive.c:110 rerere.c:469 rerere.c:676 sequencer.c:3615
-#: sequencer.c:3641 sequencer.c:5424 builtin/fsck.c:329 builtin/rebase.c:272
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3816
+#: sequencer.c:3842 sequencer.c:5657 builtin/fsck.c:327 builtin/rebase.c:271
 #, c-format
 msgid "could not write '%s'"
 msgstr ""
 
-#: rebase-interactive.c:116 builtin/rebase.c:204 builtin/rebase.c:230
-#: builtin/rebase.c:254
+#: rebase-interactive.c:119 builtin/rebase.c:203 builtin/rebase.c:229
+#: builtin/rebase.c:253
 #, c-format
 msgid "could not write '%s'."
 msgstr ""
 
-#: rebase-interactive.c:193
+#: rebase-interactive.c:196
 #, c-format
 msgid ""
 "Warning: some commits may have been dropped accidentally.\n"
 "Dropped commits (newer to older):\n"
 msgstr ""
 
-#: rebase-interactive.c:200
+#: rebase-interactive.c:203
 #, c-format
 msgid ""
 "To avoid this message, use \"drop\" to explicitly remove a commit.\n"
@@ -6024,14 +6221,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2402
-#: builtin/rebase.c:190 builtin/rebase.c:215 builtin/rebase.c:241
-#: builtin/rebase.c:266
+#: rebase-interactive.c:236 rebase-interactive.c:241 sequencer.c:2597
+#: builtin/rebase.c:189 builtin/rebase.c:214 builtin/rebase.c:240
+#: builtin/rebase.c:265
 #, c-format
 msgid "could not read '%s'."
 msgstr ""
 
-#: ref-filter.c:42 wt-status.c:1975
+#: ref-filter.c:42 wt-status.c:1978
 msgid "gone"
 msgstr ""
 
@@ -6186,110 +6383,111 @@ msgstr ""
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr ""
 
-#: ref-filter.c:806
+#: ref-filter.c:807
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr ""
 
-#: ref-filter.c:808
+#: ref-filter.c:809
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr ""
 
-#: ref-filter.c:810
+#: ref-filter.c:811
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr ""
 
-#: ref-filter.c:838
+#: ref-filter.c:839
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr ""
 
-#: ref-filter.c:840
+#: ref-filter.c:841
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr ""
 
-#: ref-filter.c:842
+#: ref-filter.c:843
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr ""
 
-#: ref-filter.c:857
+#: ref-filter.c:858
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr ""
 
-#: ref-filter.c:914
+#: ref-filter.c:915
 #, c-format
 msgid "malformed format string %s"
 msgstr ""
 
-#: ref-filter.c:1555
+#: ref-filter.c:1556
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr ""
 
-#: ref-filter.c:1558
+#: ref-filter.c:1559
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr ""
 
-#: ref-filter.c:1561
+#: ref-filter.c:1562
+#, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr ""
 
-#: ref-filter.c:1565
+#: ref-filter.c:1566
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr ""
 
-#: ref-filter.c:1568
+#: ref-filter.c:1569
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr ""
 
-#: ref-filter.c:1571
+#: ref-filter.c:1572
 msgid "(no branch)"
 msgstr ""
 
-#: ref-filter.c:1603 ref-filter.c:1812
+#: ref-filter.c:1604 ref-filter.c:1813
 #, c-format
 msgid "missing object %s for %s"
 msgstr ""
 
-#: ref-filter.c:1613
+#: ref-filter.c:1614
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr ""
 
-#: ref-filter.c:1996
+#: ref-filter.c:1997
 #, c-format
 msgid "malformed object at '%s'"
 msgstr ""
 
-#: ref-filter.c:2085
+#: ref-filter.c:2086
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr ""
 
-#: ref-filter.c:2090 refs.c:676
+#: ref-filter.c:2091 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr ""
 
-#: ref-filter.c:2430
+#: ref-filter.c:2431
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr ""
 
-#: ref-filter.c:2529
+#: ref-filter.c:2525
 #, c-format
 msgid "malformed object name %s"
 msgstr ""
 
-#: ref-filter.c:2534
+#: ref-filter.c:2530
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr ""
@@ -6730,8 +6928,8 @@ msgstr ""
 msgid "Recorded preimage for '%s'"
 msgstr ""
 
-#: rerere.c:865 submodule.c:2088 builtin/log.c:1991
-#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:1890
+#: rerere.c:865 submodule.c:2089 builtin/log.c:2000
+#: builtin/submodule--helper.c:1879 builtin/submodule--helper.c:1891
 #, c-format
 msgid "could not create directory '%s'"
 msgstr ""
@@ -6767,27 +6965,27 @@ msgstr ""
 
 #: reset.c:42
 msgid "could not determine HEAD revision"
-msgstr ""
+msgstr "tidak dapat menentukan revisi HEAD"
 
-#: reset.c:70 reset.c:76 sequencer.c:3468
+#: reset.c:70 reset.c:76 sequencer.c:3669
 #, c-format
 msgid "failed to find tree of %s"
-msgstr ""
+msgstr "gagal menemukan pohon %s"
 
-#: revision.c:2338
+#: revision.c:2343
 msgid "--unpacked=<packfile> no longer supported"
 msgstr ""
 
-#: revision.c:2668
+#: revision.c:2683
 msgid "your current branch appears to be broken"
 msgstr ""
 
-#: revision.c:2671
+#: revision.c:2686
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr ""
 
-#: revision.c:2877
+#: revision.c:2892
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr ""
 
@@ -6795,140 +6993,148 @@ msgstr ""
 msgid "open /dev/null failed"
 msgstr ""
 
-#: run-command.c:1274
+#: run-command.c:1275
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr ""
 
-#: run-command.c:1338
+#: run-command.c:1345
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
 "You can disable this warning with `git config advice.ignoredHook false`."
 msgstr ""
 
-#: send-pack.c:146
+#: send-pack.c:150
 msgid "unexpected flush packet while reading remote unpack status"
 msgstr ""
 
-#: send-pack.c:148
+#: send-pack.c:152
 #, c-format
 msgid "unable to parse remote unpack status: %s"
 msgstr ""
 
-#: send-pack.c:150
+#: send-pack.c:154
 #, c-format
 msgid "remote unpack failed: %s"
 msgstr ""
 
-#: send-pack.c:374
+#: send-pack.c:378
 msgid "failed to sign the push certificate"
 msgstr ""
 
-#: send-pack.c:467
+#: send-pack.c:433
+msgid "send-pack: unable to fork off fetch subprocess"
+msgstr ""
+
+#: send-pack.c:455
+msgid "push negotiation failed; proceeding anyway with push"
+msgstr ""
+
+#: send-pack.c:520
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr ""
 
-#: send-pack.c:476
+#: send-pack.c:529
 msgid "the receiving end does not support --signed push"
 msgstr ""
 
-#: send-pack.c:478
+#: send-pack.c:531
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
 msgstr ""
 
-#: send-pack.c:490
+#: send-pack.c:543
 msgid "the receiving end does not support --atomic push"
 msgstr ""
 
-#: send-pack.c:495
+#: send-pack.c:548
 msgid "the receiving end does not support push options"
 msgstr ""
 
-#: sequencer.c:195
+#: sequencer.c:196
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr ""
 
-#: sequencer.c:323
+#: sequencer.c:324
 #, c-format
 msgid "could not delete '%s'"
 msgstr ""
 
-#: sequencer.c:343 builtin/rebase.c:757 builtin/rebase.c:1602 builtin/rm.c:385
+#: sequencer.c:344 builtin/rebase.c:757 builtin/rebase.c:1592 builtin/rm.c:402
 #, c-format
 msgid "could not remove '%s'"
 msgstr ""
 
-#: sequencer.c:353
+#: sequencer.c:354
 msgid "revert"
 msgstr ""
 
-#: sequencer.c:355
+#: sequencer.c:356
 msgid "cherry-pick"
 msgstr ""
 
-#: sequencer.c:357
+#: sequencer.c:358
 msgid "rebase"
 msgstr ""
 
-#: sequencer.c:359
+#: sequencer.c:360
 #, c-format
 msgid "unknown action: %d"
 msgstr ""
 
-#: sequencer.c:418
+#: sequencer.c:419
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
 msgstr ""
 
-#: sequencer.c:421
+#: sequencer.c:422
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
 "and commit the result with 'git commit'"
 msgstr ""
 
-#: sequencer.c:434 sequencer.c:3070
+#: sequencer.c:435 sequencer.c:3271
 #, c-format
 msgid "could not lock '%s'"
 msgstr ""
 
-#: sequencer.c:436 sequencer.c:2869 sequencer.c:3074 sequencer.c:3088
-#: sequencer.c:3345 sequencer.c:5334 strbuf.c:1168 wrapper.c:631
+#: sequencer.c:437 sequencer.c:3070 sequencer.c:3275 sequencer.c:3289
+#: sequencer.c:3546 sequencer.c:5567 strbuf.c:1170 wrapper.c:631
 #, c-format
 msgid "could not write to '%s'"
 msgstr ""
 
-#: sequencer.c:441
+#: sequencer.c:442
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr ""
 
-#: sequencer.c:446 sequencer.c:2874 sequencer.c:3076 sequencer.c:3090
-#: sequencer.c:3353
+#: sequencer.c:447 sequencer.c:3075 sequencer.c:3277 sequencer.c:3291
+#: sequencer.c:3554
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr ""
 
-#: sequencer.c:485
+#: sequencer.c:486
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr ""
 
-#: sequencer.c:489
+#: sequencer.c:490
 msgid "commit your changes or stash them to proceed."
 msgstr ""
 
-#: sequencer.c:521
+#: sequencer.c:522
 #, c-format
 msgid "%s: fast-forward"
 msgstr ""
 
-#: sequencer.c:560 builtin/tag.c:598
+#: sequencer.c:561 builtin/tag.c:609
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr ""
@@ -6936,65 +7142,65 @@ msgstr ""
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:670
+#: sequencer.c:671
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr ""
 
-#: sequencer.c:684
+#: sequencer.c:685
 msgid "unable to update cache tree"
 msgstr ""
 
-#: sequencer.c:698
+#: sequencer.c:699
 msgid "could not resolve HEAD commit"
 msgstr ""
 
-#: sequencer.c:778
+#: sequencer.c:779
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr ""
 
-#: sequencer.c:789
+#: sequencer.c:790
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr ""
 
-#: sequencer.c:826 wrapper.c:201 wrapper.c:371 builtin/am.c:710
-#: builtin/am.c:802 builtin/merge.c:1136 builtin/rebase.c:910
+#: sequencer.c:827 wrapper.c:201 wrapper.c:371 builtin/am.c:728
+#: builtin/am.c:820 builtin/merge.c:1140 builtin/rebase.c:910
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr ""
 
-#: sequencer.c:836
+#: sequencer.c:837
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr ""
 
-#: sequencer.c:841
+#: sequencer.c:842
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr ""
 
-#: sequencer.c:846
+#: sequencer.c:847
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr ""
 
-#: sequencer.c:850
+#: sequencer.c:851
 #, c-format
 msgid "unknown variable '%s'"
 msgstr ""
 
-#: sequencer.c:855
+#: sequencer.c:856
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr ""
 
-#: sequencer.c:857
+#: sequencer.c:858
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr ""
 
-#: sequencer.c:859
+#: sequencer.c:860
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr ""
 
-#: sequencer.c:924
+#: sequencer.c:925
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7011,11 +7217,11 @@ msgid ""
 "  git rebase --continue\n"
 msgstr ""
 
-#: sequencer.c:1211
+#: sequencer.c:1212
 msgid "'prepare-commit-msg' hook failed"
 msgstr ""
 
-#: sequencer.c:1217
+#: sequencer.c:1218
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7030,7 +7236,7 @@ msgid ""
 "    git commit --amend --reset-author\n"
 msgstr ""
 
-#: sequencer.c:1230
+#: sequencer.c:1231
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7044,354 +7250,358 @@ msgid ""
 "    git commit --amend --reset-author\n"
 msgstr ""
 
-#: sequencer.c:1272
+#: sequencer.c:1273
 msgid "couldn't look up newly created commit"
 msgstr ""
 
-#: sequencer.c:1274
+#: sequencer.c:1275
 msgid "could not parse newly created commit"
 msgstr ""
 
-#: sequencer.c:1320
+#: sequencer.c:1321
 msgid "unable to resolve HEAD after creating commit"
 msgstr ""
 
-#: sequencer.c:1322
+#: sequencer.c:1323
 msgid "detached HEAD"
 msgstr ""
 
-#: sequencer.c:1326
+#: sequencer.c:1327
 msgid " (root-commit)"
 msgstr ""
 
-#: sequencer.c:1347
+#: sequencer.c:1348
 msgid "could not parse HEAD"
 msgstr ""
 
-#: sequencer.c:1349
+#: sequencer.c:1350
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr ""
 
-#: sequencer.c:1353 sequencer.c:1431 builtin/commit.c:1577
+#: sequencer.c:1354 sequencer.c:1432 builtin/commit.c:1692
 msgid "could not parse HEAD commit"
 msgstr ""
 
-#: sequencer.c:1409 sequencer.c:2108
+#: sequencer.c:1410 sequencer.c:2295
 msgid "unable to parse commit author"
 msgstr ""
 
-#: sequencer.c:1420 builtin/am.c:1566 builtin/merge.c:702
+#: sequencer.c:1421 builtin/am.c:1614 builtin/merge.c:706
 msgid "git write-tree failed to write a tree"
 msgstr ""
 
-#: sequencer.c:1453 sequencer.c:1573
+#: sequencer.c:1454 sequencer.c:1574
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr ""
 
-#: sequencer.c:1484 sequencer.c:1516
+#: sequencer.c:1485 sequencer.c:1517
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr ""
 
-#: sequencer.c:1490
+#: sequencer.c:1491
 msgid "corrupt author: missing date information"
 msgstr ""
 
-#: sequencer.c:1529 builtin/am.c:1593 builtin/commit.c:1678 builtin/merge.c:905
-#: builtin/merge.c:930 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1530 builtin/am.c:1641 builtin/commit.c:1806 builtin/merge.c:909
+#: builtin/merge.c:934 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr ""
 
-#: sequencer.c:1556 sequencer.c:4291 t/helper/test-fast-rebase.c:198
+#: sequencer.c:1557 sequencer.c:4493 t/helper/test-fast-rebase.c:198
 #, c-format
 msgid "could not update %s"
 msgstr ""
 
-#: sequencer.c:1605
+#: sequencer.c:1606
 #, c-format
 msgid "could not parse commit %s"
 msgstr ""
 
-#: sequencer.c:1610
+#: sequencer.c:1611
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr ""
 
-#: sequencer.c:1693 sequencer.c:1804
+#: sequencer.c:1694 sequencer.c:1975
 #, c-format
 msgid "unknown command: %d"
 msgstr ""
 
-#: sequencer.c:1751 sequencer.c:1776
-#, c-format
-msgid "This is a combination of %d commits."
-msgstr ""
-
-#: sequencer.c:1761
-msgid "need a HEAD to fixup"
-msgstr ""
-
-#: sequencer.c:1763 sequencer.c:3380
-msgid "could not read HEAD"
-msgstr ""
-
-#: sequencer.c:1765
-msgid "could not read HEAD's commit message"
-msgstr ""
-
-#: sequencer.c:1771
-#, c-format
-msgid "cannot write '%s'"
-msgstr ""
-
-#: sequencer.c:1778 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1736 git-rebase--preserve-merges.sh:486
 msgid "This is the 1st commit message:"
 msgstr ""
 
-#: sequencer.c:1786
-#, c-format
-msgid "could not read commit message of %s"
-msgstr ""
-
-#: sequencer.c:1793
+#: sequencer.c:1737
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr ""
 
-#: sequencer.c:1799
+#: sequencer.c:1738
+msgid "The 1st commit message will be skipped:"
+msgstr ""
+
+#: sequencer.c:1739
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr ""
 
-#: sequencer.c:1887
+#: sequencer.c:1740
+#, c-format
+msgid "This is a combination of %d commits."
+msgstr ""
+
+#: sequencer.c:1887 sequencer.c:1944
+#, c-format
+msgid "cannot write '%s'"
+msgstr ""
+
+#: sequencer.c:1934
+msgid "need a HEAD to fixup"
+msgstr ""
+
+#: sequencer.c:1936 sequencer.c:3581
+msgid "could not read HEAD"
+msgstr ""
+
+#: sequencer.c:1938
+msgid "could not read HEAD's commit message"
+msgstr ""
+
+#: sequencer.c:1962
+#, c-format
+msgid "could not read commit message of %s"
+msgstr ""
+
+#: sequencer.c:2072
 msgid "your index file is unmerged."
 msgstr ""
 
-#: sequencer.c:1894
+#: sequencer.c:2079
 msgid "cannot fixup root commit"
 msgstr ""
 
-#: sequencer.c:1913
+#: sequencer.c:2098
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr ""
 
-#: sequencer.c:1921 sequencer.c:1929
+#: sequencer.c:2106 sequencer.c:2114
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr ""
 
-#: sequencer.c:1935
+#: sequencer.c:2120
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr ""
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1954
+#: sequencer.c:2139
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr ""
 
-#: sequencer.c:2019
+#: sequencer.c:2205
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr ""
 
-#: sequencer.c:2079
+#: sequencer.c:2265
 #, c-format
 msgid "could not revert %s... %s"
 msgstr ""
 
-#: sequencer.c:2080
+#: sequencer.c:2266
 #, c-format
 msgid "could not apply %s... %s"
 msgstr ""
 
-#: sequencer.c:2100
+#: sequencer.c:2287
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr ""
 
-#: sequencer.c:2158
+#: sequencer.c:2345
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr ""
 
-#: sequencer.c:2165
+#: sequencer.c:2352
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr ""
 
-#: sequencer.c:2242
+#: sequencer.c:2425
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr ""
 
-#: sequencer.c:2251
+#: sequencer.c:2434
 #, c-format
 msgid "missing arguments for %s"
 msgstr ""
 
-#: sequencer.c:2282
+#: sequencer.c:2477
 #, c-format
 msgid "could not parse '%s'"
 msgstr ""
 
-#: sequencer.c:2343
+#: sequencer.c:2538
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr ""
 
-#: sequencer.c:2354
+#: sequencer.c:2549
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr ""
 
-#: sequencer.c:2440
+#: sequencer.c:2635
 msgid "cancelling a cherry picking in progress"
 msgstr ""
 
-#: sequencer.c:2449
+#: sequencer.c:2644
 msgid "cancelling a revert in progress"
 msgstr ""
 
-#: sequencer.c:2493
+#: sequencer.c:2690
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
 
-#: sequencer.c:2495
+#: sequencer.c:2692
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr ""
 
-#: sequencer.c:2500
+#: sequencer.c:2697
 msgid "no commits parsed."
 msgstr ""
 
-#: sequencer.c:2511
+#: sequencer.c:2708
 msgid "cannot cherry-pick during a revert."
 msgstr ""
 
-#: sequencer.c:2513
+#: sequencer.c:2710
 msgid "cannot revert during a cherry-pick."
 msgstr ""
 
-#: sequencer.c:2591
+#: sequencer.c:2788
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr ""
 
-#: sequencer.c:2698
+#: sequencer.c:2897
 msgid "unusable squash-onto"
 msgstr ""
 
-#: sequencer.c:2718
+#: sequencer.c:2917
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr ""
 
-#: sequencer.c:2811 sequencer.c:4644
+#: sequencer.c:3012 sequencer.c:4869
 msgid "empty commit set passed"
 msgstr ""
 
-#: sequencer.c:2828
+#: sequencer.c:3029
 msgid "revert is already in progress"
 msgstr ""
 
-#: sequencer.c:2830
+#: sequencer.c:3031
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr ""
 
-#: sequencer.c:2833
+#: sequencer.c:3034
 msgid "cherry-pick is already in progress"
 msgstr ""
 
-#: sequencer.c:2835
+#: sequencer.c:3036
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr ""
 
-#: sequencer.c:2849
+#: sequencer.c:3050
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr ""
 
-#: sequencer.c:2864
+#: sequencer.c:3065
 msgid "could not lock HEAD"
 msgstr ""
 
-#: sequencer.c:2924 sequencer.c:4379
+#: sequencer.c:3125 sequencer.c:4582
 msgid "no cherry-pick or revert in progress"
 msgstr ""
 
-#: sequencer.c:2926 sequencer.c:2937
+#: sequencer.c:3127 sequencer.c:3138
 msgid "cannot resolve HEAD"
 msgstr ""
 
-#: sequencer.c:2928 sequencer.c:2972
+#: sequencer.c:3129 sequencer.c:3173
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 
-#: sequencer.c:2958 builtin/grep.c:757
+#: sequencer.c:3159 builtin/grep.c:759
 #, c-format
 msgid "cannot open '%s'"
 msgstr ""
 
-#: sequencer.c:2960
+#: sequencer.c:3161
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr ""
 
-#: sequencer.c:2961
+#: sequencer.c:3162
 msgid "unexpected end of file"
 msgstr ""
 
-#: sequencer.c:2967
+#: sequencer.c:3168
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr ""
 
-#: sequencer.c:2978
+#: sequencer.c:3179
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 
-#: sequencer.c:3019
+#: sequencer.c:3220
 msgid "no revert in progress"
 msgstr ""
 
-#: sequencer.c:3028
+#: sequencer.c:3229
 msgid "no cherry-pick in progress"
 msgstr ""
 
-#: sequencer.c:3038
+#: sequencer.c:3239
 msgid "failed to skip the commit"
 msgstr ""
 
-#: sequencer.c:3045
+#: sequencer.c:3246
 msgid "there is nothing to skip"
 msgstr ""
 
-#: sequencer.c:3048
+#: sequencer.c:3249
 #, c-format
 msgid ""
 "have you committed already?\n"
 "try \"git %s --continue\""
 msgstr ""
 
-#: sequencer.c:3210 sequencer.c:4271
+#: sequencer.c:3411 sequencer.c:4473
 msgid "cannot read HEAD"
 msgstr ""
 
-#: sequencer.c:3227
+#: sequencer.c:3428
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr ""
 
-#: sequencer.c:3235
+#: sequencer.c:3436
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -7403,27 +7613,27 @@ msgid ""
 "  git rebase --continue\n"
 msgstr ""
 
-#: sequencer.c:3245
+#: sequencer.c:3446
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr ""
 
-#: sequencer.c:3252
+#: sequencer.c:3453
 #, c-format
 msgid "Could not merge %.*s"
 msgstr ""
 
-#: sequencer.c:3266 sequencer.c:3270 builtin/difftool.c:640
+#: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr ""
 
-#: sequencer.c:3282
+#: sequencer.c:3483
 #, c-format
 msgid "Executing: %s\n"
 msgstr ""
 
-#: sequencer.c:3297
+#: sequencer.c:3498
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -7433,11 +7643,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: sequencer.c:3303
+#: sequencer.c:3504
 msgid "and made changes to the index and/or the working tree\n"
 msgstr ""
 
-#: sequencer.c:3309
+#: sequencer.c:3510
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -7448,90 +7658,90 @@ msgid ""
 "\n"
 msgstr ""
 
-#: sequencer.c:3370
+#: sequencer.c:3571
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr ""
 
-#: sequencer.c:3424
+#: sequencer.c:3625
 msgid "writing fake root commit"
 msgstr ""
 
-#: sequencer.c:3429
+#: sequencer.c:3630
 msgid "writing squash-onto"
 msgstr ""
 
-#: sequencer.c:3513
+#: sequencer.c:3714
 #, c-format
 msgid "could not resolve '%s'"
 msgstr ""
 
-#: sequencer.c:3546
+#: sequencer.c:3747
 msgid "cannot merge without a current revision"
 msgstr ""
 
-#: sequencer.c:3568
+#: sequencer.c:3769
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr ""
 
-#: sequencer.c:3577
+#: sequencer.c:3778
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr ""
 
-#: sequencer.c:3589
+#: sequencer.c:3790
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
 
-#: sequencer.c:3605
+#: sequencer.c:3806
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr ""
 
-#: sequencer.c:3788
+#: sequencer.c:3989
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr ""
 
-#: sequencer.c:3804
+#: sequencer.c:4005
 msgid "merge: Unable to write new index file"
 msgstr ""
 
-#: sequencer.c:3878
+#: sequencer.c:4079
 msgid "Cannot autostash"
 msgstr ""
 
-#: sequencer.c:3881
+#: sequencer.c:4082
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr ""
 
-#: sequencer.c:3887
+#: sequencer.c:4088
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr ""
 
-#: sequencer.c:3890
+#: sequencer.c:4091
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr ""
 
-#: sequencer.c:3894
+#: sequencer.c:4095
 msgid "could not reset --hard"
 msgstr ""
 
-#: sequencer.c:3919
+#: sequencer.c:4120
 #, c-format
 msgid "Applied autostash.\n"
 msgstr ""
 
-#: sequencer.c:3931
+#: sequencer.c:4132
 #, c-format
 msgid "cannot store %s"
 msgstr ""
 
-#: sequencer.c:3934
+#: sequencer.c:4135
 #, c-format
 msgid ""
 "%s\n"
@@ -7539,29 +7749,29 @@ msgid ""
 "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
 msgstr ""
 
-#: sequencer.c:3939
+#: sequencer.c:4140
 msgid "Applying autostash resulted in conflicts."
 msgstr ""
 
-#: sequencer.c:3940
+#: sequencer.c:4141
 msgid "Autostash exists; creating a new stash entry."
 msgstr ""
 
-#: sequencer.c:4033 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4234 git-rebase--preserve-merges.sh:769
 msgid "could not detach HEAD"
 msgstr ""
 
-#: sequencer.c:4048
+#: sequencer.c:4249
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr ""
 
-#: sequencer.c:4050
+#: sequencer.c:4251
 #, c-format
 msgid "Stopped at %s\n"
 msgstr ""
 
-#: sequencer.c:4058
+#: sequencer.c:4259
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -7574,108 +7784,108 @@ msgid ""
 "    git rebase --continue\n"
 msgstr ""
 
-#: sequencer.c:4104
+#: sequencer.c:4305
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr ""
 
-#: sequencer.c:4149
+#: sequencer.c:4351
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr ""
 
-#: sequencer.c:4220
+#: sequencer.c:4422
 #, c-format
 msgid "unknown command %d"
 msgstr ""
 
-#: sequencer.c:4279
+#: sequencer.c:4481
 msgid "could not read orig-head"
 msgstr ""
 
-#: sequencer.c:4284
+#: sequencer.c:4486
 msgid "could not read 'onto'"
 msgstr ""
 
-#: sequencer.c:4298
+#: sequencer.c:4500
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr ""
 
-#: sequencer.c:4358
+#: sequencer.c:4560
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr ""
 
-#: sequencer.c:4391
+#: sequencer.c:4612
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 
-#: sequencer.c:4400
+#: sequencer.c:4621
 msgid "cannot amend non-existing commit"
 msgstr ""
 
-#: sequencer.c:4402
+#: sequencer.c:4623
 #, c-format
 msgid "invalid file: '%s'"
 msgstr ""
 
-#: sequencer.c:4404
+#: sequencer.c:4625
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr ""
 
-#: sequencer.c:4407
+#: sequencer.c:4628
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
 "first and then run 'git rebase --continue' again."
 msgstr ""
 
-#: sequencer.c:4443 sequencer.c:4482
+#: sequencer.c:4664 sequencer.c:4703
 #, c-format
 msgid "could not write file: '%s'"
 msgstr ""
 
-#: sequencer.c:4498
+#: sequencer.c:4719
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr ""
 
-#: sequencer.c:4505
+#: sequencer.c:4726
 msgid "could not commit staged changes."
 msgstr ""
 
-#: sequencer.c:4621
+#: sequencer.c:4846
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr ""
 
-#: sequencer.c:4625
+#: sequencer.c:4850
 #, c-format
 msgid "%s: bad revision"
 msgstr ""
 
-#: sequencer.c:4660
+#: sequencer.c:4885
 msgid "can't revert as initial commit"
 msgstr ""
 
-#: sequencer.c:5137
+#: sequencer.c:5362
 msgid "make_script: unhandled options"
 msgstr ""
 
-#: sequencer.c:5140
+#: sequencer.c:5365
 msgid "make_script: error preparing revisions"
 msgstr ""
 
-#: sequencer.c:5382 sequencer.c:5399
+#: sequencer.c:5615 sequencer.c:5632
 msgid "nothing to do"
 msgstr ""
 
-#: sequencer.c:5418
+#: sequencer.c:5651
 msgid "could not skip unnecessary pick commands"
 msgstr ""
 
-#: sequencer.c:5512
+#: sequencer.c:5751
 msgid "the script was already rearranged."
 msgstr ""
 
@@ -7808,63 +8018,76 @@ msgid ""
 "Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)."
 msgstr ""
 
-#: setup.c:1362
+#: setup.c:1370
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
 "The owner of files must always have read and write permissions."
 msgstr ""
 
-#: setup.c:1409
+#: setup.c:1417
 msgid "open /dev/null or dup failed"
 msgstr ""
 
-#: setup.c:1424
+#: setup.c:1432
 msgid "fork failed"
 msgstr ""
 
-#: setup.c:1429
+#: setup.c:1437 t/helper/test-simple-ipc.c:285
 msgid "setsid failed"
 msgstr ""
 
+#: sparse-index.c:151
+msgid "attempting to use sparse-index without cone mode"
+msgstr ""
+
+#: sparse-index.c:156
+msgid "unable to update cache-tree, staying full"
+msgstr ""
+
+#: sparse-index.c:239
+#, c-format
+msgid "index entry is a directory, but not sparse (%08x)"
+msgstr ""
+
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
-#: strbuf.c:848
+#: strbuf.c:850
 #, c-format
 msgid "%u.%2.2u GiB"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte/second
-#: strbuf.c:850
+#: strbuf.c:852
 #, c-format
 msgid "%u.%2.2u GiB/s"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte
-#: strbuf.c:858
+#: strbuf.c:860
 #, c-format
 msgid "%u.%2.2u MiB"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte/second
-#: strbuf.c:860
+#: strbuf.c:862
 #, c-format
 msgid "%u.%2.2u MiB/s"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte
-#: strbuf.c:867
+#: strbuf.c:869
 #, c-format
 msgid "%u.%2.2u KiB"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte/second
-#: strbuf.c:869
+#: strbuf.c:871
 #, c-format
 msgid "%u.%2.2u KiB/s"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 byte
-#: strbuf.c:875
+#: strbuf.c:877
 #, c-format
 msgid "%u byte"
 msgid_plural "%u bytes"
@@ -7872,20 +8095,20 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. TRANSLATORS: IEC 80000-13:2008 byte/second
-#: strbuf.c:877
+#: strbuf.c:879
 #, c-format
 msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: strbuf.c:1166 wrapper.c:199 wrapper.c:369 builtin/am.c:719
+#: strbuf.c:1168 wrapper.c:199 wrapper.c:369 builtin/am.c:737
 #: builtin/rebase.c:866
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr ""
 
-#: strbuf.c:1175
+#: strbuf.c:1177
 #, c-format
 msgid "could not edit '%s'"
 msgstr ""
@@ -7893,252 +8116,271 @@ msgstr ""
 #: submodule-config.c:237
 #, c-format
 msgid "ignoring suspicious submodule name: %s"
-msgstr ""
+msgstr "abaikan nama submodul dicurigai: %s"
 
 #: submodule-config.c:304
 msgid "negative values not allowed for submodule.fetchjobs"
-msgstr ""
+msgstr "nilai negatif tidak diperbolehkan untuk submodule.fetchjobs"
 
 #: submodule-config.c:402
 #, c-format
 msgid "ignoring '%s' which may be interpreted as a command-line option: %s"
-msgstr ""
+msgstr "abaikan '%s' yang mungkin ditafsirkan sebagai opsi baris perintah: %s"
 
 #: submodule-config.c:499
 #, c-format
 msgid "invalid value for %s"
-msgstr ""
+msgstr "nilai tidak valid untuk %s"
 
 #: submodule-config.c:766
 #, c-format
 msgid "Could not update .gitmodules entry %s"
-msgstr ""
+msgstr "Tidak dapat memperbarui entri .gitmodules %s"
 
 #: submodule.c:114 submodule.c:143
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
 msgstr ""
+"Tidak dapat mengubah .gitmodules yang tak tergabung, selesaikan konflik "
+"penggabungan terlebih dahulu"
 
 #: submodule.c:118 submodule.c:147
 #, c-format
 msgid "Could not find section in .gitmodules where path=%s"
-msgstr ""
+msgstr "Tidak dapat menemukan bagian .gitmodules dimana path=%s"
 
 #: submodule.c:154
 #, c-format
 msgid "Could not remove .gitmodules entry for %s"
-msgstr ""
+msgstr "Tidak dapat menghapus entri .gitmodules untuk %s"
 
 #: submodule.c:165
 msgid "staging updated .gitmodules failed"
-msgstr ""
+msgstr "gagal menggelar .gitmodules terbarui"
 
-#: submodule.c:327
+#: submodule.c:328
 #, c-format
 msgid "in unpopulated submodule '%s'"
-msgstr ""
+msgstr "dalam submodul tak terisi '%s'"
 
-#: submodule.c:358
+#: submodule.c:359
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
-msgstr ""
+msgstr "Spek jalur '%s' di dalam submodul '%.*s'"
 
-#: submodule.c:435
+#: submodule.c:436
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
-msgstr ""
+msgstr "argumen --ignore-submodules jelek: %s"
 
-#: submodule.c:817
+#: submodule.c:818
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
 "same. Skipping it."
 msgstr ""
+"Submodul dalam komit %s pada jalur '%s' bertabrakan dengan submodul yang "
+"bernama sama. Melewati itu."
 
-#: submodule.c:920
+#: submodule.c:921
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
-msgstr ""
+msgstr "entri submodul '%s' (%s) adalah %s, bukan komit"
 
-#: submodule.c:1005
+#: submodule.c:1006
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
 "submodule %s"
 msgstr ""
+"Tidak dapat menjalankan perintah 'git rev-list <komit> --not --remotes -n 1' "
+"dalam submodul %s"
 
-#: submodule.c:1128
+#: submodule.c:1129
 #, c-format
 msgid "process for submodule '%s' failed"
-msgstr ""
+msgstr "proses untuk submodul '%s' gagal"
 
-#: submodule.c:1157 builtin/branch.c:689 builtin/submodule--helper.c:2469
+#: submodule.c:1158 builtin/branch.c:691 builtin/submodule--helper.c:2470
 msgid "Failed to resolve HEAD as a valid ref."
-msgstr ""
+msgstr "Gagal menguraikan HEAD sebagai referensi valid."
 
-#: submodule.c:1168
+#: submodule.c:1169
 #, c-format
 msgid "Pushing submodule '%s'\n"
-msgstr ""
+msgstr "Mendorong submodul '%s'\n"
 
-#: submodule.c:1171
+#: submodule.c:1172
 #, c-format
 msgid "Unable to push submodule '%s'\n"
-msgstr ""
+msgstr "Tidak dapat mendorong submodul '%s'\n"
 
-#: submodule.c:1463
+#: submodule.c:1464
 #, c-format
 msgid "Fetching submodule %s%s\n"
-msgstr ""
+msgstr "Mengambil submodul %s%s\n"
 
-#: submodule.c:1497
+#: submodule.c:1498
 #, c-format
 msgid "Could not access submodule '%s'\n"
-msgstr ""
+msgstr "Tidak dapat mengakses submodul '%s'\n"
 
-#: submodule.c:1652
+#: submodule.c:1653
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
 "%s"
 msgstr ""
+"Kesalahan saat pengambilan submodul:\n"
+"%s"
 
-#: submodule.c:1677
+#: submodule.c:1678
 #, c-format
 msgid "'%s' not recognized as a git repository"
-msgstr ""
+msgstr "'%s' tak dikenal sebagai repositori git"
 
-#: submodule.c:1694
+#: submodule.c:1695
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
-msgstr ""
+msgstr "Tidak dapat menjalankan 'git status --porcelain=2' dalam submodul %s"
 
-#: submodule.c:1735
+#: submodule.c:1736
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
-msgstr ""
+msgstr "'git status --porcelain=2' gagal dalam submodul %s"
 
-#: submodule.c:1810
+#: submodule.c:1811
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
-msgstr ""
+msgstr "Tidak dalat memulai 'git status' dalam submodul '%s'"
 
-#: submodule.c:1823
+#: submodule.c:1824
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
-msgstr ""
+msgstr "tidak dapat menjalankan 'git status' dalam submodul '%s'"
 
-#: submodule.c:1838
+#: submodule.c:1839
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
-msgstr ""
+msgstr "Tidak dapat batal setel setelan core.worktree dalam submodul '%s'"
 
-#: submodule.c:1865 submodule.c:2175
+#: submodule.c:1866 submodule.c:2176
 #, c-format
 msgid "could not recurse into submodule '%s'"
-msgstr ""
+msgstr "tidak dapat rekursi ke dalam submodul '%s'"
 
-#: submodule.c:1886
+#: submodule.c:1887
 msgid "could not reset submodule index"
-msgstr ""
+msgstr "tidak dapat reset indeks submodul"
 
-#: submodule.c:1928
+#: submodule.c:1929
 #, c-format
 msgid "submodule '%s' has dirty index"
-msgstr ""
+msgstr "submodul '%s' punya indeks kotor"
 
-#: submodule.c:1980
+#: submodule.c:1981
 #, c-format
 msgid "Submodule '%s' could not be updated."
-msgstr ""
+msgstr "Submodul '%s' tidak dapat diperbarui."
 
-#: submodule.c:2048
+#: submodule.c:2049
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
-msgstr ""
+msgstr "direktori submodul git '%s' di dalam direktori git '%.*s'"
 
-#: submodule.c:2069
+#: submodule.c:2070
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
 msgstr ""
+"relocate_gitdir untuk submodul '%s' dengan lebih dari satu pohon kerja tidak "
+"didukung"
 
-#: submodule.c:2081 submodule.c:2140
+#: submodule.c:2082 submodule.c:2141
 #, c-format
 msgid "could not lookup name for submodule '%s'"
-msgstr ""
+msgstr "tidak dapat mencari nama untuk submodul '%s'"
 
-#: submodule.c:2085
+#: submodule.c:2086
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
-msgstr ""
+msgstr "menolak memindahkan '%s' ke dalam direktori git yang ada"
 
-#: submodule.c:2092
+#: submodule.c:2093
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
 "'%s' to\n"
 "'%s'\n"
 msgstr ""
+"Memigrasikan direktori git '%s%s' dari\n"
+"'%s' ke\n"
+"'%s'\n"
 
-#: submodule.c:2220
+#: submodule.c:2221
 msgid "could not start ls-files in .."
-msgstr ""
+msgstr "tidak dapat memulai ls-files dalam .."
 
-#: submodule.c:2260
+#: submodule.c:2261
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
+msgstr "ls-tree kembalikan kode kembali %d yang tak diharapkan"
+
+#: symlinks.c:244
+#, c-format
+msgid "failed to lstat '%s'"
 msgstr ""
 
-#: trailer.c:236
+#: trailer.c:244
 #, c-format
 msgid "running trailer command '%s' failed"
 msgstr ""
 
-#: trailer.c:483 trailer.c:488 trailer.c:493 trailer.c:547 trailer.c:551
-#: trailer.c:555
+#: trailer.c:493 trailer.c:498 trailer.c:503 trailer.c:562 trailer.c:566
+#: trailer.c:570
 #, c-format
 msgid "unknown value '%s' for key '%s'"
 msgstr ""
 
-#: trailer.c:537 trailer.c:542 builtin/remote.c:299 builtin/remote.c:324
+#: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
+#: builtin/remote.c:324
 #, c-format
 msgid "more than one %s"
 msgstr ""
 
-#: trailer.c:728
+#: trailer.c:743
 #, c-format
 msgid "empty trailer token in trailer '%.*s'"
 msgstr ""
 
-#: trailer.c:748
+#: trailer.c:763
 #, c-format
 msgid "could not read input file '%s'"
 msgstr ""
 
-#: trailer.c:751 builtin/mktag.c:91
+#: trailer.c:766 builtin/mktag.c:88
 msgid "could not read from stdin"
 msgstr ""
 
-#: trailer.c:1009 wrapper.c:676
+#: trailer.c:1024 wrapper.c:676
 #, c-format
 msgid "could not stat %s"
 msgstr ""
 
-#: trailer.c:1011
+#: trailer.c:1026
 #, c-format
 msgid "file %s is not a regular file"
 msgstr ""
 
-#: trailer.c:1013
+#: trailer.c:1028
 #, c-format
 msgid "file %s is not writable by user"
 msgstr ""
 
-#: trailer.c:1025
+#: trailer.c:1040
 msgid "could not open temporary file"
 msgstr ""
 
-#: trailer.c:1065
+#: trailer.c:1080
 #, c-format
 msgid "could not rename temporary file to %s"
 msgstr ""
@@ -8185,7 +8427,7 @@ msgstr ""
 msgid "error while running fast-import"
 msgstr ""
 
-#: transport-helper.c:549 transport-helper.c:1237
+#: transport-helper.c:549 transport-helper.c:1247
 #, c-format
 msgid "could not read ref %s"
 msgstr ""
@@ -8203,7 +8445,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr ""
 
-#: transport-helper.c:661 transport.c:1447
+#: transport-helper.c:661 transport.c:1471
 msgid "operation not supported by protocol"
 msgstr ""
 
@@ -8212,120 +8454,124 @@ msgstr ""
 msgid "can't connect to subservice %s"
 msgstr ""
 
-#: transport-helper.c:745
+#: transport-helper.c:693 transport.c:397
+msgid "--negotiate-only requires protocol v2"
+msgstr ""
+
+#: transport-helper.c:755
 msgid "'option' without a matching 'ok/error' directive"
 msgstr ""
 
-#: transport-helper.c:788
+#: transport-helper.c:798
 #, c-format
 msgid "expected ok/error, helper said '%s'"
 msgstr ""
 
-#: transport-helper.c:845
+#: transport-helper.c:855
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr ""
 
-#: transport-helper.c:928
+#: transport-helper.c:938
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr ""
 
-#: transport-helper.c:931
+#: transport-helper.c:941
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr ""
 
-#: transport-helper.c:934
+#: transport-helper.c:944
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr ""
 
-#: transport-helper.c:939
+#: transport-helper.c:949
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr ""
 
-#: transport-helper.c:943
+#: transport-helper.c:953
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr ""
 
-#: transport-helper.c:950
+#: transport-helper.c:960
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr ""
 
-#: transport-helper.c:1050
+#: transport-helper.c:1060
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr ""
 
-#: transport-helper.c:1055
+#: transport-helper.c:1065
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr ""
 
-#: transport-helper.c:1102
+#: transport-helper.c:1112
 msgid "couldn't run fast-export"
 msgstr ""
 
-#: transport-helper.c:1107
+#: transport-helper.c:1117
 msgid "error while running fast-export"
 msgstr ""
 
-#: transport-helper.c:1132
+#: transport-helper.c:1142
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
 "Perhaps you should specify a branch.\n"
 msgstr ""
 
-#: transport-helper.c:1214
+#: transport-helper.c:1224
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr ""
 
-#: transport-helper.c:1223
+#: transport-helper.c:1233
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr ""
 
-#: transport-helper.c:1375
+#: transport-helper.c:1385
 #, c-format
 msgid "read(%s) failed"
 msgstr ""
 
-#: transport-helper.c:1402
+#: transport-helper.c:1412
 #, c-format
 msgid "write(%s) failed"
 msgstr ""
 
-#: transport-helper.c:1451
+#: transport-helper.c:1461
 #, c-format
 msgid "%s thread failed"
 msgstr ""
 
-#: transport-helper.c:1455
+#: transport-helper.c:1465
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr ""
 
-#: transport-helper.c:1474 transport-helper.c:1478
+#: transport-helper.c:1484 transport-helper.c:1488
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr ""
 
-#: transport-helper.c:1515
+#: transport-helper.c:1525
 #, c-format
 msgid "%s process failed to wait"
 msgstr ""
 
-#: transport-helper.c:1519
+#: transport-helper.c:1529
 #, c-format
 msgid "%s process failed"
 msgstr ""
 
-#: transport-helper.c:1537 transport-helper.c:1546
+#: transport-helper.c:1547 transport-helper.c:1556
 msgid "can't start thread for copying data"
 msgstr ""
 
@@ -8344,44 +8590,48 @@ msgstr ""
 msgid "transport: invalid depth option '%s'"
 msgstr ""
 
-#: transport.c:269
+#: transport.c:272
 msgid "see protocol.version in 'git help config' for more details"
 msgstr ""
 
-#: transport.c:270
+#: transport.c:273
 msgid "server options require protocol version 2 or later"
 msgstr ""
 
-#: transport.c:727
+#: transport.c:400
+msgid "server does not support wait-for-done"
+msgstr ""
+
+#: transport.c:751
 msgid "could not parse transport.color.* config"
 msgstr ""
 
-#: transport.c:802
+#: transport.c:826
 msgid "support for protocol v2 not implemented yet"
 msgstr ""
 
-#: transport.c:936
+#: transport.c:960
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr ""
 
-#: transport.c:1002
+#: transport.c:1026
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr ""
 
-#: transport.c:1055
+#: transport.c:1079
 msgid "git-over-rsync is no longer supported"
 msgstr ""
 
-#: transport.c:1157
+#: transport.c:1181
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
 "not be found on any remote:\n"
 msgstr ""
 
-#: transport.c:1161
+#: transport.c:1185
 #, c-format
 msgid ""
 "\n"
@@ -8397,11 +8647,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: transport.c:1169
+#: transport.c:1193
 msgid "Aborting."
 msgstr ""
 
-#: transport.c:1316
+#: transport.c:1340
 msgid "failed to push all needed submodules"
 msgstr ""
 
@@ -8421,103 +8671,95 @@ msgstr ""
 msgid "too-short tree file"
 msgstr ""
 
-#: unpack-trees.c:113
+#: unpack-trees.c:115
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
 "%%sPlease commit your changes or stash them before you switch branches."
 msgstr ""
 
-#: unpack-trees.c:115
+#: unpack-trees.c:117
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
 "%%s"
 msgstr ""
 
-#: unpack-trees.c:118
+#: unpack-trees.c:120
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "%%sPlease commit your changes or stash them before you merge."
 msgstr ""
 
-#: unpack-trees.c:120
+#: unpack-trees.c:122
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "%%s"
 msgstr ""
 
-#: unpack-trees.c:123
+#: unpack-trees.c:125
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
 "%%sPlease commit your changes or stash them before you %s."
 msgstr ""
 
-#: unpack-trees.c:125
+#: unpack-trees.c:127
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
 "%%s"
 msgstr ""
 
-#: unpack-trees.c:130
+#: unpack-trees.c:132
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
 "%s"
 msgstr ""
 
-#: unpack-trees.c:134
+#: unpack-trees.c:136
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
 "%%sPlease move or remove them before you switch branches."
 msgstr ""
 
-#: unpack-trees.c:136
+#: unpack-trees.c:138
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
 "%%s"
-msgstr ""
-
-#: unpack-trees.c:139
-#, c-format
-msgid ""
-"The following untracked working tree files would be removed by merge:\n"
-"%%sPlease move or remove them before you merge."
 msgstr ""
 
 #: unpack-trees.c:141
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
-"%%s"
+"%%sPlease move or remove them before you merge."
 msgstr ""
 
-#: unpack-trees.c:144
+#: unpack-trees.c:143
 #, c-format
 msgid ""
-"The following untracked working tree files would be removed by %s:\n"
-"%%sPlease move or remove them before you %s."
+"The following untracked working tree files would be removed by merge:\n"
+"%%s"
 msgstr ""
 
 #: unpack-trees.c:146
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
-"%%s"
+"%%sPlease move or remove them before you %s."
 msgstr ""
 
-#: unpack-trees.c:152
+#: unpack-trees.c:148
 #, c-format
 msgid ""
-"The following untracked working tree files would be overwritten by "
-"checkout:\n"
-"%%sPlease move or remove them before you switch branches."
+"The following untracked working tree files would be removed by %s:\n"
+"%%s"
 msgstr ""
 
 #: unpack-trees.c:154
@@ -8525,50 +8767,58 @@ msgstr ""
 msgid ""
 "The following untracked working tree files would be overwritten by "
 "checkout:\n"
-"%%s"
+"%%sPlease move or remove them before you switch branches."
 msgstr ""
 
-#: unpack-trees.c:157
+#: unpack-trees.c:156
 #, c-format
 msgid ""
-"The following untracked working tree files would be overwritten by merge:\n"
-"%%sPlease move or remove them before you merge."
+"The following untracked working tree files would be overwritten by "
+"checkout:\n"
+"%%s"
 msgstr ""
 
 #: unpack-trees.c:159
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
-"%%s"
+"%%sPlease move or remove them before you merge."
 msgstr ""
 
-#: unpack-trees.c:162
+#: unpack-trees.c:161
 #, c-format
 msgid ""
-"The following untracked working tree files would be overwritten by %s:\n"
-"%%sPlease move or remove them before you %s."
+"The following untracked working tree files would be overwritten by merge:\n"
+"%%s"
 msgstr ""
 
 #: unpack-trees.c:164
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
+"%%sPlease move or remove them before you %s."
+msgstr ""
+
+#: unpack-trees.c:166
+#, c-format
+msgid ""
+"The following untracked working tree files would be overwritten by %s:\n"
 "%%s"
 msgstr ""
 
-#: unpack-trees.c:172
+#: unpack-trees.c:174
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
 msgstr ""
 
-#: unpack-trees.c:175
+#: unpack-trees.c:177
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
 "%s"
 msgstr ""
 
-#: unpack-trees.c:178
+#: unpack-trees.c:180
 #, c-format
 msgid ""
 "The following paths are not up to date and were left despite sparse "
@@ -8576,14 +8826,14 @@ msgid ""
 "%s"
 msgstr ""
 
-#: unpack-trees.c:180
+#: unpack-trees.c:182
 #, c-format
 msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
 "%s"
 msgstr ""
 
-#: unpack-trees.c:182
+#: unpack-trees.c:184
 #, c-format
 msgid ""
 "The following paths were already present and thus not updated despite sparse "
@@ -8591,34 +8841,39 @@ msgid ""
 "%s"
 msgstr ""
 
-#: unpack-trees.c:262
+#: unpack-trees.c:264
 #, c-format
 msgid "Aborting\n"
 msgstr ""
 
-#: unpack-trees.c:289
+#: unpack-trees.c:291
 #, c-format
 msgid ""
 "After fixing the above paths, you may want to run `git sparse-checkout "
 "reapply`.\n"
 msgstr ""
 
-#: unpack-trees.c:350
+#: unpack-trees.c:352
 msgid "Updating files"
 msgstr ""
 
-#: unpack-trees.c:382
+#: unpack-trees.c:384
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
 "colliding group is in the working tree:\n"
 msgstr ""
 
-#: unpack-trees.c:1498
+#: unpack-trees.c:1519
 msgid "Updating index flags"
 msgstr ""
 
-#: upload-pack.c:1543
+#: unpack-trees.c:2608
+#, c-format
+msgid "worktree and untracked commit have duplicate entries: %s"
+msgstr ""
+
+#: upload-pack.c:1548
 msgid "expected flush after fetch arguments"
 msgstr ""
 
@@ -8655,101 +8910,102 @@ msgstr ""
 msgid "Fetching objects"
 msgstr ""
 
-#: worktree.c:238 builtin/am.c:2103
+#: worktree.c:238 builtin/am.c:2151
 #, c-format
 msgid "failed to read '%s'"
-msgstr ""
+msgstr "gagal membaca '%s'"
 
 #: worktree.c:304
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
-msgstr ""
+msgstr "'%s' pada pohon kerja utama bukan direktori repositori"
 
 #: worktree.c:315
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
-msgstr ""
+msgstr "berkas '%s' tidak berisi jalur absolut ke lokasi pohon kerja"
 
 #: worktree.c:327
 #, c-format
 msgid "'%s' does not exist"
-msgstr ""
+msgstr "'%s' tidak ada"
 
 #: worktree.c:333
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
-msgstr ""
+msgstr "'%s' bukan berkas .git, kode error %d"
 
 #: worktree.c:342
 #, c-format
 msgid "'%s' does not point back to '%s'"
-msgstr ""
+msgstr "'%s' tidak menunjuk kembali ke '%s'"
 
 #: worktree.c:608
 msgid "not a directory"
-msgstr ""
+msgstr "bukan direktori"
 
 #: worktree.c:617
 msgid ".git is not a file"
-msgstr ""
+msgstr ".git bukan berkas"
 
 #: worktree.c:619
 msgid ".git file broken"
-msgstr ""
+msgstr "berkas .git rusak"
 
 #: worktree.c:621
 msgid ".git file incorrect"
-msgstr ""
+msgstr "berkas .git salah"
 
 #: worktree.c:727
 msgid "not a valid path"
-msgstr ""
+msgstr "bukan jalur valid"
 
 #: worktree.c:733
 msgid "unable to locate repository; .git is not a file"
-msgstr ""
+msgstr "tidak dapat menempatkan repositori; .git bukan berkas"
 
 #: worktree.c:737
 msgid "unable to locate repository; .git file does not reference a repository"
 msgstr ""
+"tidak dapat menempatkan repositori; berkas .git tidak merujuk repositori"
 
 #: worktree.c:741
 msgid "unable to locate repository; .git file broken"
-msgstr ""
+msgstr "tidak dapat menempatkan repositori; berkas .git rusak"
 
 #: worktree.c:747
 msgid "gitdir unreadable"
-msgstr ""
+msgstr "gitdir tidak dapat dibaca"
 
 #: worktree.c:751
 msgid "gitdir incorrect"
-msgstr ""
+msgstr "gitdir salah"
 
 #: worktree.c:776
 msgid "not a valid directory"
-msgstr ""
+msgstr "bukan direktori valid"
 
 #: worktree.c:782
 msgid "gitdir file does not exist"
-msgstr ""
+msgstr "berkas gitdir tidak ada"
 
 #: worktree.c:787 worktree.c:796
 #, c-format
 msgid "unable to read gitdir file (%s)"
-msgstr ""
+msgstr "tidak dapat membaca berkas gitdir (%s)"
 
 #: worktree.c:806
 #, c-format
 msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
-msgstr ""
+msgstr "baca singkat (diharapkan %<PRIuMAX> bita, terbaca %<PRIuMAX>)"
 
 #: worktree.c:814
 msgid "invalid gitdir file"
-msgstr ""
+msgstr "berkas gitdir tidak valid"
 
 #: worktree.c:822
 msgid "gitdir file points to non-existent location"
-msgstr ""
+msgstr "berkas gitdir menunjuk ke lokasi yang tidak ada"
 
 #: wrapper.c:197 wrapper.c:367
 #, c-format
@@ -8798,11 +9054,11 @@ msgstr ""
 msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr "  (gunakan \"git rm <berkas>\" untuk menandai penyelesaian)"
 
-#: wt-status.c:211 wt-status.c:1072
+#: wt-status.c:211 wt-status.c:1075
 msgid "Changes to be committed:"
 msgstr "Perubahan yang akan dikomit:"
 
-#: wt-status.c:234 wt-status.c:1081
+#: wt-status.c:234 wt-status.c:1084
 msgid "Changes not staged for commit:"
 msgstr "Perubahan yang tidak digelar untuk komit:"
 
@@ -8906,22 +9162,22 @@ msgstr "konten yang dimodifikasi, "
 msgid "untracked content, "
 msgstr "konten yang tak dilacak, "
 
-#: wt-status.c:905
+#: wt-status.c:908
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Simpanan Anda saat ini ada %d entri"
 msgstr[1] "Simpanan Anda saat ini ada %d entri"
 
-#: wt-status.c:936
+#: wt-status.c:939
 msgid "Submodules changed but not updated:"
 msgstr "Submodul berubah tapi tak diperbarui:"
 
-#: wt-status.c:938
+#: wt-status.c:941
 msgid "Submodule changes to be committed:"
 msgstr "Perubahan submodul yang akan dikomit:"
 
-#: wt-status.c:1020
+#: wt-status.c:1023
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -8929,7 +9185,7 @@ msgstr ""
 "Jangan ubah atau hapus baris diatas.\n"
 "Semua dibawahnya akan diabaikan."
 
-#: wt-status.c:1112
+#: wt-status.c:1115
 #, c-format
 msgid ""
 "\n"
@@ -8940,262 +9196,262 @@ msgstr ""
 "Butuh %.2f detik untuk menghitung cabang di depan/di belakang nilai.\n"
 "Anda bisa gunakan '--no-ahead-behind' untuk menghindari hal tersebut.\n"
 
-#: wt-status.c:1142
+#: wt-status.c:1145
 msgid "You have unmerged paths."
 msgstr "Anda punya jalur yang tak tergabung."
 
-#: wt-status.c:1145
+#: wt-status.c:1148
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (selesaikan konflik dan jalankan \"git commit\")"
 
-#: wt-status.c:1147
+#: wt-status.c:1150
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (gunakan \"git merge --abort\" untuk membatalkan penggabungan)"
 
-#: wt-status.c:1151
+#: wt-status.c:1154
 msgid "All conflicts fixed but you are still merging."
 msgstr "Semua konflik sudah selesai tapi Anda masih menggabungkan."
 
-#: wt-status.c:1154
+#: wt-status.c:1157
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (gunakan \"git commit\" untuk mengakhiri penggabungan)"
 
-#: wt-status.c:1163
+#: wt-status.c:1166
 msgid "You are in the middle of an am session."
 msgstr "Anda berada ditengah-tengah sesi am."
 
-#: wt-status.c:1166
+#: wt-status.c:1169
 msgid "The current patch is empty."
 msgstr "Jalur saat ini kosong"
 
-#: wt-status.c:1170
+#: wt-status.c:1173
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (selesaikan konflik lalu jalankan \"git am --continue\")"
 
-#: wt-status.c:1172
+#: wt-status.c:1175
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (gunakan \"git am --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1174
+#: wt-status.c:1177
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr "  (gunakan \"git am --abort\" untuk mengembalikan cabang asal)"
 
-#: wt-status.c:1307
+#: wt-status.c:1310
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo hilang."
 
-#: wt-status.c:1309
+#: wt-status.c:1312
 msgid "No commands done."
 msgstr "Tidak ada perintah selesai."
 
-#: wt-status.c:1312
+#: wt-status.c:1315
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Perintah yang selesai (%d perintah):"
 msgstr[1] "Perintah yang selesai (%d perintah):"
 
-#: wt-status.c:1323
+#: wt-status.c:1326
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (lihat lebih lanjut di berkas %s)"
 
-#: wt-status.c:1328
+#: wt-status.c:1331
 msgid "No commands remaining."
 msgstr "Tidak ada perintah yang tersisa."
 
-#: wt-status.c:1331
+#: wt-status.c:1334
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Perintah berikutnya (%d perintah tersisa):"
 msgstr[1] "Perintah berikutnya (%d perintah tersisa):"
 
-#: wt-status.c:1339
+#: wt-status.c:1342
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (gunakan \"git rebase --edit-todo\" untuk lihat dan sunting)"
 
-#: wt-status.c:1351
+#: wt-status.c:1354
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Anda sedang mendasarkan ulang cabang '%s' pada '%s'."
 
-#: wt-status.c:1356
+#: wt-status.c:1359
 msgid "You are currently rebasing."
 msgstr "Anda sedang mendasarkan ulang."
 
-#: wt-status.c:1369
+#: wt-status.c:1372
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr "  (selesaikan konflik lalu jalankan \"git rebase --continue\")"
 
-#: wt-status.c:1371
+#: wt-status.c:1374
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (gunakan \"git rebase --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1373
+#: wt-status.c:1376
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr "  (gunakan \"git rebase --abort\" untuk check out cabang asal)"
 
-#: wt-status.c:1380
+#: wt-status.c:1383
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (semua konflik sudah selesai: jalankan \"git rebase --continue\")"
 
-#: wt-status.c:1384
+#: wt-status.c:1387
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Anda sedang membelah komit saat mendasarkan ulang cabang '%s' pada '%s'."
 
-#: wt-status.c:1389
+#: wt-status.c:1392
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Anda sedang membelah komit saat mendasarkan ulang."
 
-#: wt-status.c:1392
+#: wt-status.c:1395
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Setelah direktori kerja Anda bersih, jalankan \"git rebase --continue\")"
 
-#: wt-status.c:1396
+#: wt-status.c:1399
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Anda sedang menyunting komit saat mendasarkan ulang cabang '%s' pada '%s'."
 
-#: wt-status.c:1401
+#: wt-status.c:1404
 msgid "You are currently editing a commit during a rebase."
 msgstr "Anda sedang menyunting komit saat mendasarkan ulang."
 
-#: wt-status.c:1404
+#: wt-status.c:1407
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr "  (gunakan \"git commit --amend\" untuk mengubah komit saat ini)"
 
-#: wt-status.c:1406
+#: wt-status.c:1409
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (gunakan \"git rebase --continue\" begitu Anda puas dengan perubahan Anda)"
 
-#: wt-status.c:1417
+#: wt-status.c:1420
 msgid "Cherry-pick currently in progress."
 msgstr "Petik ceri sedang berjalan."
 
-#: wt-status.c:1420
+#: wt-status.c:1423
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Anda sedang memetik ceri komit %s."
 
-#: wt-status.c:1427
+#: wt-status.c:1430
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (selesaikan konflik dan jalankan \"git cherry-pick --continue\")"
 
-#: wt-status.c:1430
+#: wt-status.c:1433
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (jalankan \"git cherry-pick --continue\" untuk melanjutkan)"
 
-#: wt-status.c:1433
+#: wt-status.c:1436
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (semua konflik sudah selesai: jalankan \"git cherry-pick --continue\")"
 
-#: wt-status.c:1435
+#: wt-status.c:1438
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr "  (gunakan \"git cherry-pick --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1437
+#: wt-status.c:1440
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (gunakan \"git cherry-pick --abort\" untuk membatalkan operasi petik ceri)"
 
-#: wt-status.c:1447
+#: wt-status.c:1450
 msgid "Revert currently in progress."
 msgstr "Pengembalian sedang berjalang."
 
-#: wt-status.c:1450
+#: wt-status.c:1453
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Anda sedang mengembalikan komit %s."
 
-#: wt-status.c:1456
+#: wt-status.c:1459
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (selesaikan konflik dan jalankan \"git revert --continue\")"
 
-#: wt-status.c:1459
+#: wt-status.c:1462
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (jalankan \"git revert --continue\" untuk melanjutkan)"
 
-#: wt-status.c:1462
+#: wt-status.c:1465
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (semua konflik sudah selesai: jalankan \"git revert --continue\")"
 
-#: wt-status.c:1464
+#: wt-status.c:1467
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (gunakan \"git revert --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1466
+#: wt-status.c:1469
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr ""
 "  (gunakan \"git revert --abort\" untuk membatalkan operasi pengembalian)"
 
-#: wt-status.c:1476
+#: wt-status.c:1479
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Anda sedang membagi dua, dimulai dari cabang '%s'."
 
-#: wt-status.c:1480
+#: wt-status.c:1483
 msgid "You are currently bisecting."
 msgstr "Anda sedang membagi dua."
 
-#: wt-status.c:1483
+#: wt-status.c:1486
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr "  (gunakan \"git bisect reset\" untuk kembali ke cabang asal)"
 
-#: wt-status.c:1494
+#: wt-status.c:1497
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr "Anda berada dalam checkout tipis dengan %d%% berkas terlacak ada."
 
-#: wt-status.c:1733
+#: wt-status.c:1736
 msgid "On branch "
 msgstr "Pada cabang "
 
-#: wt-status.c:1740
+#: wt-status.c:1743
 msgid "interactive rebase in progress; onto "
 msgstr "sedang mendasarkan ulang interaktif; ke "
 
-#: wt-status.c:1742
+#: wt-status.c:1745
 msgid "rebase in progress; onto "
 msgstr "sedang mendasarkan ulang; ke "
 
-#: wt-status.c:1747
+#: wt-status.c:1750
 msgid "HEAD detached at "
 msgstr ""
 
-#: wt-status.c:1749
+#: wt-status.c:1752
 msgid "HEAD detached from "
 msgstr ""
 
-#: wt-status.c:1752
+#: wt-status.c:1755
 msgid "Not currently on any branch."
 msgstr "Tidak sedang berada pada cabang apapun."
 
-#: wt-status.c:1769
+#: wt-status.c:1772
 msgid "Initial commit"
 msgstr "Komit awal"
 
-#: wt-status.c:1770
+#: wt-status.c:1773
 msgid "No commits yet"
 msgstr "Tidak ada komit"
 
-#: wt-status.c:1784
+#: wt-status.c:1787
 msgid "Untracked files"
 msgstr "Berkas tak terlacak"
 
-#: wt-status.c:1786
+#: wt-status.c:1789
 msgid "Ignored files"
 msgstr "Berkas yang diabaikan"
 
-#: wt-status.c:1790
+#: wt-status.c:1793
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -9206,32 +9462,32 @@ msgstr ""
 "mungkin bisa mempercepat, tapi Anda harus berhati-hati jangan sampai lupa\n"
 "untuk tambahkan berkas baru sendiri (lihat 'git help status')."
 
-#: wt-status.c:1796
+#: wt-status.c:1799
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Berkas tak terlacak yang tak disebutkan%s"
 
-#: wt-status.c:1798
+#: wt-status.c:1801
 msgid " (use -u option to show untracked files)"
 msgstr " (gunakan opsi -u untuk melihat berkas yang tak terlacak)"
 
-#: wt-status.c:1804
+#: wt-status.c:1807
 msgid "No changes"
 msgstr "Tidak ada perubahan"
 
-#: wt-status.c:1809
+#: wt-status.c:1812
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "tidak ada perubahan untuk dikomit (gunakan \"git add\" dan/atau \"git commit "
 "-a\")\n"
 
-#: wt-status.c:1813
+#: wt-status.c:1816
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "tidak ada perubahan untuk dikomit\n"
 
-#: wt-status.c:1817
+#: wt-status.c:1820
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -9240,201 +9496,220 @@ msgstr ""
 "tidak ada perubahan untuk dikomit tapi berkas yang tak terlacak ada(gunakan "
 "\"git add\" untuk lacak)\n"
 
-#: wt-status.c:1821
+#: wt-status.c:1824
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "tidak ada perubahan untuk dikomit tapi berkas yang tak terlacak ada\n"
 
-#: wt-status.c:1825
+#: wt-status.c:1828
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "tidak ada yang dikomit (buat/salin berkas dan gunakan \"git add\" untuk "
 "lacak)\n"
 
-#: wt-status.c:1829 wt-status.c:1835
+#: wt-status.c:1832 wt-status.c:1838
 #, c-format
 msgid "nothing to commit\n"
 msgstr "tidak ada yang dikomit\n"
 
-#: wt-status.c:1832
+#: wt-status.c:1835
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr "tidak ada yang dikomit (gunakan -u untuk lihat berkas tak terlacak)\n"
 
-#: wt-status.c:1837
+#: wt-status.c:1840
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "tidak ada yang dikomit, pohon kerja bersih\n"
 
-#: wt-status.c:1942
+#: wt-status.c:1945
 msgid "No commits yet on "
 msgstr "Tidak ada komit apapun pada "
 
-#: wt-status.c:1946
+#: wt-status.c:1949
 msgid "HEAD (no branch)"
 msgstr "HEAD (tanpa cabang)"
 
-#: wt-status.c:1977
+#: wt-status.c:1980
 msgid "different"
 msgstr "berbeda"
 
-#: wt-status.c:1979 wt-status.c:1987
+#: wt-status.c:1982 wt-status.c:1990
 msgid "behind "
 msgstr "di belakang "
 
-#: wt-status.c:1982 wt-status.c:1985
+#: wt-status.c:1985 wt-status.c:1988
 msgid "ahead "
 msgstr "di depan "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2507
+#: wt-status.c:2511
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "tidak dapat %s: Anda punya perubahan yang tidak digelar."
 
-#: wt-status.c:2513
+#: wt-status.c:2517
 msgid "additionally, your index contains uncommitted changes."
 msgstr "juga indeks Anda berisi perubahan yang belum dikomit."
 
-#: wt-status.c:2515
+#: wt-status.c:2519
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "tidak dapat %s: indeks Anda berisi perubahan yang belum dikomit."
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:457
+#: compat/simple-ipc/ipc-unix-socket.c:178
+msgid "could not send IPC command"
+msgstr ""
+
+#: compat/simple-ipc/ipc-unix-socket.c:185
+msgid "could not read IPC response"
+msgstr ""
+
+#: compat/simple-ipc/ipc-unix-socket.c:862
+#, c-format
+msgid "could not start accept_thread '%s'"
+msgstr ""
+
+#: compat/simple-ipc/ipc-unix-socket.c:874
+#, c-format
+msgid "could not start worker[0] for '%s'"
+msgstr ""
+
+#: compat/precompose_utf8.c:58 builtin/clone.c:461
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr ""
 
 #: builtin/add.c:26
 msgid "git add [<options>] [--] <pathspec>..."
-msgstr ""
+msgstr "git add [<opsi>] [--] <pathspec>..."
 
-#: builtin/add.c:58
+#: builtin/add.c:61
+#, c-format
 msgid "cannot chmod %cx '%s'"
-msgstr ""
+msgstr "tidak dapat chmod %cx '%s'"
 
-#: builtin/add.c:96
+#: builtin/add.c:99
 #, c-format
 msgid "unexpected diff status %c"
-msgstr ""
+msgstr "status diff tak diharapkan %c"
 
-#: builtin/add.c:101 builtin/commit.c:285
+#: builtin/add.c:104 builtin/commit.c:297
 msgid "updating files failed"
-msgstr ""
+msgstr "gagal memperbarui berkas"
 
-#: builtin/add.c:111
+#: builtin/add.c:114
 #, c-format
 msgid "remove '%s'\n"
-msgstr ""
+msgstr "hapus '%s'\n"
 
-#: builtin/add.c:186
+#: builtin/add.c:198
 msgid "Unstaged changes after refreshing the index:"
-msgstr ""
+msgstr "Perubahan tak tergelar setelah menyegarkan indeks:"
 
-#: builtin/add.c:280 builtin/rev-parse.c:991
+#: builtin/add.c:307 builtin/rev-parse.c:991
 msgid "Could not read the index"
-msgstr ""
+msgstr "Tidak dapat membaca indeks"
 
-#: builtin/add.c:291
+#: builtin/add.c:318
 #, c-format
 msgid "Could not open '%s' for writing."
-msgstr ""
+msgstr "Tidak dapat membuka '%s' untuk ditulis."
 
-#: builtin/add.c:295
+#: builtin/add.c:322
 msgid "Could not write patch"
-msgstr ""
+msgstr "Tidak dapat menulis tambalan"
 
-#: builtin/add.c:298
+#: builtin/add.c:325
 msgid "editing patch failed"
-msgstr ""
+msgstr "Gagal menyunting tambalan"
 
-#: builtin/add.c:301
+#: builtin/add.c:328
 #, c-format
 msgid "Could not stat '%s'"
-msgstr ""
+msgstr "Tidak dapat men-stat '%s'"
 
-#: builtin/add.c:303
+#: builtin/add.c:330
 msgid "Empty patch. Aborted."
-msgstr ""
+msgstr "Tambalan kosong. Dibatalkan."
 
-#: builtin/add.c:308
+#: builtin/add.c:335
 #, c-format
 msgid "Could not apply '%s'"
-msgstr ""
+msgstr "Tidak dapat terapkan '%s'"
 
-#: builtin/add.c:316
+#: builtin/add.c:343
 msgid "The following paths are ignored by one of your .gitignore files:\n"
-msgstr ""
+msgstr "Jalur berikut diabaikan oleh salah satu dari berkas .gitignore Anda:\n"
 
-#: builtin/add.c:336 builtin/clean.c:904 builtin/fetch.c:169 builtin/mv.c:124
+#: builtin/add.c:363 builtin/clean.c:904 builtin/fetch.c:173 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:559
-#: builtin/remote.c:1427 builtin/rm.c:242 builtin/send-pack.c:190
+#: builtin/remote.c:1427 builtin/rm.c:243 builtin/send-pack.c:190
 msgid "dry run"
 msgstr "latihan"
 
-#: builtin/add.c:339
+#: builtin/add.c:366
 msgid "interactive picking"
-msgstr ""
+msgstr "pengambilan interaktif"
 
-#: builtin/add.c:340 builtin/checkout.c:1546 builtin/reset.c:308
+#: builtin/add.c:367 builtin/checkout.c:1567 builtin/reset.c:308
 msgid "select hunks interactively"
-msgstr ""
+msgstr "pilih bingkah secara interaktif"
 
-#: builtin/add.c:341
+#: builtin/add.c:368
 msgid "edit current diff and apply"
-msgstr ""
+msgstr "sunting diff saat ini dan terapkan"
 
-#: builtin/add.c:342
+#: builtin/add.c:369
 msgid "allow adding otherwise ignored files"
-msgstr ""
+msgstr "perbolehkan tambah berkas yang diabaikan"
 
-#: builtin/add.c:343
+#: builtin/add.c:370
 msgid "update tracked files"
-msgstr ""
+msgstr "perbarui berkas terlacak"
 
-#: builtin/add.c:344
+#: builtin/add.c:371
 msgid "renormalize EOL of tracked files (implies -u)"
-msgstr ""
+msgstr "normalisasi ulang EOL berkas terlacak (menyiratkan -u)"
 
-#: builtin/add.c:345
+#: builtin/add.c:372
 msgid "record only the fact that the path will be added later"
-msgstr ""
+msgstr "rekam hanya fakta bahwa jalur akan ditambahkan nanti"
 
-#: builtin/add.c:346
+#: builtin/add.c:373
 msgid "add changes from all tracked and untracked files"
-msgstr ""
+msgstr "tambahkan perubahan dari semua berkas terlacak dan tak terlacak"
 
-#: builtin/add.c:349
+#: builtin/add.c:376
 msgid "ignore paths removed in the working tree (same as --no-all)"
-msgstr ""
+msgstr "abaikan jalur yang terhapus dari pohon kerja (sama dengan --no-all)"
 
-#: builtin/add.c:351
+#: builtin/add.c:378
 msgid "don't add, only refresh the index"
-msgstr ""
+msgstr "jangan tambahkan, hanya segarkan indeks"
 
-#: builtin/add.c:352
+#: builtin/add.c:379
 msgid "just skip files which cannot be added because of errors"
-msgstr ""
+msgstr "hanya lewatkan berkas yang tidak dapat ditambah karena error"
 
-#: builtin/add.c:353
+#: builtin/add.c:380
 msgid "check if - even missing - files are ignored in dry run"
-msgstr ""
+msgstr "periksa bahwa berkas yang - bahkan hilang - diabaikan dalam latihan"
 
-#: builtin/add.c:355 builtin/update-index.c:1004
+#: builtin/add.c:382 builtin/update-index.c:1006
 msgid "override the executable bit of the listed files"
-msgstr ""
+msgstr "timpa bit yang dapat dieksekusi dari berkas terdaftar"
 
-#: builtin/add.c:357
+#: builtin/add.c:384
 msgid "warn when adding an embedded repository"
-msgstr ""
+msgstr "peringatkan ketika menambahkan repositori tertanam"
 
-#: builtin/add.c:359
+#: builtin/add.c:386
 msgid "backend for `git stash -p`"
-msgstr ""
+msgstr "tulang belakang untuk `git stash -p`"
 
-#: builtin/add.c:377
+#: builtin/add.c:404
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -9451,188 +9726,211 @@ msgid ""
 "\n"
 "See \"git help submodule\" for more information."
 msgstr ""
+"Anda telah menambahkan repositori git yang lain di dalam repositori Anda\n"
+"saat ini. Kloningan repositori luar tidak akan berisi isi repositori\n"
+"tertanam dan tidak akan tahu bagaimana cara mendapatkannya.\n"
+"Jika maksud anda menambahkan submodul, gunakan:\n"
+"\n"
+"\tgit submodule add <url> %s\n"
+"\n"
+"Jika Anda menambahkan jalur itu sebagai kesengajaan, Anda dapat menghapus\n"
+"itu dari indeks dengan:\n"
+"\n"
+"\tgit rm --cached %s\n"
+"\n"
+"Lihat \"git help submodule\" untuk selengkapnya."
 
-#: builtin/add.c:405
+#: builtin/add.c:432
 #, c-format
 msgid "adding embedded git repository: %s"
-msgstr ""
+msgstr "menambahkan repositori git tertanam: %s"
 
-#: builtin/add.c:424
+#: builtin/add.c:451
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
 "\"git config advice.addIgnoredFile false\""
 msgstr ""
+"Gunakan -f jika Anda benar-benar ingin tambahkan itu.\n"
+"Matikan pesan ini dengan menjalankan\n"
+"\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:433
+#: builtin/add.c:460
 msgid "adding files failed"
-msgstr ""
+msgstr "gagal menambahkan berkas"
 
-#: builtin/add.c:461 builtin/commit.c:345
+#: builtin/add.c:488
+msgid "--dry-run is incompatible with --interactive/--patch"
+msgstr "--dry-run tidak kompatibel dengan --interactive/--patch"
+
+#: builtin/add.c:490 builtin/commit.c:357
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
-msgstr ""
+msgstr "--pathspec-from-file tidak kompatibel dengan --interactive/--patch"
 
-#: builtin/add.c:478
+#: builtin/add.c:507
 msgid "--pathspec-from-file is incompatible with --edit"
-msgstr ""
+msgstr "--pathspec-from-file tidak kompatibel dengan --edit"
 
-#: builtin/add.c:490
+#: builtin/add.c:519
 msgid "-A and -u are mutually incompatible"
-msgstr ""
+msgstr "-A dan -u saling tak kompatibel"
 
-#: builtin/add.c:493
+#: builtin/add.c:522
 msgid "Option --ignore-missing can only be used together with --dry-run"
-msgstr ""
-
-#: builtin/add.c:497
-#, c-format
-msgid "--chmod param '%s' must be either -x or +x"
-msgstr ""
-
-#: builtin/add.c:515 builtin/checkout.c:1714 builtin/commit.c:351
-#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1569
-msgid "--pathspec-from-file is incompatible with pathspec arguments"
-msgstr ""
-
-#: builtin/add.c:522 builtin/checkout.c:1726 builtin/commit.c:357
-#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1575
-msgid "--pathspec-file-nul requires --pathspec-from-file"
-msgstr ""
+msgstr "Opsi --ignore-missing hanya dapat digunakan bersama dengan --dry-run"
 
 #: builtin/add.c:526
 #, c-format
-msgid "Nothing specified, nothing added.\n"
-msgstr ""
+msgid "--chmod param '%s' must be either -x or +x"
+msgstr "--chmod param '%s' harus berupa -x atau +x"
 
-#: builtin/add.c:528
+#: builtin/add.c:544 builtin/checkout.c:1735 builtin/commit.c:363
+#: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1637
+msgid "--pathspec-from-file is incompatible with pathspec arguments"
+msgstr "--pathspec-from-file tidak kompatibel dengan argumen pathspec"
+
+#: builtin/add.c:551 builtin/checkout.c:1747 builtin/commit.c:369
+#: builtin/reset.c:334 builtin/rm.c:279 builtin/stash.c:1643
+msgid "--pathspec-file-nul requires --pathspec-from-file"
+msgstr "--pathspec-file-nul butuh --pathspec-from-file"
+
+#: builtin/add.c:555
+#, c-format
+msgid "Nothing specified, nothing added.\n"
+msgstr "Tidak ada yang disebutkan, tidak ada yang ditambahkan.\n"
+
+#: builtin/add.c:557
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
 "\"git config advice.addEmptyPathspec false\""
 msgstr ""
+"Mungkin Anda ingin bilang 'git add .'?\n"
+"Matikan pesan ini dengan menjalankan\n"
+"\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:352
+#: builtin/am.c:364
 msgid "could not parse author script"
 msgstr ""
 
-#: builtin/am.c:436
+#: builtin/am.c:454
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr ""
 
-#: builtin/am.c:478
+#: builtin/am.c:496
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr ""
 
-#: builtin/am.c:516
+#: builtin/am.c:534
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr ""
 
-#: builtin/am.c:542
+#: builtin/am.c:560
 msgid "fseek failed"
 msgstr ""
 
-#: builtin/am.c:730
+#: builtin/am.c:748
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr ""
 
-#: builtin/am.c:795
+#: builtin/am.c:813
 msgid "Only one StGIT patch series can be applied at once"
 msgstr ""
 
-#: builtin/am.c:843
+#: builtin/am.c:861
 msgid "invalid timestamp"
 msgstr ""
 
-#: builtin/am.c:848 builtin/am.c:860
+#: builtin/am.c:866 builtin/am.c:878
 msgid "invalid Date line"
 msgstr ""
 
-#: builtin/am.c:855
+#: builtin/am.c:873
 msgid "invalid timezone offset"
 msgstr ""
 
-#: builtin/am.c:948
+#: builtin/am.c:966
 msgid "Patch format detection failed."
 msgstr ""
 
-#: builtin/am.c:953 builtin/clone.c:410
+#: builtin/am.c:971 builtin/clone.c:414
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr ""
 
-#: builtin/am.c:958
+#: builtin/am.c:976
 msgid "Failed to split patches."
 msgstr ""
 
-#: builtin/am.c:1089
+#: builtin/am.c:1125
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr ""
 
-#: builtin/am.c:1090
+#: builtin/am.c:1126
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 
-#: builtin/am.c:1091
+#: builtin/am.c:1127
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 
-#: builtin/am.c:1174
+#: builtin/am.c:1222
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 
-#: builtin/am.c:1202
+#: builtin/am.c:1250
 msgid "Patch is empty."
 msgstr ""
 
-#: builtin/am.c:1267
+#: builtin/am.c:1315
 #, c-format
 msgid "missing author line in commit %s"
 msgstr ""
 
-#: builtin/am.c:1270
+#: builtin/am.c:1318
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr ""
 
-#: builtin/am.c:1489
+#: builtin/am.c:1537
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 
-#: builtin/am.c:1491
+#: builtin/am.c:1539
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 
-#: builtin/am.c:1510
+#: builtin/am.c:1558
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
 msgstr ""
 
-#: builtin/am.c:1516
+#: builtin/am.c:1564
 msgid "Falling back to patching base and 3-way merge..."
 msgstr ""
 
-#: builtin/am.c:1542
+#: builtin/am.c:1590
 msgid "Failed to merge in the changes."
 msgstr ""
 
-#: builtin/am.c:1574
+#: builtin/am.c:1622
 msgid "applying to an empty history"
 msgstr ""
 
-#: builtin/am.c:1626 builtin/am.c:1630
+#: builtin/am.c:1674 builtin/am.c:1678
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr ""
 
-#: builtin/am.c:1648
+#: builtin/am.c:1696
 msgid "Commit Body is:"
 msgstr ""
 
@@ -9640,46 +9938,46 @@ msgstr ""
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1658
+#: builtin/am.c:1706
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 
-#: builtin/am.c:1704 builtin/commit.c:395
+#: builtin/am.c:1752 builtin/commit.c:408
 msgid "unable to write index file"
 msgstr ""
 
-#: builtin/am.c:1708
+#: builtin/am.c:1756
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr ""
 
-#: builtin/am.c:1748 builtin/am.c:1816
+#: builtin/am.c:1796 builtin/am.c:1864
 #, c-format
 msgid "Applying: %.*s"
 msgstr ""
 
-#: builtin/am.c:1765
+#: builtin/am.c:1813
 msgid "No changes -- Patch already applied."
 msgstr ""
 
-#: builtin/am.c:1771
+#: builtin/am.c:1819
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr ""
 
-#: builtin/am.c:1775
+#: builtin/am.c:1823
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 
-#: builtin/am.c:1819
+#: builtin/am.c:1867
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
 "already introduced the same changes; you might want to skip this patch."
 msgstr ""
 
-#: builtin/am.c:1826
+#: builtin/am.c:1874
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -9687,197 +9985,201 @@ msgid ""
 "You might run `git rm` on a file to accept \"deleted by them\" for it."
 msgstr ""
 
-#: builtin/am.c:1933 builtin/am.c:1937 builtin/am.c:1949 builtin/reset.c:347
+#: builtin/am.c:1981 builtin/am.c:1985 builtin/am.c:1997 builtin/reset.c:347
 #: builtin/reset.c:355
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Tidak dapat mengurai objek '%s'."
 
-#: builtin/am.c:1985
+#: builtin/am.c:2033
 msgid "failed to clean index"
 msgstr ""
 
-#: builtin/am.c:2029
+#: builtin/am.c:2077
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
 msgstr ""
 
-#: builtin/am.c:2136
+#: builtin/am.c:2184
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr ""
 
-#: builtin/am.c:2178
+#: builtin/am.c:2226
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr ""
 
-#: builtin/am.c:2182
+#: builtin/am.c:2230
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr ""
 
-#: builtin/am.c:2213
+#: builtin/am.c:2261
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr ""
 
-#: builtin/am.c:2214
+#: builtin/am.c:2262
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr ""
 
-#: builtin/am.c:2220
+#: builtin/am.c:2268
 msgid "run interactively"
 msgstr ""
 
-#: builtin/am.c:2222
+#: builtin/am.c:2270
 msgid "historical option -- no-op"
 msgstr ""
 
-#: builtin/am.c:2224
+#: builtin/am.c:2272
 msgid "allow fall back on 3way merging if needed"
 msgstr ""
 
-#: builtin/am.c:2225 builtin/init-db.c:560 builtin/prune-packed.c:16
-#: builtin/repack.c:334 builtin/stash.c:882
+#: builtin/am.c:2273 builtin/init-db.c:546 builtin/prune-packed.c:16
+#: builtin/repack.c:472 builtin/stash.c:948
 msgid "be quiet"
 msgstr ""
 
-#: builtin/am.c:2227
+#: builtin/am.c:2275
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr ""
 
-#: builtin/am.c:2230
+#: builtin/am.c:2278
 msgid "recode into utf8 (default)"
 msgstr ""
 
-#: builtin/am.c:2232
+#: builtin/am.c:2280
 msgid "pass -k flag to git-mailinfo"
 msgstr ""
 
-#: builtin/am.c:2234
+#: builtin/am.c:2282
 msgid "pass -b flag to git-mailinfo"
 msgstr ""
 
-#: builtin/am.c:2236
+#: builtin/am.c:2284
 msgid "pass -m flag to git-mailinfo"
 msgstr ""
 
-#: builtin/am.c:2238
+#: builtin/am.c:2286
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr ""
 
-#: builtin/am.c:2241
+#: builtin/am.c:2289
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 
-#: builtin/am.c:2244
+#: builtin/am.c:2292
 msgid "strip everything before a scissors line"
 msgstr ""
 
-#: builtin/am.c:2246 builtin/am.c:2249 builtin/am.c:2252 builtin/am.c:2255
-#: builtin/am.c:2258 builtin/am.c:2261 builtin/am.c:2264 builtin/am.c:2267
-#: builtin/am.c:2273
+#: builtin/am.c:2294
+msgid "pass it through git-mailinfo"
+msgstr ""
+
+#: builtin/am.c:2297 builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306
+#: builtin/am.c:2309 builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318
+#: builtin/am.c:2324
 msgid "pass it through git-apply"
 msgstr ""
 
-#: builtin/am.c:2263 builtin/commit.c:1395 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:904 builtin/merge.c:261
+#: builtin/am.c:2314 builtin/commit.c:1505 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:906 builtin/merge.c:261
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1347 builtin/repack.c:345 builtin/repack.c:349
-#: builtin/repack.c:351 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:436 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: builtin/rebase.c:1342 builtin/repack.c:483 builtin/repack.c:487
+#: builtin/repack.c:489 builtin/show-branch.c:650 builtin/show-ref.c:172
+#: builtin/tag.c:447 parse-options.h:155 parse-options.h:176
+#: parse-options.h:317
 msgid "n"
 msgstr ""
 
-#: builtin/am.c:2269 builtin/branch.c:670 builtin/bugreport.c:136
-#: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:470
+#: builtin/am.c:2320 builtin/branch.c:672 builtin/bugreport.c:137
+#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:481
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr ""
 
-#: builtin/am.c:2270
+#: builtin/am.c:2321
 msgid "format the patch(es) are in"
 msgstr ""
 
-#: builtin/am.c:2276
+#: builtin/am.c:2327
 msgid "override error message when patch failure occurs"
 msgstr ""
 
-#: builtin/am.c:2278
+#: builtin/am.c:2329
 msgid "continue applying patches after resolving a conflict"
 msgstr ""
 
-#: builtin/am.c:2281
+#: builtin/am.c:2332
 msgid "synonyms for --continue"
 msgstr ""
 
-#: builtin/am.c:2284
+#: builtin/am.c:2335
 msgid "skip the current patch"
 msgstr ""
 
-#: builtin/am.c:2287
+#: builtin/am.c:2338
 msgid "restore the original branch and abort the patching operation"
 msgstr ""
 
-#: builtin/am.c:2290
+#: builtin/am.c:2341
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr ""
 
-#: builtin/am.c:2294
+#: builtin/am.c:2345
 msgid "show the patch being applied"
 msgstr ""
 
-#: builtin/am.c:2299
+#: builtin/am.c:2350
 msgid "lie about committer date"
 msgstr ""
 
-#: builtin/am.c:2301
+#: builtin/am.c:2352
 msgid "use current timestamp for author date"
 msgstr ""
 
-#: builtin/am.c:2303 builtin/commit-tree.c:120 builtin/commit.c:1515
-#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:538
-#: builtin/rebase.c:1400 builtin/revert.c:117 builtin/tag.c:451
+#: builtin/am.c:2354 builtin/commit-tree.c:120 builtin/commit.c:1630
+#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:537
+#: builtin/rebase.c:1395 builtin/revert.c:117 builtin/tag.c:462
 msgid "key-id"
 msgstr ""
 
-#: builtin/am.c:2304 builtin/rebase.c:539 builtin/rebase.c:1401
+#: builtin/am.c:2355 builtin/rebase.c:538 builtin/rebase.c:1396
 msgid "GPG-sign commits"
 msgstr ""
 
-#: builtin/am.c:2307
+#: builtin/am.c:2358
 msgid "(internal use for git-rebase)"
 msgstr ""
 
-#: builtin/am.c:2325
+#: builtin/am.c:2376
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
 msgstr ""
 
-#: builtin/am.c:2332
+#: builtin/am.c:2383
 msgid "failed to read the index"
 msgstr ""
 
-#: builtin/am.c:2347
+#: builtin/am.c:2398
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
 
-#: builtin/am.c:2371
+#: builtin/am.c:2422
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
 "Use \"git am --abort\" to remove it."
 msgstr ""
 
-#: builtin/am.c:2377
+#: builtin/am.c:2428
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr ""
 
-#: builtin/am.c:2387
+#: builtin/am.c:2438
 msgid "interactive mode requires patches on the command line"
 msgstr ""
 
@@ -10067,7 +10369,7 @@ msgid ""
 "Supported options are: --term-good|--term-old and --term-bad|--term-new."
 msgstr ""
 
-#: builtin/bisect--helper.c:497 builtin/bisect--helper.c:1014
+#: builtin/bisect--helper.c:497 builtin/bisect--helper.c:1021
 msgid "revision walk setup failed\n"
 msgstr ""
 
@@ -10133,85 +10435,91 @@ msgstr ""
 msgid "'git bisect %s' can take only one argument."
 msgstr ""
 
-#: builtin/bisect--helper.c:867 builtin/bisect--helper.c:878
+#: builtin/bisect--helper.c:867 builtin/bisect--helper.c:880
 #, c-format
 msgid "Bad rev input: %s"
 msgstr ""
 
-#: builtin/bisect--helper.c:912
+#: builtin/bisect--helper.c:887
+#, c-format
+msgid "Bad rev input (not a commit): %s"
+msgstr ""
+
+#: builtin/bisect--helper.c:919
 msgid "We are not bisecting."
 msgstr ""
 
-#: builtin/bisect--helper.c:962
+#: builtin/bisect--helper.c:969
 #, c-format
 msgid "'%s'?? what are you talking about?"
 msgstr ""
 
-#: builtin/bisect--helper.c:974
+#: builtin/bisect--helper.c:981
+#, c-format
 msgid "cannot read file '%s' for replaying"
 msgstr ""
 
-#: builtin/bisect--helper.c:1047
+#: builtin/bisect--helper.c:1054
 msgid "reset the bisection state"
 msgstr ""
 
-#: builtin/bisect--helper.c:1049
+#: builtin/bisect--helper.c:1056
 msgid "check whether bad or good terms exist"
 msgstr ""
 
-#: builtin/bisect--helper.c:1051
+#: builtin/bisect--helper.c:1058
 msgid "print out the bisect terms"
 msgstr ""
 
-#: builtin/bisect--helper.c:1053
+#: builtin/bisect--helper.c:1060
 msgid "start the bisect session"
 msgstr ""
 
-#: builtin/bisect--helper.c:1055
+#: builtin/bisect--helper.c:1062
 msgid "find the next bisection commit"
 msgstr ""
 
-#: builtin/bisect--helper.c:1057
+#: builtin/bisect--helper.c:1064
 msgid "mark the state of ref (or refs)"
 msgstr ""
 
-#: builtin/bisect--helper.c:1059
+#: builtin/bisect--helper.c:1066
 msgid "list the bisection steps so far"
 msgstr ""
 
-#: builtin/bisect--helper.c:1061
+#: builtin/bisect--helper.c:1068
 msgid "replay the bisection process from the given file"
 msgstr ""
 
-#: builtin/bisect--helper.c:1063
+#: builtin/bisect--helper.c:1070
 msgid "skip some commits for checkout"
 msgstr ""
 
-#: builtin/bisect--helper.c:1065
+#: builtin/bisect--helper.c:1072
 msgid "no log for BISECT_WRITE"
 msgstr ""
 
-#: builtin/bisect--helper.c:1080
+#: builtin/bisect--helper.c:1087
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr ""
 
-#: builtin/bisect--helper.c:1085
+#: builtin/bisect--helper.c:1092
 msgid "--bisect-next-check requires 2 or 3 arguments"
 msgstr ""
 
-#: builtin/bisect--helper.c:1091
+#: builtin/bisect--helper.c:1098
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr ""
 
-#: builtin/bisect--helper.c:1100
+#: builtin/bisect--helper.c:1107
 msgid "--bisect-next requires 0 arguments"
 msgstr ""
 
-#: builtin/bisect--helper.c:1111
+#: builtin/bisect--helper.c:1118
 msgid "--bisect-log requires 0 arguments"
 msgstr ""
 
-#: builtin/bisect--helper.c:1116
+#: builtin/bisect--helper.c:1123
 msgid "no logfile given"
 msgstr ""
 
@@ -10262,9 +10570,9 @@ msgstr ""
 msgid "show work cost statistics"
 msgstr ""
 
-#: builtin/blame.c:871 builtin/checkout.c:1503 builtin/clone.c:92
-#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:175
-#: builtin/merge.c:297 builtin/multi-pack-index.c:27 builtin/pull.c:119
+#: builtin/blame.c:871 builtin/checkout.c:1524 builtin/clone.c:94
+#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:179
+#: builtin/merge.c:297 builtin/multi-pack-index.c:55 builtin/pull.c:119
 #: builtin/push.c:575 builtin/send-pack.c:198
 msgid "force progress reporting"
 msgstr "paksa laporkan perkembangan"
@@ -10313,7 +10621,7 @@ msgstr ""
 msgid "ignore whitespace differences"
 msgstr ""
 
-#: builtin/blame.c:883 builtin/log.c:1812
+#: builtin/blame.c:883 builtin/log.c:1820
 msgid "rev"
 msgstr ""
 
@@ -10394,31 +10702,31 @@ msgstr ""
 
 #: builtin/branch.c:29
 msgid "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
-msgstr ""
+msgstr "git branch [<opsi>] [-r | -a] [--merged] [--no-merged]"
 
 #: builtin/branch.c:30
 msgid "git branch [<options>] [-l] [-f] <branch-name> [<start-point>]"
-msgstr ""
+msgstr "git branch [<opsi>] [-l] [-f] <nama-cabang> [<titik-awal>]"
 
 #: builtin/branch.c:31
 msgid "git branch [<options>] [-r] (-d | -D) <branch-name>..."
-msgstr ""
+msgstr "git branch [<opsi> [-r] (-d | -D) <nama-cabang>...]"
 
 #: builtin/branch.c:32
 msgid "git branch [<options>] (-m | -M) [<old-branch>] <new-branch>"
-msgstr ""
+msgstr "git branch [<opsi>] (-m | -M) [<cabang-lama>] <cabang-baru>"
 
 #: builtin/branch.c:33
 msgid "git branch [<options>] (-c | -C) [<old-branch>] <new-branch>"
-msgstr ""
+msgstr "git branch [<opsi>] (-c | -C) [<cabang-lama>] <cabang-baru>"
 
 #: builtin/branch.c:34
 msgid "git branch [<options>] [-r | -a] [--points-at]"
-msgstr ""
+msgstr "git branch [<opsi>] [-r | -a] [--points-at]"
 
 #: builtin/branch.c:35
 msgid "git branch [<options>] [-r | -a] [--format]"
-msgstr ""
+msgstr "git branch [<opsi>] [-r | -a] [--format]"
 
 #: builtin/branch.c:154
 #, c-format
@@ -10426,6 +10734,8 @@ msgid ""
 "deleting branch '%s' that has been merged to\n"
 "         '%s', but not yet merged to HEAD."
 msgstr ""
+"menghapus cabang '%s' yang sudah digabungkan ke\n"
+"         '%s', tapi belum digabungkan ke HEAD."
 
 #: builtin/branch.c:158
 #, c-format
@@ -10433,11 +10743,13 @@ msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
 "         '%s', even though it is merged to HEAD."
 msgstr ""
+"tidak menghapus cabang '%s' yang belum digabungkan ke\n"
+"         '%s', walaupun tergabung ke HEAD."
 
 #: builtin/branch.c:172
 #, c-format
 msgid "Couldn't look up commit object for '%s'"
-msgstr ""
+msgstr "Tidak dapat mencari objek komit untuk '%s'"
 
 #: builtin/branch.c:176
 #, c-format
@@ -10445,332 +10757,345 @@ msgid ""
 "The branch '%s' is not fully merged.\n"
 "If you are sure you want to delete it, run 'git branch -D %s'."
 msgstr ""
+"Cabang '%s' belum sepenuhnya tergabung.\n"
+"Kalau Anda yakin ingin menghapus itu, jalankan 'git branch -D %s'."
 
 #: builtin/branch.c:189
 msgid "Update of config-file failed"
-msgstr ""
+msgstr "Pembaruan berkas konfigurasi gagal"
 
 #: builtin/branch.c:223
 msgid "cannot use -a with -d"
-msgstr ""
+msgstr "tidak dapat gunakan -a dengan -d"
 
 #: builtin/branch.c:230
 msgid "Couldn't look up commit object for HEAD"
-msgstr ""
+msgstr "Tidak dapat mencari objek komit untuk HEAD"
 
 #: builtin/branch.c:244
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
-msgstr ""
+msgstr "Tidak dapat menghapus cabang '%s' yang ter-checkout pada '%s'"
 
 #: builtin/branch.c:259
 #, c-format
 msgid "remote-tracking branch '%s' not found."
-msgstr ""
+msgstr "cabang pelacak remote '%s' tidak ditemukan."
 
 #: builtin/branch.c:260
 #, c-format
 msgid "branch '%s' not found."
-msgstr ""
+msgstr "cabang '%s' tidak ditemukan."
 
 #: builtin/branch.c:291
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
-msgstr ""
+msgstr "Cabang pelacak remote %s (yaitu %s) dihapus.\n"
 
 #: builtin/branch.c:292
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
-msgstr ""
+msgstr "Cabang %s (yaitu %s) dihapus.\n"
 
-#: builtin/branch.c:438 builtin/tag.c:61
+#: builtin/branch.c:440 builtin/tag.c:63
 msgid "unable to parse format string"
-msgstr ""
+msgstr "tidak dapat menguraikan untai format"
 
-#: builtin/branch.c:469
+#: builtin/branch.c:471
 msgid "could not resolve HEAD"
-msgstr ""
+msgstr "tidak dapat menguraikan HEAD"
 
-#: builtin/branch.c:475
+#: builtin/branch.c:477
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
-msgstr ""
+msgstr "HEAD (%s) merujuk diluar refs/heads/"
 
-#: builtin/branch.c:490
+#: builtin/branch.c:492
 #, c-format
 msgid "Branch %s is being rebased at %s"
-msgstr ""
+msgstr "Cabang %s sedang didasarkan ulang pada %s"
 
-#: builtin/branch.c:494
+#: builtin/branch.c:496
 #, c-format
 msgid "Branch %s is being bisected at %s"
-msgstr ""
-
-#: builtin/branch.c:511
-msgid "cannot copy the current branch while not on any."
-msgstr ""
+msgstr "Cabang %s sedang dibagi dua pada %s"
 
 #: builtin/branch.c:513
-msgid "cannot rename the current branch while not on any."
-msgstr ""
+msgid "cannot copy the current branch while not on any."
+msgstr "tidak dapat menyalin cabang saat ini ketika tidak ada."
 
-#: builtin/branch.c:524
+#: builtin/branch.c:515
+msgid "cannot rename the current branch while not on any."
+msgstr "tidak dapat mengganti nama cabang saat ini ketika tidak ada."
+
+#: builtin/branch.c:526
 #, c-format
 msgid "Invalid branch name: '%s'"
-msgstr ""
-
-#: builtin/branch.c:553
-msgid "Branch rename failed"
-msgstr ""
+msgstr "Nama cabang tidak valid: '%s'"
 
 #: builtin/branch.c:555
-msgid "Branch copy failed"
-msgstr ""
+msgid "Branch rename failed"
+msgstr "Penggantian nama cabang gagal"
 
-#: builtin/branch.c:559
+#: builtin/branch.c:557
+msgid "Branch copy failed"
+msgstr "Penyalinan cabang gagal"
+
+#: builtin/branch.c:561
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
-msgstr ""
+msgstr "Salinan cabang salah nama '%s' dibuat"
 
-#: builtin/branch.c:562
+#: builtin/branch.c:564
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
-msgstr ""
+msgstr "Cabang salah nama '%s' berganti nama"
 
-#: builtin/branch.c:568
+#: builtin/branch.c:570
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
-msgstr ""
-
-#: builtin/branch.c:577
-msgid "Branch is renamed, but update of config-file failed"
-msgstr ""
+msgstr "Cabang berganti nama ke %s, tapi HEAD tidak diperbarui!"
 
 #: builtin/branch.c:579
-msgid "Branch is copied, but update of config-file failed"
-msgstr ""
+msgid "Branch is renamed, but update of config-file failed"
+msgstr "Cabang berganti nama, tapi pembaruan berkas konfigurasi gagal"
 
-#: builtin/branch.c:595
+#: builtin/branch.c:581
+msgid "Branch is copied, but update of config-file failed"
+msgstr "Cabang disalin, tapi pembaruan berkas konfigurasi gagal"
+
+#: builtin/branch.c:597
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
 "  %s\n"
 "Lines starting with '%c' will be stripped.\n"
 msgstr ""
-
-#: builtin/branch.c:629
-msgid "Generic options"
-msgstr ""
+"Mohon sunting deskripsi untuk cabang\n"
+"  %s\n"
+"Baris yang diawali dengan '%c' akan dicopot.\n"
 
 #: builtin/branch.c:631
-msgid "show hash and subject, give twice for upstream branch"
-msgstr ""
-
-#: builtin/branch.c:632
-msgid "suppress informational messages"
-msgstr ""
+msgid "Generic options"
+msgstr "Opsi generik"
 
 #: builtin/branch.c:633
-msgid "set up tracking mode (see git-pull(1))"
-msgstr ""
+msgid "show hash and subject, give twice for upstream branch"
+msgstr "perlihatkan hash dan subjek, berikan dua kali untuk cabang hulu"
+
+#: builtin/branch.c:634
+msgid "suppress informational messages"
+msgstr "sembunyikan pesan informasi"
 
 #: builtin/branch.c:635
-msgid "do not use"
-msgstr ""
-
-#: builtin/branch.c:637 builtin/rebase.c:534
-msgid "upstream"
-msgstr ""
+msgid "set up tracking mode (see git-pull(1))"
+msgstr "pasang mode pelacakan (lihat git-pull(1))"
 
 #: builtin/branch.c:637
-msgid "change the upstream info"
-msgstr ""
+msgid "do not use"
+msgstr "jangan gunakan"
 
-#: builtin/branch.c:638
-msgid "unset the upstream info"
-msgstr ""
+#: builtin/branch.c:639 builtin/rebase.c:533
+msgid "upstream"
+msgstr "hulu"
 
 #: builtin/branch.c:639
-msgid "use colored output"
-msgstr ""
+msgid "change the upstream info"
+msgstr "ubah info hulu"
 
 #: builtin/branch.c:640
+msgid "unset the upstream info"
+msgstr "batal-setel info hulu"
+
+#: builtin/branch.c:641
+msgid "use colored output"
+msgstr "gunakan keluaran berwarna"
+
+#: builtin/branch.c:642
 msgid "act on remote-tracking branches"
-msgstr ""
+msgstr "lakukan pada cabang pelacak remote"
 
-#: builtin/branch.c:642 builtin/branch.c:644
+#: builtin/branch.c:644 builtin/branch.c:646
 msgid "print only branches that contain the commit"
-msgstr ""
+msgstr "cetak hanya cabang yang berisi komit"
 
-#: builtin/branch.c:643 builtin/branch.c:645
+#: builtin/branch.c:645 builtin/branch.c:647
 msgid "print only branches that don't contain the commit"
-msgstr ""
+msgstr "cetak hanya cabang yang tak berisi komit"
 
-#: builtin/branch.c:648
+#: builtin/branch.c:650
 msgid "Specific git-branch actions:"
-msgstr ""
-
-#: builtin/branch.c:649
-msgid "list both remote-tracking and local branches"
-msgstr ""
+msgstr "Aksi git-branch spesifik:"
 
 #: builtin/branch.c:651
-msgid "delete fully merged branch"
-msgstr ""
-
-#: builtin/branch.c:652
-msgid "delete branch (even if not merged)"
-msgstr ""
+msgid "list both remote-tracking and local branches"
+msgstr "sebut baik cabang pelacak remote dan cabang lokal"
 
 #: builtin/branch.c:653
-msgid "move/rename a branch and its reflog"
-msgstr ""
+msgid "delete fully merged branch"
+msgstr "hapus cabang yang tergabung sepenuhnya"
 
 #: builtin/branch.c:654
-msgid "move/rename a branch, even if target exists"
-msgstr ""
+msgid "delete branch (even if not merged)"
+msgstr "hapus cabang (walaupun tak tergabung)"
 
 #: builtin/branch.c:655
-msgid "copy a branch and its reflog"
-msgstr ""
+msgid "move/rename a branch and its reflog"
+msgstr "pindah/ganti nama cabang dan reflog-nya"
 
 #: builtin/branch.c:656
-msgid "copy a branch, even if target exists"
-msgstr ""
+msgid "move/rename a branch, even if target exists"
+msgstr "pindah/ganti nama cabang, walaupun target ada"
 
 #: builtin/branch.c:657
-msgid "list branch names"
-msgstr ""
+msgid "copy a branch and its reflog"
+msgstr "salin cabang dan reflog-nya"
 
 #: builtin/branch.c:658
-msgid "show current branch name"
-msgstr ""
+msgid "copy a branch, even if target exists"
+msgstr "salin cabang, walapun target ada"
 
 #: builtin/branch.c:659
-msgid "create the branch's reflog"
-msgstr ""
+msgid "list branch names"
+msgstr "sebut nama cabang"
+
+#: builtin/branch.c:660
+msgid "show current branch name"
+msgstr "perlihatkan nama cabang saat ini"
 
 #: builtin/branch.c:661
-msgid "edit the description for the branch"
-msgstr ""
-
-#: builtin/branch.c:662
-msgid "force creation, move/rename, deletion"
-msgstr ""
+msgid "create the branch's reflog"
+msgstr "buat reflog cabang"
 
 #: builtin/branch.c:663
-msgid "print only branches that are merged"
-msgstr ""
+msgid "edit the description for the branch"
+msgstr "sunting deskripsi cabang"
 
 #: builtin/branch.c:664
-msgid "print only branches that are not merged"
-msgstr ""
+msgid "force creation, move/rename, deletion"
+msgstr "paksa buat, pindah/ganti nama, hapus"
 
 #: builtin/branch.c:665
+msgid "print only branches that are merged"
+msgstr "cetak hanya cabang yang tergabung"
+
+#: builtin/branch.c:666
+msgid "print only branches that are not merged"
+msgstr "cetak hanya cabang yang tak tergabung"
+
+#: builtin/branch.c:667
 msgid "list branches in columns"
-msgstr ""
+msgstr "sebut cabang dalam kolom"
 
-#: builtin/branch.c:667 builtin/for-each-ref.c:42 builtin/notes.c:415
+#: builtin/branch.c:669 builtin/for-each-ref.c:44 builtin/notes.c:415
 #: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:466
+#: builtin/tag.c:477
 msgid "object"
-msgstr ""
+msgstr "objek"
 
-#: builtin/branch.c:668
+#: builtin/branch.c:670
 msgid "print only branches of the object"
-msgstr ""
+msgstr "cetak hanya cabang objek"
 
-#: builtin/branch.c:669 builtin/for-each-ref.c:48 builtin/tag.c:473
+#: builtin/branch.c:671 builtin/for-each-ref.c:50 builtin/tag.c:484
 msgid "sorting and filtering are case insensitive"
-msgstr ""
+msgstr "pengurutan dan penyaringan tak peka kapital"
 
-#: builtin/branch.c:670 builtin/for-each-ref.c:38 builtin/tag.c:471
+#: builtin/branch.c:672 builtin/for-each-ref.c:40 builtin/tag.c:482
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
-msgstr ""
+msgstr "format yang digunakan untuk keluaran"
 
-#: builtin/branch.c:693 builtin/clone.c:790
+#: builtin/branch.c:695 builtin/clone.c:794
 msgid "HEAD not found below refs/heads!"
-msgstr ""
+msgstr "HEAD tidak ditemukan di bawah refs/heads!"
 
-#: builtin/branch.c:717
+#: builtin/branch.c:719
 msgid "--column and --verbose are incompatible"
-msgstr ""
+msgstr "--column dan --verbose tidak kompatibel"
 
-#: builtin/branch.c:732 builtin/branch.c:788 builtin/branch.c:797
+#: builtin/branch.c:734 builtin/branch.c:790 builtin/branch.c:799
 msgid "branch name required"
-msgstr ""
+msgstr "nama cabang diperlukan"
 
-#: builtin/branch.c:764
+#: builtin/branch.c:766
 msgid "Cannot give description to detached HEAD"
-msgstr ""
+msgstr "Tidak dapat memberikan deskripsi ke HEAD terpisah"
 
-#: builtin/branch.c:769
+#: builtin/branch.c:771
 msgid "cannot edit description of more than one branch"
-msgstr ""
+msgstr "tidak dapat menyunting deskripsi lebih dari satu cabang"
 
-#: builtin/branch.c:776
+#: builtin/branch.c:778
 #, c-format
 msgid "No commit on branch '%s' yet."
-msgstr ""
+msgstr "Belum ada komit pada cabang '%s'."
 
-#: builtin/branch.c:779
+#: builtin/branch.c:781
 #, c-format
 msgid "No branch named '%s'."
-msgstr ""
+msgstr "Tidak ada cabang bernama '%s'."
 
-#: builtin/branch.c:794
+#: builtin/branch.c:796
 msgid "too many branches for a copy operation"
-msgstr ""
+msgstr "terlalu banyak cabang untuk operasi penyalinan"
 
-#: builtin/branch.c:803
+#: builtin/branch.c:805
 msgid "too many arguments for a rename operation"
-msgstr ""
+msgstr "terlalu banyak argumen untuk operasi penggantian nama"
 
-#: builtin/branch.c:808
+#: builtin/branch.c:810
 msgid "too many arguments to set new upstream"
-msgstr ""
+msgstr "terlalu banyak argumen untuk menyetel hulu baru"
 
-#: builtin/branch.c:812
+#: builtin/branch.c:814
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
 msgstr ""
+"tidak dapat menyetel hulu HEAD ke %s ketika itu tak menunjuk pada cabang "
+"apapun."
 
-#: builtin/branch.c:815 builtin/branch.c:838
+#: builtin/branch.c:817 builtin/branch.c:840
 #, c-format
 msgid "no such branch '%s'"
-msgstr ""
+msgstr "tidak ada cabang '%s'"
 
-#: builtin/branch.c:819
+#: builtin/branch.c:821
 #, c-format
 msgid "branch '%s' does not exist"
-msgstr ""
+msgstr "cabang '%s' tidak ada"
 
-#: builtin/branch.c:832
+#: builtin/branch.c:834
 msgid "too many arguments to unset upstream"
-msgstr ""
+msgstr "terlalu banyak argumen untuk batal-setel hulu"
 
-#: builtin/branch.c:836
+#: builtin/branch.c:838
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
+"tidak dapat membatal-setel hulu HEAD ketika itu tak menunjuk pada cabang "
+"apapun."
 
-#: builtin/branch.c:842
+#: builtin/branch.c:844
 #, c-format
 msgid "Branch '%s' has no upstream information"
-msgstr ""
+msgstr "Cabang '%s' tidak ada informasi hulu"
 
-#: builtin/branch.c:852
+#: builtin/branch.c:854
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
 msgstr ""
+"Opsi -a dan -r tidak mengambil nama cabang.\n"
+"Mungkin maksud Anda gunakan: -a|-r --list <pola>?"
 
-#: builtin/branch.c:856
+#: builtin/branch.c:858
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
 msgstr ""
+"opsi '--set-upstream' tidak lagi didukung. Mohon gunakan '--track' atau '--"
+"set-upstream-to' sebagai gantinya."
 
 #: builtin/bugreport.c:15
 msgid "git version:\n"
@@ -10816,38 +11141,38 @@ msgid ""
 "You can delete any lines you don't wish to share.\n"
 msgstr ""
 
-#: builtin/bugreport.c:135
+#: builtin/bugreport.c:136
 msgid "specify a destination for the bugreport file"
 msgstr ""
 
-#: builtin/bugreport.c:137
+#: builtin/bugreport.c:138
 msgid "specify a strftime format suffix for the filename"
 msgstr ""
 
-#: builtin/bugreport.c:159
+#: builtin/bugreport.c:160
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr ""
 
-#: builtin/bugreport.c:166
+#: builtin/bugreport.c:167
 msgid "System Info"
 msgstr ""
 
-#: builtin/bugreport.c:169
+#: builtin/bugreport.c:170
 msgid "Enabled Hooks"
 msgstr ""
 
-#: builtin/bugreport.c:176
+#: builtin/bugreport.c:177
 #, c-format
 msgid "couldn't create a new file at '%s'"
 msgstr ""
 
-#: builtin/bugreport.c:179
+#: builtin/bugreport.c:180
 #, c-format
 msgid "unable to write to %s"
 msgstr ""
 
-#: builtin/bugreport.c:189
+#: builtin/bugreport.c:190
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr ""
@@ -10868,19 +11193,19 @@ msgstr ""
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr ""
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3495
+#: builtin/bundle.c:67 builtin/pack-objects.c:3747
 msgid "do not show progress meter"
 msgstr ""
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3497
+#: builtin/bundle.c:69 builtin/pack-objects.c:3749
 msgid "show progress meter"
 msgstr ""
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3499
+#: builtin/bundle.c:71 builtin/pack-objects.c:3751
 msgid "show progress meter during object writing phase"
 msgstr ""
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3502
+#: builtin/bundle.c:74 builtin/pack-objects.c:3754
 msgid "similar to --all-progress when progress meter is shown"
 msgstr ""
 
@@ -11018,8 +11343,8 @@ msgstr ""
 msgid "terminate input and output records by a NUL character"
 msgstr ""
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1499 builtin/gc.c:549
-#: builtin/worktree.c:489
+#: builtin/check-ignore.c:21 builtin/checkout.c:1520 builtin/gc.c:549
+#: builtin/worktree.c:491
 msgid "suppress progress reporting"
 msgstr ""
 
@@ -11031,27 +11356,27 @@ msgstr ""
 msgid "ignore index when checking"
 msgstr ""
 
-#: builtin/check-ignore.c:163
+#: builtin/check-ignore.c:165
 msgid "cannot specify pathnames with --stdin"
 msgstr ""
 
-#: builtin/check-ignore.c:166
+#: builtin/check-ignore.c:168
 msgid "-z only makes sense with --stdin"
 msgstr ""
 
-#: builtin/check-ignore.c:168
+#: builtin/check-ignore.c:170
 msgid "no path specified"
 msgstr ""
 
-#: builtin/check-ignore.c:172
+#: builtin/check-ignore.c:174
 msgid "--quiet is only valid with a single pathname"
 msgstr ""
 
-#: builtin/check-ignore.c:174
+#: builtin/check-ignore.c:176
 msgid "cannot have both --quiet and --verbose"
 msgstr ""
 
-#: builtin/check-ignore.c:177
+#: builtin/check-ignore.c:179
 msgid "--non-matching is only valid with --verbose"
 msgstr ""
 
@@ -11072,6 +11397,21 @@ msgstr ""
 msgid "no contacts specified"
 msgstr ""
 
+#: builtin/checkout--worker.c:110
+msgid "git checkout--worker [<options>]"
+msgstr ""
+
+#: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
+#: builtin/column.c:31 builtin/submodule--helper.c:1825
+#: builtin/submodule--helper.c:1828 builtin/submodule--helper.c:1836
+#: builtin/submodule--helper.c:2334 builtin/worktree.c:719
+msgid "string"
+msgstr ""
+
+#: builtin/checkout--worker.c:119 builtin/checkout-index.c:202
+msgid "when creating files, prepend <string>"
+msgstr ""
+
 #: builtin/checkout-index.c:152
 msgid "git checkout-index [<options>] [--] [<file>...]"
 msgstr ""
@@ -11080,159 +11420,148 @@ msgstr ""
 msgid "stage should be between 1 and 3 or all"
 msgstr ""
 
-#: builtin/checkout-index.c:186
+#: builtin/checkout-index.c:187
 msgid "check out all files in the index"
 msgstr ""
 
-#: builtin/checkout-index.c:187
+#: builtin/checkout-index.c:188
 msgid "force overwrite of existing files"
 msgstr ""
 
-#: builtin/checkout-index.c:189
+#: builtin/checkout-index.c:190
 msgid "no warning for existing files and files not in index"
 msgstr ""
 
-#: builtin/checkout-index.c:191
+#: builtin/checkout-index.c:192
 msgid "don't checkout new files"
 msgstr ""
 
-#: builtin/checkout-index.c:193
+#: builtin/checkout-index.c:194
 msgid "update stat information in the index file"
 msgstr ""
 
-#: builtin/checkout-index.c:197
+#: builtin/checkout-index.c:198
 msgid "read list of paths from the standard input"
 msgstr ""
 
-#: builtin/checkout-index.c:199
+#: builtin/checkout-index.c:200
 msgid "write the content to temporary files"
 msgstr ""
 
-#: builtin/checkout-index.c:200 builtin/column.c:31
-#: builtin/submodule--helper.c:1824 builtin/submodule--helper.c:1827
-#: builtin/submodule--helper.c:1835 builtin/submodule--helper.c:2333
-#: builtin/worktree.c:717
-msgid "string"
-msgstr ""
-
-#: builtin/checkout-index.c:201
-msgid "when creating files, prepend <string>"
-msgstr ""
-
-#: builtin/checkout-index.c:203
+#: builtin/checkout-index.c:204
 msgid "copy out the files from named stage"
 msgstr ""
 
-#: builtin/checkout.c:31
+#: builtin/checkout.c:33
 msgid "git checkout [<options>] <branch>"
 msgstr "git checkout [<opsi>] <cabang>"
 
-#: builtin/checkout.c:32
+#: builtin/checkout.c:34
 msgid "git checkout [<options>] [<branch>] -- <file>..."
 msgstr "git checkout [<opsi>] [<cabang>] -- <berkas>..."
 
-#: builtin/checkout.c:37
+#: builtin/checkout.c:39
 msgid "git switch [<options>] [<branch>]"
 msgstr "git switch [<opsi>] [<cabang>]"
 
-#: builtin/checkout.c:42
+#: builtin/checkout.c:44
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [<opsi>] [--source=<cabang>] <berkas>..."
 
-#: builtin/checkout.c:188 builtin/checkout.c:227
+#: builtin/checkout.c:190 builtin/checkout.c:229
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "jalur '%s' tidak punya versi kami"
 
-#: builtin/checkout.c:190 builtin/checkout.c:229
+#: builtin/checkout.c:192 builtin/checkout.c:231
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "jalur '%s' tidak punya versi mereka"
 
-#: builtin/checkout.c:206
+#: builtin/checkout.c:208
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "jalur '%s' tidak punya semua versi yang diperlukan"
 
-#: builtin/checkout.c:258
+#: builtin/checkout.c:261
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "jalur '%s' tidak punya versi yang diperlukan"
 
-#: builtin/checkout.c:275
+#: builtin/checkout.c:278
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "jalur '%s': tidak dapat gabung"
 
-#: builtin/checkout.c:291
+#: builtin/checkout.c:294
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Tidak dapat menambahkan hasil penggabungan untuk '%s'"
 
-#: builtin/checkout.c:396
+#: builtin/checkout.c:414
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Konflik penggabungan %d dibuat ulang"
 msgstr[1] "Konflik penggabungan %d dibuat ulang"
 
-#: builtin/checkout.c:401
+#: builtin/checkout.c:419
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "%d jalur diperbarui dari %s"
 msgstr[1] "%d jalur diperbarui dari %s"
 
-#: builtin/checkout.c:408
+#: builtin/checkout.c:426
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "%d jalur diperbarui dari indeks"
 msgstr[1] "%d jalur diperbarui dari indeks"
 
-#: builtin/checkout.c:431 builtin/checkout.c:434 builtin/checkout.c:437
-#: builtin/checkout.c:441
+#: builtin/checkout.c:449 builtin/checkout.c:452 builtin/checkout.c:455
+#: builtin/checkout.c:459
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "'%s' tidak dapat digunakan untuk memperbarui jalur"
 
-#: builtin/checkout.c:444 builtin/checkout.c:447
+#: builtin/checkout.c:462 builtin/checkout.c:465
 #, c-format
 msgid "'%s' cannot be used with %s"
 msgstr "'%s' tidak dapat digunakan untuk %s"
 
-#: builtin/checkout.c:451
+#: builtin/checkout.c:469
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Tidak dapat memperbarui jalur dan mengganti ke cabang '%s' dalam waktu yang "
 "bersamaan."
 
-#: builtin/checkout.c:455
+#: builtin/checkout.c:473
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "baik '%s' atau '%s' tidak disebutkan"
 
-#: builtin/checkout.c:459
+#: builtin/checkout.c:477
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "'%s' harus disebutkan ketika '%s' tidak disebutkan"
 
-#: builtin/checkout.c:464 builtin/checkout.c:469
+#: builtin/checkout.c:482 builtin/checkout.c:487
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "'%s' atau '%s' tidak dapat digunakan untuk %s"
 
-#: builtin/checkout.c:543 builtin/checkout.c:550
+#: builtin/checkout.c:563 builtin/checkout.c:570
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "jalur '%s' tak tergabung"
 
-#: builtin/checkout.c:718
+#: builtin/checkout.c:739
 msgid "you need to resolve your current index first"
 msgstr "Anda perlu selesaikan dulu indeks Anda saat ini"
 
-#: builtin/checkout.c:772
+#: builtin/checkout.c:793
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -11242,50 +11571,50 @@ msgstr ""
 "berikut:\n"
 "%s"
 
-#: builtin/checkout.c:865
+#: builtin/checkout.c:886
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Tidak dapat melakukan reflog untuk '%s': %s\n"
 
-#: builtin/checkout.c:907
+#: builtin/checkout.c:928
 msgid "HEAD is now at"
 msgstr "HEAD sekarang berada di"
 
-#: builtin/checkout.c:911 builtin/clone.c:721 t/helper/test-fast-rebase.c:202
+#: builtin/checkout.c:932 builtin/clone.c:725 t/helper/test-fast-rebase.c:202
 msgid "unable to update HEAD"
 msgstr "tidak dapat memperbarui HEAD"
 
-#: builtin/checkout.c:915
+#: builtin/checkout.c:936
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Ganti ulang cabang '%s'\n"
 
-#: builtin/checkout.c:918
+#: builtin/checkout.c:939
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Sudah berada pada '%s'\n"
 
-#: builtin/checkout.c:922
+#: builtin/checkout.c:943
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Ganti ke dan ganti cabang '%s'\n"
 
-#: builtin/checkout.c:924 builtin/checkout.c:1355
+#: builtin/checkout.c:945 builtin/checkout.c:1376
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Ganti ke cabang baru '%s'\n"
 
-#: builtin/checkout.c:926
+#: builtin/checkout.c:947
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Ganti ke cabang '%s'\n"
 
-#: builtin/checkout.c:977
+#: builtin/checkout.c:998
 #, c-format
 msgid " ... and %d more.\n"
 msgstr "... dan %d lainnya.\n"
 
-#: builtin/checkout.c:983
+#: builtin/checkout.c:1004
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -11308,7 +11637,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1002
+#: builtin/checkout.c:1023
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -11331,19 +11660,19 @@ msgstr[1] ""
 "saat yang tepat untuk dilakukan dengan:\n"
 "git branch <nama-cabang-baru> %s\n"
 
-#: builtin/checkout.c:1037
+#: builtin/checkout.c:1058
 msgid "internal error in revision walk"
 msgstr "kesalahan internal dalam jalan revisi"
 
-#: builtin/checkout.c:1041
+#: builtin/checkout.c:1062
 msgid "Previous HEAD position was"
 msgstr "Posisi HEAD sebelumnya adalah"
 
-#: builtin/checkout.c:1081 builtin/checkout.c:1350
+#: builtin/checkout.c:1102 builtin/checkout.c:1371
 msgid "You are on a branch yet to be born"
 msgstr "Anda berada pada cabang yang belum lahir"
 
-#: builtin/checkout.c:1163
+#: builtin/checkout.c:1184
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -11352,7 +11681,7 @@ msgstr ""
 "'%s' bisa jadi berkas lokal dan cabang pelacak.\n"
 "Mohon gunakan -- (dan secara opsional --no-guess) untuk disambiguasi"
 
-#: builtin/checkout.c:1170
+#: builtin/checkout.c:1191
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -11372,51 +11701,51 @@ msgstr ""
 "seperti remote 'origin', pertimbangkan untuk menyetel\n"
 "checkout.defaultRemote=origin di konfigurasi Anda"
 
-#: builtin/checkout.c:1180
+#: builtin/checkout.c:1201
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' cocok dengan banyak (%d) cabang pelacak remote"
 
-#: builtin/checkout.c:1246
+#: builtin/checkout.c:1267
 msgid "only one reference expected"
 msgstr "hanya satu referensi yang diharapkan"
 
-#: builtin/checkout.c:1263
+#: builtin/checkout.c:1284
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "hanya satu referensi yang diharapkan, %d diberikan"
 
-#: builtin/checkout.c:1309 builtin/worktree.c:270 builtin/worktree.c:438
+#: builtin/checkout.c:1330 builtin/worktree.c:270 builtin/worktree.c:438
 #, c-format
 msgid "invalid reference: %s"
 msgstr "referensi tidak valid: %s"
 
-#: builtin/checkout.c:1322 builtin/checkout.c:1688
+#: builtin/checkout.c:1343 builtin/checkout.c:1709
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "referensi bukan pohon: %s"
 
-#: builtin/checkout.c:1369
+#: builtin/checkout.c:1390
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "sebuah cabang diharapkan, dapat tag '%s'"
 
-#: builtin/checkout.c:1371
+#: builtin/checkout.c:1392
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "sebuah cabang diharapkan, dapat cabang remote '%s'"
 
-#: builtin/checkout.c:1372 builtin/checkout.c:1380
+#: builtin/checkout.c:1393 builtin/checkout.c:1401
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "sebuah cabang diharapkan, dapat '%s'"
 
-#: builtin/checkout.c:1375
+#: builtin/checkout.c:1396
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "sebuah cabang diharapkan, dapat komit '%s'"
 
-#: builtin/checkout.c:1391
+#: builtin/checkout.c:1412
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -11425,7 +11754,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git merge --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1395
+#: builtin/checkout.c:1416
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -11433,7 +11762,7 @@ msgstr ""
 "tidak dapat mengganti cabang di tengah sesi am\n"
 "Pertimbangkan untuk menggunakan \"git am --quit\" atau \"git worktree add\"."
 
-#: builtin/checkout.c:1399
+#: builtin/checkout.c:1420
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -11442,7 +11771,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git rebase --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1403
+#: builtin/checkout.c:1424
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -11451,7 +11780,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git cherry-pick --quit\" atau \"git "
 "worktree add\"."
 
-#: builtin/checkout.c:1407
+#: builtin/checkout.c:1428
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -11460,138 +11789,138 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git cherry-pick --quit\" atau \"git "
 "worktree add\"."
 
-#: builtin/checkout.c:1411
+#: builtin/checkout.c:1432
 msgid "you are switching branch while bisecting"
 msgstr "Anda mengganti cabang saat pembagian dua"
 
-#: builtin/checkout.c:1418
+#: builtin/checkout.c:1439
 msgid "paths cannot be used with switching branches"
 msgstr "jalur tidak dapat digunakan dengan mengganti cabang"
 
-#: builtin/checkout.c:1421 builtin/checkout.c:1425 builtin/checkout.c:1429
+#: builtin/checkout.c:1442 builtin/checkout.c:1446 builtin/checkout.c:1450
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' tidak dapat digunakan dengan mengganti cabang"
 
-#: builtin/checkout.c:1433 builtin/checkout.c:1436 builtin/checkout.c:1439
-#: builtin/checkout.c:1444 builtin/checkout.c:1449
+#: builtin/checkout.c:1454 builtin/checkout.c:1457 builtin/checkout.c:1460
+#: builtin/checkout.c:1465 builtin/checkout.c:1470
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' tidak dapat digunakan dengan '%s'"
 
-#: builtin/checkout.c:1446
+#: builtin/checkout.c:1467
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' tidak bisa mengambil <titik-awal>"
 
-#: builtin/checkout.c:1454
+#: builtin/checkout.c:1475
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Tidak dapat mengganti cabang ke bukan komit '%s'"
 
-#: builtin/checkout.c:1461
+#: builtin/checkout.c:1482
 msgid "missing branch or commit argument"
 msgstr "kehilangan argumen cabang atau komit"
 
-#: builtin/checkout.c:1504
+#: builtin/checkout.c:1525
 msgid "perform a 3-way merge with the new branch"
 msgstr "lakukan penggabungan 3 arah dengan cabang baru"
 
-#: builtin/checkout.c:1505 builtin/log.c:1799 parse-options.h:322
+#: builtin/checkout.c:1526 builtin/log.c:1807 parse-options.h:323
 msgid "style"
 msgstr "gaya"
 
-#: builtin/checkout.c:1506
+#: builtin/checkout.c:1527
 msgid "conflict style (merge or diff3)"
 msgstr "gaya konflik (merge atau diff3)"
 
-#: builtin/checkout.c:1518 builtin/worktree.c:486
+#: builtin/checkout.c:1539 builtin/worktree.c:488
 msgid "detach HEAD at named commit"
 msgstr "lepas HEAD pada komit bernama"
 
-#: builtin/checkout.c:1519
+#: builtin/checkout.c:1540
 msgid "set upstream info for new branch"
 msgstr "setel info hulu untuk cabang baru"
 
-#: builtin/checkout.c:1521
+#: builtin/checkout.c:1542
 msgid "force checkout (throw away local modifications)"
 msgstr "paksa checkout (buang modifikasi lokal)"
 
-#: builtin/checkout.c:1523
+#: builtin/checkout.c:1544
 msgid "new-branch"
 msgstr "cabang baru"
 
-#: builtin/checkout.c:1523
+#: builtin/checkout.c:1544
 msgid "new unparented branch"
 msgstr "cabang baru tanpa induk"
 
-#: builtin/checkout.c:1525 builtin/merge.c:301
+#: builtin/checkout.c:1546 builtin/merge.c:301
 msgid "update ignored files (default)"
 msgstr "perbarui berkas yang diabaikan (default)"
 
-#: builtin/checkout.c:1528
+#: builtin/checkout.c:1549
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "jangan periksa jika pohon kerja yang lain mempunyai referensi yang diberikan"
 
-#: builtin/checkout.c:1541
+#: builtin/checkout.c:1562
 msgid "checkout our version for unmerged files"
 msgstr "checkout versi kami untuk berkas yang tak tergabung"
 
-#: builtin/checkout.c:1544
+#: builtin/checkout.c:1565
 msgid "checkout their version for unmerged files"
 msgstr "checkout versi mereka untuk berkas yang tak tergabung"
 
-#: builtin/checkout.c:1548
+#: builtin/checkout.c:1569
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "jangan batasi jalur spek hanya ke entri tipis"
 
-#: builtin/checkout.c:1603
+#: builtin/checkout.c:1624
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "-%c, -%c dan --orphan saling eksklusif"
 
-#: builtin/checkout.c:1607
+#: builtin/checkout.c:1628
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p dan --overlay saling eksklusif"
 
-#: builtin/checkout.c:1644
+#: builtin/checkout.c:1665
 msgid "--track needs a branch name"
 msgstr "--track butuh nama cabang"
 
-#: builtin/checkout.c:1649
+#: builtin/checkout.c:1670
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kehilangan nama cabang; coba -%c"
 
-#: builtin/checkout.c:1681
+#: builtin/checkout.c:1702
 #, c-format
 msgid "could not resolve %s"
 msgstr "tidak dapat menyelesaikan %s"
 
-#: builtin/checkout.c:1697
+#: builtin/checkout.c:1718
 msgid "invalid path specification"
 msgstr "spesifikasi jalur tidak valid"
 
-#: builtin/checkout.c:1704
+#: builtin/checkout.c:1725
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "'%s' bukanlah commit dan cabang '%s' tidak dapat dibuat dari itu"
 
-#: builtin/checkout.c:1708
+#: builtin/checkout.c:1729
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach tidak mengambil argumen jalur '%s'"
 
-#: builtin/checkout.c:1717
+#: builtin/checkout.c:1738
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file tidak kompatible dengan --detach"
 
-#: builtin/checkout.c:1720 builtin/reset.c:325 builtin/stash.c:1566
+#: builtin/checkout.c:1741 builtin/reset.c:325 builtin/stash.c:1634
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file tidak kompatibel dengan --patch"
 
-#: builtin/checkout.c:1733
+#: builtin/checkout.c:1754
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -11599,70 +11928,70 @@ msgstr ""
 "git checkout: --ours/theirs, --force dan --merge tidak kompatibel saat\n"
 "men-checkout index"
 
-#: builtin/checkout.c:1738
+#: builtin/checkout.c:1759
 msgid "you must specify path(s) to restore"
 msgstr "Anda harus sebutkan jalur untuk dipulihkan"
 
-#: builtin/checkout.c:1764 builtin/checkout.c:1766 builtin/checkout.c:1815
-#: builtin/checkout.c:1817 builtin/clone.c:122 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2719 builtin/worktree.c:482
-#: builtin/worktree.c:484
+#: builtin/checkout.c:1785 builtin/checkout.c:1787 builtin/checkout.c:1836
+#: builtin/checkout.c:1838 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2720 builtin/worktree.c:484
+#: builtin/worktree.c:486
 msgid "branch"
 msgstr "cabang"
 
-#: builtin/checkout.c:1765
+#: builtin/checkout.c:1786
 msgid "create and checkout a new branch"
 msgstr "buat dan checkout cabang baru"
 
-#: builtin/checkout.c:1767
+#: builtin/checkout.c:1788
 msgid "create/reset and checkout a branch"
 msgstr "buat/setel ulang dan checkout cabang"
 
-#: builtin/checkout.c:1768
+#: builtin/checkout.c:1789
 msgid "create reflog for new branch"
 msgstr "buat reflog untuk cabang baru"
 
-#: builtin/checkout.c:1770
+#: builtin/checkout.c:1791
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "tebakan kedua 'git checkout <tidak-ada-cabang-seperti-itu>' (default)"
 
-#: builtin/checkout.c:1771
+#: builtin/checkout.c:1792
 msgid "use overlay mode (default)"
 msgstr "gunakan mode hamparan (default)"
 
-#: builtin/checkout.c:1816
+#: builtin/checkout.c:1837
 msgid "create and switch to a new branch"
 msgstr "buat dan ganti ke cabang baru"
 
-#: builtin/checkout.c:1818
+#: builtin/checkout.c:1839
 msgid "create/reset and switch to a branch"
 msgstr "buat/setel ulang dan ganti ke cabang"
 
-#: builtin/checkout.c:1820
+#: builtin/checkout.c:1841
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "tebakan kedua 'git switch <tidak-ada-cabang-seperti-itu>'"
 
-#: builtin/checkout.c:1822
+#: builtin/checkout.c:1843
 msgid "throw away local modifications"
 msgstr "buang modifikasi lokal"
 
-#: builtin/checkout.c:1856
+#: builtin/checkout.c:1877
 msgid "which tree-ish to checkout from"
 msgstr "mana mirip-cabang untuk di-checkout"
 
-#: builtin/checkout.c:1858
+#: builtin/checkout.c:1879
 msgid "restore the index"
 msgstr "pulihkan indeks"
 
-#: builtin/checkout.c:1860
+#: builtin/checkout.c:1881
 msgid "restore the working tree (default)"
 msgstr "pulihkan pohon kerja (default)"
 
-#: builtin/checkout.c:1862
+#: builtin/checkout.c:1883
 msgid "ignore unmerged entries"
 msgstr "abaikan entri yang tak tergabung"
 
-#: builtin/checkout.c:1863
+#: builtin/checkout.c:1884
 msgid "use overlay mode"
 msgstr "gunakan mode hamparan"
 
@@ -11670,36 +11999,32 @@ msgstr "gunakan mode hamparan"
 msgid ""
 "git clean [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <paths>..."
 msgstr ""
+"git clean [-d] [-f] [-i] [-n] [-q] [-e <pola>] [-x | -X] [--] <jalur>..."
 
 #: builtin/clean.c:33
 #, c-format
 msgid "Removing %s\n"
-msgstr ""
+msgstr "Menghapus %s\n"
 
 #: builtin/clean.c:34
 #, c-format
 msgid "Would remove %s\n"
-msgstr ""
+msgstr "Akan hapus %s\n"
 
 #: builtin/clean.c:35
 #, c-format
 msgid "Skipping repository %s\n"
-msgstr ""
+msgstr "Melewatkan repositori %s\n"
 
 #: builtin/clean.c:36
 #, c-format
 msgid "Would skip repository %s\n"
-msgstr ""
-
-#: builtin/clean.c:37
-#, c-format
-msgid "failed to remove %s"
-msgstr ""
+msgstr "Akan melewatkan repositori %s\n"
 
 #: builtin/clean.c:38
 #, c-format
 msgid "could not lstat %s\n"
-msgstr ""
+msgstr "tidak dapat me-lstat %s\n"
 
 #: builtin/clean.c:302 git-add--interactive.perl:593
 #, c-format
@@ -11709,6 +12034,10 @@ msgid ""
 "foo        - select item based on unique prefix\n"
 "           - (empty) select nothing\n"
 msgstr ""
+"Bisik bantuan:\n"
+"1          - pilih item bernomor\n"
+"foo        - pilih item berdasarkan prefiks unik\n"
+"           - (kosong) tidak pilih apa-apa\n"
 
 #: builtin/clean.c:306 git-add--interactive.perl:602
 #, c-format
@@ -11722,32 +12051,40 @@ msgid ""
 "*          - choose all items\n"
 "           - (empty) finish selecting\n"
 msgstr ""
+"Bisik bantuan:\n"
+"1          - pilih item tunggal\n"
+"3-5        - pilih satu rentang item\n"
+"2-3,6-9    - pilih banyak rentang\n"
+"foo        - pilih item berdasarkan prefiks unik\n"
+"-...       - batal pilih item yang disebutkan\n"
+"*          - pilih semua item\n"
+"           - (kosong) selesai memilih\n"
 
 #: builtin/clean.c:521 git-add--interactive.perl:568
 #: git-add--interactive.perl:573
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
-msgstr ""
+msgstr "Huh (%s)?\n"
 
 #: builtin/clean.c:661
 #, c-format
 msgid "Input ignore patterns>> "
-msgstr ""
+msgstr "Masukkan pola pengabaian>> "
 
 #: builtin/clean.c:696
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
-msgstr ""
+msgstr "PERINGATAN: Tidak dapat menemukan item yang cocok dengan: %s"
 
 #: builtin/clean.c:717
 msgid "Select items to delete"
-msgstr ""
+msgstr "Pilih item untuk dihapus"
 
 #. TRANSLATORS: Make sure to keep [y/N] as is
 #: builtin/clean.c:758
 #, c-format
 msgid "Remove %s [y/N]? "
-msgstr ""
+msgstr "Hapus %s [y/N]? "
 
 #: builtin/clean.c:789
 msgid ""
@@ -11759,229 +12096,245 @@ msgid ""
 "help                - this screen\n"
 "?                   - help for prompt selection"
 msgstr ""
+"clean               - mulai membersihkan\n"
+"filter by pattern   - kecualikan item dari penghapusan\n"
+"select by numbers   - pilih item untuk dihapus oleh nomor\n"
+"ask each            - konfirmasi setiap penghapusan (seperti \"rm -i\")\n"
+"quit                - berhenti membersihkan\n"
+"help                - layar ini\n"
+"?                   - bantuan untuk bisik pemilihan"
 
 #: builtin/clean.c:825
 msgid "Would remove the following item:"
 msgid_plural "Would remove the following items:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Akan menghapus item berikut:"
+msgstr[1] "Akan menghapus item berikut:"
 
 #: builtin/clean.c:841
 msgid "No more files to clean, exiting."
-msgstr ""
+msgstr "Tidak ada lagi berkas untuk dibersihkan, keluar."
 
 #: builtin/clean.c:903
 msgid "do not print names of files removed"
-msgstr ""
+msgstr "jangan cetak nama berkas yang dihapus"
 
 #: builtin/clean.c:905
 msgid "force"
-msgstr ""
+msgstr "paksa"
 
 #: builtin/clean.c:906
 msgid "interactive cleaning"
-msgstr ""
+msgstr "pembersihan interaktif"
 
 #: builtin/clean.c:908
 msgid "remove whole directories"
-msgstr ""
+msgstr "hapus keseluruhan direktori"
 
 #: builtin/clean.c:909 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:922 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:573 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:924 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:650 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
-msgstr ""
+msgstr "pola"
 
 #: builtin/clean.c:910
 msgid "add <pattern> to ignore rules"
-msgstr ""
+msgstr "tambahkan <pola> ke aturan pengabaian"
 
 #: builtin/clean.c:911
 msgid "remove ignored files, too"
-msgstr ""
+msgstr "juga hapus berkas terabaikan"
 
 #: builtin/clean.c:913
 msgid "remove only ignored files"
-msgstr ""
+msgstr "hanya hapus berkas terabaikan"
 
 #: builtin/clean.c:929
 msgid ""
 "clean.requireForce set to true and neither -i, -n, nor -f given; refusing to "
 "clean"
 msgstr ""
+"clean.requireForce disetel ke true dan baik -i, -n, atau -f tidak diberikan; "
+"menolak membersihkan"
 
 #: builtin/clean.c:932
 msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
 msgstr ""
+"clean.requireForce asal ke true dan baik -i, -n, atau -f tidak diberikan; "
+"menolak membersihkan"
 
 #: builtin/clean.c:944
 msgid "-x and -X cannot be used together"
-msgstr ""
+msgstr "-x dan -X tidak dapat digunakan bersamaan"
 
 #: builtin/clone.c:45
 msgid "git clone [<options>] [--] <repo> [<dir>]"
 msgstr "git clone [<opsi>] [--] <repo> [<direktori>]"
 
-#: builtin/clone.c:94
+#: builtin/clone.c:96
+msgid "don't clone shallow repository"
+msgstr "jangan kloning repositori dangkal"
+
+#: builtin/clone.c:98
 msgid "don't create a checkout"
 msgstr "jangan buat checkout"
 
-#: builtin/clone.c:95 builtin/clone.c:97 builtin/init-db.c:555
+#: builtin/clone.c:99 builtin/clone.c:101 builtin/init-db.c:541
 msgid "create a bare repository"
 msgstr "buat repositori bare"
 
-#: builtin/clone.c:99
+#: builtin/clone.c:103
 msgid "create a mirror repository (implies bare)"
 msgstr "buat repositori cermin (implikasikan bare)"
 
-#: builtin/clone.c:101
+#: builtin/clone.c:105
 msgid "to clone from a local repository"
 msgstr "kloning dari repositori lokal"
 
-#: builtin/clone.c:103
+#: builtin/clone.c:107
 msgid "don't use local hardlinks, always copy"
 msgstr "jangan gunakan tautan keras lokal, selalu salin"
 
-#: builtin/clone.c:105
+#: builtin/clone.c:109
 msgid "setup as shared repository"
 msgstr "siapkan sebagai repositori berbagi"
 
-#: builtin/clone.c:107
+#: builtin/clone.c:111
 msgid "pathspec"
 msgstr "spek jalur"
 
-#: builtin/clone.c:107
+#: builtin/clone.c:111
 msgid "initialize submodules in the clone"
 msgstr "inisialisasi submodul dalam klon"
 
-#: builtin/clone.c:111
+#: builtin/clone.c:115
 msgid "number of submodules cloned in parallel"
 msgstr "jumlah submodul yang diklon secara paralel"
 
-#: builtin/clone.c:112 builtin/init-db.c:552
+#: builtin/clone.c:116 builtin/init-db.c:538
 msgid "template-directory"
 msgstr "direktori templat"
 
-#: builtin/clone.c:113 builtin/init-db.c:553
+#: builtin/clone.c:117 builtin/init-db.c:539
 msgid "directory from which templates will be used"
 msgstr "direktori dimana templat akan digunakan"
 
-#: builtin/clone.c:115 builtin/clone.c:117 builtin/submodule--helper.c:1831
-#: builtin/submodule--helper.c:2336
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1832
+#: builtin/submodule--helper.c:2337
 msgid "reference repository"
 msgstr "repositori rujukan"
 
-#: builtin/clone.c:119 builtin/submodule--helper.c:1833
-#: builtin/submodule--helper.c:2338
+#: builtin/clone.c:123 builtin/submodule--helper.c:1834
+#: builtin/submodule--helper.c:2339
 msgid "use --reference only while cloning"
 msgstr "gunakan --reference hanya pada saat kloning"
 
-#: builtin/clone.c:120 builtin/column.c:27 builtin/init-db.c:563
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3561 builtin/repack.c:357
+#: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:549
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3815 builtin/repack.c:495
+#: t/helper/test-simple-ipc.c:696 t/helper/test-simple-ipc.c:698
 msgid "name"
 msgstr "nama"
 
-#: builtin/clone.c:121
+#: builtin/clone.c:125
 msgid "use <name> instead of 'origin' to track upstream"
 msgstr "gunakan <nama> daripada 'origin' untuk lacak hulu"
 
-#: builtin/clone.c:123
+#: builtin/clone.c:127
 msgid "checkout <branch> instead of the remote's HEAD"
 msgstr "checkout <cabang> daripada HEAD remote"
 
-#: builtin/clone.c:125
+#: builtin/clone.c:129
 msgid "path to git-upload-pack on the remote"
 msgstr "jalur ke git-upload-pack pada remote"
 
-#: builtin/clone.c:126 builtin/fetch.c:176 builtin/grep.c:861
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:863
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "kedalaman"
 
-#: builtin/clone.c:127
+#: builtin/clone.c:131
 msgid "create a shallow clone of that depth"
 msgstr "buat klon dangkal sedalam kedalaman tersebut"
 
-#: builtin/clone.c:128 builtin/fetch.c:178 builtin/pack-objects.c:3550
+#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3804
 #: builtin/pull.c:211
 msgid "time"
 msgstr "waktu"
 
-#: builtin/clone.c:129
+#: builtin/clone.c:133
 msgid "create a shallow clone since a specific time"
 msgstr "buat klon dangkal sejak waktu yang disebutkan"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/fetch.c:203
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1323
+#: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1318
 msgid "revision"
 msgstr "revisi"
 
-#: builtin/clone.c:131 builtin/fetch.c:181 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "perdalam riwayat klon dangkal, tidak termasuk rev"
 
-#: builtin/clone.c:133 builtin/submodule--helper.c:1843
-#: builtin/submodule--helper.c:2352
+#: builtin/clone.c:137 builtin/submodule--helper.c:1844
+#: builtin/submodule--helper.c:2353
 msgid "clone only one branch, HEAD or --branch"
 msgstr "klon hanya satu cabang, HEAD atau --branch"
 
-#: builtin/clone.c:135
+#: builtin/clone.c:139
 msgid "don't clone any tags, and make later fetches not to follow them"
 msgstr "jangan klon tag apapun, dan buat pengambilan nanti tidak mengikutinya"
 
-#: builtin/clone.c:137
+#: builtin/clone.c:141
 msgid "any cloned submodules will be shallow"
 msgstr "submodul yang diklon akan dangkal"
 
-#: builtin/clone.c:138 builtin/init-db.c:561
+#: builtin/clone.c:142 builtin/init-db.c:547
 msgid "gitdir"
 msgstr "direktori git"
 
-#: builtin/clone.c:139 builtin/init-db.c:562
+#: builtin/clone.c:143 builtin/init-db.c:548
 msgid "separate git dir from working tree"
 msgstr "pisahkan direktori git dari pohon kerja"
 
-#: builtin/clone.c:140
+#: builtin/clone.c:144
 msgid "key=value"
 msgstr "kunci=nilai"
 
-#: builtin/clone.c:141
+#: builtin/clone.c:145
 msgid "set config inside the new repository"
 msgstr "setel konfigurasi di dalam repositori baru"
 
-#: builtin/clone.c:143 builtin/fetch.c:198 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
 #: builtin/pull.c:230 builtin/push.c:584 builtin/send-pack.c:196
 msgid "server-specific"
 msgstr "spesifik ke server"
 
-#: builtin/clone.c:143 builtin/fetch.c:198 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
 #: builtin/pull.c:231 builtin/push.c:584 builtin/send-pack.c:197
 msgid "option to transmit"
 msgstr "opsi untuk transmisi"
 
-#: builtin/clone.c:144 builtin/fetch.c:199 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
 #: builtin/push.c:585
 msgid "use IPv4 addresses only"
 msgstr "gunakan hanya alamat IPv4"
 
-#: builtin/clone.c:146 builtin/fetch.c:201 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
 #: builtin/push.c:587
 msgid "use IPv6 addresses only"
 msgstr "gunakan hanya alamat IPv6"
 
-#: builtin/clone.c:150
+#: builtin/clone.c:154
 msgid "any cloned submodules will use their remote-tracking branch"
 msgstr "submodul yang diklon akan menggunakan cabang yang melacak remotenya"
 
-#: builtin/clone.c:152
+#: builtin/clone.c:156
 msgid "initialize sparse-checkout file to include only files at root"
 msgstr ""
 "inisialisasi berkas checkout tipis agar memasukkan hanya berkas pada akar"
 
-#: builtin/clone.c:288
+#: builtin/clone.c:292
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -11989,42 +12342,42 @@ msgstr ""
 "Nama direktori tidak dapat ditebak.\n"
 "Mohon sebutkan direktori pada baris perintah"
 
-#: builtin/clone.c:341
+#: builtin/clone.c:345
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: Tidak dapat menambahkan alternatif untuk '%s': %s\n"
 
-#: builtin/clone.c:414
+#: builtin/clone.c:418
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s ada dan bukan direktori"
 
-#: builtin/clone.c:432
+#: builtin/clone.c:436
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "gagal memulai iterator pada '%s'"
 
-#: builtin/clone.c:463
+#: builtin/clone.c:467
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "gagal membuat tautan '%s'"
 
-#: builtin/clone.c:467
+#: builtin/clone.c:471
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "gagal menyalin berkas ke '%s'"
 
-#: builtin/clone.c:472
+#: builtin/clone.c:476
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "gagal iterasi pada '%s'"
 
-#: builtin/clone.c:499
+#: builtin/clone.c:503
 #, c-format
 msgid "done.\n"
 msgstr "selesai.\n"
 
-#: builtin/clone.c:513
+#: builtin/clone.c:517
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -12034,105 +12387,105 @@ msgstr ""
 "Anda dapat periksa apa yang dicheckout dengan 'git status'\n"
 "dan coba lagi dengan 'git restore --source=HEAD :/'\n"
 
-#: builtin/clone.c:590
+#: builtin/clone.c:594
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Tidak dapat menemukan cabang remote %s untuk diklon."
 
-#: builtin/clone.c:709
+#: builtin/clone.c:713
 #, c-format
 msgid "unable to update %s"
 msgstr "tidak dapat memperbarui %s"
 
-#: builtin/clone.c:757
+#: builtin/clone.c:761
 msgid "failed to initialize sparse-checkout"
 msgstr "gagal menginisalisasi checkout tipis"
 
-#: builtin/clone.c:780
+#: builtin/clone.c:784
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "HEAD remote merujuk pada ref yang tidak ada, tidak dapat men-checkout.\n"
 
-#: builtin/clone.c:812
+#: builtin/clone.c:816
 msgid "unable to checkout working tree"
 msgstr "tidak dapat men-checkout pohon kerja"
 
-#: builtin/clone.c:887
+#: builtin/clone.c:894
 msgid "unable to write parameters to config file"
 msgstr "tidak dapat menulis parameter ke berkas konfigurasi"
 
-#: builtin/clone.c:950
+#: builtin/clone.c:957
 msgid "cannot repack to clean up"
 msgstr "tidak dapat memaket ulang untuk pembersihan"
 
-#: builtin/clone.c:952
+#: builtin/clone.c:959
 msgid "cannot unlink temporary alternates file"
 msgstr "tidak dapat batal-taut berkas alternatif sementara"
 
-#: builtin/clone.c:993 builtin/receive-pack.c:2493
+#: builtin/clone.c:1001 builtin/receive-pack.c:2491
 msgid "Too many arguments."
 msgstr "Terlalu banyak argumen."
 
-#: builtin/clone.c:997
+#: builtin/clone.c:1005
 msgid "You must specify a repository to clone."
 msgstr "Anda harus sebutkan repositori untuk diklon."
 
-#: builtin/clone.c:1010
+#: builtin/clone.c:1018
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "--bare dan --origin %s tidak kompatibel."
 
-#: builtin/clone.c:1013
+#: builtin/clone.c:1021
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "--bare dan --separate-git-dir tidak kompatibel."
 
-#: builtin/clone.c:1026
+#: builtin/clone.c:1035
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "repositori '%s' tidak ada"
 
-#: builtin/clone.c:1030 builtin/fetch.c:1951
+#: builtin/clone.c:1039 builtin/fetch.c:2011
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "kedalaman %s bukan bilangan positif"
 
-#: builtin/clone.c:1040
+#: builtin/clone.c:1049
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "jalur tujuan '%s' sudah ada dan bukan direktori kosong"
 
-#: builtin/clone.c:1046
+#: builtin/clone.c:1055
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr "jalur repositori '%s' sudah ada dan bukan direktori kosong"
 
-#: builtin/clone.c:1060
+#: builtin/clone.c:1069
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "pohon kerja '%s' sudah ada."
 
-#: builtin/clone.c:1075 builtin/clone.c:1096 builtin/difftool.c:271
-#: builtin/log.c:1986 builtin/worktree.c:282 builtin/worktree.c:314
+#: builtin/clone.c:1084 builtin/clone.c:1105 builtin/difftool.c:272
+#: builtin/log.c:1995 builtin/worktree.c:282 builtin/worktree.c:314
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "tidak dapat membuat direktori pendahulu '%s'"
 
-#: builtin/clone.c:1080
+#: builtin/clone.c:1089
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "tidak dapat membuat direktori pohon kerja '%s'"
 
-#: builtin/clone.c:1100
+#: builtin/clone.c:1109
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Kloning ke repositori bare '%s'...\n"
 
-#: builtin/clone.c:1102
+#: builtin/clone.c:1111
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Kloning ke '%s'...\n"
 
-#: builtin/clone.c:1126
+#: builtin/clone.c:1135
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -12140,43 +12493,43 @@ msgstr ""
 "clone --recursive tidak kompatibel dengan baik --reference dan --reference-"
 "if-able"
 
-#: builtin/clone.c:1170 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1188 builtin/remote.c:200 builtin/remote.c:705
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' bukan nama remote yang valid"
 
-#: builtin/clone.c:1211
+#: builtin/clone.c:1229
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "--depth diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1213
+#: builtin/clone.c:1231
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1215
+#: builtin/clone.c:1233
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1217
+#: builtin/clone.c:1235
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr "--filter diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1220
+#: builtin/clone.c:1240
 msgid "source repository is shallow, ignoring --local"
 msgstr "repositori sumber dangkal, abaikan --local"
 
-#: builtin/clone.c:1225
+#: builtin/clone.c:1245
 msgid "--local is ignored"
 msgstr "--local diabaikan"
 
-#: builtin/clone.c:1315 builtin/clone.c:1323
+#: builtin/clone.c:1337 builtin/clone.c:1345
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Cabang remote %s tidak ditemukan di hulu %s"
 
-#: builtin/clone.c:1326
+#: builtin/clone.c:1348
 msgid "You appear to have cloned an empty repository."
 msgstr "Anda tampaknya mengklon repositori kosong."
 
@@ -12193,19 +12546,19 @@ msgid "layout to use"
 msgstr ""
 
 #: builtin/column.c:30
-msgid "Maximum width"
+msgid "maximum width"
 msgstr ""
 
 #: builtin/column.c:31
-msgid "Padding space on left border"
+msgid "padding space on left border"
 msgstr ""
 
 #: builtin/column.c:32
-msgid "Padding space on right border"
+msgid "padding space on right border"
 msgstr ""
 
 #: builtin/column.c:33
-msgid "Padding space between columns"
+msgid "padding space between columns"
 msgstr ""
 
 #: builtin/column.c:51
@@ -12230,7 +12583,7 @@ msgid "could not find object directory matching %s"
 msgstr ""
 
 #: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:187 builtin/log.c:1768
+#: builtin/commit-graph.c:316 builtin/fetch.c:191 builtin/log.c:1776
 msgid "dir"
 msgstr ""
 
@@ -12322,7 +12675,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr ""
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:557
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:559
 #, c-format
 msgid "not a valid object name %s"
 msgstr ""
@@ -12350,13 +12703,13 @@ msgstr ""
 msgid "id of a parent commit object"
 msgstr ""
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:282
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1537
-#: builtin/tag.c:445
+#: builtin/commit-tree.c:114 builtin/commit.c:1614 builtin/merge.c:282
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1605
+#: builtin/tag.c:456
 msgid "message"
 msgstr ""
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1504
+#: builtin/commit-tree.c:115 builtin/commit.c:1614
 msgid "commit message"
 msgstr ""
 
@@ -12364,7 +12717,7 @@ msgstr ""
 msgid "read commit log message from file"
 msgstr ""
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:299
+#: builtin/commit-tree.c:121 builtin/commit.c:1631 builtin/merge.c:299
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr ""
@@ -12379,11 +12732,11 @@ msgstr ""
 
 #: builtin/commit.c:41
 msgid "git commit [<options>] [--] <pathspec>..."
-msgstr ""
+msgstr "git commit [<opsi>] [--] <spek jalur>..."
 
 #: builtin/commit.c:46
 msgid "git status [<options>] [--] <pathspec>..."
-msgstr ""
+msgstr "git status [<opsi>] [--] <spek jalur>..."
 
 #: builtin/commit.c:51
 msgid ""
@@ -12391,6 +12744,10 @@ msgid ""
 "it empty. You can repeat your command with --allow-empty, or you can\n"
 "remove the commit entirely with \"git reset HEAD^\".\n"
 msgstr ""
+"Anda diminta untuk mengubah komit terkini, tetapi melakukan\n"
+"hal itu akan membuat komit kosong. Anda dapat mengulangi perintah\n"
+"dengan --allow-empty, atau Anda dapat menghapus keseluruhan komit\n"
+"dengan \"git reset HEAD^\".\n"
 
 #: builtin/commit.c:56
 msgid ""
@@ -12400,14 +12757,19 @@ msgid ""
 "    git commit --allow-empty\n"
 "\n"
 msgstr ""
+"Petik ceri sebelumnya sekarang kosong, kemungkinan karena resolusi konflik.\n"
+"Jika Anda ingin komit, gunakan:\n"
+"\n"
+"    git commit --allow-empty\n"
+"\n"
 
 #: builtin/commit.c:63
 msgid "Otherwise, please use 'git rebase --skip'\n"
-msgstr ""
+msgstr "Selain itu, gunakan 'git rebase --skip'\n"
 
 #: builtin/commit.c:66
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
-msgstr ""
+msgstr "Selain itu, gunakan 'git cherry-pick --skip'\n"
 
 #: builtin/commit.c:69
 msgid ""
@@ -12421,111 +12783,126 @@ msgid ""
 "    git cherry-pick --skip\n"
 "\n"
 msgstr ""
+"dan gunakan:\n"
+"\n"
+"    git cherry-pick --continue\n"
+"\n"
+"untuk melanjutkan pemetikan ceri sisa komit.\n"
+"Jika Anda ingin melewatkan komit ini, gunakan:\n"
+"    git cherry-pick --skip\n"
+"\n"
 
-#: builtin/commit.c:312
+#: builtin/commit.c:324
 msgid "failed to unpack HEAD tree object"
-msgstr ""
+msgstr "gagal membuka objek pohon HEAD"
 
-#: builtin/commit.c:348
+#: builtin/commit.c:360
 msgid "--pathspec-from-file with -a does not make sense"
-msgstr ""
+msgstr "--pathspec-from-file dengan -a tidak masuk akal"
 
-#: builtin/commit.c:361
+#: builtin/commit.c:374
 msgid "No paths with --include/--only does not make sense."
-msgstr ""
+msgstr "Tanpa jalur dengan --include/--only tidak masuk akal."
 
-#: builtin/commit.c:373
+#: builtin/commit.c:386
 msgid "unable to create temporary index"
-msgstr ""
+msgstr "tidak dapat membuat indeks sementara"
 
-#: builtin/commit.c:382
+#: builtin/commit.c:395
 msgid "interactive add failed"
-msgstr ""
+msgstr "penambahan interaktif gagal"
 
-#: builtin/commit.c:397
+#: builtin/commit.c:410
 msgid "unable to update temporary index"
-msgstr ""
+msgstr "tidak dapat memperbarui indeks sementara"
 
-#: builtin/commit.c:399
+#: builtin/commit.c:412
 msgid "Failed to update main cache tree"
-msgstr ""
+msgstr "gagal memperbarui tembolok pohon utama"
 
-#: builtin/commit.c:424 builtin/commit.c:447 builtin/commit.c:495
+#: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
 msgid "unable to write new_index file"
-msgstr ""
+msgstr "tidak dapat menulis berkas indeks baru"
 
-#: builtin/commit.c:476
+#: builtin/commit.c:489
 msgid "cannot do a partial commit during a merge."
-msgstr ""
+msgstr "tidak dapat melakukan komit sebagian selama penggabungan."
 
-#: builtin/commit.c:478
+#: builtin/commit.c:491
 msgid "cannot do a partial commit during a cherry-pick."
-msgstr ""
+msgstr "tidak dapat melakukan komit sebagian selama pemetikan ceri."
 
-#: builtin/commit.c:480
+#: builtin/commit.c:493
 msgid "cannot do a partial commit during a rebase."
-msgstr ""
+msgstr "tidak dapat melakukan komit sebagian selama pendasaran ulang."
 
-#: builtin/commit.c:488
+#: builtin/commit.c:501
 msgid "cannot read the index"
-msgstr ""
+msgstr "tidak dapat membaca indeks"
 
-#: builtin/commit.c:507
+#: builtin/commit.c:520
 msgid "unable to write temporary index file"
-msgstr ""
+msgstr "tidak dapat menulis berkas indeks sementara"
 
-#: builtin/commit.c:605
+#: builtin/commit.c:618
 #, c-format
 msgid "commit '%s' lacks author header"
-msgstr ""
+msgstr "komit '%s' kurang kepala pengarang"
 
-#: builtin/commit.c:607
+#: builtin/commit.c:620
 #, c-format
 msgid "commit '%s' has malformed author line"
-msgstr ""
+msgstr "komit '%s' ada baris pengarang cacat"
 
-#: builtin/commit.c:626
+#: builtin/commit.c:639
 msgid "malformed --author parameter"
-msgstr ""
+msgstr "parameter --author cacat"
 
-#: builtin/commit.c:679
+#: builtin/commit.c:692
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
 msgstr ""
+"tidak dapat memilih karakter komentar yang tidak terpakai\n"
+"dalam pesan komit saat ini"
 
-#: builtin/commit.c:717 builtin/commit.c:750 builtin/commit.c:1097
+#: builtin/commit.c:746 builtin/commit.c:780 builtin/commit.c:1158
 #, c-format
 msgid "could not lookup commit %s"
-msgstr ""
+msgstr "tidak dapat mencari komit %s"
 
-#: builtin/commit.c:729 builtin/shortlog.c:413
+#: builtin/commit.c:758 builtin/shortlog.c:413
 #, c-format
 msgid "(reading log message from standard input)\n"
-msgstr ""
+msgstr "(baca pesan log dari standar masukan)\n"
 
-#: builtin/commit.c:731
+#: builtin/commit.c:760
 msgid "could not read log from standard input"
-msgstr ""
+msgstr "tidak dapat membaca log dari standar masukan"
 
-#: builtin/commit.c:735
+#: builtin/commit.c:764
 #, c-format
 msgid "could not read log file '%s'"
-msgstr ""
+msgstr "tidak dapat membaca berkas log '%s'"
 
-#: builtin/commit.c:766 builtin/commit.c:782
+#: builtin/commit.c:801
+#, c-format
+msgid "cannot combine -m with --fixup:%s"
+msgstr "tidak dapat menggabungkan -m dengan --fixup:%s"
+
+#: builtin/commit.c:813 builtin/commit.c:829
 msgid "could not read SQUASH_MSG"
-msgstr ""
+msgstr "tidak dapat membaca SQUASH_MSG"
 
-#: builtin/commit.c:773
+#: builtin/commit.c:820
 msgid "could not read MERGE_MSG"
-msgstr ""
+msgstr "tidak dapat membaca MERGE_MSG"
 
-#: builtin/commit.c:833
+#: builtin/commit.c:880
 msgid "could not write commit template"
-msgstr ""
+msgstr "tidak dapat menulis templat komit"
 
-#: builtin/commit.c:853
+#: builtin/commit.c:900
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -12533,8 +12910,13 @@ msgid ""
 "\tgit update-ref -d MERGE_HEAD\n"
 "and try again.\n"
 msgstr ""
+"\n"
+"Sepertinya Anda mungkin mengkomit penggabungan.\n"
+"Jika itu salah, mohon jalankan\n"
+"\tgit update-ref -d MERGE_HEAD\n"
+"dan coba lagi.\n"
 
-#: builtin/commit.c:858
+#: builtin/commit.c:905
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -12542,555 +12924,631 @@ msgid ""
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "and try again.\n"
 msgstr ""
+"\n"
+"Sepertinya Anda mungkin mengkomit petik ceri.\n"
+"Jika it salah, mohon jalankan\n"
+"\tgit update-ref -d CHERRY_PICK_HEAD\n"
+"dan coba lagi.\n"
 
-#: builtin/commit.c:868
+#: builtin/commit.c:915
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
 "with '%c' will be ignored, and an empty message aborts the commit.\n"
 msgstr ""
+"Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
+"dengan '%c' akan diabaikan, dan pesan kosong batalkan komit.\n"
 
-#: builtin/commit.c:876
+#: builtin/commit.c:923
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
 "with '%c' will be kept; you may remove them yourself if you want to.\n"
 "An empty message aborts the commit.\n"
 msgstr ""
+"Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
+"dengan '%c' akan tetap; Anda dapat menghapus itu jika Anda mau.\n"
+"Pesan kosong batalkan komit.\n"
 
-#: builtin/commit.c:893
+#: builtin/commit.c:940
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
-msgstr ""
+msgstr "%sPengarang:    %.*s <%.*s>"
 
-#: builtin/commit.c:901
+#: builtin/commit.c:948
 #, c-format
 msgid "%sDate:      %s"
-msgstr ""
+msgstr "%sTanggal:       %s"
 
-#: builtin/commit.c:908
+#: builtin/commit.c:955
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
-msgstr ""
+msgstr "%sPengkomit: %.*s <%.*s>"
 
-#: builtin/commit.c:926
+#: builtin/commit.c:973
 msgid "Cannot read index"
-msgstr ""
+msgstr "Tidak dapat membaca indeks"
 
-#: builtin/commit.c:997
+#: builtin/commit.c:1018
+msgid "unable to pass trailers to --trailers"
+msgstr "tidak dapat melewatkan trailer ke --trailers"
+
+#: builtin/commit.c:1058
 msgid "Error building trees"
-msgstr ""
+msgstr "Kesalahan membangun pohon"
 
-#: builtin/commit.c:1011 builtin/tag.c:308
+#: builtin/commit.c:1072 builtin/tag.c:319
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
-msgstr ""
+msgstr "Mohon berikan pesan baik dengan opsi -m atau -F.\n"
 
-#: builtin/commit.c:1055
+#: builtin/commit.c:1116
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
+"--author '%s' bukan 'Nama <email>' dan tidak cocok dengan pengarang yang ada"
 
-#: builtin/commit.c:1069
+#: builtin/commit.c:1130
 #, c-format
 msgid "Invalid ignored mode '%s'"
-msgstr ""
+msgstr "Mode terabaikan '%s' tidak valid"
 
-#: builtin/commit.c:1087 builtin/commit.c:1331
+#: builtin/commit.c:1148 builtin/commit.c:1441
 #, c-format
 msgid "Invalid untracked files mode '%s'"
-msgstr ""
+msgstr "Mode berkas tak terlacak '%s' tidak valid"
 
-#: builtin/commit.c:1127
+#: builtin/commit.c:1188
 msgid "--long and -z are incompatible"
+msgstr "--long dan -z tidak kompatibel"
+
+#: builtin/commit.c:1219
+msgid "You are in the middle of a merge -- cannot reword."
+msgstr "Anda berada di tengah penggabungan -- tidak dapat menulis ulang."
+
+#: builtin/commit.c:1221
+msgid "You are in the middle of a cherry-pick -- cannot reword."
+msgstr "Anda berada di tengah pemetikan ceri -- tidak dapat menulis ulang."
+
+#: builtin/commit.c:1224
+#, c-format
+msgid "cannot combine reword option of --fixup with path '%s'"
+msgstr ""
+"tidak dapat menggabungkan opsi penulisan ulang --fixup dengan jalur '%s'"
+
+#: builtin/commit.c:1226
+msgid ""
+"reword option of --fixup is mutually exclusive with --patch/--interactive/--"
+"all/--include/--only"
 msgstr ""
 
-#: builtin/commit.c:1171
+#: builtin/commit.c:1245
 msgid "Using both --reset-author and --author does not make sense"
-msgstr ""
+msgstr "Menggunakan baik --reset-author dan --author tidak masuk akal"
 
-#: builtin/commit.c:1180
+#: builtin/commit.c:1254
 msgid "You have nothing to amend."
-msgstr ""
+msgstr "Anda tidak punya apapun untuk diubah."
 
-#: builtin/commit.c:1183
+#: builtin/commit.c:1257
 msgid "You are in the middle of a merge -- cannot amend."
-msgstr ""
+msgstr "Anda berada di tengah penggabungan -- tidak dapat mengubah."
 
-#: builtin/commit.c:1185
+#: builtin/commit.c:1259
 msgid "You are in the middle of a cherry-pick -- cannot amend."
-msgstr ""
+msgstr "Anda berada di tengah pemetikan ceri -- tidak dapat mengubah."
 
-#: builtin/commit.c:1187
+#: builtin/commit.c:1261
 msgid "You are in the middle of a rebase -- cannot amend."
-msgstr ""
+msgstr "Anda berada di tengah pendasaran ulang -- tidak dapat mengubah."
 
-#: builtin/commit.c:1190
+#: builtin/commit.c:1264
 msgid "Options --squash and --fixup cannot be used together"
-msgstr ""
+msgstr "Opsi --squash dan --fixup tidak dapat digunakan bersamaan"
 
-#: builtin/commit.c:1200
+#: builtin/commit.c:1274
 msgid "Only one of -c/-C/-F/--fixup can be used."
-msgstr ""
+msgstr "Hanya salah satu dari -c/-C/-F/--fixup yang dapat digunakan."
 
-#: builtin/commit.c:1202
+#: builtin/commit.c:1276
 msgid "Option -m cannot be combined with -c/-C/-F."
-msgstr ""
+msgstr "Opsi -m tidak dapat digabung dengan -c/-C/-F."
 
-#: builtin/commit.c:1211
+#: builtin/commit.c:1285
 msgid "--reset-author can be used only with -C, -c or --amend."
-msgstr ""
+msgstr "--reset-author hanya dapat digunakan dengan -C, -c atau --amend."
 
-#: builtin/commit.c:1229
+#: builtin/commit.c:1303
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
+"Hanya salah satu dari --include/--only/--all/--interactive/--patch yang "
+"dapat digunakan."
 
-#: builtin/commit.c:1235
+#: builtin/commit.c:1331
+#, c-format
+msgid "unknown option: --fixup=%s:%s"
+msgstr ""
+
+#: builtin/commit.c:1345
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
-msgstr ""
+msgstr "jalur '%s ...' dengan -a tidak masuk akal"
 
-#: builtin/commit.c:1366 builtin/commit.c:1527
+#: builtin/commit.c:1476 builtin/commit.c:1642
 msgid "show status concisely"
-msgstr ""
+msgstr "perlihatkan status dengan ringkas"
 
-#: builtin/commit.c:1368 builtin/commit.c:1529
+#: builtin/commit.c:1478 builtin/commit.c:1644
 msgid "show branch information"
-msgstr ""
+msgstr "perlihatkan informasi cabang"
 
-#: builtin/commit.c:1370
+#: builtin/commit.c:1480
 msgid "show stash information"
-msgstr ""
+msgstr "perlihatkan informasi stase"
 
-#: builtin/commit.c:1372 builtin/commit.c:1531
+#: builtin/commit.c:1482 builtin/commit.c:1646
 msgid "compute full ahead/behind values"
-msgstr ""
+msgstr "hitung nilai didepan/dibelakang penuh"
 
-#: builtin/commit.c:1374
+#: builtin/commit.c:1484
 msgid "version"
-msgstr ""
+msgstr "versi"
 
-#: builtin/commit.c:1374 builtin/commit.c:1533 builtin/push.c:560
-#: builtin/worktree.c:679
+#: builtin/commit.c:1484 builtin/commit.c:1648 builtin/push.c:560
+#: builtin/worktree.c:681
 msgid "machine-readable output"
 msgstr "keluaran yang dapat dibaca mesin"
 
-#: builtin/commit.c:1377 builtin/commit.c:1535
+#: builtin/commit.c:1487 builtin/commit.c:1650
 msgid "show status in long format (default)"
-msgstr ""
+msgstr "perlihatkan status dalam format panjang (asali)"
 
-#: builtin/commit.c:1380 builtin/commit.c:1538
+#: builtin/commit.c:1490 builtin/commit.c:1653
 msgid "terminate entries with NUL"
-msgstr ""
+msgstr "akhiri entri dengan NUL"
 
-#: builtin/commit.c:1382 builtin/commit.c:1386 builtin/commit.c:1541
+#: builtin/commit.c:1492 builtin/commit.c:1496 builtin/commit.c:1656
 #: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1412 parse-options.h:336
+#: builtin/fast-export.c:1204 builtin/rebase.c:1407 parse-options.h:337
 msgid "mode"
-msgstr ""
+msgstr "mode"
 
-#: builtin/commit.c:1383 builtin/commit.c:1541
+#: builtin/commit.c:1493 builtin/commit.c:1656
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
+"perlihatkan berkas tak terlacak, mode opsional: all, normal, no. (Asali: all)"
 
-#: builtin/commit.c:1387
+#: builtin/commit.c:1497
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
 msgstr ""
+"perlihatkan berkas terabaikan, mode opsional: traditional, matching, no. "
+"(Asali: traditional)"
 
-#: builtin/commit.c:1389 parse-options.h:192
+#: builtin/commit.c:1499 parse-options.h:193
 msgid "when"
-msgstr ""
+msgstr "bila"
 
-#: builtin/commit.c:1390
+#: builtin/commit.c:1500
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
 msgstr ""
+"abaikan perubahan submodul, bila opsional: all, dirty, untracked. (Asali: "
+"all)"
 
-#: builtin/commit.c:1392
+#: builtin/commit.c:1502
 msgid "list untracked files in columns"
-msgstr ""
-
-#: builtin/commit.c:1393
-msgid "do not detect renames"
-msgstr ""
-
-#: builtin/commit.c:1395
-msgid "detect renames, optionally set similarity index"
-msgstr ""
-
-#: builtin/commit.c:1415
-msgid "Unsupported combination of ignored and untracked-files arguments"
-msgstr ""
-
-#: builtin/commit.c:1497
-msgid "suppress summary after successful commit"
-msgstr ""
-
-#: builtin/commit.c:1498
-msgid "show diff in commit message template"
-msgstr ""
-
-#: builtin/commit.c:1500
-msgid "Commit message options"
-msgstr ""
-
-#: builtin/commit.c:1501 builtin/merge.c:286 builtin/tag.c:447
-msgid "read message from file"
-msgstr ""
-
-#: builtin/commit.c:1502
-msgid "author"
-msgstr ""
-
-#: builtin/commit.c:1502
-msgid "override author for commit"
-msgstr ""
-
-#: builtin/commit.c:1503 builtin/gc.c:550
-msgid "date"
-msgstr ""
+msgstr "sebut berkas tak terlacak dalam kolom"
 
 #: builtin/commit.c:1503
-msgid "override date for commit"
-msgstr ""
-
-#: builtin/commit.c:1505 builtin/commit.c:1506 builtin/commit.c:1507
-#: builtin/commit.c:1508 parse-options.h:328 ref-filter.h:90
-msgid "commit"
-msgstr ""
+msgid "do not detect renames"
+msgstr "jangan deteksi penggantian nama"
 
 #: builtin/commit.c:1505
-msgid "reuse and edit message from specified commit"
-msgstr ""
-
-#: builtin/commit.c:1506
-msgid "reuse message from specified commit"
-msgstr ""
-
-#: builtin/commit.c:1507
-msgid "use autosquash formatted message to fixup specified commit"
-msgstr ""
-
-#: builtin/commit.c:1508
-msgid "use autosquash formatted message to squash specified commit"
-msgstr ""
-
-#: builtin/commit.c:1509
-msgid "the commit is authored by me now (used with -C/-c/--amend)"
-msgstr ""
-
-#: builtin/commit.c:1510 builtin/log.c:1743 builtin/merge.c:302
-#: builtin/pull.c:145 builtin/revert.c:110
-msgid "add a Signed-off-by trailer"
-msgstr ""
-
-#: builtin/commit.c:1511
-msgid "use specified template file"
-msgstr ""
-
-#: builtin/commit.c:1512
-msgid "force edit of commit"
-msgstr ""
-
-#: builtin/commit.c:1514
-msgid "include status in commit message template"
-msgstr ""
-
-#: builtin/commit.c:1519
-msgid "Commit contents options"
-msgstr ""
-
-#: builtin/commit.c:1520
-msgid "commit all changed files"
-msgstr ""
-
-#: builtin/commit.c:1521
-msgid "add specified files to index for commit"
-msgstr ""
-
-#: builtin/commit.c:1522
-msgid "interactively add files"
-msgstr ""
-
-#: builtin/commit.c:1523
-msgid "interactively add changes"
-msgstr ""
-
-#: builtin/commit.c:1524
-msgid "commit only specified files"
-msgstr ""
+msgid "detect renames, optionally set similarity index"
+msgstr "deteksi penggantian nama, setel indeks kemiripan secara opsional"
 
 #: builtin/commit.c:1525
-msgid "bypass pre-commit and commit-msg hooks"
-msgstr ""
+msgid "Unsupported combination of ignored and untracked-files arguments"
+msgstr "Kombinasi argumen berkas terabaikan dan tak terlacak tidak didukung"
 
-#: builtin/commit.c:1526
-msgid "show what would be committed"
-msgstr ""
+#: builtin/commit.c:1607
+msgid "suppress summary after successful commit"
+msgstr "sembunyikan rangkuman setelah komit berhasil"
 
-#: builtin/commit.c:1539
-msgid "amend previous commit"
-msgstr ""
+#: builtin/commit.c:1608
+msgid "show diff in commit message template"
+msgstr "perlihatkan diff dalam templat pesan komit"
 
-#: builtin/commit.c:1540
-msgid "bypass post-rewrite hook"
-msgstr ""
+#: builtin/commit.c:1610
+msgid "Commit message options"
+msgstr "Opsi pesan komit"
 
-#: builtin/commit.c:1547
-msgid "ok to record an empty change"
-msgstr ""
+#: builtin/commit.c:1611 builtin/merge.c:286 builtin/tag.c:458
+msgid "read message from file"
+msgstr "Baca pesan dari berkas"
 
-#: builtin/commit.c:1549
-msgid "ok to record a change with an empty message"
+#: builtin/commit.c:1612
+msgid "author"
+msgstr "pengarang"
+
+#: builtin/commit.c:1612
+msgid "override author for commit"
+msgstr "timpa pengarang komit"
+
+#: builtin/commit.c:1613 builtin/gc.c:550
+msgid "date"
+msgstr "tangal"
+
+#: builtin/commit.c:1613
+msgid "override date for commit"
+msgstr "timpa tanggal komit"
+
+#: builtin/commit.c:1615 builtin/commit.c:1616 builtin/commit.c:1622
+#: parse-options.h:329 ref-filter.h:90
+msgid "commit"
+msgstr "komit"
+
+#: builtin/commit.c:1615
+msgid "reuse and edit message from specified commit"
+msgstr "gunakan kembali dan sunting pesan dari komit tersebut"
+
+#: builtin/commit.c:1616
+msgid "reuse message from specified commit"
+msgstr "gunakan kembali pesan dari komit tersebut"
+
+#. TRANSLATORS: Leave "[(amend|reword):]" as-is,
+#. and only translate <commit>.
+#.
+#: builtin/commit.c:1621
+msgid "[(amend|reword):]commit"
+msgstr "[(amend|reword):]komit"
+
+#: builtin/commit.c:1621
+msgid ""
+"use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
+"gunakan pesan terformat autosquash untuk perbaiki atau ubah/tulis ulang "
+"komit yang disebutkan"
 
 #: builtin/commit.c:1622
-#, c-format
-msgid "Corrupt MERGE_HEAD file (%s)"
+msgid "use autosquash formatted message to squash specified commit"
+msgstr "gunakan pesan terformat autosquash untuk lumat komit tersebut"
+
+#: builtin/commit.c:1623
+msgid "the commit is authored by me now (used with -C/-c/--amend)"
+msgstr "komit sekarang dikarang olehku (gunakan dengan -C/-c/--amend)"
+
+#: builtin/commit.c:1624 builtin/interpret-trailers.c:111
+msgid "trailer"
 msgstr ""
+
+#: builtin/commit.c:1624
+msgid "add custom trailer(s)"
+msgstr ""
+
+#: builtin/commit.c:1625 builtin/log.c:1751 builtin/merge.c:302
+#: builtin/pull.c:145 builtin/revert.c:110
+msgid "add a Signed-off-by trailer"
+msgstr "tambahkan trailer Signed-off-by"
+
+#: builtin/commit.c:1626
+msgid "use specified template file"
+msgstr "gunakan templat berkas tersebut"
+
+#: builtin/commit.c:1627
+msgid "force edit of commit"
+msgstr "paksa sunting komit"
 
 #: builtin/commit.c:1629
-msgid "could not read MERGE_MODE"
-msgstr ""
+msgid "include status in commit message template"
+msgstr "masukkan status dalam templat pesaan komit"
 
-#: builtin/commit.c:1650
-#, c-format
-msgid "could not read commit message: %s"
-msgstr ""
+#: builtin/commit.c:1634
+msgid "Commit contents options"
+msgstr "Opsi isi komit"
 
-#: builtin/commit.c:1657
-#, c-format
-msgid "Aborting commit due to empty commit message.\n"
-msgstr ""
+#: builtin/commit.c:1635
+msgid "commit all changed files"
+msgstr "komit semua berkas terubah"
+
+#: builtin/commit.c:1636
+msgid "add specified files to index for commit"
+msgstr "tambahakn berkas tersebut ke indeks untuk dikomit"
+
+#: builtin/commit.c:1637
+msgid "interactively add files"
+msgstr "tambah berkas secara interaktif"
+
+#: builtin/commit.c:1638
+msgid "interactively add changes"
+msgstr "tambah perubahan secara interaktif"
+
+#: builtin/commit.c:1639
+msgid "commit only specified files"
+msgstr "hanya komit berkas tersebut"
+
+#: builtin/commit.c:1640
+msgid "bypass pre-commit and commit-msg hooks"
+msgstr "lewati hook pre-commit dan commit-msg"
+
+#: builtin/commit.c:1641
+msgid "show what would be committed"
+msgstr "perlihatkan apa yang akan dikomit"
+
+#: builtin/commit.c:1654
+msgid "amend previous commit"
+msgstr "ubah komit sebelumnya"
+
+#: builtin/commit.c:1655
+msgid "bypass post-rewrite hook"
+msgstr "lewati hook post-rewrite"
 
 #: builtin/commit.c:1662
+msgid "ok to record an empty change"
+msgstr "ok merekam perubahan kosong"
+
+#: builtin/commit.c:1664
+msgid "ok to record a change with an empty message"
+msgstr "ok merekam perubahan dengan pesan kosong"
+
+#: builtin/commit.c:1737
+#, c-format
+msgid "Corrupt MERGE_HEAD file (%s)"
+msgstr "Berkas MERGE_HEAD (%s) rusak"
+
+#: builtin/commit.c:1744
+msgid "could not read MERGE_MODE"
+msgstr "tidak dapat membaca MERGE_MODE"
+
+#: builtin/commit.c:1765
+#, c-format
+msgid "could not read commit message: %s"
+msgstr "tidak dapat membaca pesan komit: %s"
+
+#: builtin/commit.c:1772
+#, c-format
+msgid "Aborting commit due to empty commit message.\n"
+msgstr "Batalkan komit karena pesan komit kosong.\n"
+
+#: builtin/commit.c:1777
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
-msgstr ""
+msgstr "Batalkan komit; Anda tidak menyunting pesan.\n"
 
-#: builtin/commit.c:1696
+#: builtin/commit.c:1788
+#, c-format
+msgid "Aborting commit due to empty commit message body.\n"
+msgstr "Batalkan komit karena badan pesan komit kosong.\n"
+
+#: builtin/commit.c:1824
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
 "not exceeded, and then \"git restore --staged :/\" to recover."
 msgstr ""
+"repositori sudah diperbarui, tetapi tidak dapat menulis\n"
+"berkas indeks baru. Periksa bahwa disk tidak penuh dan kuota\n"
+"tidak terlampaui, lalu \"git restore --staged :/\" untuk pulihkan."
 
 #: builtin/config.c:11
 msgid "git config [<options>]"
-msgstr ""
+msgstr "git config [<opsi>]"
 
 #: builtin/config.c:109 builtin/env--helper.c:27
 #, c-format
 msgid "unrecognized --type argument, %s"
-msgstr ""
+msgstr "argumen --type tidak dikenal %s"
 
 #: builtin/config.c:121
 msgid "only one type at a time"
-msgstr ""
+msgstr "hanya satu tipe pada suatu saat"
 
 #: builtin/config.c:130
 msgid "Config file location"
-msgstr ""
+msgstr "Lokasi berkas konfigurasi"
 
 #: builtin/config.c:131
 msgid "use global config file"
-msgstr ""
+msgstr "gunakan berkas konfigurasi global"
 
 #: builtin/config.c:132
 msgid "use system config file"
-msgstr ""
+msgstr "gunakan berkas konfigurasi sistem"
 
 #: builtin/config.c:133
 msgid "use repository config file"
-msgstr ""
+msgstr "gunakan berkas konfigurasi repositori"
 
 #: builtin/config.c:134
 msgid "use per-worktree config file"
-msgstr ""
+msgstr "gunakan berkas konfigurasi per pohon kerja"
 
 #: builtin/config.c:135
 msgid "use given config file"
-msgstr ""
+msgstr "gunakan berkas konfigurasi yang diberikan"
 
 #: builtin/config.c:136
 msgid "blob-id"
-msgstr ""
+msgstr "id blob"
 
 #: builtin/config.c:136
 msgid "read config from given blob object"
-msgstr ""
+msgstr "baca konfigurasi dari objek blob yang diberikan"
 
 #: builtin/config.c:137
 msgid "Action"
-msgstr ""
+msgstr "Tindakan"
 
 #: builtin/config.c:138
 msgid "get value: name [value-pattern]"
-msgstr ""
+msgstr "dapatkan nilai: name [pola nilai]"
 
 #: builtin/config.c:139
 msgid "get all values: key [value-pattern]"
-msgstr ""
+msgstr "dapatkan semua nilai: key [pola nilai]"
 
 #: builtin/config.c:140
 msgid "get values for regexp: name-regex [value-pattern]"
-msgstr ""
+msgstr "dapatkan nilai dari regexp: name-regex [pola nilai]"
 
 #: builtin/config.c:141
 msgid "get value specific for the URL: section[.var] URL"
-msgstr ""
+msgstr "dapatkan nilai spesifik untuk URL: section[.var] URL"
 
 #: builtin/config.c:142
 msgid "replace all matching variables: name value [value-pattern]"
-msgstr ""
+msgstr "ganti semua variabel yang cocok: name value [pola nilai]"
 
 #: builtin/config.c:143
 msgid "add a new variable: name value"
-msgstr ""
+msgstr "tambahkan variabel baru: name value"
 
 #: builtin/config.c:144
 msgid "remove a variable: name [value-pattern]"
-msgstr ""
+msgstr "hapus variabel: name [pola nilai]"
 
 #: builtin/config.c:145
 msgid "remove all matches: name [value-pattern]"
-msgstr ""
+msgstr "hapus semua cocokan: name [pola nilai]"
 
 #: builtin/config.c:146
 msgid "rename section: old-name new-name"
-msgstr ""
+msgstr "ganti nama bagian: old-name new-name"
 
 #: builtin/config.c:147
 msgid "remove a section: name"
-msgstr ""
+msgstr "hapus bagian: name"
 
 #: builtin/config.c:148
 msgid "list all"
-msgstr ""
+msgstr "daftar semua"
 
 #: builtin/config.c:149
 msgid "use string equality when comparing values to 'value-pattern'"
-msgstr ""
+msgstr "gunakan kesamaan untai ketika membandingkan nilai ke 'pola nilai'"
 
 #: builtin/config.c:150
 msgid "open an editor"
-msgstr ""
+msgstr "buka penyunting"
 
 #: builtin/config.c:151
 msgid "find the color configured: slot [default]"
-msgstr ""
+msgstr "temukan warna terkonfigurasi: slot [asali]"
 
 #: builtin/config.c:152
 msgid "find the color setting: slot [stdout-is-tty]"
-msgstr ""
+msgstr "temukan setelan warna: slot [stdout-is-tty]"
 
 #: builtin/config.c:153
 msgid "Type"
-msgstr ""
+msgstr "Tipe"
 
 #: builtin/config.c:154 builtin/env--helper.c:43
 msgid "value is given this type"
-msgstr ""
+msgstr "Nilai diberikan tipe ini"
 
 #: builtin/config.c:155
 msgid "value is \"true\" or \"false\""
-msgstr ""
+msgstr "Nilai adala \"true\" atau \"false\""
 
 #: builtin/config.c:156
 msgid "value is decimal number"
-msgstr ""
+msgstr "nilai adalah angka desimal"
 
 #: builtin/config.c:157
 msgid "value is --bool or --int"
-msgstr ""
+msgstr "nilai adalah --bool atau --int"
 
 #: builtin/config.c:158
 msgid "value is --bool or string"
-msgstr ""
+msgstr "nilai adalah --bool atau untai"
 
 #: builtin/config.c:159
 msgid "value is a path (file or directory name)"
-msgstr ""
+msgstr "nilai adalah jalur (nama berkas atau direktori)"
 
 #: builtin/config.c:160
 msgid "value is an expiry date"
-msgstr ""
+msgstr "nilai adalah tanggal kadaluarsa"
 
 #: builtin/config.c:161
 msgid "Other"
-msgstr ""
+msgstr "Lainnya"
 
 #: builtin/config.c:162
 msgid "terminate values with NUL byte"
-msgstr ""
+msgstr "Akhiri nilai dengan bita NUL"
 
 #: builtin/config.c:163
 msgid "show variable names only"
-msgstr ""
+msgstr "perlihatkan hanya nama variabel"
 
 #: builtin/config.c:164
 msgid "respect include directives on lookup"
-msgstr ""
+msgstr "segani arahan masukkan pada pencarian"
 
 #: builtin/config.c:165
 msgid "show origin of config (file, standard input, blob, command line)"
 msgstr ""
+"perlihatkan asal konfigurasi (berkas, masukan standar, blob, baris perintah)"
 
 #: builtin/config.c:166
 msgid "show scope of config (worktree, local, global, system, command)"
 msgstr ""
+"perlihatkan cakupan konfigurasi (pohon kerja, lokal, global, sistem, "
+"perintah)"
 
 #: builtin/config.c:167 builtin/env--helper.c:45
 msgid "value"
-msgstr ""
+msgstr "nilai"
 
 #: builtin/config.c:167
 msgid "with --get, use default value when missing entry"
-msgstr ""
+msgstr "dengan --get, gunakan nilai asali ketika kehilangan entri"
 
 #: builtin/config.c:181
 #, c-format
 msgid "wrong number of arguments, should be %d"
-msgstr ""
+msgstr "jumlah argumen salah, seharusnya %d"
 
 #: builtin/config.c:183
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
-msgstr ""
+msgstr "jumlah argumen salah, seharusnya dari %d ke %d"
 
 #: builtin/config.c:339
 #, c-format
 msgid "invalid key pattern: %s"
-msgstr ""
+msgstr "pola kunci tidak valid: %s"
 
 #: builtin/config.c:377
 #, c-format
 msgid "failed to format default config value: %s"
-msgstr ""
+msgstr "gagal memformat nilai konfigurasi asali: %s"
 
 #: builtin/config.c:441
 #, c-format
 msgid "cannot parse color '%s'"
-msgstr ""
+msgstr "tidak dapat menguraikan warna '%s'"
 
 #: builtin/config.c:483
 msgid "unable to parse default color value"
-msgstr ""
+msgstr "tidak dapat menguraikan nilai warna asali"
 
 #: builtin/config.c:536 builtin/config.c:833
 msgid "not in a git directory"
-msgstr ""
+msgstr "bukan di dalam direktori git"
 
 #: builtin/config.c:539
 msgid "writing to stdin is not supported"
-msgstr ""
+msgstr "menulis ke stdin tidak didukung"
 
 #: builtin/config.c:542
 msgid "writing config blobs is not supported"
-msgstr ""
+msgstr "menulis blob konfigurasi tidak didukung"
 
 #: builtin/config.c:627
 #, c-format
@@ -13101,26 +13559,31 @@ msgid ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 msgstr ""
+"# Ini adalah berkas konfigurasi Git per pengguna.\n"
+"[user]\n"
+"# Mohon sesuaikan dan batal komen baris berikut:\n"
+"#\tname = %s\n"
+"#\temail = %s\n"
 
 #: builtin/config.c:652
 msgid "only one config file at a time"
-msgstr ""
+msgstr "hanya satu berkas konfigurasi pada suatu saat"
 
 #: builtin/config.c:658
 msgid "--local can only be used inside a git repository"
-msgstr ""
+msgstr "--local hanya dapat digunakan di dalam repositori git"
 
 #: builtin/config.c:660
 msgid "--blob can only be used inside a git repository"
-msgstr ""
+msgstr "--blob hanya dapat digunakan di dalam repositori git"
 
 #: builtin/config.c:662
 msgid "--worktree can only be used inside a git repository"
-msgstr ""
+msgstr "--worktree hanya dapat digunakan di dalam repositori git"
 
 #: builtin/config.c:684
 msgid "$HOME not set"
-msgstr ""
+msgstr "$HOME tak disetel"
 
 #: builtin/config.c:708
 msgid ""
@@ -13128,54 +13591,59 @@ msgid ""
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
 "section in \"git help worktree\" for details"
 msgstr ""
+"--worktree tidak dapat digunakan dengan banyak pohon kerja kecuali\n"
+"konfigurasi ekstensi worktreeConfig diaktifkan. Mohon baca bagian\n"
+"\"CONFIGURATION FILE\" di \"git help worktree\" untuk selengkapnya"
 
 #: builtin/config.c:743
 msgid "--get-color and variable type are incoherent"
-msgstr ""
+msgstr "--get-color dan tipe variabel raban"
 
 #: builtin/config.c:748
 msgid "only one action at a time"
-msgstr ""
+msgstr "hanya satu tindakan pada suatu saat"
 
 #: builtin/config.c:761
 msgid "--name-only is only applicable to --list or --get-regexp"
-msgstr ""
+msgstr "--name-only hanya dapat diterapkan pada --list atau --get-regexp"
 
 #: builtin/config.c:767
 msgid ""
 "--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
 "list"
 msgstr ""
+"--show-origin hanya dapat diterapkan pada --get, --get-all, --get-regexp, "
+"dan --list"
 
 #: builtin/config.c:773
 msgid "--default is only applicable to --get"
-msgstr ""
+msgstr "--default hanya dapat diterapkan pada --get"
 
 #: builtin/config.c:806
 msgid "--fixed-value only applies with 'value-pattern'"
-msgstr ""
+msgstr "--fixed-value hanya diterapkan dengan 'pola nilai'"
 
 #: builtin/config.c:822
 #, c-format
 msgid "unable to read config file '%s'"
-msgstr ""
+msgstr "tidak dapat membaca berkas konfigurasi '%s'"
 
 #: builtin/config.c:825
 msgid "error processing config file(s)"
-msgstr ""
+msgstr "kesalahan memproses berkas konfigurasi"
 
 #: builtin/config.c:835
 msgid "editing stdin is not supported"
-msgstr ""
+msgstr "menyunting stdin tidak didukung"
 
 #: builtin/config.c:837
 msgid "editing blobs is not supported"
-msgstr ""
+msgstr "menyunting blob tidak didukung"
 
 #: builtin/config.c:851
 #, c-format
 msgid "cannot create configuration file %s"
-msgstr ""
+msgstr "tidak dapat membuat berkas konfigurasi %s"
 
 #: builtin/config.c:864
 #, c-format
@@ -13183,11 +13651,13 @@ msgid ""
 "cannot overwrite multiple values with a single value\n"
 "       Use a regexp, --add or --replace-all to change %s."
 msgstr ""
+"tidak dapat menimpa banyak nilai dengan nilai tunggal\n"
+"       Gunakan regexp, --add atau --replace-all untuk mengubah %s."
 
 #: builtin/config.c:943 builtin/config.c:954
 #, c-format
 msgid "no such section: %s"
-msgstr ""
+msgstr "tidak ada bagian seperti: %s"
 
 #: builtin/count-objects.c:90
 msgid "git count-objects [-v] [-H | --human-readable]"
@@ -13197,7 +13667,7 @@ msgstr ""
 msgid "print sizes in human readable format"
 msgstr ""
 
-#: builtin/credential-cache--daemon.c:226
+#: builtin/credential-cache--daemon.c:227
 #, c-format
 msgid ""
 "The permissions on your socket directory are too loose; other\n"
@@ -13206,11 +13676,11 @@ msgid ""
 "\tchmod 0700 %s"
 msgstr ""
 
-#: builtin/credential-cache--daemon.c:275
+#: builtin/credential-cache--daemon.c:276
 msgid "print debugging messages to stderr"
 msgstr ""
 
-#: builtin/credential-cache--daemon.c:315
+#: builtin/credential-cache--daemon.c:316
 msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr ""
 
@@ -13408,7 +13878,7 @@ msgstr ""
 msgid "Not a git repository"
 msgstr ""
 
-#: builtin/diff.c:532 builtin/grep.c:682
+#: builtin/diff.c:532 builtin/grep.c:684
 #, c-format
 msgid "invalid object '%s' given."
 msgstr ""
@@ -13428,113 +13898,113 @@ msgstr ""
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr ""
 
-#: builtin/difftool.c:30
+#: builtin/difftool.c:31
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr ""
 
-#: builtin/difftool.c:260
+#: builtin/difftool.c:261
 #, c-format
 msgid "failed: %d"
 msgstr ""
 
-#: builtin/difftool.c:302
+#: builtin/difftool.c:303
 #, c-format
 msgid "could not read symlink %s"
 msgstr ""
 
-#: builtin/difftool.c:304
+#: builtin/difftool.c:305
 #, c-format
 msgid "could not read symlink file %s"
 msgstr ""
 
-#: builtin/difftool.c:312
+#: builtin/difftool.c:313
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr ""
 
-#: builtin/difftool.c:412
+#: builtin/difftool.c:413
 msgid ""
 "combined diff formats('-c' and '--cc') are not supported in\n"
 "directory diff mode('-d' and '--dir-diff')."
 msgstr ""
 
-#: builtin/difftool.c:633
+#: builtin/difftool.c:637
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr ""
 
-#: builtin/difftool.c:635
+#: builtin/difftool.c:639
 msgid "working tree file has been left."
 msgstr ""
 
-#: builtin/difftool.c:646
+#: builtin/difftool.c:650
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr ""
 
-#: builtin/difftool.c:647
+#: builtin/difftool.c:651
 msgid "you may want to cleanup or recover these."
 msgstr ""
 
-#: builtin/difftool.c:696
+#: builtin/difftool.c:700
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr ""
 
-#: builtin/difftool.c:698
+#: builtin/difftool.c:702
 msgid "perform a full-directory diff"
 msgstr ""
 
-#: builtin/difftool.c:700
+#: builtin/difftool.c:704
 msgid "do not prompt before launching a diff tool"
 msgstr ""
 
-#: builtin/difftool.c:705
+#: builtin/difftool.c:709
 msgid "use symlinks in dir-diff mode"
 msgstr ""
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:710
 msgid "tool"
 msgstr ""
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:711
 msgid "use the specified diff tool"
 msgstr ""
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:713
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:716
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
 "code"
 msgstr ""
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:719
 msgid "specify a custom command for viewing diffs"
 msgstr ""
 
-#: builtin/difftool.c:716
+#: builtin/difftool.c:720
 msgid "passed to `diff`"
 msgstr ""
 
-#: builtin/difftool.c:731
+#: builtin/difftool.c:735
 msgid "difftool requires worktree or --no-index"
 msgstr ""
 
-#: builtin/difftool.c:738
+#: builtin/difftool.c:742
 msgid "--dir-diff is incompatible with --no-index"
 msgstr ""
 
-#: builtin/difftool.c:741
+#: builtin/difftool.c:745
 msgid "--gui, --tool and --extcmd are mutually exclusive"
 msgstr ""
 
-#: builtin/difftool.c:749
+#: builtin/difftool.c:753
 msgid "no <tool> given for --tool=<tool>"
 msgstr ""
 
-#: builtin/difftool.c:756
+#: builtin/difftool.c:760
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr ""
 
@@ -13622,7 +14092,7 @@ msgstr ""
 msgid "skip output of blob data"
 msgstr ""
 
-#: builtin/fast-export.c:1222 builtin/log.c:1815
+#: builtin/fast-export.c:1222 builtin/log.c:1823
 msgid "refspec"
 msgstr ""
 
@@ -13712,96 +14182,100 @@ msgstr "git fetch --multiple [<opsi>] [(<repositori> | <grup>)]"
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<opsi>]"
 
-#: builtin/fetch.c:120
+#: builtin/fetch.c:122
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel tidak dapat bernilai negatif"
 
-#: builtin/fetch.c:143 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:185
 msgid "fetch from all remotes"
 msgstr "ambil dari semua remote"
 
-#: builtin/fetch.c:145 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:245
 msgid "set upstream for git pull/fetch"
 msgstr "setel hulu untuk git pull/fetch"
 
-#: builtin/fetch.c:147 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:188
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "tambah ke .git/FETCH_HEAD daripada timpa"
 
-#: builtin/fetch.c:149
+#: builtin/fetch.c:151
 msgid "use atomic transaction to update references"
 msgstr ""
 
-#: builtin/fetch.c:151 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:191
 msgid "path to upload pack on remote end"
 msgstr "jalur ke paket unggah pada sisi remote"
 
-#: builtin/fetch.c:152
+#: builtin/fetch.c:154
 msgid "force overwrite of local reference"
 msgstr "paksa timpa referensi lokal"
 
-#: builtin/fetch.c:154
+#: builtin/fetch.c:156
 msgid "fetch from multiple remotes"
 msgstr "ambil dari banyak remote"
 
-#: builtin/fetch.c:156 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:195
 msgid "fetch all tags and associated objects"
 msgstr "ambil semua tag dan objek yang bersesuaian"
 
-#: builtin/fetch.c:158
+#: builtin/fetch.c:160
 msgid "do not fetch all tags (--no-tags)"
 msgstr "jangan ambil semua tag (--no-tags)"
 
-#: builtin/fetch.c:160
+#: builtin/fetch.c:162
 msgid "number of submodules fetched in parallel"
 msgstr "jumlah submodul yang diambil secara bersamaan"
 
-#: builtin/fetch.c:162 builtin/pull.c:198
+#: builtin/fetch.c:164
+msgid "modify the refspec to place all refs within refs/prefetch/"
+msgstr ""
+
+#: builtin/fetch.c:166 builtin/pull.c:198
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "buang cabang pelacak remote yang tidak ada pada remote"
 
-#: builtin/fetch.c:164
+#: builtin/fetch.c:168
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr "buang tag lokal yang tidak ada pada remote dan klob tag yang berubah"
 
-#: builtin/fetch.c:165 builtin/fetch.c:190 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
 msgid "on-demand"
 msgstr "sesuai permintaan"
 
-#: builtin/fetch.c:166
+#: builtin/fetch.c:170
 msgid "control recursive fetching of submodules"
 msgstr "kontrol pengambilan submodul rekursif"
 
-#: builtin/fetch.c:171
+#: builtin/fetch.c:175
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "tulis referensi yang diambil ke berkas FETCH_HEAD"
 
-#: builtin/fetch.c:172 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:206
 msgid "keep downloaded pack"
 msgstr "simpan paket yang diunduh"
 
-#: builtin/fetch.c:174
+#: builtin/fetch.c:178
 msgid "allow updating of HEAD ref"
 msgstr "bolehkan perbarui referensi HEAD"
 
-#: builtin/fetch.c:177 builtin/fetch.c:183 builtin/pull.c:209
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
 #: builtin/pull.c:218
 msgid "deepen history of shallow clone"
 msgstr "perdalam riwayat klon dangkal"
 
-#: builtin/fetch.c:179 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:212
 msgid "deepen history of shallow repository based on time"
 msgstr "perdalam riwayat repositori dangkal berdasarkan waktu"
 
-#: builtin/fetch.c:185 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:221
 msgid "convert to a complete repository"
 msgstr "ubah ke repositori penuh"
 
-#: builtin/fetch.c:188
+#: builtin/fetch.c:192
 msgid "prepend this to submodule path output"
 msgstr "tambahkan ini ke jalur keluaran submodul"
 
-#: builtin/fetch.c:191
+#: builtin/fetch.c:195
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -13809,99 +14283,103 @@ msgstr ""
 "default untuk ambil submodul secara rekursif (prioritas lebih rendah "
 "dariberkas konfigurasi)"
 
-#: builtin/fetch.c:195 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:224
 msgid "accept refs that update .git/shallow"
 msgstr "terima referensi yang memperbarui .git/shallow"
 
-#: builtin/fetch.c:196 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:226
 msgid "refmap"
 msgstr "peta referensi"
 
-#: builtin/fetch.c:197 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:227
 msgid "specify fetch refmap"
 msgstr "sebutkan ambil peta referensi"
 
-#: builtin/fetch.c:204 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:240
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "laporkan bahwa kami hanya punya object yang bisa dicapai dari objek ini"
 
-#: builtin/fetch.c:207 builtin/fetch.c:209
+#: builtin/fetch.c:210
+msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
+msgstr ""
+
+#: builtin/fetch.c:213 builtin/fetch.c:215
 msgid "run 'maintenance --auto' after fetching"
 msgstr "lakukan 'maintenance --auto' setelah pengambilan"
 
-#: builtin/fetch.c:211 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:243
 msgid "check for forced-updates on all updated branches"
 msgstr "periksa pembaruan terpaksa pada semua cabang"
 
-#: builtin/fetch.c:213
+#: builtin/fetch.c:219
 msgid "write the commit-graph after fetching"
 msgstr "tulis grafik komit setelah pengambilan"
 
-#: builtin/fetch.c:215
+#: builtin/fetch.c:221
 msgid "accept refspecs from stdin"
 msgstr "terima spek referensi dari masukan standar"
 
-#: builtin/fetch.c:526
+#: builtin/fetch.c:586
 msgid "Couldn't find remote ref HEAD"
 msgstr "tidak dapat menemukan referensi remote HEAD"
 
-#: builtin/fetch.c:697
+#: builtin/fetch.c:757
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "konfigurasi fetch.output berisi nilai tidak valid %s"
 
-#: builtin/fetch.c:796
+#: builtin/fetch.c:856
 #, c-format
 msgid "object %s not found"
 msgstr "objek %s tidak ditemukan"
 
-#: builtin/fetch.c:800
+#: builtin/fetch.c:860
 msgid "[up to date]"
 msgstr "[terkini]"
 
-#: builtin/fetch.c:813 builtin/fetch.c:829 builtin/fetch.c:901
+#: builtin/fetch.c:873 builtin/fetch.c:889 builtin/fetch.c:961
 msgid "[rejected]"
 msgstr "[tertolak]"
 
-#: builtin/fetch.c:814
+#: builtin/fetch.c:874
 msgid "can't fetch in current branch"
 msgstr "tidak dapat mengambil di cabang saat ini"
 
-#: builtin/fetch.c:824
+#: builtin/fetch.c:884
 msgid "[tag update]"
 msgstr "[pembaruan tag]"
 
-#: builtin/fetch.c:825 builtin/fetch.c:862 builtin/fetch.c:884
-#: builtin/fetch.c:896
+#: builtin/fetch.c:885 builtin/fetch.c:922 builtin/fetch.c:944
+#: builtin/fetch.c:956
 msgid "unable to update local ref"
 msgstr "tidak dapat memperbarui referensi lokal"
 
-#: builtin/fetch.c:829
+#: builtin/fetch.c:889
 msgid "would clobber existing tag"
 msgstr "akan klob tag yang ada"
 
-#: builtin/fetch.c:851
+#: builtin/fetch.c:911
 msgid "[new tag]"
 msgstr "[tag baru]"
 
-#: builtin/fetch.c:854
+#: builtin/fetch.c:914
 msgid "[new branch]"
 msgstr "[cabang baru]"
 
-#: builtin/fetch.c:857
+#: builtin/fetch.c:917
 msgid "[new ref]"
 msgstr "[referensi baru]"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:956
 msgid "forced update"
 msgstr "pembaruan terpaksa"
 
-#: builtin/fetch.c:901
+#: builtin/fetch.c:961
 msgid "non-fast-forward"
 msgstr "bukan-maju-cepat"
 
-#: builtin/fetch.c:1005
+#: builtin/fetch.c:1065
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -13912,7 +14390,7 @@ msgstr ""
 "'--show-forced-updates' atau jalankan 'git config fetch.showForcedUpdates "
 "true'."
 
-#: builtin/fetch.c:1009
+#: builtin/fetch.c:1069
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -13925,22 +14403,22 @@ msgstr ""
 "'git config fetch.showForcedUpdates false'\n"
 " untuk menghindari pemeriksaan ini.\n"
 
-#: builtin/fetch.c:1041
+#: builtin/fetch.c:1101
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s tidak mengirim semua objek yang diperlukan\n"
 
-#: builtin/fetch.c:1069
+#: builtin/fetch.c:1129
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr "tolak %s karena akar dangkal tidak diperkenankan untuk diperbarui"
 
-#: builtin/fetch.c:1146 builtin/fetch.c:1297
+#: builtin/fetch.c:1206 builtin/fetch.c:1357
 #, c-format
 msgid "From %.*s\n"
 msgstr "Dari %.*s\n"
 
-#: builtin/fetch.c:1168
+#: builtin/fetch.c:1228
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -13949,56 +14427,56 @@ msgstr ""
 "beberapa referensi lokal tidak dapat diperbarui; coba jalankan\n"
 " 'git remote prune %s' untuk hapus cabang yang lama dan berkonflik"
 
-#: builtin/fetch.c:1267
+#: builtin/fetch.c:1327
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s akan menjadi terjuntai)"
 
-#: builtin/fetch.c:1268
+#: builtin/fetch.c:1328
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s telah menjadi terjuntai)"
 
-#: builtin/fetch.c:1300
+#: builtin/fetch.c:1360
 msgid "[deleted]"
 msgstr "[dihapus]"
 
-#: builtin/fetch.c:1301 builtin/remote.c:1118
+#: builtin/fetch.c:1361 builtin/remote.c:1118
 msgid "(none)"
 msgstr "(tidak ada)"
 
-#: builtin/fetch.c:1324
+#: builtin/fetch.c:1384
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr "Tolak mengambil ke cabang saat ini %s dari repositori non-bare"
 
-#: builtin/fetch.c:1343
+#: builtin/fetch.c:1403
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Opsi \"%s\" nilai \"%s\" tidak valid untuk %s"
 
-#: builtin/fetch.c:1346
+#: builtin/fetch.c:1406
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Opsi \"%s\" diabaikan untuk %s\n"
 
-#: builtin/fetch.c:1558
+#: builtin/fetch.c:1618
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "banyak cabang terdeteksi, tidak kompatibel dengan --set-upstream"
 
-#: builtin/fetch.c:1573
+#: builtin/fetch.c:1633
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "tidak setel hulu untuk cabang remote pelacak remote"
 
-#: builtin/fetch.c:1575
+#: builtin/fetch.c:1635
 msgid "not setting upstream for a remote tag"
 msgstr "tidak setel hulu untuk tag remote"
 
-#: builtin/fetch.c:1577
+#: builtin/fetch.c:1637
 msgid "unknown branch type"
 msgstr "tipe cabang tidak diketahui"
 
-#: builtin/fetch.c:1579
+#: builtin/fetch.c:1639
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -14006,22 +14484,22 @@ msgstr ""
 "cabang sumber tidak ditemukan.\n"
 "Anda harus sebutkan tepat satu cabang dengan opsi --set-upstream."
 
-#: builtin/fetch.c:1708 builtin/fetch.c:1771
+#: builtin/fetch.c:1768 builtin/fetch.c:1831
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Mengambil %s\n"
 
-#: builtin/fetch.c:1718 builtin/fetch.c:1773 builtin/remote.c:101
+#: builtin/fetch.c:1778 builtin/fetch.c:1833 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Tidak dapat mengambil %s"
 
-#: builtin/fetch.c:1730
+#: builtin/fetch.c:1790
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "tidak dapat mengambil '%s' (kode keluar: %d)\n"
 
-#: builtin/fetch.c:1834
+#: builtin/fetch.c:1894
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -14029,44 +14507,52 @@ msgstr ""
 "Repositori remot tidak disebutkan. Mohon sebutkan baik URL atau nama\n"
 "cabang yang mana revisi baru sebaiknya diambil."
 
-#: builtin/fetch.c:1870
+#: builtin/fetch.c:1930
 msgid "You need to specify a tag name."
 msgstr "Anda perlu sebutkan nama tag"
 
-#: builtin/fetch.c:1935
+#: builtin/fetch.c:1995
 msgid "Negative depth in --deepen is not supported"
 msgstr "Kedalaman negatif di --deepen tidak didukung"
 
-#: builtin/fetch.c:1937
+#: builtin/fetch.c:1997
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen dan --depth saling eksklusif"
 
-#: builtin/fetch.c:1942
+#: builtin/fetch.c:2002
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth dan --unshallow tidak dapat digunakan bersamaan"
 
-#: builtin/fetch.c:1944
+#: builtin/fetch.c:2004
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow pada repositori penuh tidak masuk akal"
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:2021
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all tidak mengambil argumen repositori"
 
-#: builtin/fetch.c:1963
+#: builtin/fetch.c:2023
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all tidak masuk akal dengan spek referensi"
 
-#: builtin/fetch.c:1972
+#: builtin/fetch.c:2032
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "tidak ada remote atau grup remote seperti itu: %s"
 
-#: builtin/fetch.c:1979
+#: builtin/fetch.c:2039
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr "Ambil grup dan sebutkan spek referensi tidak masuk akal"
 
-#: builtin/fetch.c:1997
+#: builtin/fetch.c:2055
+msgid "must supply remote when using --negotiate-only"
+msgstr ""
+
+#: builtin/fetch.c:2060
+msgid "Protocol does not support --negotiate-only, exiting."
+msgstr ""
+
+#: builtin/fetch.c:2079
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -14074,11 +14560,11 @@ msgstr ""
 "--filter hanya dapat digunakan dengan remote yang terkonfigurasi di "
 "extensions.partialclone"
 
-#: builtin/fetch.c:2001
+#: builtin/fetch.c:2083
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic hanya dapat digunakan saat mengambil dari satu remote"
 
-#: builtin/fetch.c:2005
+#: builtin/fetch.c:2087
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin hanya dapat digunakan saat mengambil dari satu remote"
 
@@ -14123,47 +14609,47 @@ msgstr ""
 msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
 msgstr ""
 
-#: builtin/for-each-ref.c:28
+#: builtin/for-each-ref.c:30
 msgid "quote placeholders suitably for shells"
 msgstr ""
 
-#: builtin/for-each-ref.c:30
+#: builtin/for-each-ref.c:32
 msgid "quote placeholders suitably for perl"
 msgstr ""
 
-#: builtin/for-each-ref.c:32
+#: builtin/for-each-ref.c:34
 msgid "quote placeholders suitably for python"
 msgstr ""
 
-#: builtin/for-each-ref.c:34
+#: builtin/for-each-ref.c:36
 msgid "quote placeholders suitably for Tcl"
 msgstr ""
 
-#: builtin/for-each-ref.c:37
+#: builtin/for-each-ref.c:39
 msgid "show only <n> matched refs"
 msgstr ""
 
-#: builtin/for-each-ref.c:39 builtin/tag.c:472
+#: builtin/for-each-ref.c:41 builtin/tag.c:483
 msgid "respect format colors"
 msgstr ""
 
-#: builtin/for-each-ref.c:42
+#: builtin/for-each-ref.c:44
 msgid "print only refs which points at the given object"
 msgstr ""
 
-#: builtin/for-each-ref.c:44
+#: builtin/for-each-ref.c:46
 msgid "print only refs that are merged"
 msgstr ""
 
-#: builtin/for-each-ref.c:45
+#: builtin/for-each-ref.c:47
 msgid "print only refs that are not merged"
 msgstr ""
 
-#: builtin/for-each-ref.c:46
+#: builtin/for-each-ref.c:48
 msgid "print only refs which contain the commit"
 msgstr ""
 
-#: builtin/for-each-ref.c:47
+#: builtin/for-each-ref.c:49
 msgid "print only refs which don't contain the commit"
 msgstr ""
 
@@ -14183,243 +14669,243 @@ msgstr ""
 msgid "missing --config=<config>"
 msgstr ""
 
-#: builtin/fsck.c:69 builtin/fsck.c:130 builtin/fsck.c:131
+#: builtin/fsck.c:69 builtin/fsck.c:127 builtin/fsck.c:128
 msgid "unknown"
 msgstr ""
 
 #. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
-#: builtin/fsck.c:83 builtin/fsck.c:103
+#: builtin/fsck.c:78 builtin/fsck.c:100
 #, c-format
 msgid "error in %s %s: %s"
 msgstr ""
 
 #. TRANSLATORS: e.g. warning in tree 01bfda: <more explanation>
-#: builtin/fsck.c:97
+#: builtin/fsck.c:94
 #, c-format
 msgid "warning in %s %s: %s"
 msgstr ""
 
-#: builtin/fsck.c:126 builtin/fsck.c:129
+#: builtin/fsck.c:123 builtin/fsck.c:126
 #, c-format
 msgid "broken link from %7s %s"
 msgstr ""
 
-#: builtin/fsck.c:138
+#: builtin/fsck.c:135
 msgid "wrong object type in link"
 msgstr ""
 
-#: builtin/fsck.c:154
+#: builtin/fsck.c:151
 #, c-format
 msgid ""
 "broken link from %7s %s\n"
 "              to %7s %s"
 msgstr ""
 
-#: builtin/fsck.c:265
+#: builtin/fsck.c:263
 #, c-format
 msgid "missing %s %s"
 msgstr ""
 
-#: builtin/fsck.c:292
+#: builtin/fsck.c:290
 #, c-format
 msgid "unreachable %s %s"
 msgstr ""
 
-#: builtin/fsck.c:312
+#: builtin/fsck.c:310
 #, c-format
 msgid "dangling %s %s"
 msgstr ""
 
-#: builtin/fsck.c:322
+#: builtin/fsck.c:320
 msgid "could not create lost-found"
 msgstr ""
 
-#: builtin/fsck.c:333
+#: builtin/fsck.c:331
 #, c-format
 msgid "could not finish '%s'"
 msgstr ""
 
-#: builtin/fsck.c:350
+#: builtin/fsck.c:348
 #, c-format
 msgid "Checking %s"
 msgstr ""
 
-#: builtin/fsck.c:388
+#: builtin/fsck.c:386
 #, c-format
 msgid "Checking connectivity (%d objects)"
 msgstr ""
 
-#: builtin/fsck.c:407
+#: builtin/fsck.c:405
 #, c-format
 msgid "Checking %s %s"
 msgstr ""
 
-#: builtin/fsck.c:412
+#: builtin/fsck.c:410
 msgid "broken links"
 msgstr ""
 
-#: builtin/fsck.c:421
+#: builtin/fsck.c:419
 #, c-format
 msgid "root %s"
 msgstr ""
 
-#: builtin/fsck.c:429
+#: builtin/fsck.c:427
 #, c-format
 msgid "tagged %s %s (%s) in %s"
 msgstr ""
 
-#: builtin/fsck.c:458
+#: builtin/fsck.c:456
 #, c-format
 msgid "%s: object corrupt or missing"
 msgstr ""
 
-#: builtin/fsck.c:483
+#: builtin/fsck.c:481
 #, c-format
 msgid "%s: invalid reflog entry %s"
 msgstr ""
 
-#: builtin/fsck.c:497
+#: builtin/fsck.c:495
 #, c-format
 msgid "Checking reflog %s->%s"
 msgstr ""
 
-#: builtin/fsck.c:531
+#: builtin/fsck.c:529
 #, c-format
 msgid "%s: invalid sha1 pointer %s"
 msgstr ""
 
-#: builtin/fsck.c:538
+#: builtin/fsck.c:536
 #, c-format
 msgid "%s: not a commit"
 msgstr ""
 
-#: builtin/fsck.c:592
+#: builtin/fsck.c:590
 msgid "notice: No default references"
 msgstr ""
 
-#: builtin/fsck.c:607
+#: builtin/fsck.c:605
 #, c-format
 msgid "%s: object corrupt or missing: %s"
 msgstr ""
 
-#: builtin/fsck.c:620
+#: builtin/fsck.c:618
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr ""
 
-#: builtin/fsck.c:640
+#: builtin/fsck.c:638
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr ""
 
-#: builtin/fsck.c:655
+#: builtin/fsck.c:653
 msgid "Checking object directory"
 msgstr ""
 
-#: builtin/fsck.c:658
+#: builtin/fsck.c:656
 msgid "Checking object directories"
 msgstr ""
 
-#: builtin/fsck.c:673
+#: builtin/fsck.c:671
 #, c-format
 msgid "Checking %s link"
 msgstr ""
 
-#: builtin/fsck.c:678 builtin/index-pack.c:865
+#: builtin/fsck.c:676 builtin/index-pack.c:866
 #, c-format
 msgid "invalid %s"
 msgstr "%s tidak valid"
 
-#: builtin/fsck.c:685
+#: builtin/fsck.c:683
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr ""
 
-#: builtin/fsck.c:691
+#: builtin/fsck.c:689
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr ""
 
-#: builtin/fsck.c:695
+#: builtin/fsck.c:693
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr ""
 
-#: builtin/fsck.c:707
+#: builtin/fsck.c:705
 msgid "Checking cache tree"
 msgstr ""
 
-#: builtin/fsck.c:712
+#: builtin/fsck.c:710
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr ""
 
-#: builtin/fsck.c:721
+#: builtin/fsck.c:719
 msgid "non-tree in cache-tree"
 msgstr ""
 
-#: builtin/fsck.c:752
+#: builtin/fsck.c:750
 msgid "git fsck [<options>] [<object>...]"
 msgstr ""
 
-#: builtin/fsck.c:758
+#: builtin/fsck.c:756
 msgid "show unreachable objects"
 msgstr ""
 
-#: builtin/fsck.c:759
+#: builtin/fsck.c:757
 msgid "show dangling objects"
 msgstr ""
 
-#: builtin/fsck.c:760
+#: builtin/fsck.c:758
 msgid "report tags"
 msgstr ""
 
-#: builtin/fsck.c:761
+#: builtin/fsck.c:759
 msgid "report root nodes"
 msgstr ""
 
-#: builtin/fsck.c:762
+#: builtin/fsck.c:760
 msgid "make index objects head nodes"
 msgstr ""
 
-#: builtin/fsck.c:763
+#: builtin/fsck.c:761
 msgid "make reflogs head nodes (default)"
 msgstr ""
 
-#: builtin/fsck.c:764
+#: builtin/fsck.c:762
 msgid "also consider packs and alternate objects"
 msgstr ""
 
-#: builtin/fsck.c:765
+#: builtin/fsck.c:763
 msgid "check only connectivity"
 msgstr ""
 
-#: builtin/fsck.c:766 builtin/mktag.c:78
+#: builtin/fsck.c:764 builtin/mktag.c:75
 msgid "enable more strict checking"
 msgstr ""
 
-#: builtin/fsck.c:768
+#: builtin/fsck.c:766
 msgid "write dangling objects in .git/lost-found"
 msgstr ""
 
-#: builtin/fsck.c:769 builtin/prune.c:134
+#: builtin/fsck.c:767 builtin/prune.c:134
 msgid "show progress"
 msgstr ""
 
-#: builtin/fsck.c:770
+#: builtin/fsck.c:768
 msgid "show verbose names for reachable objects"
 msgstr ""
 
-#: builtin/fsck.c:829 builtin/index-pack.c:261
+#: builtin/fsck.c:827 builtin/index-pack.c:262
 msgid "Checking objects"
 msgstr "Memeriksa objek"
 
-#: builtin/fsck.c:857
+#: builtin/fsck.c:855
 #, c-format
 msgid "%s: object missing"
 msgstr ""
 
-#: builtin/fsck.c:868
+#: builtin/fsck.c:866
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr ""
@@ -14438,12 +14924,12 @@ msgstr ""
 msgid "failed to parse '%s' value '%s'"
 msgstr ""
 
-#: builtin/gc.c:487 builtin/init-db.c:58
+#: builtin/gc.c:487 builtin/init-db.c:57
 #, c-format
 msgid "cannot stat '%s'"
 msgstr ""
 
-#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:562
+#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:573
 #, c-format
 msgid "cannot read '%s'"
 msgstr ""
@@ -14532,140 +15018,143 @@ msgstr ""
 msgid "failed to write commit-graph"
 msgstr ""
 
-#: builtin/gc.c:914
-msgid "failed to fill remotes"
+#: builtin/gc.c:905
+msgid "failed to prefetch remotes"
 msgstr ""
 
-#: builtin/gc.c:1037
+#: builtin/gc.c:1022
 msgid "failed to start 'git pack-objects' process"
 msgstr ""
 
-#: builtin/gc.c:1054
+#: builtin/gc.c:1039
 msgid "failed to finish 'git pack-objects' process"
 msgstr ""
 
-#: builtin/gc.c:1106
+#: builtin/gc.c:1091
 msgid "failed to write multi-pack-index"
 msgstr ""
 
-#: builtin/gc.c:1124
+#: builtin/gc.c:1109
 msgid "'git multi-pack-index expire' failed"
 msgstr ""
 
-#: builtin/gc.c:1185
+#: builtin/gc.c:1170
 msgid "'git multi-pack-index repack' failed"
 msgstr ""
 
-#: builtin/gc.c:1194
+#: builtin/gc.c:1179
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 
-#: builtin/gc.c:1298
+#: builtin/gc.c:1283
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr ""
 
-#: builtin/gc.c:1328
+#: builtin/gc.c:1313
 #, c-format
 msgid "task '%s' failed"
 msgstr ""
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1395
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr ""
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1400
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr ""
 
-#: builtin/gc.c:1430
+#: builtin/gc.c:1415
 msgid "run tasks based on the state of the repository"
 msgstr ""
 
-#: builtin/gc.c:1431
+#: builtin/gc.c:1416
 msgid "frequency"
 msgstr ""
 
-#: builtin/gc.c:1432
+#: builtin/gc.c:1417
 msgid "run tasks based on frequency"
 msgstr ""
 
-#: builtin/gc.c:1435
+#: builtin/gc.c:1420
 msgid "do not report progress or other information over stderr"
 msgstr ""
 
-#: builtin/gc.c:1436
+#: builtin/gc.c:1421
 msgid "task"
 msgstr ""
 
-#: builtin/gc.c:1437
+#: builtin/gc.c:1422
 msgid "run a specific task"
 msgstr ""
 
-#: builtin/gc.c:1454
+#: builtin/gc.c:1439
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr ""
 
-#: builtin/gc.c:1497
+#: builtin/gc.c:1482
 msgid "failed to run 'git config'"
 msgstr ""
 
-#: builtin/gc.c:1562
+#: builtin/gc.c:1547
+#, c-format
 msgid "failed to expand path '%s'"
 msgstr ""
 
-#: builtin/gc.c:1591
+#: builtin/gc.c:1576
 msgid "failed to start launchctl"
 msgstr ""
 
-#: builtin/gc.c:1628
+#: builtin/gc.c:1613
+#, c-format
 msgid "failed to create directories for '%s'"
 msgstr ""
 
-#: builtin/gc.c:1689
+#: builtin/gc.c:1674
+#, c-format
 msgid "failed to bootstrap service %s"
 msgstr ""
 
-#: builtin/gc.c:1760
+#: builtin/gc.c:1745
 msgid "failed to create temp xml file"
 msgstr ""
 
-#: builtin/gc.c:1850
+#: builtin/gc.c:1835
 msgid "failed to start schtasks"
 msgstr ""
 
-#: builtin/gc.c:1894
+#: builtin/gc.c:1879
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 
-#: builtin/gc.c:1911
+#: builtin/gc.c:1896
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 
-#: builtin/gc.c:1915
+#: builtin/gc.c:1900
 msgid "failed to open stdin of 'crontab'"
 msgstr ""
 
-#: builtin/gc.c:1956
+#: builtin/gc.c:1942
 msgid "'crontab' died"
 msgstr ""
 
-#: builtin/gc.c:1990
+#: builtin/gc.c:1976
 msgid "another process is scheduling background maintenance"
 msgstr ""
 
-#: builtin/gc.c:2009
+#: builtin/gc.c:2000
 msgid "failed to add repo to global config"
 msgstr ""
 
-#: builtin/gc.c:2019
+#: builtin/gc.c:2010
 msgid "git maintenance <subcommand> [<options>]"
 msgstr ""
 
-#: builtin/gc.c:2038
+#: builtin/gc.c:2029
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr ""
@@ -14688,258 +15177,258 @@ msgstr ""
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1808
-#: builtin/pack-objects.c:2944
+#: builtin/grep.c:285 builtin/index-pack.c:1590 builtin/index-pack.c:1793
+#: builtin/pack-objects.c:2969
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "tidak ada dukungan utas, abaikan %s"
 
-#: builtin/grep.c:473 builtin/grep.c:601 builtin/grep.c:641
+#: builtin/grep.c:473 builtin/grep.c:603 builtin/grep.c:643
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr ""
 
-#: builtin/grep.c:656
+#: builtin/grep.c:658
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr ""
 
-#: builtin/grep.c:737
+#: builtin/grep.c:739
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr ""
 
-#: builtin/grep.c:836
+#: builtin/grep.c:838
 msgid "search in index instead of in the work tree"
 msgstr ""
 
-#: builtin/grep.c:838
+#: builtin/grep.c:840
 msgid "find in contents not managed by git"
 msgstr ""
 
-#: builtin/grep.c:840
+#: builtin/grep.c:842
 msgid "search in both tracked and untracked files"
 msgstr ""
 
-#: builtin/grep.c:842
+#: builtin/grep.c:844
 msgid "ignore files specified via '.gitignore'"
 msgstr ""
 
-#: builtin/grep.c:844
+#: builtin/grep.c:846
 msgid "recursively search in each submodule"
 msgstr ""
 
-#: builtin/grep.c:847
+#: builtin/grep.c:849
 msgid "show non-matching lines"
 msgstr ""
 
-#: builtin/grep.c:849
+#: builtin/grep.c:851
 msgid "case insensitive matching"
 msgstr ""
 
-#: builtin/grep.c:851
+#: builtin/grep.c:853
 msgid "match patterns only at word boundaries"
 msgstr ""
 
-#: builtin/grep.c:853
+#: builtin/grep.c:855
 msgid "process binary files as text"
 msgstr ""
 
-#: builtin/grep.c:855
+#: builtin/grep.c:857
 msgid "don't match patterns in binary files"
 msgstr ""
 
-#: builtin/grep.c:858
+#: builtin/grep.c:860
 msgid "process binary files with textconv filters"
 msgstr ""
 
-#: builtin/grep.c:860
+#: builtin/grep.c:862
 msgid "search in subdirectories (default)"
 msgstr ""
 
-#: builtin/grep.c:862
+#: builtin/grep.c:864
 msgid "descend at most <depth> levels"
 msgstr ""
 
-#: builtin/grep.c:866
+#: builtin/grep.c:868
 msgid "use extended POSIX regular expressions"
 msgstr ""
 
-#: builtin/grep.c:869
+#: builtin/grep.c:871
 msgid "use basic POSIX regular expressions (default)"
 msgstr ""
 
-#: builtin/grep.c:872
+#: builtin/grep.c:874
 msgid "interpret patterns as fixed strings"
 msgstr ""
 
-#: builtin/grep.c:875
+#: builtin/grep.c:877
 msgid "use Perl-compatible regular expressions"
 msgstr ""
 
-#: builtin/grep.c:878
+#: builtin/grep.c:880
 msgid "show line numbers"
 msgstr ""
 
-#: builtin/grep.c:879
+#: builtin/grep.c:881
 msgid "show column number of first match"
 msgstr ""
 
-#: builtin/grep.c:880
+#: builtin/grep.c:882
 msgid "don't show filenames"
 msgstr ""
 
-#: builtin/grep.c:881
+#: builtin/grep.c:883
 msgid "show filenames"
 msgstr ""
 
-#: builtin/grep.c:883
+#: builtin/grep.c:885
 msgid "show filenames relative to top directory"
 msgstr ""
 
-#: builtin/grep.c:885
+#: builtin/grep.c:887
 msgid "show only filenames instead of matching lines"
 msgstr ""
 
-#: builtin/grep.c:887
+#: builtin/grep.c:889
 msgid "synonym for --files-with-matches"
 msgstr ""
 
-#: builtin/grep.c:890
+#: builtin/grep.c:892
 msgid "show only the names of files without match"
 msgstr ""
 
-#: builtin/grep.c:892
+#: builtin/grep.c:894
 msgid "print NUL after filenames"
 msgstr ""
 
-#: builtin/grep.c:895
+#: builtin/grep.c:897
 msgid "show only matching parts of a line"
 msgstr ""
 
-#: builtin/grep.c:897
+#: builtin/grep.c:899
 msgid "show the number of matches instead of matching lines"
 msgstr ""
 
-#: builtin/grep.c:898
+#: builtin/grep.c:900
 msgid "highlight matches"
 msgstr ""
 
-#: builtin/grep.c:900
+#: builtin/grep.c:902
 msgid "print empty line between matches from different files"
 msgstr ""
 
-#: builtin/grep.c:902
+#: builtin/grep.c:904
 msgid "show filename only once above matches from same file"
 msgstr ""
 
-#: builtin/grep.c:905
+#: builtin/grep.c:907
 msgid "show <n> context lines before and after matches"
 msgstr ""
 
-#: builtin/grep.c:908
+#: builtin/grep.c:910
 msgid "show <n> context lines before matches"
 msgstr ""
 
-#: builtin/grep.c:910
+#: builtin/grep.c:912
 msgid "show <n> context lines after matches"
 msgstr ""
 
-#: builtin/grep.c:912
+#: builtin/grep.c:914
 msgid "use <n> worker threads"
 msgstr ""
 
-#: builtin/grep.c:913
+#: builtin/grep.c:915
 msgid "shortcut for -C NUM"
 msgstr ""
 
-#: builtin/grep.c:916
+#: builtin/grep.c:918
 msgid "show a line with the function name before matches"
 msgstr ""
 
-#: builtin/grep.c:918
+#: builtin/grep.c:920
 msgid "show the surrounding function"
 msgstr ""
 
-#: builtin/grep.c:921
+#: builtin/grep.c:923
 msgid "read patterns from file"
 msgstr ""
 
-#: builtin/grep.c:923
+#: builtin/grep.c:925
 msgid "match <pattern>"
 msgstr ""
 
-#: builtin/grep.c:925
+#: builtin/grep.c:927
 msgid "combine patterns specified with -e"
 msgstr ""
 
-#: builtin/grep.c:937
+#: builtin/grep.c:939
 msgid "indicate hit with exit status without output"
 msgstr ""
 
-#: builtin/grep.c:939
+#: builtin/grep.c:941
 msgid "show only matches from files that match all patterns"
 msgstr ""
 
-#: builtin/grep.c:942
+#: builtin/grep.c:944
 msgid "pager"
 msgstr ""
 
-#: builtin/grep.c:942
+#: builtin/grep.c:944
 msgid "show matching files in the pager"
 msgstr ""
 
-#: builtin/grep.c:946
+#: builtin/grep.c:948
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr ""
 
-#: builtin/grep.c:1012
+#: builtin/grep.c:1014
 msgid "no pattern given"
 msgstr ""
 
-#: builtin/grep.c:1048
+#: builtin/grep.c:1050
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr ""
 
-#: builtin/grep.c:1056
+#: builtin/grep.c:1058
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr ""
 
-#: builtin/grep.c:1086
+#: builtin/grep.c:1088
 msgid "--untracked not supported with --recurse-submodules"
 msgstr ""
 
-#: builtin/grep.c:1090
+#: builtin/grep.c:1092
 msgid "invalid option combination, ignoring --threads"
 msgstr ""
 
-#: builtin/grep.c:1093 builtin/pack-objects.c:3672
+#: builtin/grep.c:1095 builtin/pack-objects.c:3930
 msgid "no threads support, ignoring --threads"
 msgstr ""
 
-#: builtin/grep.c:1096 builtin/index-pack.c:1586 builtin/pack-objects.c:2941
+#: builtin/grep.c:1098 builtin/index-pack.c:1587 builtin/pack-objects.c:2966
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "jumlah utas tersebut (%d) tidak valid"
 
-#: builtin/grep.c:1130
+#: builtin/grep.c:1132
 msgid "--open-files-in-pager only works on the worktree"
 msgstr ""
 
-#: builtin/grep.c:1156
+#: builtin/grep.c:1158
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr ""
 
-#: builtin/grep.c:1159
+#: builtin/grep.c:1161
 msgid "--untracked cannot be used with --cached"
 msgstr ""
 
-#: builtin/grep.c:1165
+#: builtin/grep.c:1167
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 
-#: builtin/grep.c:1173
+#: builtin/grep.c:1175
 msgid "both --cached and trees are given"
 msgstr ""
 
@@ -14980,62 +15469,62 @@ msgstr ""
 
 #: builtin/help.c:47
 msgid "print all available commands"
-msgstr ""
+msgstr "cetak semua perintah yang tersedia"
 
 #: builtin/help.c:48
 msgid "exclude guides"
-msgstr ""
+msgstr "kecualikan panduan"
 
 #: builtin/help.c:49
 msgid "print list of useful guides"
-msgstr ""
+msgstr "cetak daftar panduan berguna"
 
 #: builtin/help.c:50
 msgid "print all configuration variable names"
-msgstr ""
+msgstr "cetak semua nama variabel konfigurasi"
 
 #: builtin/help.c:52
 msgid "show man page"
-msgstr ""
+msgstr "perlihatkan halaman man"
 
 #: builtin/help.c:53
 msgid "show manual in web browser"
-msgstr ""
+msgstr "perlihatkan manual dalam penjelajah web"
 
 #: builtin/help.c:55
 msgid "show info page"
-msgstr ""
+msgstr "perlihatkan halaman info"
 
 #: builtin/help.c:57
 msgid "print command description"
-msgstr ""
+msgstr "perlihatkan deskripsi perintah"
 
 #: builtin/help.c:62
 msgid "git help [--all] [--guides] [--man | --web | --info] [<command>]"
-msgstr ""
+msgstr "git help [--all] [--guides] [--man | --web | --info] [<command>]"
 
 #: builtin/help.c:163
 #, c-format
 msgid "unrecognized help format '%s'"
-msgstr ""
+msgstr "format bantuan tidak dikenal '%s'"
 
 #: builtin/help.c:190
 msgid "Failed to start emacsclient."
-msgstr ""
+msgstr "gagal menjalankan emacsclient."
 
 #: builtin/help.c:203
 msgid "Failed to parse emacsclient version."
-msgstr ""
+msgstr "gagal menguraikan versi emacsclient."
 
 #: builtin/help.c:211
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
-msgstr ""
+msgstr "versi emacsclient '%d' terlalu usang (< 22)."
 
 #: builtin/help.c:229 builtin/help.c:251 builtin/help.c:261 builtin/help.c:269
 #, c-format
 msgid "failed to exec '%s'"
-msgstr ""
+msgstr "gagal menjalankan '%s'"
 
 #: builtin/help.c:307
 #, c-format
@@ -15043,6 +15532,8 @@ msgid ""
 "'%s': path for unsupported man viewer.\n"
 "Please consider using 'man.<tool>.cmd' instead."
 msgstr ""
+"'%s': jalur untuk pembaca man yang tidak didukung.\n"
+"Mohon gunakan 'man.<tool>.cmd' sebagai gantinya."
 
 #: builtin/help.c:319
 #, c-format
@@ -15050,429 +15541,427 @@ msgid ""
 "'%s': cmd for supported man viewer.\n"
 "Please consider using 'man.<tool>.path' instead."
 msgstr ""
+"'%s': cmd untuk pembaca man yang didukung.\n"
+"Mohon gunakan 'man.<tool>.path' sebagai gantinya."
 
 #: builtin/help.c:436
 #, c-format
 msgid "'%s': unknown man viewer."
-msgstr ""
+msgstr "'%s': pembaca man tidak dikenal"
 
 #: builtin/help.c:453
 msgid "no man viewer handled the request"
-msgstr ""
+msgstr "tidak ada pembaca man yang menangani permintaan"
 
 #: builtin/help.c:461
 msgid "no info viewer handled the request"
-msgstr ""
+msgstr "tidak ada pembaca info yang menangani permintaan"
 
-#: builtin/help.c:520 builtin/help.c:531 git.c:340
+#: builtin/help.c:520 builtin/help.c:531 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
-msgstr ""
+msgstr "'%s' dialiaskan ke '%s'"
 
-#: builtin/help.c:534 git.c:372
+#: builtin/help.c:534 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
-msgstr ""
+msgstr "untai alias.%s jelek: %s"
 
 #: builtin/help.c:563 builtin/help.c:593
 #, c-format
 msgid "usage: %s%s"
-msgstr ""
+msgstr "penggunaan: %s%s"
 
 #: builtin/help.c:577
 msgid "'git help config' for more information"
-msgstr ""
+msgstr "'git help config' untuk informasi lebih lanjut"
 
-#: builtin/index-pack.c:221
+#: builtin/index-pack.c:222
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "tipe objek tidak cocok pada %s"
 
-#: builtin/index-pack.c:241
+#: builtin/index-pack.c:242
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "tidak menerima objek yang diharapkan %s"
 
-#: builtin/index-pack.c:244
+#: builtin/index-pack.c:245
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "objek %s: yang diharapkan %s, yang didapat %s"
 
-#: builtin/index-pack.c:294
+#: builtin/index-pack.c:295
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:304
+#: builtin/index-pack.c:305
 msgid "early EOF"
 msgstr "EOF awal"
 
-#: builtin/index-pack.c:305
+#: builtin/index-pack.c:306
 msgid "read error on input"
 msgstr "kesalahan baca pada masukan"
 
-#: builtin/index-pack.c:317
+#: builtin/index-pack.c:318
 msgid "used more bytes than were available"
 msgstr "gunakan lebih banyak pita dari pada yang tersedia"
 
-#: builtin/index-pack.c:324 builtin/pack-objects.c:624
+#: builtin/index-pack.c:325 builtin/pack-objects.c:624
 msgid "pack too large for current definition of off_t"
 msgstr "paket terlalu besar untuk definisi off_t saat ini"
 
-#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:328 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "paket melebihi ukuran maksimum yang diperbolehkan"
 
-#: builtin/index-pack.c:342
+#: builtin/index-pack.c:343
 #, c-format
 msgid "unable to create '%s'"
 msgstr "tidak dapat membuat '%s'"
 
-#: builtin/index-pack.c:348
+#: builtin/index-pack.c:349
 #, c-format
 msgid "cannot open packfile '%s'"
 msgstr "tidak dapat membuka berkas paket '%s'"
 
-#: builtin/index-pack.c:362
+#: builtin/index-pack.c:363
 msgid "pack signature mismatch"
 msgstr "tanda tangan paket tidak cocok"
 
-#: builtin/index-pack.c:364
+#: builtin/index-pack.c:365
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "versi paket %<PRIu32> tidak didukung"
 
-#: builtin/index-pack.c:382
+#: builtin/index-pack.c:383
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "paket ada objek jelek pada offset %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:488
+#: builtin/index-pack.c:489
 #, c-format
 msgid "inflate returned %d"
 msgstr "inflate mengembalikan %d"
 
-#: builtin/index-pack.c:537
+#: builtin/index-pack.c:538
 msgid "offset value overflow for delta base object"
 msgstr "nilai offset meluap untuk objek basis delta"
 
-#: builtin/index-pack.c:545
+#: builtin/index-pack.c:546
 msgid "delta base offset is out of bound"
 msgstr "offset basis delta di luar jangkauan"
 
-#: builtin/index-pack.c:553
+#: builtin/index-pack.c:554
 #, c-format
 msgid "unknown object type %d"
 msgstr "tipe objek tidak diketahui %d"
 
-#: builtin/index-pack.c:584
+#: builtin/index-pack.c:585
 msgid "cannot pread pack file"
 msgstr "tidak dapat pread berkas paket"
 
-#: builtin/index-pack.c:586
+#: builtin/index-pack.c:587
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:612
+#: builtin/index-pack.c:613
 msgid "serious inflate inconsistency"
 msgstr "inkonsistensi inflate serius"
 
-#: builtin/index-pack.c:757 builtin/index-pack.c:763 builtin/index-pack.c:787
-#: builtin/index-pack.c:826 builtin/index-pack.c:835
+#: builtin/index-pack.c:758 builtin/index-pack.c:764 builtin/index-pack.c:788
+#: builtin/index-pack.c:827 builtin/index-pack.c:836
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "TUMBUKAN SHA1 DITEMUKAN DENGAN %s !"
 
-#: builtin/index-pack.c:760 builtin/pack-objects.c:171
+#: builtin/index-pack.c:761 builtin/pack-objects.c:171
 #: builtin/pack-objects.c:231 builtin/pack-objects.c:326
 #, c-format
 msgid "unable to read %s"
 msgstr "tidak dapat membaca %s"
 
-#: builtin/index-pack.c:824
+#: builtin/index-pack.c:825
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "tidak dapat membaca info objek yang ada %s"
 
-#: builtin/index-pack.c:832
+#: builtin/index-pack.c:833
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "tidak dapat membaca objek yang ada %s"
 
-#: builtin/index-pack.c:846
+#: builtin/index-pack.c:847
 #, c-format
 msgid "invalid blob object %s"
 msgstr "objek blob tidak valid %s"
 
-#: builtin/index-pack.c:849 builtin/index-pack.c:868
+#: builtin/index-pack.c:850 builtin/index-pack.c:869
 msgid "fsck error in packed object"
 msgstr "kesalahan fsck dalam objek terpaket"
 
-#: builtin/index-pack.c:870
+#: builtin/index-pack.c:871
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Tidak semua objek anak dari %s bisa dicapai"
 
-#: builtin/index-pack.c:931 builtin/index-pack.c:978
+#: builtin/index-pack.c:932 builtin/index-pack.c:979
 msgid "failed to apply delta"
 msgstr "gagal menerapkan delta"
 
-#: builtin/index-pack.c:1161
+#: builtin/index-pack.c:1162
 msgid "Receiving objects"
 msgstr "Menerima objek"
 
-#: builtin/index-pack.c:1161
+#: builtin/index-pack.c:1162
 msgid "Indexing objects"
 msgstr "Mengindeks objek"
 
-#: builtin/index-pack.c:1195
+#: builtin/index-pack.c:1196
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "paket rusak (SHA1 tidak cocok)"
 
-#: builtin/index-pack.c:1200
+#: builtin/index-pack.c:1201
 msgid "cannot fstat packfile"
 msgstr "tidak dapat fstat berkas paket"
 
-#: builtin/index-pack.c:1203
+#: builtin/index-pack.c:1204
 msgid "pack has junk at the end"
 msgstr "paket memiliki sampah pada ujung"
 
-#: builtin/index-pack.c:1215
+#: builtin/index-pack.c:1216
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "bingung di luar kegilaan di parse_pack_objects()"
 
-#: builtin/index-pack.c:1238
+#: builtin/index-pack.c:1239
 msgid "Resolving deltas"
 msgstr "Menguraikan delta"
 
-#: builtin/index-pack.c:1249 builtin/pack-objects.c:2707
+#: builtin/index-pack.c:1250 builtin/pack-objects.c:2732
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "tidak dapat membuat utas: %s"
 
-#: builtin/index-pack.c:1282
+#: builtin/index-pack.c:1283
 msgid "confusion beyond insanity"
 msgstr "bingung di luar kegilaan"
 
-#: builtin/index-pack.c:1288
+#: builtin/index-pack.c:1289
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1300
+#: builtin/index-pack.c:1301
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Checksum ekor tidak diharapkan untuk %s (kerusakan disk?)"
 
-#: builtin/index-pack.c:1304
+#: builtin/index-pack.c:1305
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1328
+#: builtin/index-pack.c:1329
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "tidak dapat menggemboskan objek tertambah (%d)"
 
-#: builtin/index-pack.c:1424
+#: builtin/index-pack.c:1425
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "objek lokal %s rusak"
 
-#: builtin/index-pack.c:1445
+#: builtin/index-pack.c:1446
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "nama berkas paket '%s' tidak diakhiri dengan '.%s'"
 
-#: builtin/index-pack.c:1469
+#: builtin/index-pack.c:1470
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "tidak dapat menulis %s berkas '%s'"
 
-#: builtin/index-pack.c:1477
+#: builtin/index-pack.c:1478
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "tidak dapat menutup %s berkas tertulis '%s'"
 
-#: builtin/index-pack.c:1503
+#: builtin/index-pack.c:1504
 msgid "error while closing pack file"
 msgstr "kesalahan menutup berkas paket"
 
-#: builtin/index-pack.c:1517
+#: builtin/index-pack.c:1518
 msgid "cannot store pack file"
 msgstr "tidak dapat menyimpan berkas paket"
 
-#: builtin/index-pack.c:1525
+#: builtin/index-pack.c:1526
 msgid "cannot store index file"
 msgstr "tidak dapat menyimpan berkas indeks"
 
-#: builtin/index-pack.c:1534
-msgid "cannot store reverse index file"
-msgstr "tidak dapat menyimpan berkas indeks balik"
-
-#: builtin/index-pack.c:1580 builtin/pack-objects.c:2952
+#: builtin/index-pack.c:1581 builtin/pack-objects.c:2977
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "pack.indexversion=%<PRIu32> jelek"
 
-#: builtin/index-pack.c:1650
+#: builtin/index-pack.c:1651
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "tidak dapat membuka berkas paket yang ada '%s'"
 
-#: builtin/index-pack.c:1652
+#: builtin/index-pack.c:1653
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "tidak dapat membuka berkas indeks paket untuk '%s'"
 
-#: builtin/index-pack.c:1700
+#: builtin/index-pack.c:1701
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1707
+#: builtin/index-pack.c:1708
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1765
+#: builtin/index-pack.c:1750
 msgid "Cannot come back to cwd"
 msgstr "tidak dapat kembali ke direktori kerja saat ini"
 
-#: builtin/index-pack.c:1819 builtin/index-pack.c:1822
-#: builtin/index-pack.c:1838 builtin/index-pack.c:1842
+#: builtin/index-pack.c:1804 builtin/index-pack.c:1807
+#: builtin/index-pack.c:1823 builtin/index-pack.c:1827
 #, c-format
 msgid "bad %s"
 msgstr "%s jelek"
 
-#: builtin/index-pack.c:1848 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1833 builtin/init-db.c:378 builtin/init-db.c:613
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algoritma hash tak dikenal '%s'"
 
-#: builtin/index-pack.c:1867
+#: builtin/index-pack.c:1852
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin tidak dapat digunakan tanpa --stdin"
 
-#: builtin/index-pack.c:1869
+#: builtin/index-pack.c:1854
 msgid "--stdin requires a git repository"
 msgstr "--stdin memerlukan repositori git"
 
-#: builtin/index-pack.c:1871
+#: builtin/index-pack.c:1856
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format tidak dapat digunakan dengan --stdin"
 
-#: builtin/index-pack.c:1886
+#: builtin/index-pack.c:1871
 msgid "--verify with no packfile name given"
 msgstr "--verify tanpa nama berkas paket diberikan"
 
-#: builtin/index-pack.c:1956 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1937 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "kesalahan fsck dalam objek paket"
 
-#: builtin/init-db.c:64
+#: builtin/init-db.c:63
 #, c-format
 msgid "cannot stat template '%s'"
 msgstr "tidak dapat men-stat templat '%s'"
 
-#: builtin/init-db.c:69
+#: builtin/init-db.c:68
 #, c-format
 msgid "cannot opendir '%s'"
 msgstr "tidak dapat membuka direktori '%s'"
 
-#: builtin/init-db.c:81
+#: builtin/init-db.c:80
 #, c-format
 msgid "cannot readlink '%s'"
 msgstr "tidak dapat membaca tautan '%s'"
 
-#: builtin/init-db.c:83
+#: builtin/init-db.c:82
 #, c-format
 msgid "cannot symlink '%s' '%s'"
 msgstr "tidak dapat menautkan simbolik '%s' '%s'"
 
-#: builtin/init-db.c:89
+#: builtin/init-db.c:88
 #, c-format
 msgid "cannot copy '%s' to '%s'"
 msgstr "tidak dapat menyalin '%s' ke '%s'"
 
-#: builtin/init-db.c:93
+#: builtin/init-db.c:92
 #, c-format
 msgid "ignoring template %s"
 msgstr "mengabaikan templat %s"
 
-#: builtin/init-db.c:124
+#: builtin/init-db.c:123
 #, c-format
 msgid "templates not found in %s"
 msgstr "templat tidak ditemukan di %s"
 
-#: builtin/init-db.c:139
+#: builtin/init-db.c:138
 #, c-format
 msgid "not copying templates from '%s': %s"
 msgstr "tidak menyalin templat dari '%s': %s"
 
-#: builtin/init-db.c:275
+#: builtin/init-db.c:262
 #, c-format
 msgid "invalid initial branch name: '%s'"
 msgstr "nama cabang asal salah: '%s'"
 
-#: builtin/init-db.c:367
+#: builtin/init-db.c:353
 #, c-format
 msgid "unable to handle file type %d"
 msgstr "tidak dapat menangani tipe berkas %d"
 
-#: builtin/init-db.c:370
+#: builtin/init-db.c:356
 #, c-format
 msgid "unable to move %s to %s"
 msgstr "tidak dapat memindahkan %s ke %s"
 
-#: builtin/init-db.c:386
+#: builtin/init-db.c:372
 msgid "attempt to reinitialize repository with different hash"
 msgstr "mencoba menginisialisasi ulang repositori dengan hash yang berbeda"
 
-#: builtin/init-db.c:410 builtin/init-db.c:413
+#: builtin/init-db.c:396 builtin/init-db.c:399
 #, c-format
 msgid "%s already exists"
 msgstr "%s sudah ada"
 
-#: builtin/init-db.c:445
+#: builtin/init-db.c:431
 #, c-format
 msgid "re-init: ignored --initial-branch=%s"
 msgstr "re-init: --initial-branch=%s diabaikan"
 
-#: builtin/init-db.c:476
+#: builtin/init-db.c:462
 #, c-format
 msgid "Reinitialized existing shared Git repository in %s%s\n"
 msgstr "Repositori berbagi Git yang sudah ada diinisialisasi ulang di %s%s\n"
 
-#: builtin/init-db.c:477
+#: builtin/init-db.c:463
 #, c-format
 msgid "Reinitialized existing Git repository in %s%s\n"
 msgstr "Repositori Git diinisialisasi ulang di %s%s\n"
 
-#: builtin/init-db.c:481
+#: builtin/init-db.c:467
 #, c-format
 msgid "Initialized empty shared Git repository in %s%s\n"
 msgstr "Repositori berbagi Git kosong diinisialisasi di %s%s\n"
 
-#: builtin/init-db.c:482
+#: builtin/init-db.c:468
 #, c-format
 msgid "Initialized empty Git repository in %s%s\n"
 msgstr "Repositori Git kosong dinisialisasi di %s%s\n"
 
-#: builtin/init-db.c:531
+#: builtin/init-db.c:517
 msgid ""
 "git init [-q | --quiet] [--bare] [--template=<template-directory>] [--"
 "shared[=<permissions>]] [<directory>]"
@@ -15480,42 +15969,42 @@ msgstr ""
 "git init [-q | --quiet] [--bare] [--template=<direktori-templat>][--"
 "shared[=<perizinan>]] [<direktori>]"
 
-#: builtin/init-db.c:557
+#: builtin/init-db.c:543
 msgid "permissions"
 msgstr "perizinan"
 
-#: builtin/init-db.c:558
+#: builtin/init-db.c:544
 msgid "specify that the git repository is to be shared amongst several users"
 msgstr ""
 "tentukan bahwa repositori git untuk dibagikan di antara beberapa pengguna"
 
-#: builtin/init-db.c:564
+#: builtin/init-db.c:550
 msgid "override the name of the initial branch"
 msgstr "timpa nama cabang asal"
 
-#: builtin/init-db.c:565 builtin/verify-pack.c:74
+#: builtin/init-db.c:551 builtin/verify-pack.c:74
 msgid "hash"
 msgstr ""
 
-#: builtin/init-db.c:566 builtin/show-index.c:22 builtin/verify-pack.c:75
+#: builtin/init-db.c:552 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "tentukan algoritma hash yang akan digunakan"
 
-#: builtin/init-db.c:573
+#: builtin/init-db.c:559
 msgid "--separate-git-dir and --bare are mutually exclusive"
 msgstr "--separate-git-dir dan --bare saling eksklusif"
 
-#: builtin/init-db.c:602 builtin/init-db.c:607
+#: builtin/init-db.c:590 builtin/init-db.c:595
 #, c-format
 msgid "cannot mkdir %s"
 msgstr "tidak dapat membuat direktori %s"
 
-#: builtin/init-db.c:611 builtin/init-db.c:666
+#: builtin/init-db.c:599 builtin/init-db.c:654
 #, c-format
 msgid "cannot chdir to %s"
 msgstr "tidak dapat mengganti direktori ke %s"
 
-#: builtin/init-db.c:638
+#: builtin/init-db.c:626
 #, c-format
 msgid ""
 "%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
@@ -15524,12 +16013,12 @@ msgstr ""
 "%s (atau --work-tree=<direktori>) tidak diperbolehkan tanpa sebutkan %s "
 "(atau--git-dir=<direktori>)"
 
-#: builtin/init-db.c:690
+#: builtin/init-db.c:678
 #, c-format
 msgid "Cannot access work tree '%s'"
 msgstr "Tidak dapat mengakses pohon kerja '%s'"
 
-#: builtin/init-db.c:695
+#: builtin/init-db.c:683
 msgid "--separate-git-dir incompatible with bare repository"
 msgstr "--separate-git-dir tidak kompatibel dengan repositori bare"
 
@@ -15579,10 +16068,6 @@ msgstr ""
 msgid "do not treat --- specially"
 msgstr ""
 
-#: builtin/interpret-trailers.c:111
-msgid "trailer"
-msgstr ""
-
 #: builtin/interpret-trailers.c:112
 msgid "trailer(s) to add"
 msgstr ""
@@ -15597,520 +16082,537 @@ msgstr ""
 
 #: builtin/log.c:59
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
-msgstr ""
+msgstr "git log [<opsi>] [<rentang revisi>] [[--] <jalur>...]"
 
 #: builtin/log.c:60
 msgid "git show [<options>] <object>..."
-msgstr ""
+msgstr "git show [<opsi>] <objek>..."
 
 #: builtin/log.c:113
 #, c-format
 msgid "invalid --decorate option: %s"
-msgstr ""
+msgstr "opsi --decorate tidak valid: %s"
 
 #: builtin/log.c:180
 msgid "show source"
-msgstr ""
+msgstr "perlihatkan sumber"
 
 #: builtin/log.c:181
 msgid "use mail map file"
-msgstr ""
+msgstr "gunakan berkas peta surat"
 
 #: builtin/log.c:184
 msgid "only decorate refs that match <pattern>"
-msgstr ""
+msgstr "hanya dekorasi referensi yang cocok dengan <pola>"
 
 #: builtin/log.c:186
 msgid "do not decorate refs that match <pattern>"
-msgstr ""
+msgstr "jangan dekorasi referensi yang cocok dengan <pola>"
 
 #: builtin/log.c:187
 msgid "decorate options"
-msgstr ""
+msgstr "opsi dekorasi"
 
 #: builtin/log.c:190
 msgid ""
 "trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
 msgstr ""
+"lacak evolusi rentang baris <awal>,<akhir> atau fungsi :<nama fungsi> dalam "
+"<berkas>"
 
 #: builtin/log.c:213
 msgid "-L<range>:<file> cannot be used with pathspec"
-msgstr ""
+msgstr "-L<rentang>:<berkas> tidak dapat digunakan dengan spek jalur"
 
 #: builtin/log.c:303
 #, c-format
 msgid "Final output: %d %s\n"
-msgstr ""
+msgstr "Keluaran terakhir: %d %s\n"
 
-#: builtin/log.c:566
+#: builtin/log.c:568
 #, c-format
 msgid "git show %s: bad file"
-msgstr ""
+msgstr "git show %s: berkas jelek"
 
-#: builtin/log.c:581 builtin/log.c:671
+#: builtin/log.c:583 builtin/log.c:673
 #, c-format
 msgid "could not read object %s"
-msgstr ""
+msgstr "tidak dapat membaca objek %s"
 
-#: builtin/log.c:696
+#: builtin/log.c:698
 #, c-format
 msgid "unknown type: %d"
-msgstr ""
+msgstr "tipe tidak dikenal: %d"
 
-#: builtin/log.c:841
+#: builtin/log.c:843
 #, c-format
 msgid "%s: invalid cover from description mode"
-msgstr ""
+msgstr "%s: sampul tidak valid dari mode deskripsi"
 
-#: builtin/log.c:848
+#: builtin/log.c:850
 msgid "format.headers without value"
-msgstr ""
+msgstr "format.headers tanpa nilai"
 
-#: builtin/log.c:977
+#: builtin/log.c:979
 #, c-format
 msgid "cannot open patch file %s"
-msgstr ""
+msgstr "tidak dapat membuka berkas tambalan %s"
 
-#: builtin/log.c:994
+#: builtin/log.c:996
 msgid "need exactly one range"
-msgstr ""
+msgstr "butuh tepatnya satu rentang"
 
-#: builtin/log.c:1004
+#: builtin/log.c:1006
 msgid "not a range"
-msgstr ""
+msgstr "bukan sebuah rentang"
 
-#: builtin/log.c:1168
+#: builtin/log.c:1170
 msgid "cover letter needs email format"
-msgstr ""
+msgstr "sampul surat butuh format email"
 
-#: builtin/log.c:1174
+#: builtin/log.c:1176
 msgid "failed to create cover-letter file"
-msgstr ""
+msgstr "gagal membuat berkas sampul surat"
 
-#: builtin/log.c:1261
+#: builtin/log.c:1263
 #, c-format
 msgid "insane in-reply-to: %s"
-msgstr ""
+msgstr "in-reply-to gila: %s"
 
-#: builtin/log.c:1288
+#: builtin/log.c:1290
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
-msgstr ""
+msgstr "git format-patch [<opsi>] [<sejak> | <rentang revisi>]"
 
-#: builtin/log.c:1346
+#: builtin/log.c:1348
 msgid "two output directories?"
-msgstr ""
+msgstr "dua direktori keluaran?"
 
-#: builtin/log.c:1497 builtin/log.c:2317 builtin/log.c:2319 builtin/log.c:2331
+#: builtin/log.c:1499 builtin/log.c:2326 builtin/log.c:2328 builtin/log.c:2340
 #, c-format
 msgid "unknown commit %s"
-msgstr ""
+msgstr "komit tidak dikenal %s"
 
-#: builtin/log.c:1508 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1510 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
-msgstr ""
+msgstr "gagal menguraikan '%s' sebagai referensi valid"
 
-#: builtin/log.c:1517
+#: builtin/log.c:1519
 msgid "could not find exact merge base"
-msgstr ""
+msgstr "tidak dapat menemukan dasar penggabungan eksak"
 
-#: builtin/log.c:1527
+#: builtin/log.c:1529
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
 "Or you could specify base commit by --base=<base-commit-id> manually"
 msgstr ""
+"gagal mendapatkan hulu, jika Anda ingin merekam dasar komit secara "
+"otomatis,\n"
+"mohon gunakan git branch --set-upstream-to untuk melacak cabang remote.\n"
+"Atau Anda dapat menyebutkan dasar komit secara manual dengan --base=<id "
+"dasar komit>"
 
-#: builtin/log.c:1550
+#: builtin/log.c:1552
 msgid "failed to find exact merge base"
-msgstr ""
+msgstr "tidak dapat menemukan dasar penggabungan eksak"
 
-#: builtin/log.c:1567
+#: builtin/log.c:1569
 msgid "base commit should be the ancestor of revision list"
-msgstr ""
+msgstr "dasar komit seharusnya menjadi leluhur daftar revisi"
 
-#: builtin/log.c:1577
+#: builtin/log.c:1579
 msgid "base commit shouldn't be in revision list"
-msgstr ""
+msgstr "dasar komit tidak seharusnya dalam daftar revisi"
 
-#: builtin/log.c:1635
+#: builtin/log.c:1637
 msgid "cannot get patch id"
-msgstr ""
+msgstr "tidak dapat mendapatkan id tambalan"
 
-#: builtin/log.c:1692
+#: builtin/log.c:1700
 msgid "failed to infer range-diff origin of current series"
-msgstr ""
+msgstr "gagal menduga asal range-diff dari seri saat ini"
 
-#: builtin/log.c:1694
+#: builtin/log.c:1702
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
-msgstr ""
+msgstr "menggunakan '%s' sebagai asal range-diff dari seri saat ini"
 
-#: builtin/log.c:1738
+#: builtin/log.c:1746
 msgid "use [PATCH n/m] even with a single patch"
-msgstr ""
-
-#: builtin/log.c:1741
-msgid "use [PATCH] even with multiple patches"
-msgstr ""
-
-#: builtin/log.c:1745
-msgid "print patches to standard out"
-msgstr ""
-
-#: builtin/log.c:1747
-msgid "generate a cover letter"
-msgstr ""
+msgstr "gunakan [PATCH n/m] bahkan dengan satu tambalan"
 
 #: builtin/log.c:1749
-msgid "use simple number sequence for output file names"
-msgstr ""
-
-#: builtin/log.c:1750
-msgid "sfx"
-msgstr ""
-
-#: builtin/log.c:1751
-msgid "use <sfx> instead of '.patch'"
-msgstr ""
+msgid "use [PATCH] even with multiple patches"
+msgstr "gunakan [PATCH] bahkan dengan banyak tambalan"
 
 #: builtin/log.c:1753
-msgid "start numbering patches at <n> instead of 1"
-msgstr ""
+msgid "print patches to standard out"
+msgstr "cetak tambalan ke keluaran standar"
 
 #: builtin/log.c:1755
-msgid "mark the series as Nth re-roll"
-msgstr ""
+msgid "generate a cover letter"
+msgstr "buat sampul surat"
 
 #: builtin/log.c:1757
-msgid "max length of output filename"
-msgstr ""
+msgid "use simple number sequence for output file names"
+msgstr "gunakan urutan bilangan sederhana untuk keluarkan nama berkas"
+
+#: builtin/log.c:1758
+msgid "sfx"
+msgstr "sfx"
 
 #: builtin/log.c:1759
-msgid "use [RFC PATCH] instead of [PATCH]"
-msgstr ""
+msgid "use <sfx> instead of '.patch'"
+msgstr "gunakan <akhiran> daripada '.patch'"
+
+#: builtin/log.c:1761
+msgid "start numbering patches at <n> instead of 1"
+msgstr "mulai menomorkan tambalan pada <n> daripada 1"
 
 #: builtin/log.c:1762
-msgid "cover-from-description-mode"
+msgid "reroll-count"
 msgstr ""
 
 #: builtin/log.c:1763
-msgid "generate parts of a cover letter based on a branch's description"
-msgstr ""
+msgid "mark the series as Nth re-roll"
+msgstr "tandai seri sebagai gulung ulang ke-N"
 
 #: builtin/log.c:1765
-msgid "use [<prefix>] instead of [PATCH]"
-msgstr ""
+msgid "max length of output filename"
+msgstr "panjang nama berkas keluaran maksimum"
 
-#: builtin/log.c:1768
-msgid "store resulting files in <dir>"
-msgstr ""
+#: builtin/log.c:1767
+msgid "use [RFC PATCH] instead of [PATCH]"
+msgstr "gunakan [RFC PATCH] daripada [PATCH]"
+
+#: builtin/log.c:1770
+msgid "cover-from-description-mode"
+msgstr "cover-from-description-mode"
 
 #: builtin/log.c:1771
-msgid "don't strip/add [PATCH]"
-msgstr ""
+msgid "generate parts of a cover letter based on a branch's description"
+msgstr "buat bagian dari sampul surat berdasarkan deskripsi cabang"
 
-#: builtin/log.c:1774
-msgid "don't output binary diffs"
-msgstr ""
+#: builtin/log.c:1773
+msgid "use [<prefix>] instead of [PATCH]"
+msgstr "gunakan [<prefix>] daripada [PATCH]"
 
 #: builtin/log.c:1776
-msgid "output all-zero hash in From header"
-msgstr ""
+msgid "store resulting files in <dir>"
+msgstr "simpan hasil berkas di <direktori>"
 
-#: builtin/log.c:1778
-msgid "don't include a patch matching a commit upstream"
-msgstr ""
-
-#: builtin/log.c:1780
-msgid "show patch format instead of default (patch + stat)"
-msgstr ""
+#: builtin/log.c:1779
+msgid "don't strip/add [PATCH]"
+msgstr "jangan copot/tambah [PATCH]"
 
 #: builtin/log.c:1782
-msgid "Messaging"
-msgstr ""
-
-#: builtin/log.c:1783
-msgid "header"
-msgstr ""
+msgid "don't output binary diffs"
+msgstr "jangan keluarkan diff biner"
 
 #: builtin/log.c:1784
-msgid "add email header"
-msgstr ""
-
-#: builtin/log.c:1785 builtin/log.c:1786
-msgid "email"
-msgstr ""
-
-#: builtin/log.c:1785
-msgid "add To: header"
-msgstr ""
+msgid "output all-zero hash in From header"
+msgstr "keluarkan hash semua-nol di kepala From"
 
 #: builtin/log.c:1786
-msgid "add Cc: header"
-msgstr ""
-
-#: builtin/log.c:1787
-msgid "ident"
-msgstr ""
+msgid "don't include a patch matching a commit upstream"
+msgstr "jangan termasuk tambalan yang cocok dengan komit hulu"
 
 #: builtin/log.c:1788
-msgid "set From address to <ident> (or committer ident if absent)"
-msgstr ""
+msgid "show patch format instead of default (patch + stat)"
+msgstr "perlihatkan format tambalan daripada asali (tambalan + stat)"
 
 #: builtin/log.c:1790
-msgid "message-id"
-msgstr ""
+msgid "Messaging"
+msgstr "Perpesanan"
 
 #: builtin/log.c:1791
-msgid "make first mail a reply to <message-id>"
-msgstr ""
+msgid "header"
+msgstr "kepala"
 
-#: builtin/log.c:1792 builtin/log.c:1795
-msgid "boundary"
-msgstr ""
+#: builtin/log.c:1792
+msgid "add email header"
+msgstr "tambahkan kepala email"
+
+#: builtin/log.c:1793 builtin/log.c:1794
+msgid "email"
+msgstr "email"
 
 #: builtin/log.c:1793
-msgid "attach the patch"
-msgstr ""
+msgid "add To: header"
+msgstr "tambahkan kepala To:"
+
+#: builtin/log.c:1794
+msgid "add Cc: header"
+msgstr "tambahkan kepala Cc:"
+
+#: builtin/log.c:1795
+msgid "ident"
+msgstr "ident"
 
 #: builtin/log.c:1796
-msgid "inline the patch"
+msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
+"setel alamat From ke <identitas> (atau identitas pengkomit jika tidak ada)"
 
-#: builtin/log.c:1800
-msgid "enable message threading, styles: shallow, deep"
-msgstr ""
+#: builtin/log.c:1798
+msgid "message-id"
+msgstr "message-id"
 
-#: builtin/log.c:1802
-msgid "signature"
-msgstr ""
+#: builtin/log.c:1799
+msgid "make first mail a reply to <message-id>"
+msgstr "buat surat pertama balasan ke <id pesan>"
 
-#: builtin/log.c:1803
-msgid "add a signature"
-msgstr ""
+#: builtin/log.c:1800 builtin/log.c:1803
+msgid "boundary"
+msgstr "perbatasan"
+
+#: builtin/log.c:1801
+msgid "attach the patch"
+msgstr "lampirkan tambalan"
 
 #: builtin/log.c:1804
-msgid "base-commit"
-msgstr ""
-
-#: builtin/log.c:1805
-msgid "add prerequisite tree info to the patch series"
-msgstr ""
+msgid "inline the patch"
+msgstr "bariskan tambalan"
 
 #: builtin/log.c:1808
-msgid "add a signature from a file"
-msgstr ""
+msgid "enable message threading, styles: shallow, deep"
+msgstr "aktifkan utasan pesan, gaya: shallow, deep"
 
-#: builtin/log.c:1809
-msgid "don't print the patch filenames"
-msgstr ""
+#: builtin/log.c:1810
+msgid "signature"
+msgstr "tanda tangan"
 
 #: builtin/log.c:1811
-msgid "show progress while generating patches"
-msgstr ""
+msgid "add a signature"
+msgstr "tambah tanda tangan"
+
+#: builtin/log.c:1812
+msgid "base-commit"
+msgstr "dasar komit"
 
 #: builtin/log.c:1813
-msgid "show changes against <rev> in cover letter or single patch"
-msgstr ""
+msgid "add prerequisite tree info to the patch series"
+msgstr "tambahkan info pohon prasyarat ke seri tambalan"
 
 #: builtin/log.c:1816
+msgid "add a signature from a file"
+msgstr "tambahkan tandatangan dari berkas"
+
+#: builtin/log.c:1817
+msgid "don't print the patch filenames"
+msgstr "jangan cetak nama berkas tambalan"
+
+#: builtin/log.c:1819
+msgid "show progress while generating patches"
+msgstr "perlihatkan perkembangan ketika membuat tambalan"
+
+#: builtin/log.c:1821
+msgid "show changes against <rev> in cover letter or single patch"
+msgstr ""
+"perlihatkan perubahan terhadap <revisi> di sampul surat atau satu tambalan"
+
+#: builtin/log.c:1824
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
+"perlihatkan perubahan terhadap <spek referensi> di sampul surat atau satu "
+"tambalan"
 
-#: builtin/log.c:1818
+#: builtin/log.c:1826 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
-msgstr ""
+msgstr "persentase dimana pembuatan tertimbang"
 
-#: builtin/log.c:1904
+#: builtin/log.c:1913
 #, c-format
 msgid "invalid ident line: %s"
-msgstr ""
+msgstr "baris identitas tidak valid: %s"
 
-#: builtin/log.c:1919
+#: builtin/log.c:1928
 msgid "-n and -k are mutually exclusive"
-msgstr ""
+msgstr "-n dan -k saling eksklusif"
 
-#: builtin/log.c:1921
+#: builtin/log.c:1930
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
-msgstr ""
+msgstr "--subject-prefix/--rfc dan -k saling eksklusif"
 
-#: builtin/log.c:1929
+#: builtin/log.c:1938
 msgid "--name-only does not make sense"
-msgstr ""
+msgstr "--name-only tidak masuk akal"
 
-#: builtin/log.c:1931
+#: builtin/log.c:1940
 msgid "--name-status does not make sense"
-msgstr ""
+msgstr "--name-status tidak masuk akal"
 
-#: builtin/log.c:1933
+#: builtin/log.c:1942
 msgid "--check does not make sense"
-msgstr ""
+msgstr "--check tidak masuk akal"
 
-#: builtin/log.c:1955
+#: builtin/log.c:1964
 msgid "--stdout, --output, and --output-directory are mutually exclusive"
-msgstr ""
+msgstr "--stdout, --output, dan --output-directory saling eksklusif"
 
-#: builtin/log.c:2078
+#: builtin/log.c:2087
 msgid "--interdiff requires --cover-letter or single patch"
-msgstr ""
+msgstr "--interdiff butuh --cover-letter atau satu tambalan"
 
-#: builtin/log.c:2082
+#: builtin/log.c:2091
 msgid "Interdiff:"
-msgstr ""
+msgstr "Interdiff:"
 
-#: builtin/log.c:2083
+#: builtin/log.c:2092
 #, c-format
 msgid "Interdiff against v%d:"
-msgstr ""
+msgstr "Interdiff terhadap v%d:"
 
-#: builtin/log.c:2089
+#: builtin/log.c:2098
 msgid "--creation-factor requires --range-diff"
-msgstr ""
-
-#: builtin/log.c:2093
-msgid "--range-diff requires --cover-letter or single patch"
-msgstr ""
-
-#: builtin/log.c:2101
-msgid "Range-diff:"
-msgstr ""
+msgstr "--creation-factor butuh --range-diff"
 
 #: builtin/log.c:2102
+msgid "--range-diff requires --cover-letter or single patch"
+msgstr "--range-diff butuh --cover-letter atau satu tambalan"
+
+#: builtin/log.c:2110
+msgid "Range-diff:"
+msgstr "Range-diff:"
+
+#: builtin/log.c:2111
 #, c-format
 msgid "Range-diff against v%d:"
-msgstr ""
+msgstr "Range-diff terhadap v%d:"
 
-#: builtin/log.c:2113
+#: builtin/log.c:2122
 #, c-format
 msgid "unable to read signature file '%s'"
-msgstr ""
+msgstr "tidak dapat membaca berkas tanda tangan '%s'"
 
-#: builtin/log.c:2149
+#: builtin/log.c:2158
 msgid "Generating patches"
-msgstr ""
+msgstr "Membuat tambalan"
 
-#: builtin/log.c:2193
+#: builtin/log.c:2202
 msgid "failed to create output files"
-msgstr ""
+msgstr "tidak dapat membuat berkas keluaran"
 
-#: builtin/log.c:2252
+#: builtin/log.c:2261
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
-msgstr ""
+msgstr "git cherry [-v] [<hulu> [<kepala> [<batas>]]]"
 
-#: builtin/log.c:2306
+#: builtin/log.c:2315
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
 msgstr ""
+"Tidak dapat menemukan cabang remote terlacak, mohon sebutkan <hulu>\n"
+"secara manual.\n"
 
-#: builtin/ls-files.c:486
+#: builtin/ls-files.c:563
 msgid "git ls-files [<options>] [<file>...]"
 msgstr ""
 
-#: builtin/ls-files.c:542
+#: builtin/ls-files.c:619
 msgid "identify the file status with tags"
 msgstr ""
 
-#: builtin/ls-files.c:544
+#: builtin/ls-files.c:621
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr ""
 
-#: builtin/ls-files.c:546
+#: builtin/ls-files.c:623
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr ""
 
-#: builtin/ls-files.c:548
+#: builtin/ls-files.c:625
 msgid "show cached files in the output (default)"
 msgstr ""
 
-#: builtin/ls-files.c:550
+#: builtin/ls-files.c:627
 msgid "show deleted files in the output"
 msgstr ""
 
-#: builtin/ls-files.c:552
+#: builtin/ls-files.c:629
 msgid "show modified files in the output"
 msgstr ""
 
-#: builtin/ls-files.c:554
+#: builtin/ls-files.c:631
 msgid "show other files in the output"
 msgstr ""
 
-#: builtin/ls-files.c:556
+#: builtin/ls-files.c:633
 msgid "show ignored files in the output"
 msgstr ""
 
-#: builtin/ls-files.c:559
+#: builtin/ls-files.c:636
 msgid "show staged contents' object name in the output"
 msgstr ""
 
-#: builtin/ls-files.c:561
+#: builtin/ls-files.c:638
 msgid "show files on the filesystem that need to be removed"
 msgstr ""
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:640
 msgid "show 'other' directories' names only"
 msgstr ""
 
-#: builtin/ls-files.c:565
+#: builtin/ls-files.c:642
 msgid "show line endings of files"
 msgstr ""
 
-#: builtin/ls-files.c:567
+#: builtin/ls-files.c:644
 msgid "don't show empty directories"
 msgstr ""
 
-#: builtin/ls-files.c:570
+#: builtin/ls-files.c:647
 msgid "show unmerged files in the output"
 msgstr ""
 
-#: builtin/ls-files.c:572
+#: builtin/ls-files.c:649
 msgid "show resolve-undo information"
 msgstr ""
 
-#: builtin/ls-files.c:574
+#: builtin/ls-files.c:651
 msgid "skip files matching pattern"
 msgstr ""
 
-#: builtin/ls-files.c:577
+#: builtin/ls-files.c:654
 msgid "exclude patterns are read from <file>"
 msgstr ""
 
-#: builtin/ls-files.c:580
+#: builtin/ls-files.c:657
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr ""
 
-#: builtin/ls-files.c:582
+#: builtin/ls-files.c:659
 msgid "add the standard git exclusions"
 msgstr ""
 
-#: builtin/ls-files.c:586
+#: builtin/ls-files.c:663
 msgid "make the output relative to the project top directory"
 msgstr ""
 
-#: builtin/ls-files.c:589
+#: builtin/ls-files.c:666
 msgid "recurse through submodules"
 msgstr ""
 
-#: builtin/ls-files.c:591
+#: builtin/ls-files.c:668
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr ""
 
-#: builtin/ls-files.c:592
+#: builtin/ls-files.c:669
 msgid "tree-ish"
 msgstr ""
 
-#: builtin/ls-files.c:593
+#: builtin/ls-files.c:670
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 
-#: builtin/ls-files.c:595
+#: builtin/ls-files.c:672
 msgid "show debugging data"
 msgstr ""
 
-#: builtin/ls-files.c:597
+#: builtin/ls-files.c:674
 msgid "suppress duplicate entries"
 msgstr ""
 
@@ -16125,7 +16627,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr ""
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1404
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1399
 msgid "exec"
 msgstr ""
 
@@ -16191,6 +16693,55 @@ msgstr ""
 
 #: builtin/ls-tree.c:145
 msgid "list entire tree; not just current directory (implies --full-name)"
+msgstr ""
+
+#. TRANSLATORS: keep <> in "<" mail ">" info.
+#: builtin/mailinfo.c:14
+msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
+msgstr ""
+
+#: builtin/mailinfo.c:58
+msgid "keep subject"
+msgstr ""
+
+#: builtin/mailinfo.c:60
+msgid "keep non patch brackets in subject"
+msgstr ""
+
+#: builtin/mailinfo.c:62
+msgid "copy Message-ID to the end of commit message"
+msgstr ""
+
+#: builtin/mailinfo.c:64
+msgid "re-code metadata to i18n.commitEncoding"
+msgstr ""
+
+#: builtin/mailinfo.c:67
+msgid "disable charset re-coding of metadata"
+msgstr ""
+
+#: builtin/mailinfo.c:69
+msgid "encoding"
+msgstr ""
+
+#: builtin/mailinfo.c:70
+msgid "re-code metadata to this encoding"
+msgstr ""
+
+#: builtin/mailinfo.c:72
+msgid "use scissors"
+msgstr ""
+
+#: builtin/mailinfo.c:73
+msgid "<action>"
+msgstr ""
+
+#: builtin/mailinfo.c:74
+msgid "action when quoted CR is found"
+msgstr ""
+
+#: builtin/mailinfo.c:77
+msgid "use headers in message's body"
 msgstr ""
 
 #: builtin/mailsplit.c:241
@@ -16309,412 +16860,420 @@ msgstr ""
 
 #: builtin/merge.c:58
 msgid "git merge [<options>] [<commit>...]"
-msgstr ""
+msgstr "git merge [<opsi>] [<komit>...]"
 
 #: builtin/merge.c:59
 msgid "git merge --abort"
-msgstr ""
+msgstr "git merge --abort"
 
 #: builtin/merge.c:60
 msgid "git merge --continue"
-msgstr ""
+msgstr "git merge --continue"
 
 #: builtin/merge.c:123
 msgid "switch `m' requires a value"
-msgstr ""
+msgstr "tombol `m' butuh sebuah nilai"
 
 #: builtin/merge.c:146
 #, c-format
 msgid "option `%s' requires a value"
-msgstr ""
+msgstr "opsi `%s' butuh sebuah nilai"
 
 #: builtin/merge.c:199
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
-msgstr ""
+msgstr "Tidak dapat menemukan strategi penggabungan '%s'.\n"
 
 #: builtin/merge.c:200
 #, c-format
 msgid "Available strategies are:"
-msgstr ""
+msgstr "Strategi yang tersedia:"
 
 #: builtin/merge.c:205
 #, c-format
 msgid "Available custom strategies are:"
-msgstr ""
+msgstr "Strategi kustom yang tersedia:"
 
 #: builtin/merge.c:256 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
-msgstr ""
+msgstr "jangan perlihatkan diffstat pada akhir penggabungan"
 
 #: builtin/merge.c:259 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
-msgstr ""
+msgstr "perlihatkan diffstat pada akhir penggabungan"
 
 #: builtin/merge.c:260 builtin/pull.c:139
 msgid "(synonym to --stat)"
-msgstr ""
+msgstr "(sinonim untuk --stat)"
 
 #: builtin/merge.c:262 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
+"tambah (paling banyak <n>) entri dari log pendek ke pesan komit penggabungan"
 
 #: builtin/merge.c:265 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
-msgstr ""
+msgstr "buat satu komit daripada melakukan penggabungan"
 
 #: builtin/merge.c:267 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
-msgstr ""
+msgstr "lakukan komit jika penggabungan sukses (asali)"
 
 #: builtin/merge.c:269 builtin/pull.c:154
 msgid "edit message before committing"
-msgstr ""
+msgstr "sunting pesan sebelum komit"
 
 #: builtin/merge.c:271
 msgid "allow fast-forward (default)"
-msgstr ""
+msgstr "perbolehkan maju cepat (asali)"
 
 #: builtin/merge.c:273 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
-msgstr ""
+msgstr "batalkan jika maju cepat tidak dimungkinkan"
 
 #: builtin/merge.c:277 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
-msgstr ""
+msgstr "periksa bahwa komit bernama punya tandatangan GPG yang valid"
 
 #: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:541 builtin/rebase.c:1418 builtin/revert.c:114
+#: builtin/rebase.c:540 builtin/rebase.c:1413 builtin/revert.c:114
 msgid "strategy"
-msgstr ""
+msgstr "strategi"
 
 #: builtin/merge.c:279 builtin/pull.c:169
 msgid "merge strategy to use"
-msgstr ""
+msgstr "strategi penggabungan yang digunakan"
 
 #: builtin/merge.c:280 builtin/pull.c:172
 msgid "option=value"
-msgstr ""
+msgstr "opsi=nilai"
 
 #: builtin/merge.c:281 builtin/pull.c:173
 msgid "option for selected merge strategy"
-msgstr ""
+msgstr "opsi untuk strategi penggabungan yang dipilih"
 
 #: builtin/merge.c:283
 msgid "merge commit message (for a non-fast-forward merge)"
-msgstr ""
+msgstr "pesan komit penggabungan (untuk penggabungan bukan maju cepat)"
 
 #: builtin/merge.c:290
 msgid "abort the current in-progress merge"
-msgstr ""
+msgstr "batalkan penggabungan yang sedang berlangsung saat ini"
 
 #: builtin/merge.c:292
 msgid "--abort but leave index and working tree alone"
-msgstr ""
+msgstr "--abort tapi biarkan indeks dan pohon kerja"
 
 #: builtin/merge.c:294
 msgid "continue the current in-progress merge"
-msgstr ""
+msgstr "lanjutkan penggabungan yang sedang berlangsung saat ini"
 
 #: builtin/merge.c:296 builtin/pull.c:180
 msgid "allow merging unrelated histories"
-msgstr ""
+msgstr "perbolehkan penggabungan riwayat yang tak terkait"
 
 #: builtin/merge.c:303
 msgid "bypass pre-merge-commit and commit-msg hooks"
-msgstr ""
+msgstr "lewati hook pre-merge-commit dan commit-msg"
 
 #: builtin/merge.c:320
 msgid "could not run stash."
-msgstr ""
+msgstr "tidak dapat menjalankan stase."
 
 #: builtin/merge.c:325
 msgid "stash failed"
-msgstr ""
+msgstr "stase gagal"
 
 #: builtin/merge.c:330
 #, c-format
 msgid "not a valid object: %s"
-msgstr ""
+msgstr "bukan objek valid: %s"
 
 #: builtin/merge.c:352 builtin/merge.c:369
 msgid "read-tree failed"
-msgstr ""
+msgstr "read-tree gagal"
 
-#: builtin/merge.c:399
-msgid " (nothing to squash)"
-msgstr ""
+#: builtin/merge.c:400
+msgid "Already up to date. (nothing to squash)"
+msgstr "Sudah diperbarui. (tidak ada yang bisa dilumat)"
 
-#: builtin/merge.c:410
+#: builtin/merge.c:414
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
-msgstr ""
+msgstr "Lumat komit -- tak perbarui HEAD\n"
 
-#: builtin/merge.c:460
+#: builtin/merge.c:464
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
-msgstr ""
+msgstr "Tidak ada pesan komit -- tak perbarui HEAD\n"
 
-#: builtin/merge.c:511
+#: builtin/merge.c:515
 #, c-format
 msgid "'%s' does not point to a commit"
-msgstr ""
+msgstr "'%s' tidak menunjuk pada sebuah komit"
 
-#: builtin/merge.c:598
+#: builtin/merge.c:602
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
-msgstr ""
+msgstr "Untai branch.%s.mergeoptions jelek: %s"
 
-#: builtin/merge.c:724
+#: builtin/merge.c:728
 msgid "Not handling anything other than two heads merge."
-msgstr ""
+msgstr "Tak tangani apapun selain penggabungan dua kepala."
 
-#: builtin/merge.c:737
+#: builtin/merge.c:741
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
-msgstr ""
+msgstr "Opsi merge-recursive tak dikenal: -X%s"
 
-#: builtin/merge.c:756 t/helper/test-fast-rebase.c:209
+#: builtin/merge.c:760 t/helper/test-fast-rebase.c:209
 #, c-format
 msgid "unable to write %s"
-msgstr ""
+msgstr "tidak dapat menulis %s"
 
-#: builtin/merge.c:808
+#: builtin/merge.c:812
 #, c-format
 msgid "Could not read from '%s'"
-msgstr ""
+msgstr "Tidak dapat membaca dari '%s'"
 
-#: builtin/merge.c:817
+#: builtin/merge.c:821
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
+"Tak mengkomit penggabungan; gunakan 'git commit' untuk menyelesaikan "
+"penggabungan.\n"
 
-#: builtin/merge.c:823
+#: builtin/merge.c:827
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
 "\n"
 msgstr ""
+"Mohon masukkan pesan komit untuk jelaskan mengapa penggabungan ini\n"
+"diperlukan, khususnya jika itu menggabungkan hulu terbarui ke cabang\n"
+"topik.\n"
 
-#: builtin/merge.c:828
+#: builtin/merge.c:832
 msgid "An empty message aborts the commit.\n"
-msgstr ""
+msgstr "Pesan kosong membatalkan komit.\n"
 
-#: builtin/merge.c:831
+#: builtin/merge.c:835
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
 "the commit.\n"
 msgstr ""
+"Baris yang diawali dengan '%c' akan diabaikan, dan pesan kosong batalkan\n"
+"komit.\n"
 
-#: builtin/merge.c:884
+#: builtin/merge.c:888
 msgid "Empty commit message."
-msgstr ""
+msgstr "Pesan komit kosong"
 
-#: builtin/merge.c:899
+#: builtin/merge.c:903
 #, c-format
 msgid "Wonderful.\n"
-msgstr ""
+msgstr "Luar biasa.\n"
 
-#: builtin/merge.c:960
+#: builtin/merge.c:964
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
-msgstr ""
-
-#: builtin/merge.c:999
-msgid "No current branch."
-msgstr ""
-
-#: builtin/merge.c:1001
-msgid "No remote for the current branch."
-msgstr ""
+msgstr "Penggabungan otomatis gagal; selesaikan konflik lalu komit hasilnya.\n"
 
 #: builtin/merge.c:1003
-msgid "No default upstream defined for the current branch."
-msgstr ""
+msgid "No current branch."
+msgstr "Tidak ada cabang saat ini."
 
-#: builtin/merge.c:1008
+#: builtin/merge.c:1005
+msgid "No remote for the current branch."
+msgstr "Tidak ada remote untuk cabang saat ini."
+
+#: builtin/merge.c:1007
+msgid "No default upstream defined for the current branch."
+msgstr "Tidak ada hulu asali yang ditentukan untuk cabang saat ini."
+
+#: builtin/merge.c:1012
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
-msgstr ""
+msgstr "Tidak ada cabang pelacak remote untuk %s dari %s"
 
-#: builtin/merge.c:1065
+#: builtin/merge.c:1069
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
-msgstr ""
+msgstr "Nilai jelek '%s' dalam lingkungan '%s'"
 
-#: builtin/merge.c:1168
+#: builtin/merge.c:1172
 #, c-format
 msgid "not something we can merge in %s: %s"
-msgstr ""
+msgstr "bukan sesuatu yang kami bisa gabungkan di %s: %s"
 
-#: builtin/merge.c:1202
+#: builtin/merge.c:1206
 msgid "not something we can merge"
-msgstr ""
-
-#: builtin/merge.c:1312
-msgid "--abort expects no arguments"
-msgstr ""
+msgstr "bukan sesuatu yang kami bisa gabungkan"
 
 #: builtin/merge.c:1316
+msgid "--abort expects no arguments"
+msgstr "--abort harap tanpa argumen"
+
+#: builtin/merge.c:1320
 msgid "There is no merge to abort (MERGE_HEAD missing)."
-msgstr ""
+msgstr "Tidak ada penggabungan yang bisa dibatalkan (MERGE_HEAD hilang)."
 
-#: builtin/merge.c:1334
+#: builtin/merge.c:1338
 msgid "--quit expects no arguments"
-msgstr ""
-
-#: builtin/merge.c:1347
-msgid "--continue expects no arguments"
-msgstr ""
+msgstr "--quit harap tanpa argumen"
 
 #: builtin/merge.c:1351
-msgid "There is no merge in progress (MERGE_HEAD missing)."
-msgstr ""
+msgid "--continue expects no arguments"
+msgstr "--continue harap tanpa argumen"
 
-#: builtin/merge.c:1367
+#: builtin/merge.c:1355
+msgid "There is no merge in progress (MERGE_HEAD missing)."
+msgstr "Tidak ada penggabungan yang sedang berlangsung (MERGE_HEAD hilang)."
+
+#: builtin/merge.c:1371
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
 msgstr ""
+"Anda belum mengakhiri penggabungan Anda (MERGE_HEAD ada).\n"
+"Mohon komit perubahan Anda sebelum Anda gabungkan."
 
-#: builtin/merge.c:1374
+#: builtin/merge.c:1378
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
 msgstr ""
+"Anda belum mengakhiri pemetikan ceri Anda (CHERRY_PICK_HEAD ada).\n"
+"Mohon komit perubahan Anda sebelum Anda gabungkan."
 
-#: builtin/merge.c:1377
+#: builtin/merge.c:1381
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
-msgstr ""
+msgstr "Anda belum mengakhiri pemetikan ceri Anda (CHERRY_PICK_HEAD ada)."
 
-#: builtin/merge.c:1391
+#: builtin/merge.c:1395
 msgid "You cannot combine --squash with --no-ff."
-msgstr ""
+msgstr "Anda tidak dapat menggabungkan --squash dengan --no-ff."
 
-#: builtin/merge.c:1393
+#: builtin/merge.c:1397
 msgid "You cannot combine --squash with --commit."
-msgstr ""
+msgstr "Anda tidak dapat menggabungkan --squash dengan --commit"
 
-#: builtin/merge.c:1409
+#: builtin/merge.c:1413
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
+"Tidak ada komit yang disebutkan dan merge.defaultToUpstream tidak disetel."
 
-#: builtin/merge.c:1426
+#: builtin/merge.c:1430
 msgid "Squash commit into empty head not supported yet"
-msgstr ""
+msgstr "Lumat komit ke kepala kosong belum didukung"
 
-#: builtin/merge.c:1428
+#: builtin/merge.c:1432
 msgid "Non-fast-forward commit does not make sense into an empty head"
-msgstr ""
+msgstr "Komit nir maju cepat tidak masuk akal ke kepala kosong"
 
-#: builtin/merge.c:1433
+#: builtin/merge.c:1437
 #, c-format
 msgid "%s - not something we can merge"
-msgstr ""
+msgstr "%s - bukan sesuatu yang kami bisa gabungkan"
 
-#: builtin/merge.c:1435
+#: builtin/merge.c:1439
 msgid "Can merge only exactly one commit into empty head"
-msgstr ""
+msgstr "Hanya bisa menggabungkan tepantnya satu komit ke kepala kosong"
 
-#: builtin/merge.c:1516
+#: builtin/merge.c:1520
 msgid "refusing to merge unrelated histories"
-msgstr ""
+msgstr "menolak menggabungkan riwayat tak terkait"
 
-#: builtin/merge.c:1525
-msgid "Already up to date."
-msgstr ""
-
-#: builtin/merge.c:1535
+#: builtin/merge.c:1539
 #, c-format
 msgid "Updating %s..%s\n"
-msgstr ""
+msgstr "Memperbarui %s..%s\n"
 
-#: builtin/merge.c:1581
+#: builtin/merge.c:1585
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
-msgstr ""
+msgstr "Mencoba penggabungan dalam indeks yang sangat sepele\n"
 
-#: builtin/merge.c:1588
+#: builtin/merge.c:1592
 #, c-format
 msgid "Nope.\n"
-msgstr ""
+msgstr "Tidak.\n"
 
-#: builtin/merge.c:1613
-msgid "Already up to date. Yeeah!"
-msgstr ""
-
-#: builtin/merge.c:1619
+#: builtin/merge.c:1623
 msgid "Not possible to fast-forward, aborting."
-msgstr ""
+msgstr "Tidak mungkin untuk maju cepat, batalkan."
 
-#: builtin/merge.c:1647 builtin/merge.c:1712
+#: builtin/merge.c:1651 builtin/merge.c:1716
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
-msgstr ""
+msgstr "Memutar ulang pohon ke asli...\n"
 
-#: builtin/merge.c:1651
+#: builtin/merge.c:1655
 #, c-format
 msgid "Trying merge strategy %s...\n"
-msgstr ""
+msgstr "Mencoba strategi penggabungan %s...\n"
 
-#: builtin/merge.c:1703
+#: builtin/merge.c:1707
 #, c-format
 msgid "No merge strategy handled the merge.\n"
-msgstr ""
+msgstr "Tidak ada strategi yang menangani penggabungan.\n"
 
-#: builtin/merge.c:1705
+#: builtin/merge.c:1709
 #, c-format
 msgid "Merge with strategy %s failed.\n"
-msgstr ""
+msgstr "Penggabungan dengan strategi %s gagal.\n"
 
-#: builtin/merge.c:1714
+#: builtin/merge.c:1718
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
-msgstr ""
+msgstr "Menggunakan %s untuk menyiapkan penyelesaian dengan tangan.\n"
 
-#: builtin/merge.c:1728
+#: builtin/merge.c:1732
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
+"Penggabungan otomatis berjalan baik; berhenti sebelum mengkomit seperti yang "
+"diminta\n"
 
 #: builtin/mktag.c:10
 msgid "git mktag"
 msgstr ""
 
-#: builtin/mktag.c:30
+#: builtin/mktag.c:27
 #, c-format
 msgid "warning: tag input does not pass fsck: %s"
 msgstr ""
 
-#: builtin/mktag.c:41
+#: builtin/mktag.c:38
 #, c-format
 msgid "error: tag input does not pass fsck: %s"
 msgstr ""
 
-#: builtin/mktag.c:44
+#: builtin/mktag.c:41
 #, c-format
 msgid "%d (FSCK_IGNORE?) should never trigger this callback"
 msgstr ""
 
-#: builtin/mktag.c:59
+#: builtin/mktag.c:56
+#, c-format
 msgid "could not read tagged object '%s'"
 msgstr ""
 
-#: builtin/mktag.c:62
+#: builtin/mktag.c:59
 #, c-format
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr ""
 
-#: builtin/mktag.c:99
+#: builtin/mktag.c:97
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr ""
 
-#: builtin/mktag.c:102
+#: builtin/mktag.c:100
 msgid "tag on stdin did not refer to a valid object"
 msgstr ""
 
-#: builtin/mktag.c:105 builtin/tag.c:232
+#: builtin/mktag.c:103 builtin/tag.c:243
 msgid "unable to write tag file"
 msgstr ""
 
@@ -16734,133 +17293,141 @@ msgstr ""
 msgid "allow creation of more than one tree"
 msgstr ""
 
-#: builtin/multi-pack-index.c:9
-msgid ""
-"git multi-pack-index [<options>] (write|verify|expire|repack --batch-"
-"size=<size>)"
+#: builtin/multi-pack-index.c:10
+msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
 msgstr ""
 
-#: builtin/multi-pack-index.c:26
+#: builtin/multi-pack-index.c:13
+msgid "git multi-pack-index [<options>] verify"
+msgstr ""
+
+#: builtin/multi-pack-index.c:16
+msgid "git multi-pack-index [<options>] expire"
+msgstr ""
+
+#: builtin/multi-pack-index.c:19
+msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
+msgstr ""
+
+#: builtin/multi-pack-index.c:54
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
 
-#: builtin/multi-pack-index.c:29
+#: builtin/multi-pack-index.c:69
+msgid "preferred-pack"
+msgstr ""
+
+#: builtin/multi-pack-index.c:70
+msgid "pack for reuse when computing a multi-pack bitmap"
+msgstr ""
+
+#: builtin/multi-pack-index.c:128
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
 
-#: builtin/multi-pack-index.c:50 builtin/notes.c:376 builtin/notes.c:431
-#: builtin/notes.c:509 builtin/notes.c:521 builtin/notes.c:598
-#: builtin/notes.c:665 builtin/notes.c:815 builtin/notes.c:963
-#: builtin/notes.c:985 builtin/prune-packed.c:25 builtin/tag.c:575
-msgid "too many arguments"
-msgstr ""
-
-#: builtin/multi-pack-index.c:60
-msgid "--batch-size option is only for 'repack' subcommand"
-msgstr ""
-
-#: builtin/multi-pack-index.c:69
+#: builtin/multi-pack-index.c:180
 #, c-format
 msgid "unrecognized subcommand: %s"
 msgstr ""
 
 #: builtin/mv.c:18
 msgid "git mv [<options>] <source>... <destination>"
-msgstr ""
+msgstr "git mv [<opsi>] <sumber>... <tujuan>"
 
 #: builtin/mv.c:83
 #, c-format
 msgid "Directory %s is in index and no submodule?"
-msgstr ""
+msgstr "Direktori %s di dalam indeks dan tidak ada submodul?"
 
 #: builtin/mv.c:85
 msgid "Please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
+"Mohon gelar perubahan Anda ke .gitmodules atau stase itu untuk melanjutkan"
 
 #: builtin/mv.c:103
 #, c-format
 msgid "%.*s is in index"
-msgstr ""
+msgstr "%.*s di dalam indeks"
 
 #: builtin/mv.c:125
 msgid "force move/rename even if target exists"
-msgstr ""
+msgstr "paksa pindah/ganti nama bahkan jika target ada"
 
 #: builtin/mv.c:127
 msgid "skip move/rename errors"
-msgstr ""
+msgstr "lewati kesalahan pindah/ganti nama"
 
 #: builtin/mv.c:170
 #, c-format
 msgid "destination '%s' is not a directory"
-msgstr ""
+msgstr "tujuan '%s' bukan direktori"
 
 #: builtin/mv.c:181
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
-msgstr ""
+msgstr "Memeriksa penamaan ulang '%s' ke '%s'\n"
 
 #: builtin/mv.c:185
 msgid "bad source"
-msgstr ""
+msgstr "sumber jelek"
 
 #: builtin/mv.c:188
 msgid "can not move directory into itself"
-msgstr ""
+msgstr "tidak dapat memindahkan direktori ke dirinya sendiri"
 
 #: builtin/mv.c:191
 msgid "cannot move directory over file"
-msgstr ""
+msgstr "tidak dapat memindahkan direktori ke berkas"
 
 #: builtin/mv.c:200
 msgid "source directory is empty"
-msgstr ""
+msgstr "direktori asal kosong"
 
 #: builtin/mv.c:225
 msgid "not under version control"
-msgstr ""
+msgstr "bukan dalam kontrol versi"
 
 #: builtin/mv.c:227
 msgid "conflicted"
-msgstr ""
+msgstr "terkonflik"
 
 #: builtin/mv.c:230
 msgid "destination exists"
-msgstr ""
+msgstr "tujuan ada"
 
 #: builtin/mv.c:238
 #, c-format
 msgid "overwriting '%s'"
-msgstr ""
+msgstr "menimpa '%s'"
 
 #: builtin/mv.c:241
 msgid "Cannot overwrite"
-msgstr ""
+msgstr "Tidak dapat menimpa"
 
 #: builtin/mv.c:244
 msgid "multiple sources for the same target"
-msgstr ""
+msgstr "banyak asal untuk target yang sama"
 
 #: builtin/mv.c:246
 msgid "destination directory does not exist"
-msgstr ""
+msgstr "direktori tujuan tidak ada"
 
 #: builtin/mv.c:253
 #, c-format
 msgid "%s, source=%s, destination=%s"
-msgstr ""
+msgstr "%s, source=%s, destination=%s"
 
 #: builtin/mv.c:274
 #, c-format
 msgid "Renaming %s to %s\n"
-msgstr ""
+msgstr "Mengganti nama %s ke %s\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:483
+#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:667
 #, c-format
 msgid "renaming '%s' failed"
-msgstr ""
+msgstr "gagal mengganti nama '%s'"
 
 #: builtin/name-rev.c:465
 msgid "git name-rev [<options>] <commit>..."
@@ -17042,7 +17609,7 @@ msgstr ""
 msgid "the note contents have been left in %s"
 msgstr ""
 
-#: builtin/notes.c:242 builtin/tag.c:565
+#: builtin/notes.c:242 builtin/tag.c:576
 #, c-format
 msgid "could not open or read '%s'"
 msgstr ""
@@ -17080,6 +17647,13 @@ msgstr ""
 #: builtin/notes.c:356
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
+msgstr ""
+
+#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
+#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
+#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
+#: builtin/prune-packed.c:25 builtin/tag.c:586
+msgid "too many arguments"
 msgstr ""
 
 #: builtin/notes.c:389 builtin/notes.c:678
@@ -17257,7 +17831,7 @@ msgid ""
 "abort'.\n"
 msgstr ""
 
-#: builtin/notes.c:897 builtin/tag.c:578
+#: builtin/notes.c:897 builtin/tag.c:589
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr ""
@@ -17291,7 +17865,7 @@ msgstr ""
 msgid "use notes from <notes-ref>"
 msgstr ""
 
-#: builtin/notes.c:1034 builtin/stash.c:1671
+#: builtin/notes.c:1034 builtin/stash.c:1739
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr ""
@@ -17356,317 +17930,339 @@ msgstr ""
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr ""
 
-#: builtin/pack-objects.c:1358
+#: builtin/pack-objects.c:1383
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 
-#: builtin/pack-objects.c:1806
+#: builtin/pack-objects.c:1831
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:1815
+#: builtin/pack-objects.c:1840
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:2096
+#: builtin/pack-objects.c:2121
 msgid "Counting objects"
 msgstr ""
 
-#: builtin/pack-objects.c:2241
+#: builtin/pack-objects.c:2266
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr ""
 
-#: builtin/pack-objects.c:2311 builtin/pack-objects.c:2327
-#: builtin/pack-objects.c:2337
+#: builtin/pack-objects.c:2336 builtin/pack-objects.c:2352
+#: builtin/pack-objects.c:2362
 #, c-format
 msgid "object %s cannot be read"
 msgstr ""
 
-#: builtin/pack-objects.c:2314 builtin/pack-objects.c:2341
+#: builtin/pack-objects.c:2339 builtin/pack-objects.c:2366
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr ""
 
-#: builtin/pack-objects.c:2351
+#: builtin/pack-objects.c:2376
 msgid "suboptimal pack - out of memory"
 msgstr ""
 
-#: builtin/pack-objects.c:2666
+#: builtin/pack-objects.c:2691
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr ""
 
-#: builtin/pack-objects.c:2805
+#: builtin/pack-objects.c:2830
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr ""
 
-#: builtin/pack-objects.c:2891
+#: builtin/pack-objects.c:2916
 msgid "Compressing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:2897
+#: builtin/pack-objects.c:2922
 msgid "inconsistency with delta count"
 msgstr ""
 
-#: builtin/pack-objects.c:2976
+#: builtin/pack-objects.c:3001
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
 "hash> <uri>' (got '%s')"
 msgstr ""
 
-#: builtin/pack-objects.c:2979
+#: builtin/pack-objects.c:3004
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
 msgstr ""
 
-#: builtin/pack-objects.c:3008
+#: builtin/pack-objects.c:3039
+#, c-format
+msgid "could not get type of object %s in pack %s"
+msgstr ""
+
+#: builtin/pack-objects.c:3161 builtin/pack-objects.c:3175
+#, c-format
+msgid "could not find pack '%s'"
+msgstr ""
+
+#: builtin/pack-objects.c:3218
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
 " %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3014
+#: builtin/pack-objects.c:3224
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
 " %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3112
+#: builtin/pack-objects.c:3322
 msgid "invalid value for --missing"
 msgstr ""
 
-#: builtin/pack-objects.c:3171 builtin/pack-objects.c:3279
+#: builtin/pack-objects.c:3381 builtin/pack-objects.c:3490
 msgid "cannot open pack index"
 msgstr ""
 
-#: builtin/pack-objects.c:3202
+#: builtin/pack-objects.c:3412
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr ""
 
-#: builtin/pack-objects.c:3287
+#: builtin/pack-objects.c:3498
 msgid "unable to force loose object"
 msgstr ""
 
-#: builtin/pack-objects.c:3380
+#: builtin/pack-objects.c:3628
 #, c-format
 msgid "not a rev '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3383
+#: builtin/pack-objects.c:3631
 #, c-format
 msgid "bad revision '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3408
+#: builtin/pack-objects.c:3659
 msgid "unable to add recent objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3461
+#: builtin/pack-objects.c:3712
 #, c-format
 msgid "unsupported index version %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3465
+#: builtin/pack-objects.c:3716
 #, c-format
 msgid "bad index version '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3503
+#: builtin/pack-objects.c:3755
 msgid "<version>[,<offset>]"
 msgstr ""
 
-#: builtin/pack-objects.c:3504
+#: builtin/pack-objects.c:3756
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 
-#: builtin/pack-objects.c:3507
+#: builtin/pack-objects.c:3759
 msgid "maximum size of each output pack file"
 msgstr ""
 
-#: builtin/pack-objects.c:3509
+#: builtin/pack-objects.c:3761
 msgid "ignore borrowed objects from alternate object store"
 msgstr ""
 
-#: builtin/pack-objects.c:3511
+#: builtin/pack-objects.c:3763
 msgid "ignore packed objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3513
+#: builtin/pack-objects.c:3765
 msgid "limit pack window by objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3515
+#: builtin/pack-objects.c:3767
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 
-#: builtin/pack-objects.c:3517
+#: builtin/pack-objects.c:3769
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 
-#: builtin/pack-objects.c:3519
+#: builtin/pack-objects.c:3771
 msgid "reuse existing deltas"
 msgstr ""
 
-#: builtin/pack-objects.c:3521
+#: builtin/pack-objects.c:3773
 msgid "reuse existing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3523
+#: builtin/pack-objects.c:3775
 msgid "use OFS_DELTA objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3525
+#: builtin/pack-objects.c:3777
 msgid "use threads when searching for best delta matches"
 msgstr ""
 
-#: builtin/pack-objects.c:3527
+#: builtin/pack-objects.c:3779
 msgid "do not create an empty pack output"
 msgstr ""
 
-#: builtin/pack-objects.c:3529
+#: builtin/pack-objects.c:3781
 msgid "read revision arguments from standard input"
 msgstr ""
 
-#: builtin/pack-objects.c:3531
+#: builtin/pack-objects.c:3783
 msgid "limit the objects to those that are not yet packed"
 msgstr ""
 
-#: builtin/pack-objects.c:3534
+#: builtin/pack-objects.c:3786
 msgid "include objects reachable from any reference"
 msgstr ""
 
-#: builtin/pack-objects.c:3537
+#: builtin/pack-objects.c:3789
 msgid "include objects referred by reflog entries"
 msgstr ""
 
-#: builtin/pack-objects.c:3540
+#: builtin/pack-objects.c:3792
 msgid "include objects referred to by the index"
 msgstr ""
 
-#: builtin/pack-objects.c:3543
+#: builtin/pack-objects.c:3795
+msgid "read packs from stdin"
+msgstr ""
+
+#: builtin/pack-objects.c:3797
 msgid "output pack to stdout"
 msgstr ""
 
-#: builtin/pack-objects.c:3545
+#: builtin/pack-objects.c:3799
 msgid "include tag objects that refer to objects to be packed"
 msgstr ""
 
-#: builtin/pack-objects.c:3547
+#: builtin/pack-objects.c:3801
 msgid "keep unreachable objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3549
+#: builtin/pack-objects.c:3803
 msgid "pack loose unreachable objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3551
+#: builtin/pack-objects.c:3805
 msgid "unpack unreachable objects newer than <time>"
 msgstr ""
 
-#: builtin/pack-objects.c:3554
+#: builtin/pack-objects.c:3808
 msgid "use the sparse reachability algorithm"
 msgstr ""
 
-#: builtin/pack-objects.c:3556
+#: builtin/pack-objects.c:3810
 msgid "create thin packs"
 msgstr ""
 
-#: builtin/pack-objects.c:3558
+#: builtin/pack-objects.c:3812
 msgid "create packs suitable for shallow fetches"
 msgstr ""
 
-#: builtin/pack-objects.c:3560
+#: builtin/pack-objects.c:3814
 msgid "ignore packs that have companion .keep file"
 msgstr ""
 
-#: builtin/pack-objects.c:3562
+#: builtin/pack-objects.c:3816
 msgid "ignore this pack"
 msgstr ""
 
-#: builtin/pack-objects.c:3564
+#: builtin/pack-objects.c:3818
 msgid "pack compression level"
 msgstr ""
 
-#: builtin/pack-objects.c:3566
+#: builtin/pack-objects.c:3820
 msgid "do not hide commits by grafts"
 msgstr ""
 
-#: builtin/pack-objects.c:3568
+#: builtin/pack-objects.c:3822
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3570
+#: builtin/pack-objects.c:3824
 msgid "write a bitmap index together with the pack index"
 msgstr ""
 
-#: builtin/pack-objects.c:3574
+#: builtin/pack-objects.c:3828
 msgid "write a bitmap index if possible"
 msgstr ""
 
-#: builtin/pack-objects.c:3578
+#: builtin/pack-objects.c:3832
 msgid "handling for missing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3581
+#: builtin/pack-objects.c:3835
 msgid "do not pack objects in promisor packfiles"
 msgstr ""
 
-#: builtin/pack-objects.c:3583
+#: builtin/pack-objects.c:3837
 msgid "respect islands during delta compression"
 msgstr ""
 
-#: builtin/pack-objects.c:3585
+#: builtin/pack-objects.c:3839
 msgid "protocol"
 msgstr ""
 
-#: builtin/pack-objects.c:3586
+#: builtin/pack-objects.c:3840
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
 
-#: builtin/pack-objects.c:3617
+#: builtin/pack-objects.c:3873
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr ""
 
-#: builtin/pack-objects.c:3622
+#: builtin/pack-objects.c:3878
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr ""
 
-#: builtin/pack-objects.c:3676
+#: builtin/pack-objects.c:3934
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 
-#: builtin/pack-objects.c:3678
+#: builtin/pack-objects.c:3936
 msgid "minimum pack size limit is 1 MiB"
 msgstr ""
 
-#: builtin/pack-objects.c:3683
+#: builtin/pack-objects.c:3941
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 
-#: builtin/pack-objects.c:3686
+#: builtin/pack-objects.c:3944
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr ""
 
-#: builtin/pack-objects.c:3692
+#: builtin/pack-objects.c:3950
 msgid "cannot use --filter without --stdout"
 msgstr ""
 
-#: builtin/pack-objects.c:3752
+#: builtin/pack-objects.c:3952
+msgid "cannot use --filter with --stdin-packs"
+msgstr ""
+
+#: builtin/pack-objects.c:3956
+msgid "cannot use internal rev list with --stdin-packs"
+msgstr ""
+
+#: builtin/pack-objects.c:4015
 msgid "Enumerating objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3783
+#: builtin/pack-objects.c:4052
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -17721,65 +18317,71 @@ msgstr ""
 #: builtin/pull.c:45 builtin/pull.c:47
 #, c-format
 msgid "Invalid value for %s: %s"
-msgstr ""
+msgstr "Nilai tidak valid untuk %s: %s"
 
 #: builtin/pull.c:67
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
-msgstr ""
+msgstr "git pull [<opsi>] [<repositori> [<spek referensi>]]"
 
 #: builtin/pull.c:123
 msgid "control for recursive fetching of submodules"
-msgstr ""
+msgstr "kontrol pengambilan rekursif submodul"
 
 #: builtin/pull.c:127
 msgid "Options related to merging"
-msgstr ""
+msgstr "Opsi yang berkaitan dengan penggabungan"
 
 #: builtin/pull.c:130
 msgid "incorporate changes by rebasing rather than merging"
-msgstr ""
+msgstr "masukkan perubahan dengan pendasaran ulang daripada penggabungan"
 
-#: builtin/pull.c:158 builtin/rebase.c:492 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/rebase.c:491 builtin/revert.c:126
 msgid "allow fast-forward"
-msgstr ""
+msgstr "perbolehkan maju cepat"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:167 parse-options.h:340
 msgid "automatically stash/stash pop before and after"
-msgstr ""
+msgstr "stash/stash pop otomatis sebelum dan sesudah"
 
 #: builtin/pull.c:183
 msgid "Options related to fetching"
-msgstr ""
+msgstr "Opsi yang berkaitan dengan pengambilan"
 
 #: builtin/pull.c:193
 msgid "force overwrite of local branch"
-msgstr ""
+msgstr "paksa timpa cabang lokal"
 
 #: builtin/pull.c:201
 msgid "number of submodules pulled in parallel"
-msgstr ""
+msgstr "nomor submodul ditarik dalam paralel"
 
 #: builtin/pull.c:317
 #, c-format
 msgid "Invalid value for pull.ff: %s"
-msgstr ""
+msgstr "Nilai tidak valid untuk pull.ff: %s"
 
 #: builtin/pull.c:445
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
 msgstr ""
+"Tidak ada kandidat untuk didasarkan ulang diantara referensi yang baru saja "
+"Anda ambil."
 
 #: builtin/pull.c:447
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
+"Tidak ada kandidat untuk digabungkan diantara referensi yang baru sajaAnda "
+"ambil."
 
 #: builtin/pull.c:448
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
 msgstr ""
+"Umumnya itu berarti Anda memberikan spek referensi wildcard yang tidak\n"
+"cocok pada ujung remote."
 
 #: builtin/pull.c:451
 #, c-format
@@ -17788,40 +18390,45 @@ msgid ""
 "a branch. Because this is not the default configured remote\n"
 "for your current branch, you must specify a branch on the command line."
 msgstr ""
+"Anda minta untuk tarik dari remote '%s', tapi tidak menyebutkan\n"
+"satu cabang. Oleh karena ini bukan remote terkonfigurasi asali untuk\n"
+"cabang Anda saat ini, Anda harus sebutkan satu cabang pada baris perintah."
 
-#: builtin/pull.c:456 builtin/rebase.c:1253
+#: builtin/pull.c:456 builtin/rebase.c:1248
 msgid "You are not currently on a branch."
-msgstr ""
+msgstr "Anda tidak berada pada sebuah cabang."
 
 #: builtin/pull.c:458 builtin/pull.c:473
 msgid "Please specify which branch you want to rebase against."
-msgstr ""
+msgstr "Mohon sebutkan cabang mana yang Anda ingin didasarkan ulang."
 
 #: builtin/pull.c:460 builtin/pull.c:475
 msgid "Please specify which branch you want to merge with."
-msgstr ""
+msgstr "Mohon sebutkan cabang mana yang Anda ingin digabungkan."
 
 #: builtin/pull.c:461 builtin/pull.c:476
 msgid "See git-pull(1) for details."
-msgstr ""
+msgstr "Lihat git-pull(1) untuk selengkapnya."
 
 #: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
-#: builtin/rebase.c:1259
+#: builtin/rebase.c:1254
 msgid "<remote>"
-msgstr ""
+msgstr "<remote>"
 
 #: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
 msgid "<branch>"
-msgstr ""
+msgstr "<cabang>"
 
-#: builtin/pull.c:471 builtin/rebase.c:1251
+#: builtin/pull.c:471 builtin/rebase.c:1246
 msgid "There is no tracking information for the current branch."
-msgstr ""
+msgstr "Tidak ada informasi pelacakan untuk cabang saat ini."
 
 #: builtin/pull.c:480
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
+"Jika Anda ingin menyetel informasi pelacakan untuk cabang ini Anda bisa "
+"melakukannya dengan:"
 
 #: builtin/pull.c:485
 #, c-format
@@ -17829,15 +18436,17 @@ msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
 "from the remote, but no such ref was fetched."
 msgstr ""
+"Konfigurasi Anda menyebutkan untuk menggabungkan dengan referensi '%s'\n"
+"dari remote, tapi tidak ada referensi seperti itu yang diambil."
 
 #: builtin/pull.c:596
 #, c-format
 msgid "unable to access commit %s"
-msgstr ""
+msgstr "Tidak dapat mengakses komit %s"
 
 #: builtin/pull.c:902
 msgid "ignoring --verify-signatures for rebase"
-msgstr ""
+msgstr "mengabaikan --verify-signatures untuk pendasaran ulang"
 
 #: builtin/pull.c:930
 msgid ""
@@ -17855,18 +18464,32 @@ msgid ""
 "or --ff-only on the command line to override the configured default per\n"
 "invocation.\n"
 msgstr ""
+"Menarik tanpa menyebutkan cara merujukkan cabang yang berlainan tidak\n"
+"disarankan. Anda dapat mematikan pesan ini dengan menjalankan salah\n"
+"satu perintah berikut sebelum penarikan berikutnya:\n"
+"\n"
+"  git config pull.rebase false  # penggabungan (strategi asali)\n"
+"  git config pull.rebase true   # pendasaran ulang\n"
+"  git config pull.ff only       # hanya maju cepat\n"
+"\n"
+"Anda dapat mengganti \"git config\" dengan \"git config --global\" untuk\n"
+"menyetel pilihan asali untuk semua repositori. Anda juga dapat melewatkan\n"
+"--rebase, --no-rebase, atau --ff-only pada baris perintah untuk menimpa\n"
+"asali terkonfigurasi untuk setiap invokasi.\n"
 
 #: builtin/pull.c:991
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
+"Memperbarui cabang yang belum lahir dengan perubahan yang ditambahkan ke "
+"indeks."
 
 #: builtin/pull.c:995
 msgid "pull with rebase"
-msgstr ""
+msgstr "tarik dengan pendasaran ulang"
 
 #: builtin/pull.c:996
 msgid "please commit or stash them."
-msgstr ""
+msgstr "mohon komit atau stase itu."
 
 #: builtin/pull.c:1021
 #, c-format
@@ -17875,6 +18498,8 @@ msgid ""
 "fast-forwarding your working tree from\n"
 "commit %s."
 msgstr ""
+"fetch memperbarui kepala cabang saat ini.\n"
+"memajukan-cepat pohon kerja Anda dari komit %s."
 
 #: builtin/pull.c:1027
 #, c-format
@@ -17886,18 +18511,25 @@ msgid ""
 "$ git reset --hard\n"
 "to recover."
 msgstr ""
+"Tidak dapat maju-cepat pohon kerja Anda.\n"
+"Setelah Anda yakin Anda simpan apapun yang penting dari keluaran\n"
+"$ git diff %s,\n"
+"jalankan\n"
+"$ git reset --hard\n"
+"untuk memulihkan."
 
 #: builtin/pull.c:1042
 msgid "Cannot merge multiple branches into empty head."
-msgstr ""
+msgstr "Tidak dapat menggabungkan banyak cabang ke kepala kosong."
 
 #: builtin/pull.c:1046
 msgid "Cannot rebase onto multiple branches."
-msgstr ""
+msgstr "Tidak dapat mendasarkan ulang pada banyak cabang."
 
 #: builtin/pull.c:1067
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
+"tidak dapat mendasarkan ulang dengan modifikasi submodul yang terekam lokal."
 
 #: builtin/push.c:19
 msgid "git push [<options>] [<repository> [<refspec>...]]"
@@ -18214,10 +18846,6 @@ msgstr ""
 msgid "git range-diff [<options>] <base> <old-tip> <new-tip>"
 msgstr ""
 
-#: builtin/range-diff.c:28
-msgid "Percentage by which creation is weighted"
-msgstr ""
-
 #: builtin/range-diff.c:30
 msgid "use simple diff colors"
 msgstr ""
@@ -18335,201 +18963,205 @@ msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase> | --keep-base] "
 "[<upstream> [<branch>]]"
 msgstr ""
+"git rebase [-i] [opsi] [--exec <perintah>] [--onto <basis baru> | --keep-"
+"base][<hulu> [<cabang>]]"
 
 #: builtin/rebase.c:37
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] --root [<branch>]"
 msgstr ""
+"git rebase [-i] [opsi] [--exec <perintah>] [--onto <basis baru>] --root "
+"[<cabang>]"
 
 #: builtin/rebase.c:39
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
-msgstr ""
+msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:195 builtin/rebase.c:219 builtin/rebase.c:246
+#: builtin/rebase.c:194 builtin/rebase.c:218 builtin/rebase.c:245
 #, c-format
 msgid "unusable todo list: '%s'"
-msgstr ""
+msgstr "daftar todo tidak dapat digunakan: '%s'"
 
-#: builtin/rebase.c:312
+#: builtin/rebase.c:311
 #, c-format
 msgid "could not create temporary %s"
-msgstr ""
+msgstr "tidak dapat membuat %s sementara"
 
-#: builtin/rebase.c:318
+#: builtin/rebase.c:317
 msgid "could not mark as interactive"
-msgstr ""
+msgstr "tidak dapat menandai sebagai interaktif"
 
-#: builtin/rebase.c:371
+#: builtin/rebase.c:370
 msgid "could not generate todo list"
-msgstr ""
+msgstr "tidak dapat membuat daftar todo"
 
-#: builtin/rebase.c:413
+#: builtin/rebase.c:412
 msgid "a base commit must be provided with --upstream or --onto"
-msgstr ""
+msgstr "basis komit harus diberikan dengan --upstream atau --onto"
 
-#: builtin/rebase.c:482
+#: builtin/rebase.c:481
 msgid "git rebase--interactive [<options>]"
-msgstr ""
+msgstr "git rebase--interactive [<opsi>]"
 
-#: builtin/rebase.c:495 builtin/rebase.c:1394
+#: builtin/rebase.c:494 builtin/rebase.c:1389
 msgid "keep commits which start empty"
-msgstr ""
+msgstr "simpan komit yang dimulai kosong"
 
-#: builtin/rebase.c:499 builtin/revert.c:128
+#: builtin/rebase.c:498 builtin/revert.c:128
 msgid "allow commits with empty messages"
-msgstr ""
+msgstr "perbolehkan komit dengan pesan kosong"
 
-#: builtin/rebase.c:501
+#: builtin/rebase.c:500
 msgid "rebase merge commits"
-msgstr ""
+msgstr "dasarkan ulang komit penggabungan"
 
-#: builtin/rebase.c:503
+#: builtin/rebase.c:502
 msgid "keep original branch points of cousins"
-msgstr ""
+msgstr "simpan titik cabang sepupu asal "
+
+#: builtin/rebase.c:504
+msgid "move commits that begin with squash!/fixup!"
+msgstr "pindahkan komit yang diawali dengan squash!/fixup!"
 
 #: builtin/rebase.c:505
-msgid "move commits that begin with squash!/fixup!"
-msgstr ""
-
-#: builtin/rebase.c:506
 msgid "sign commits"
-msgstr ""
+msgstr "tandatangani komit"
 
-#: builtin/rebase.c:508 builtin/rebase.c:1333
+#: builtin/rebase.c:507 builtin/rebase.c:1328
 msgid "display a diffstat of what changed upstream"
-msgstr ""
+msgstr "perlihatkan diffstat apa yang berubah di hulu"
 
-#: builtin/rebase.c:510
+#: builtin/rebase.c:509
 msgid "continue rebase"
-msgstr ""
+msgstr "lanjutkan pendasaran ulang"
+
+#: builtin/rebase.c:511
+msgid "skip commit"
+msgstr "lewatkan komit"
 
 #: builtin/rebase.c:512
-msgid "skip commit"
-msgstr ""
-
-#: builtin/rebase.c:513
 msgid "edit the todo list"
-msgstr ""
+msgstr "sunting daftar todo"
 
-#: builtin/rebase.c:515
+#: builtin/rebase.c:514
 msgid "show the current patch"
-msgstr ""
+msgstr "perlihatkan tambalan saat ini"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:517
 msgid "shorten commit ids in the todo list"
-msgstr ""
+msgstr "pendekkan id komit dalam daftar todo"
 
-#: builtin/rebase.c:520
+#: builtin/rebase.c:519
 msgid "expand commit ids in the todo list"
-msgstr ""
+msgstr "jabarkan id komit dalam daftar todo"
 
-#: builtin/rebase.c:522
+#: builtin/rebase.c:521
 msgid "check the todo list"
-msgstr ""
+msgstr "periksa daftar todo"
 
-#: builtin/rebase.c:524
+#: builtin/rebase.c:523
 msgid "rearrange fixup/squash lines"
-msgstr ""
+msgstr "susun ulang baris fixup/squash"
+
+#: builtin/rebase.c:525
+msgid "insert exec commands in todo list"
+msgstr "masukkan perintah exec ke dalam daftar todo"
 
 #: builtin/rebase.c:526
-msgid "insert exec commands in todo list"
-msgstr ""
-
-#: builtin/rebase.c:527
 msgid "onto"
-msgstr ""
+msgstr "ke"
 
-#: builtin/rebase.c:530
+#: builtin/rebase.c:529
 msgid "restrict-revision"
-msgstr ""
+msgstr "restrict-revision"
 
-#: builtin/rebase.c:530
+#: builtin/rebase.c:529
 msgid "restrict revision"
-msgstr ""
+msgstr "batasi revisi"
+
+#: builtin/rebase.c:531
+msgid "squash-onto"
+msgstr "squash-onto"
 
 #: builtin/rebase.c:532
-msgid "squash-onto"
-msgstr ""
-
-#: builtin/rebase.c:533
 msgid "squash onto"
-msgstr ""
+msgstr "lumat ke"
 
-#: builtin/rebase.c:535
+#: builtin/rebase.c:534
 msgid "the upstream commit"
-msgstr ""
+msgstr "komit hulu"
 
-#: builtin/rebase.c:537
+#: builtin/rebase.c:536
 msgid "head-name"
-msgstr ""
+msgstr "head-name"
 
-#: builtin/rebase.c:537
+#: builtin/rebase.c:536
 msgid "head name"
-msgstr ""
+msgstr "nama kepala"
+
+#: builtin/rebase.c:541
+msgid "rebase strategy"
+msgstr "strategi pendasaran"
 
 #: builtin/rebase.c:542
-msgid "rebase strategy"
-msgstr ""
+msgid "strategy-opts"
+msgstr "strategy-opts"
 
 #: builtin/rebase.c:543
-msgid "strategy-opts"
-msgstr ""
+msgid "strategy options"
+msgstr "opsi strategi"
 
 #: builtin/rebase.c:544
-msgid "strategy options"
-msgstr ""
+msgid "switch-to"
+msgstr "switch-to"
 
 #: builtin/rebase.c:545
-msgid "switch-to"
-msgstr ""
+msgid "the branch or commit to checkout"
+msgstr "cabang atau komit untuk di-checkout"
 
 #: builtin/rebase.c:546
-msgid "the branch or commit to checkout"
-msgstr ""
-
-#: builtin/rebase.c:547
 msgid "onto-name"
-msgstr ""
+msgstr "onto-name"
+
+#: builtin/rebase.c:546
+msgid "onto name"
+msgstr "nama ke"
 
 #: builtin/rebase.c:547
-msgid "onto name"
-msgstr ""
-
-#: builtin/rebase.c:548
 msgid "cmd"
-msgstr ""
+msgstr "cmd"
 
-#: builtin/rebase.c:548
+#: builtin/rebase.c:547
 msgid "the command to run"
-msgstr ""
+msgstr "perintah untuk dijalankan"
 
-#: builtin/rebase.c:551 builtin/rebase.c:1427
+#: builtin/rebase.c:550 builtin/rebase.c:1422
 msgid "automatically re-schedule any `exec` that fails"
-msgstr ""
+msgstr "jadwal ulang otomatis `exec` apa saja yang gagal"
 
-#: builtin/rebase.c:567
+#: builtin/rebase.c:566
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-msgstr ""
+msgstr "--[no-]rebase-cousins tidak ada efek tanpa --rebase-merges"
 
-#: builtin/rebase.c:583
+#: builtin/rebase.c:582
 #, c-format
 msgid "%s requires the merge backend"
-msgstr ""
+msgstr "%s butuh tulang belakang penggabungan"
 
-#: builtin/rebase.c:626
+#: builtin/rebase.c:625
 #, c-format
 msgid "could not get 'onto': '%s'"
-msgstr ""
+msgstr "tidak dapat mendapatkan 'ke': '%s'"
 
-#: builtin/rebase.c:643
+#: builtin/rebase.c:642
 #, c-format
 msgid "invalid orig-head: '%s'"
-msgstr ""
+msgstr "orig-head tidak valid: '%s'"
 
-#: builtin/rebase.c:668
+#: builtin/rebase.c:667
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
-msgstr ""
+msgstr "abaikan allow_rerere_autoupdate yang tak valid: '%s'"
 
 #: builtin/rebase.c:813 git-rebase--preserve-merges.sh:81
 msgid ""
@@ -18539,6 +19171,12 @@ msgid ""
 "To abort and get back to the state before \"git rebase\", run \"git rebase --"
 "abort\"."
 msgstr ""
+"Selesaikan semua konflik secara manual, tandai sebagai terselesaikan\n"
+"dengan \"git add/rm <berkas terkonflik>\", lalu jalankan\n"
+"\"git rebase --continue\".\n"
+"Anda juga bisa melewatkan komit ini: jalankan \"git rebase --skip\".\n"
+"Untuk membatalkan dan kembali ke kondisi sebelum \"git rebase\",jalankan "
+"\"git rebase --abort\"."
 
 #: builtin/rebase.c:896
 #, c-format
@@ -18551,15 +19189,24 @@ msgid ""
 "\n"
 "As a result, git cannot rebase them."
 msgstr ""
+"\n"
+"git menemui kesalahan ketika menyiapan tambalan untuk memainkan ulang\n"
+"revisi berikut:\n"
+"\n"
+"    %s\n"
+"\n"
+"Hasilnya git tidak dapat mendasarkan ulang itu."
 
-#: builtin/rebase.c:1227
+#: builtin/rebase.c:1222
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
 "\"."
 msgstr ""
+"tipe kosong tak dikenali '%s'; nilai yang valid adalah \"drop\", \"keep\", "
+"dan \"ask\"."
 
-#: builtin/rebase.c:1245
+#: builtin/rebase.c:1240
 #, c-format
 msgid ""
 "%s\n"
@@ -18569,8 +19216,14 @@ msgid ""
 "    git rebase '<branch>'\n"
 "\n"
 msgstr ""
+"%s\n"
+"Mohon sebutkan cabang mana yang Anda ingin dasarkan ulang.\n"
+"Lihat git-rebase(1) untuk selengkapnya.\n"
+"\n"
+"    git rebase '<cabang>'.\n"
+"\n"
 
-#: builtin/rebase.c:1261
+#: builtin/rebase.c:1256
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -18578,202 +19231,205 @@ msgid ""
 "    git branch --set-upstream-to=%s/<branch> %s\n"
 "\n"
 msgstr ""
+"Kalau Anda ingin menyetel informasi pelacakan untuk cabang ini Anda\n"
+"dapat melakukan hal itu dengan:\n"
+"    git branch --set-upstream-to=%s/<cabang> %s\n"
+"\n"
 
-#: builtin/rebase.c:1291
+#: builtin/rebase.c:1286
 msgid "exec commands cannot contain newlines"
-msgstr ""
+msgstr "perintah exec tidak dapat berisi baris baru"
 
-#: builtin/rebase.c:1295
+#: builtin/rebase.c:1290
 msgid "empty exec command"
-msgstr ""
+msgstr "perintah exec kosong"
 
-#: builtin/rebase.c:1324
+#: builtin/rebase.c:1319
 msgid "rebase onto given branch instead of upstream"
-msgstr ""
+msgstr "dasarkan ulang kepada cabang yang diberikan daripada hulu"
 
-#: builtin/rebase.c:1326
+#: builtin/rebase.c:1321
 msgid "use the merge-base of upstream and branch as the current base"
-msgstr ""
+msgstr "gunakan merge-base hulu dan cabang sebagai dasar saat ini"
 
-#: builtin/rebase.c:1328
+#: builtin/rebase.c:1323
 msgid "allow pre-rebase hook to run"
-msgstr ""
+msgstr "perbolehkan hook pre-rebase untuk dijalankan"
 
-#: builtin/rebase.c:1330
+#: builtin/rebase.c:1325
 msgid "be quiet. implies --no-stat"
-msgstr ""
+msgstr "diam. menyiratkan --no-stat"
 
-#: builtin/rebase.c:1336
+#: builtin/rebase.c:1331
 msgid "do not show diffstat of what changed upstream"
-msgstr ""
+msgstr "jangan perlihatkan diffstat apa yang berubah di hulu"
+
+#: builtin/rebase.c:1334
+msgid "add a Signed-off-by trailer to each commit"
+msgstr "tambahkan trailer Signed-off-by ke setiap komit"
+
+#: builtin/rebase.c:1337
+msgid "make committer date match author date"
+msgstr "jadikan tanggal pengkomit sama dengan tanggal pengarang"
 
 #: builtin/rebase.c:1339
-msgid "add a Signed-off-by trailer to each commit"
-msgstr ""
-
-#: builtin/rebase.c:1342
-msgid "make committer date match author date"
-msgstr ""
-
-#: builtin/rebase.c:1344
 msgid "ignore author date and use current date"
-msgstr ""
+msgstr "abaikan tanggal pengarang dan gunakan tanggal saat ini"
 
-#: builtin/rebase.c:1346
+#: builtin/rebase.c:1341
 msgid "synonym of --reset-author-date"
-msgstr ""
+msgstr "sinonim dari --reset-author-date"
 
-#: builtin/rebase.c:1348 builtin/rebase.c:1352
+#: builtin/rebase.c:1343 builtin/rebase.c:1347
 msgid "passed to 'git apply'"
-msgstr ""
+msgstr "lewatkan ke 'git apply'"
 
-#: builtin/rebase.c:1350
+#: builtin/rebase.c:1345
 msgid "ignore changes in whitespace"
-msgstr ""
+msgstr "abaikan perubahan spasi"
 
-#: builtin/rebase.c:1354 builtin/rebase.c:1357
+#: builtin/rebase.c:1349 builtin/rebase.c:1352
 msgid "cherry-pick all commits, even if unchanged"
-msgstr ""
+msgstr "petik ceri semua komit, bahkan jika tak berubah"
+
+#: builtin/rebase.c:1354
+msgid "continue"
+msgstr "lanjutkan"
+
+#: builtin/rebase.c:1357
+msgid "skip current patch and continue"
+msgstr "lewatkan tambalan saat ini dan lanjutkan"
 
 #: builtin/rebase.c:1359
-msgid "continue"
-msgstr ""
+msgid "abort and check out the original branch"
+msgstr "hentikan dan check out cabang asli"
 
 #: builtin/rebase.c:1362
-msgid "skip current patch and continue"
-msgstr ""
-
-#: builtin/rebase.c:1364
-msgid "abort and check out the original branch"
-msgstr ""
-
-#: builtin/rebase.c:1367
 msgid "abort but keep HEAD where it is"
-msgstr ""
+msgstr "hentikan tapi simpan HEAD dimana itu berada"
 
-#: builtin/rebase.c:1368
+#: builtin/rebase.c:1363
 msgid "edit the todo list during an interactive rebase"
-msgstr ""
+msgstr "sunting daftar todo selama pendasaran ulang interaktif"
 
-#: builtin/rebase.c:1371
+#: builtin/rebase.c:1366
 msgid "show the patch file being applied or merged"
-msgstr ""
+msgstr "perlihatkan berkas tambalan yang sedang diterapkan atau digabungkan"
 
-#: builtin/rebase.c:1374
+#: builtin/rebase.c:1369
 msgid "use apply strategies to rebase"
-msgstr ""
+msgstr "gunakan strategi penerapan ke pendasaran ulang"
 
-#: builtin/rebase.c:1378
+#: builtin/rebase.c:1373
 msgid "use merging strategies to rebase"
-msgstr ""
+msgstr "gunakan strategi penggabungan ke pendasaran ulang"
 
-#: builtin/rebase.c:1382
+#: builtin/rebase.c:1377
 msgid "let the user edit the list of commits to rebase"
-msgstr ""
+msgstr "biarkan pengguna menyunting daftar komit untuk didasarkan ulang"
+
+#: builtin/rebase.c:1381
+msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
+msgstr "(USANG) coba buat ulang penggabungan daripada abaikan itu"
 
 #: builtin/rebase.c:1386
-msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
-msgstr ""
-
-#: builtin/rebase.c:1391
 msgid "how to handle commits that become empty"
-msgstr ""
+msgstr "bagaimana cara menangani komit yang menjadi kosong"
 
-#: builtin/rebase.c:1398
+#: builtin/rebase.c:1393
 msgid "move commits that begin with squash!/fixup! under -i"
-msgstr ""
+msgstr "pindahakan komit yang diawali dengan squash!/fixup! di bawah -i"
 
-#: builtin/rebase.c:1405
+#: builtin/rebase.c:1400
 msgid "add exec lines after each commit of the editable list"
 msgstr ""
+"tambahkan baris exec setelah setiap komit dari daftar yang bisa disunting"
 
-#: builtin/rebase.c:1409
+#: builtin/rebase.c:1404
 msgid "allow rebasing commits with empty messages"
-msgstr ""
+msgstr "perbolehkan mendasarkan ulang komit dengan pesan kosong"
+
+#: builtin/rebase.c:1408
+msgid "try to rebase merges instead of skipping them"
+msgstr "coba mendasarkan ulang penggabungan daripada melewatkan itu"
+
+#: builtin/rebase.c:1411
+msgid "use 'merge-base --fork-point' to refine upstream"
+msgstr "gunakan 'merge-base --fork-point' untuk menyaring hulu"
 
 #: builtin/rebase.c:1413
-msgid "try to rebase merges instead of skipping them"
-msgstr ""
+msgid "use the given merge strategy"
+msgstr "gunakan strategi penggabungan yang diberikan"
+
+#: builtin/rebase.c:1415 builtin/revert.c:115
+msgid "option"
+msgstr "opsi"
 
 #: builtin/rebase.c:1416
-msgid "use 'merge-base --fork-point' to refine upstream"
-msgstr ""
-
-#: builtin/rebase.c:1418
-msgid "use the given merge strategy"
-msgstr ""
-
-#: builtin/rebase.c:1420 builtin/revert.c:115
-msgid "option"
-msgstr ""
-
-#: builtin/rebase.c:1421
 msgid "pass the argument through to the merge strategy"
-msgstr ""
+msgstr "lewatkan argumen ke strategi penggabungan"
+
+#: builtin/rebase.c:1419
+msgid "rebase all reachable commits up to the root(s)"
+msgstr "dasarkan ulang semua komit yang bisa dicapai hingga ke akar"
 
 #: builtin/rebase.c:1424
-msgid "rebase all reachable commits up to the root(s)"
-msgstr ""
-
-#: builtin/rebase.c:1429
 msgid "apply all changes, even those already present upstream"
-msgstr ""
+msgstr "terapkan semua perubahan, bahkan yang sudah ada di hulu"
 
-#: builtin/rebase.c:1446
-msgid ""
-"the rebase.useBuiltin support has been removed!\n"
-"See its entry in 'git help config' for details."
-msgstr ""
-
-#: builtin/rebase.c:1452
+#: builtin/rebase.c:1442
 msgid "It looks like 'git am' is in progress. Cannot rebase."
-msgstr ""
+msgstr "Sepertinya 'git am' sedang berjalan. Tidak dapat mendasarkan ulang"
 
-#: builtin/rebase.c:1493
+#: builtin/rebase.c:1483
 msgid ""
 "git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
 msgstr ""
+"git rebase --preserve-merges usang. Gunakan --rebase-merges sebagai gantinya."
 
-#: builtin/rebase.c:1498
+#: builtin/rebase.c:1488
 msgid "cannot combine '--keep-base' with '--onto'"
-msgstr ""
+msgstr "tidak dapat menggabungkan '--keep-base' dengan '--onto'"
 
-#: builtin/rebase.c:1500
+#: builtin/rebase.c:1490
 msgid "cannot combine '--keep-base' with '--root'"
-msgstr ""
+msgstr "tidak dapat menggabungkan '--keep-base' dengan '--root'"
 
-#: builtin/rebase.c:1504
+#: builtin/rebase.c:1494
 msgid "cannot combine '--root' with '--fork-point'"
-msgstr ""
+msgstr "tidak dapat menggabungkan '--root' dengan '--fork-point'"
 
-#: builtin/rebase.c:1507
+#: builtin/rebase.c:1497
 msgid "No rebase in progress?"
-msgstr ""
+msgstr "Tidak ada pendasaran ulang yang sedang berjalan?"
 
-#: builtin/rebase.c:1511
+#: builtin/rebase.c:1501
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
+"Aksi --edit-todo hanya dapat digunakan selama pendasaran ulang interaktif."
 
-#: builtin/rebase.c:1534 t/helper/test-fast-rebase.c:123
+#: builtin/rebase.c:1524 t/helper/test-fast-rebase.c:123
 msgid "Cannot read HEAD"
-msgstr ""
+msgstr "Tidak dapat membaca HEAD"
 
-#: builtin/rebase.c:1546
+#: builtin/rebase.c:1536
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
 msgstr ""
+"Anda harus menyunting semua konflik penggabungan lalu\n"
+"tandai itu sebagai terselesaikan menggunakan git add"
 
-#: builtin/rebase.c:1565
+#: builtin/rebase.c:1555
 msgid "could not discard worktree changes"
-msgstr ""
+msgstr "tidak dapat menyingkirkan perubahan pohon kerja"
 
-#: builtin/rebase.c:1584
+#: builtin/rebase.c:1574
 #, c-format
 msgid "could not move back to %s"
-msgstr ""
+msgstr "tidak dapt memindahkan kembali ke %s"
 
-#: builtin/rebase.c:1630
+#: builtin/rebase.c:1620
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -18785,135 +19441,147 @@ msgid ""
 "and run me again.  I am stopping in case you still have something\n"
 "valuable there.\n"
 msgstr ""
+"Sepertinya sudah ada direktori %s, dan saya ingin tahu kalau Anda\n"
+"berada di tengah-tengah pendasaran ulang yang lain. Jika itu maksudnya,\n"
+"mohon coba \n"
+"\t%s\n"
+"Jika itu bukan, mohon\n"
+"\t%s\n"
+"dan jalankan saya lagi. Saya berhenti seandainya Anda masih punya\n"
+"sesuatu yang berharga di sana.\n"
 
-#: builtin/rebase.c:1658
+#: builtin/rebase.c:1648
 msgid "switch `C' expects a numerical value"
-msgstr ""
+msgstr "tombol `C' harap nilai numerik"
 
-#: builtin/rebase.c:1700
+#: builtin/rebase.c:1690
 #, c-format
 msgid "Unknown mode: %s"
-msgstr ""
+msgstr "Mode tidak dikenal: %s"
 
-#: builtin/rebase.c:1739
+#: builtin/rebase.c:1729
 msgid "--strategy requires --merge or --interactive"
-msgstr ""
+msgstr "--strategy butuh --merge atau --interactive"
 
-#: builtin/rebase.c:1769
+#: builtin/rebase.c:1759
 msgid "cannot combine apply options with merge options"
-msgstr ""
+msgstr "tidak dapat menggabungkan opsi penerapan dengan opsi penggabungan"
 
-#: builtin/rebase.c:1782
+#: builtin/rebase.c:1772
 #, c-format
 msgid "Unknown rebase backend: %s"
-msgstr ""
+msgstr "Tulang belakang pendasaran ulang tidak dikenal: %s"
 
-#: builtin/rebase.c:1812
+#: builtin/rebase.c:1802
 msgid "--reschedule-failed-exec requires --exec or --interactive"
-msgstr ""
+msgstr "--reschedule-failed-exec butuh --exec atau --interactive"
 
-#: builtin/rebase.c:1832
+#: builtin/rebase.c:1822
 msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-msgstr ""
+msgstr "tidak dapat menggabungkan '--preserve-merges' dengan '--rebase-merges'"
 
-#: builtin/rebase.c:1836
+#: builtin/rebase.c:1826
 msgid ""
 "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
+"error: tidak dapat menggabungkan '--preserve-merges' dengan '--reschedule-"
+"failed-exec'"
 
-#: builtin/rebase.c:1860
+#: builtin/rebase.c:1850
 #, c-format
 msgid "invalid upstream '%s'"
-msgstr ""
+msgstr "hulu tidak valid '%s'"
 
-#: builtin/rebase.c:1866
+#: builtin/rebase.c:1856
 msgid "Could not create new root commit"
-msgstr ""
+msgstr "tidak dapat membuat komit akar baru"
 
-#: builtin/rebase.c:1892
+#: builtin/rebase.c:1882
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
-msgstr ""
+msgstr "'%s': butuh tepatnya satu dasar penggabungan dengan cabang"
 
-#: builtin/rebase.c:1895
+#: builtin/rebase.c:1885
 #, c-format
 msgid "'%s': need exactly one merge base"
-msgstr ""
+msgstr "'%s': butuh tepatnya satu dasar penggabungan"
 
-#: builtin/rebase.c:1903
+#: builtin/rebase.c:1893
 #, c-format
 msgid "Does not point to a valid commit '%s'"
-msgstr ""
+msgstr "Tidak menunjuk pada komit yang valid '%s'"
 
-#: builtin/rebase.c:1931
+#: builtin/rebase.c:1921
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
-msgstr ""
+msgstr "fatal: tidak ada cabang/komit seperti '%s'"
 
-#: builtin/rebase.c:1939 builtin/submodule--helper.c:40
-#: builtin/submodule--helper.c:2414
+#: builtin/rebase.c:1929 builtin/submodule--helper.c:40
+#: builtin/submodule--helper.c:2415
 #, c-format
 msgid "No such ref: %s"
-msgstr ""
+msgstr "Tidak ada referensi seperti: %s"
 
-#: builtin/rebase.c:1950
+#: builtin/rebase.c:1940
 msgid "Could not resolve HEAD to a revision"
-msgstr ""
+msgstr "Tidak dapat menguraikan HEAD ke sebuah revisi"
 
-#: builtin/rebase.c:1971
+#: builtin/rebase.c:1961
 msgid "Please commit or stash them."
-msgstr ""
+msgstr "Mohon komit atau stase itu."
 
-#: builtin/rebase.c:2007
+#: builtin/rebase.c:1997
 #, c-format
 msgid "could not switch to %s"
-msgstr ""
+msgstr "tidak dapat mengganti ke %s"
+
+#: builtin/rebase.c:2008
+msgid "HEAD is up to date."
+msgstr "HEAD terbaru."
+
+#: builtin/rebase.c:2010
+#, c-format
+msgid "Current branch %s is up to date.\n"
+msgstr "Cabang saat ini %s terbaru.\n"
 
 #: builtin/rebase.c:2018
-msgid "HEAD is up to date."
-msgstr ""
+msgid "HEAD is up to date, rebase forced."
+msgstr "HEAD terbaru, pendasaran ulang dipaksa."
 
 #: builtin/rebase.c:2020
 #, c-format
-msgid "Current branch %s is up to date.\n"
-msgstr ""
+msgid "Current branch %s is up to date, rebase forced.\n"
+msgstr "Cabang saat ini %s terbaru, pendasaran ulang dipaksa.\n"
 
 #: builtin/rebase.c:2028
-msgid "HEAD is up to date, rebase forced."
-msgstr ""
-
-#: builtin/rebase.c:2030
-#, c-format
-msgid "Current branch %s is up to date, rebase forced.\n"
-msgstr ""
-
-#: builtin/rebase.c:2038
 msgid "The pre-rebase hook refused to rebase."
-msgstr ""
+msgstr "Hook pre-rebase menolak mendasarkan ulang."
 
-#: builtin/rebase.c:2045
+#: builtin/rebase.c:2035
 #, c-format
 msgid "Changes to %s:\n"
-msgstr ""
+msgstr "Perubahan unuk %s:\n"
 
-#: builtin/rebase.c:2048
+#: builtin/rebase.c:2038
 #, c-format
 msgid "Changes from %s to %s:\n"
-msgstr ""
+msgstr "Perubahan dari %s ke %s:\n"
 
-#: builtin/rebase.c:2073
+#: builtin/rebase.c:2063
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
+"Pertama, memutar ulang kepala untuk memainkan ulang karya Anda diatas "
+"itu...\n"
 
-#: builtin/rebase.c:2082
+#: builtin/rebase.c:2072
 msgid "Could not detach HEAD"
-msgstr ""
+msgstr "Tidak dapat melepas HEAD"
 
-#: builtin/rebase.c:2091
+#: builtin/rebase.c:2081
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
-msgstr ""
+msgstr "Maju-cepat %s ke %s.\n"
 
 #: builtin/receive-pack.c:34
 msgid "git receive-pack <git-dir>"
@@ -18948,11 +19616,11 @@ msgid ""
 "To squelch this message, you can set it to 'refuse'."
 msgstr ""
 
-#: builtin/receive-pack.c:2481
+#: builtin/receive-pack.c:2479
 msgid "quiet"
 msgstr ""
 
-#: builtin/receive-pack.c:2495
+#: builtin/receive-pack.c:2493
 msgid "You must specify a directory."
 msgstr ""
 
@@ -19013,158 +19681,163 @@ msgstr ""
 
 #: builtin/remote.c:17
 msgid "git remote [-v | --verbose]"
-msgstr ""
+msgstr "git remote [-v | --verbose]"
 
 #: builtin/remote.c:18
 msgid ""
 "git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--"
 "mirror=<fetch|push>] <name> <url>"
 msgstr ""
+"git remote add [-t <cabang>] [-m <master>] [-f] [--tags | --no-tags] [--"
+"mirror=<fetch|push>] <nama> <url>"
 
 #: builtin/remote.c:19 builtin/remote.c:39
 msgid "git remote rename <old> <new>"
-msgstr ""
+msgstr "git remote rename <lama> <baru>"
 
 #: builtin/remote.c:20 builtin/remote.c:44
 msgid "git remote remove <name>"
-msgstr ""
+msgstr "git remote remove <nama>"
 
 #: builtin/remote.c:21 builtin/remote.c:49
 msgid "git remote set-head <name> (-a | --auto | -d | --delete | <branch>)"
-msgstr ""
+msgstr "git remote set-head <nama> (-a | --auto | -d | --delete | <cabang>)"
 
 #: builtin/remote.c:22
 msgid "git remote [-v | --verbose] show [-n] <name>"
-msgstr ""
+msgstr "git remote [-v | --verbose] show [-n] <nama>"
 
 #: builtin/remote.c:23
 msgid "git remote prune [-n | --dry-run] <name>"
-msgstr ""
+msgstr "git remote prune [-n | --dry-run] <nama>"
 
 #: builtin/remote.c:24
 msgid ""
 "git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]"
 msgstr ""
+"git remote [-v | --verbose] update [-p | --prune] [(<grup> | <remote>)...]"
 
 #: builtin/remote.c:25
 msgid "git remote set-branches [--add] <name> <branch>..."
-msgstr ""
+msgstr "git remote set-branches [--add] <nama> <cabang>..."
 
 #: builtin/remote.c:26 builtin/remote.c:75
 msgid "git remote get-url [--push] [--all] <name>"
-msgstr ""
+msgstr "git remote get-url [--push] [--all] <nama>"
 
 #: builtin/remote.c:27 builtin/remote.c:80
 msgid "git remote set-url [--push] <name> <newurl> [<oldurl>]"
-msgstr ""
+msgstr "git remote set-url [--push] <nama> <url baru> [<url lama>]"
 
 #: builtin/remote.c:28 builtin/remote.c:81
 msgid "git remote set-url --add <name> <newurl>"
-msgstr ""
+msgstr "git remote set-url --add <nama> <url baru>"
 
 #: builtin/remote.c:29 builtin/remote.c:82
 msgid "git remote set-url --delete <name> <url>"
-msgstr ""
+msgstr "git remote set-url --delete <nama> <url>"
 
 #: builtin/remote.c:34
 msgid "git remote add [<options>] <name> <url>"
-msgstr ""
+msgstr "git remote add [<opsi>] <nama> <url>"
 
 #: builtin/remote.c:54
 msgid "git remote set-branches <name> <branch>..."
-msgstr ""
+msgstr "git remote set-branches <nama> <cabang>"
 
 #: builtin/remote.c:55
 msgid "git remote set-branches --add <name> <branch>..."
-msgstr ""
+msgstr "git remote set-branches --add <nama> <cabang>"
 
 #: builtin/remote.c:60
 msgid "git remote show [<options>] <name>"
-msgstr ""
+msgstr "git remote show [<opsi>] <nama>"
 
 #: builtin/remote.c:65
 msgid "git remote prune [<options>] <name>"
-msgstr ""
+msgstr "git remote prune [<opsi>] <nama>"
 
 #: builtin/remote.c:70
 msgid "git remote update [<options>] [<group> | <remote>]..."
-msgstr ""
+msgstr "git remote update [<opsi>] [<group> | <remote>]..."
 
 #: builtin/remote.c:99
 #, c-format
 msgid "Updating %s"
-msgstr ""
+msgstr "Memperbarui %s"
 
 #: builtin/remote.c:131
 msgid ""
 "--mirror is dangerous and deprecated; please\n"
 "\t use --mirror=fetch or --mirror=push instead"
 msgstr ""
+"--mirror berbahaya dan usang; mohon gunakan --mirror=fetch\n"
+"\t atau --mirror=push sebagai gantinya"
 
 #: builtin/remote.c:148
 #, c-format
 msgid "unknown mirror argument: %s"
-msgstr ""
+msgstr "argumen mirror tidak dikenal: %s"
 
 #: builtin/remote.c:164
 msgid "fetch the remote branches"
-msgstr ""
+msgstr "ambil cabang remote"
 
 #: builtin/remote.c:166
 msgid "import all tags and associated objects when fetching"
-msgstr ""
+msgstr "impor semua tag dan objek yang terkait ketika mengambil"
 
 #: builtin/remote.c:169
 msgid "or do not fetch any tag at all (--no-tags)"
-msgstr ""
+msgstr "atau jangan mengambil tag apapun (--no-tags)"
 
 #: builtin/remote.c:171
 msgid "branch(es) to track"
-msgstr ""
+msgstr "cabang untuk dilacak"
 
 #: builtin/remote.c:172
 msgid "master branch"
-msgstr ""
+msgstr "cabang master"
 
 #: builtin/remote.c:174
 msgid "set up remote as a mirror to push to or fetch from"
-msgstr ""
+msgstr "atur remote sebagai cermin untuk didorong atau diambil"
 
 #: builtin/remote.c:186
 msgid "specifying a master branch makes no sense with --mirror"
-msgstr ""
+msgstr "menyebutkan cabang master tidak masuk akal dengan --mirror"
 
 #: builtin/remote.c:188
 msgid "specifying branches to track makes sense only with fetch mirrors"
-msgstr ""
+msgstr "menyebutkan cabang untuk dilacak hanya masuk akal dengan cermin ambil"
 
 #: builtin/remote.c:195 builtin/remote.c:700
 #, c-format
 msgid "remote %s already exists."
-msgstr ""
+msgstr "remote %s sudah ada"
 
 #: builtin/remote.c:240
 #, c-format
 msgid "Could not setup master '%s'"
-msgstr ""
+msgstr "Tidak dapat mengatur master '%s'"
 
 #: builtin/remote.c:355
 #, c-format
 msgid "Could not get fetch map for refspec %s"
-msgstr ""
+msgstr "Tidak dapat mendapatkan peta pengambilan untuk spek referensi %s"
 
 #: builtin/remote.c:454 builtin/remote.c:462
 msgid "(matching)"
-msgstr ""
+msgstr "(sepadan)"
 
 #: builtin/remote.c:466
 msgid "(delete)"
-msgstr ""
+msgstr "(hapus)"
 
 #: builtin/remote.c:655
 #, c-format
 msgid "could not set '%s'"
-msgstr ""
+msgstr "tidak dapat menyetel '%s'"
 
 #: builtin/remote.c:660
 #, c-format
@@ -19173,16 +19846,19 @@ msgid ""
 "\t%s:%d\n"
 "now names the non-existent remote '%s'"
 msgstr ""
+"Konfigurasi %s remote.pushDefault di:\n"
+"\t%s:%d\n"
+"sekarang menamai remote yang tiada '%s'"
 
-#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:946
+#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:943
 #, c-format
 msgid "No such remote: '%s'"
-msgstr ""
+msgstr "Tidak ada remote seperti: '%s'"
 
 #: builtin/remote.c:710
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
-msgstr ""
+msgstr "Tidak dapat menamai ulang bagian konfigurasi '%s' ke '%s'"
 
 #: builtin/remote.c:730
 #, c-format
@@ -19191,16 +19867,19 @@ msgid ""
 "\t%s\n"
 "\tPlease update the configuration manually if necessary."
 msgstr ""
+"Tidak memperbarui spek referensi pengambilan bukan asali\n"
+"\t%s\n"
+"\tMohon perbarui konfigurasi secara manual bila diperlukan."
 
 #: builtin/remote.c:770
 #, c-format
 msgid "deleting '%s' failed"
-msgstr ""
+msgstr "menghapus '%s' gagal"
 
 #: builtin/remote.c:804
 #, c-format
 msgid "creating '%s' failed"
-msgstr ""
+msgstr "membuat '%s' gagal"
 
 #: builtin/remote.c:882
 msgid ""
@@ -19210,122 +19889,128 @@ msgid_plural ""
 "Note: Some branches outside the refs/remotes/ hierarchy were not removed;\n"
 "to delete them, use:"
 msgstr[0] ""
+"Catatan: Sebuah cabang diluar hierarki refs/remotes tidak dihapus;\n"
+"untuk menghapus itu, gunakan:"
 msgstr[1] ""
+"Catatan: Beberapa cabang diluar hierarki refs/remotes tidak dihapus;\n"
+"untuk menghapus itu, gunakan:"
 
 #: builtin/remote.c:896
 #, c-format
 msgid "Could not remove config section '%s'"
-msgstr ""
+msgstr "Tidak dapat menghapus bagian konfigurasi '%s'"
 
 #: builtin/remote.c:999
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
-msgstr ""
+msgstr " baru (pengambilan berikutnya akan simpan di remotes/%s)"
 
 #: builtin/remote.c:1002
 msgid " tracked"
-msgstr ""
+msgstr " dilacak"
 
 #: builtin/remote.c:1004
 msgid " stale (use 'git remote prune' to remove)"
-msgstr ""
+msgstr " basi (gunakan 'git remote prune' untuk hapus)"
 
 #: builtin/remote.c:1006
 msgid " ???"
-msgstr ""
+msgstr " ???"
 
 #: builtin/remote.c:1047
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr ""
+"branch.%s.merge tidak valid; tidak dapat mendasarkan ulang ke lebih dari "
+"satu cabang"
 
 #: builtin/remote.c:1056
 #, c-format
 msgid "rebases interactively onto remote %s"
-msgstr ""
+msgstr "dasarkan ulang secara interaktif ke remote %s"
 
 #: builtin/remote.c:1058
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
-msgstr ""
+msgstr "dasarkan ulang secara interaktif (dengan penggabungan) ke remote %s"
 
 #: builtin/remote.c:1061
 #, c-format
 msgid "rebases onto remote %s"
-msgstr ""
+msgstr "dasarkan ulang ke remote %s"
 
 #: builtin/remote.c:1065
 #, c-format
 msgid " merges with remote %s"
-msgstr ""
+msgstr " gabungkan dengan remote %s"
 
 #: builtin/remote.c:1068
 #, c-format
 msgid "merges with remote %s"
-msgstr ""
+msgstr "gabungkan dengan remote %s"
 
 #: builtin/remote.c:1071
 #, c-format
 msgid "%-*s    and with remote %s\n"
-msgstr ""
+msgstr "%-*s    dan dengan remote %s\n"
 
 #: builtin/remote.c:1114
 msgid "create"
-msgstr ""
+msgstr "buat"
 
 #: builtin/remote.c:1117
 msgid "delete"
-msgstr ""
+msgstr "hapus"
 
 #: builtin/remote.c:1121
 msgid "up to date"
-msgstr ""
+msgstr "terbaru"
 
 #: builtin/remote.c:1124
 msgid "fast-forwardable"
-msgstr ""
+msgstr "bisa dimaju cepat"
 
 #: builtin/remote.c:1127
 msgid "local out of date"
-msgstr ""
+msgstr "lokal kuno"
 
 #: builtin/remote.c:1134
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
-msgstr ""
+msgstr "    %-*s memaksa untuk %-*s (%s)"
 
 #: builtin/remote.c:1137
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
-msgstr ""
+msgstr "    %-*s mendorong ke %-*s (%s)"
 
 #: builtin/remote.c:1141
 #, c-format
 msgid "    %-*s forces to %s"
-msgstr ""
+msgstr "    %-*s memaksa untuk %s"
 
 #: builtin/remote.c:1144
 #, c-format
 msgid "    %-*s pushes to %s"
-msgstr ""
+msgstr "    %-*s mendorong ke %s"
 
 #: builtin/remote.c:1212
 msgid "do not query remotes"
-msgstr ""
+msgstr "jangan tanyakan remote"
 
 #: builtin/remote.c:1239
 #, c-format
 msgid "* remote %s"
-msgstr ""
+msgstr "* remote %s"
 
 #: builtin/remote.c:1240
 #, c-format
 msgid "  Fetch URL: %s"
-msgstr ""
+msgstr "  URL pengambilan: %s"
 
 #: builtin/remote.c:1241 builtin/remote.c:1257 builtin/remote.c:1396
 msgid "(no URL)"
-msgstr ""
+msgstr "(tidak ada URL)"
 
 #. TRANSLATORS: the colon ':' should align
 #. with the one in " Fetch URL: %s"
@@ -19334,175 +20019,176 @@ msgstr ""
 #: builtin/remote.c:1255 builtin/remote.c:1257
 #, c-format
 msgid "  Push  URL: %s"
-msgstr ""
+msgstr "  URL pendorongan: %s"
 
 #: builtin/remote.c:1259 builtin/remote.c:1261 builtin/remote.c:1263
 #, c-format
 msgid "  HEAD branch: %s"
-msgstr ""
+msgstr "  Cabang HEAD: %s"
 
 #: builtin/remote.c:1259
 msgid "(not queried)"
-msgstr ""
+msgstr "(tidak ditanyakan)"
 
 #: builtin/remote.c:1261
 msgid "(unknown)"
-msgstr ""
+msgstr "(tidak diketahui)"
 
 #: builtin/remote.c:1265
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr ""
+"  Cabang HEAD (HEAD remote ambigu, bisa jadi salah satu dari yang berikut):\n"
 
 #: builtin/remote.c:1277
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "  Cabang remote:%s"
+msgstr[1] "  Cabang remote:%s"
 
 #: builtin/remote.c:1280 builtin/remote.c:1306
 msgid " (status not queried)"
-msgstr ""
+msgstr " (status tidak ditanyakan)"
 
 #: builtin/remote.c:1289
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "  Cabang lokal dikonfigurasi untuk 'git pull':"
+msgstr[1] "  Cabang lokal dikonfigurasi untuk 'git pull':"
 
 #: builtin/remote.c:1297
 msgid "  Local refs will be mirrored by 'git push'"
-msgstr ""
+msgstr "  Referensi lokal yang akan dicerminkan oleh 'git push'"
 
 #: builtin/remote.c:1303
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "  Referensi lokal dikonfigurasi untuk 'git push'%s:"
+msgstr[1] "  Referensi lokal dikonfigurasi untuk 'git push'%s:"
 
 #: builtin/remote.c:1324
 msgid "set refs/remotes/<name>/HEAD according to remote"
-msgstr ""
+msgstr "setel refs/remotes/<nama>/HEAD tergantung remote"
 
 #: builtin/remote.c:1326
 msgid "delete refs/remotes/<name>/HEAD"
-msgstr ""
+msgstr "hapus refs/remotes/<nama>/HEAD"
 
 #: builtin/remote.c:1341
 msgid "Cannot determine remote HEAD"
-msgstr ""
+msgstr "Tidak dapat menentukan HEAD remote"
 
 #: builtin/remote.c:1343
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
-msgstr ""
+msgstr "Banyak cabang HEAD remote. Mohon pilih satu secara eksplisit dengan:"
 
 #: builtin/remote.c:1353
 #, c-format
 msgid "Could not delete %s"
-msgstr ""
+msgstr "Tidak dapat menghapus %s"
 
 #: builtin/remote.c:1361
 #, c-format
 msgid "Not a valid ref: %s"
-msgstr ""
+msgstr "Bukan referensi valid: %s"
 
 #: builtin/remote.c:1363
 #, c-format
 msgid "Could not setup %s"
-msgstr ""
+msgstr "Tidak dapat mengatur %s"
 
 #: builtin/remote.c:1381
 #, c-format
 msgid " %s will become dangling!"
-msgstr ""
+msgstr " %s akan menjadi teruntai!"
 
 #: builtin/remote.c:1382
 #, c-format
 msgid " %s has become dangling!"
-msgstr ""
+msgstr " %s telah menjadi teruntai!"
 
 #: builtin/remote.c:1392
 #, c-format
 msgid "Pruning %s"
-msgstr ""
+msgstr "Memangkas %s"
 
 #: builtin/remote.c:1393
 #, c-format
 msgid "URL: %s"
-msgstr ""
+msgstr "URL: %s"
 
 #: builtin/remote.c:1409
 #, c-format
 msgid " * [would prune] %s"
-msgstr ""
+msgstr " * [akan pangkas] %s"
 
 #: builtin/remote.c:1412
 #, c-format
 msgid " * [pruned] %s"
-msgstr ""
+msgstr " * [dipangkas] %s"
 
 #: builtin/remote.c:1457
 msgid "prune remotes after fetching"
-msgstr ""
+msgstr "pangkas remote setelah pengambilan"
 
 #: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
 #, c-format
 msgid "No such remote '%s'"
-msgstr ""
+msgstr "Tidak ada remote seperti '%s'"
 
 #: builtin/remote.c:1539
 msgid "add branch"
-msgstr ""
+msgstr "tambah cabang"
 
 #: builtin/remote.c:1546
 msgid "no remote specified"
-msgstr ""
+msgstr "tidak ada remote yang disebutkan"
 
 #: builtin/remote.c:1563
 msgid "query push URLs rather than fetch URLs"
-msgstr ""
+msgstr "tanyakan URL pendorongan daripada URL pengambilan"
 
 #: builtin/remote.c:1565
 msgid "return all URLs"
-msgstr ""
+msgstr "kembalikan semua URL"
 
 #: builtin/remote.c:1595
 #, c-format
 msgid "no URLs configured for remote '%s'"
-msgstr ""
+msgstr "tidak ada URL yang dikonfigurasi untuk remote '%s'"
 
 #: builtin/remote.c:1621
 msgid "manipulate push URLs"
-msgstr ""
+msgstr "manipulasi URL pendorongan"
 
 #: builtin/remote.c:1623
 msgid "add URL"
-msgstr ""
+msgstr "tambah URL"
 
 #: builtin/remote.c:1625
 msgid "delete URLs"
-msgstr ""
+msgstr "hapus URL"
 
 #: builtin/remote.c:1632
 msgid "--add --delete doesn't make sense"
-msgstr ""
+msgstr "--add --delete tidak masuk akal"
 
 #: builtin/remote.c:1673
 #, c-format
 msgid "Invalid old URL pattern: %s"
-msgstr ""
+msgstr "pola URL lama tidak valid: %s"
 
 #: builtin/remote.c:1681
 #, c-format
 msgid "No such URL found: %s"
-msgstr ""
+msgstr "Tidak ada URL yang ditemukan seperti: %s"
 
 #: builtin/remote.c:1683
 msgid "Will not delete all non-push URLs"
-msgstr ""
+msgstr "Tidak akan hapus semua URL non-dorong"
 
 #: builtin/repack.c:26
 msgid "git repack [<options>]"
@@ -19518,7 +20204,7 @@ msgstr ""
 msgid "could not start pack-objects to repack promisor objects"
 msgstr ""
 
-#: builtin/repack.c:270 builtin/repack.c:446
+#: builtin/repack.c:270 builtin/repack.c:630
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 
@@ -19526,104 +20212,127 @@ msgstr ""
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 
-#: builtin/repack.c:322
-msgid "pack everything in a single pack"
-msgstr ""
-
-#: builtin/repack.c:324
-msgid "same as -a, and turn unreachable objects loose"
-msgstr ""
-
-#: builtin/repack.c:327
-msgid "remove redundant packs, and run git-prune-packed"
-msgstr ""
-
-#: builtin/repack.c:329
-msgid "pass --no-reuse-delta to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:331
-msgid "pass --no-reuse-object to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:333
-msgid "do not run git-update-server-info"
-msgstr ""
-
-#: builtin/repack.c:336
-msgid "pass --local to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:338
-msgid "write bitmap index"
-msgstr ""
-
-#: builtin/repack.c:340
-msgid "pass --delta-islands to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:341
-msgid "approxidate"
-msgstr ""
-
-#: builtin/repack.c:342
-msgid "with -A, do not loosen objects older than this"
-msgstr ""
-
-#: builtin/repack.c:344
-msgid "with -a, repack unreachable objects"
-msgstr ""
-
-#: builtin/repack.c:346
-msgid "size of the window used for delta compression"
-msgstr ""
-
-#: builtin/repack.c:347 builtin/repack.c:353
-msgid "bytes"
-msgstr ""
-
-#: builtin/repack.c:348
-msgid "same as the above, but limit memory size instead of entries count"
-msgstr ""
-
-#: builtin/repack.c:350
-msgid "limits the maximum delta depth"
-msgstr ""
-
-#: builtin/repack.c:352
-msgid "limits the maximum number of threads"
-msgstr ""
-
-#: builtin/repack.c:354
-msgid "maximum size of each packfile"
-msgstr ""
-
-#: builtin/repack.c:356
-msgid "repack objects in packs marked with .keep"
-msgstr ""
-
-#: builtin/repack.c:358
-msgid "do not repack this pack"
+#: builtin/repack.c:309
+#, c-format
+msgid "cannot open index for %s"
 msgstr ""
 
 #: builtin/repack.c:368
+#, c-format
+msgid "pack %s too large to consider in geometric progression"
+msgstr ""
+
+#: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
+#, c-format
+msgid "pack %s too large to roll up"
+msgstr ""
+
+#: builtin/repack.c:460
+msgid "pack everything in a single pack"
+msgstr ""
+
+#: builtin/repack.c:462
+msgid "same as -a, and turn unreachable objects loose"
+msgstr ""
+
+#: builtin/repack.c:465
+msgid "remove redundant packs, and run git-prune-packed"
+msgstr ""
+
+#: builtin/repack.c:467
+msgid "pass --no-reuse-delta to git-pack-objects"
+msgstr ""
+
+#: builtin/repack.c:469
+msgid "pass --no-reuse-object to git-pack-objects"
+msgstr ""
+
+#: builtin/repack.c:471
+msgid "do not run git-update-server-info"
+msgstr ""
+
+#: builtin/repack.c:474
+msgid "pass --local to git-pack-objects"
+msgstr ""
+
+#: builtin/repack.c:476
+msgid "write bitmap index"
+msgstr ""
+
+#: builtin/repack.c:478
+msgid "pass --delta-islands to git-pack-objects"
+msgstr ""
+
+#: builtin/repack.c:479
+msgid "approxidate"
+msgstr ""
+
+#: builtin/repack.c:480
+msgid "with -A, do not loosen objects older than this"
+msgstr ""
+
+#: builtin/repack.c:482
+msgid "with -a, repack unreachable objects"
+msgstr ""
+
+#: builtin/repack.c:484
+msgid "size of the window used for delta compression"
+msgstr ""
+
+#: builtin/repack.c:485 builtin/repack.c:491
+msgid "bytes"
+msgstr ""
+
+#: builtin/repack.c:486
+msgid "same as the above, but limit memory size instead of entries count"
+msgstr ""
+
+#: builtin/repack.c:488
+msgid "limits the maximum delta depth"
+msgstr ""
+
+#: builtin/repack.c:490
+msgid "limits the maximum number of threads"
+msgstr ""
+
+#: builtin/repack.c:492
+msgid "maximum size of each packfile"
+msgstr ""
+
+#: builtin/repack.c:494
+msgid "repack objects in packs marked with .keep"
+msgstr ""
+
+#: builtin/repack.c:496
+msgid "do not repack this pack"
+msgstr ""
+
+#: builtin/repack.c:498
+msgid "find a geometric progression with factor <N>"
+msgstr ""
+
+#: builtin/repack.c:508
 msgid "cannot delete packs in a precious-objects repo"
 msgstr ""
 
-#: builtin/repack.c:372
+#: builtin/repack.c:512
 msgid "--keep-unreachable and -A are incompatible"
 msgstr ""
 
-#: builtin/repack.c:455
+#: builtin/repack.c:527
+msgid "--geometric is incompatible with -A, -a"
+msgstr ""
+
+#: builtin/repack.c:639
 msgid "Nothing new to pack."
 msgstr ""
 
-#: builtin/repack.c:485
+#: builtin/repack.c:669
 #, c-format
 msgid "missing required file: %s"
 msgstr ""
 
-#: builtin/repack.c:487
+#: builtin/repack.c:671
 #, c-format
 msgid "could not unlink: %s"
 msgstr ""
@@ -19947,8 +20656,8 @@ msgstr "HEAD sekarang pada %s"
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Tidak dapat lakukan reset %s di tengah-tengah penggabungan."
 
-#: builtin/reset.c:295 builtin/stash.c:587 builtin/stash.c:661
-#: builtin/stash.c:685
+#: builtin/reset.c:295 builtin/stash.c:589 builtin/stash.c:663
+#: builtin/stash.c:687
 msgid "be quiet, only report errors"
 msgstr "diam, hanya laporkan kesalahan"
 
@@ -20031,19 +20740,19 @@ msgstr "Tidak dapat menyetel ulang berkas indeks ke revisi '%s'."
 msgid "Could not write new index file."
 msgstr "Tidak dapat menulis berkas indeks baru."
 
-#: builtin/rev-list.c:534
+#: builtin/rev-list.c:538
 msgid "cannot combine --exclude-promisor-objects and --missing"
 msgstr ""
 
-#: builtin/rev-list.c:595
+#: builtin/rev-list.c:599
 msgid "object filtering requires --objects"
 msgstr ""
 
-#: builtin/rev-list.c:651
+#: builtin/rev-list.c:659
 msgid "rev-list does not support display of notes"
 msgstr ""
 
-#: builtin/rev-list.c:656
+#: builtin/rev-list.c:664
 msgid "marked counting is incompatible with --objects"
 msgstr ""
 
@@ -20150,19 +20859,19 @@ msgstr ""
 msgid "keep redundant, empty commits"
 msgstr ""
 
-#: builtin/revert.c:239
+#: builtin/revert.c:237
 msgid "revert failed"
 msgstr ""
 
-#: builtin/revert.c:252
+#: builtin/revert.c:250
 msgid "cherry-pick failed"
 msgstr ""
 
-#: builtin/rm.c:19
+#: builtin/rm.c:20
 msgid "git rm [<options>] [--] <file>..."
-msgstr ""
+msgstr "git rm [<opsi>] [--] <berkas>..."
 
-#: builtin/rm.c:207
+#: builtin/rm.c:208
 msgid ""
 "the following file has staged content different from both the\n"
 "file and the HEAD:"
@@ -20170,69 +20879,79 @@ msgid_plural ""
 "the following files have staged content different from both the\n"
 "file and the HEAD:"
 msgstr[0] ""
+"berkas berikut punya konten tergelar yang berbeda dengan baik\n"
+"berkas dan HEAD:"
 msgstr[1] ""
+"berkas berikut punya konten tergelar yang berbeda dengan baik\n"
+"berkas dan HEAD:"
 
-#: builtin/rm.c:212
+#: builtin/rm.c:213
 msgid ""
 "\n"
 "(use -f to force removal)"
 msgstr ""
+"\n"
+"(gunakan -f untuk paksa hapus)"
 
-#: builtin/rm.c:216
+#: builtin/rm.c:217
 msgid "the following file has changes staged in the index:"
 msgid_plural "the following files have changes staged in the index:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "berkas berikut punya perubahan tergelar dalam indeks:"
+msgstr[1] "berkas berikut punya perubahan tergelar dalam indeks:"
 
-#: builtin/rm.c:220 builtin/rm.c:229
+#: builtin/rm.c:221 builtin/rm.c:230
 msgid ""
 "\n"
 "(use --cached to keep the file, or -f to force removal)"
 msgstr ""
+"\n"
+"(gunakan --cached untuk jaga berkas, atau -f untuk paksa hapus)"
 
-#: builtin/rm.c:226
+#: builtin/rm.c:227
 msgid "the following file has local modifications:"
 msgid_plural "the following files have local modifications:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: builtin/rm.c:243
-msgid "do not list removed files"
-msgstr ""
+msgstr[0] "berkas berikut punya modifikasi lokal:"
+msgstr[1] "berkas berikut punya modifikasi lokal:"
 
 #: builtin/rm.c:244
-msgid "only remove from the index"
-msgstr ""
+msgid "do not list removed files"
+msgstr "jangan daftar berkas terhapus"
 
 #: builtin/rm.c:245
-msgid "override the up-to-date check"
-msgstr ""
+msgid "only remove from the index"
+msgstr "hanya hapus dari indeks"
 
 #: builtin/rm.c:246
+msgid "override the up-to-date check"
+msgstr "timpa pemeriksaan terbaru"
+
+#: builtin/rm.c:247
 msgid "allow recursive removal"
-msgstr ""
+msgstr "perbolehkan penghapusan rekursif"
 
-#: builtin/rm.c:248
+#: builtin/rm.c:249
 msgid "exit with a zero status even if nothing matched"
-msgstr ""
+msgstr "keluar dengan nol bahkan jika tidak ada yang cocok"
 
-#: builtin/rm.c:282
+#: builtin/rm.c:283
 msgid "No pathspec was given. Which files should I remove?"
 msgstr ""
+"Tidak ada spek jalur yang diberikan. Berkas mana yang harusnya saya hapus?"
 
-#: builtin/rm.c:305
+#: builtin/rm.c:310
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
+"mohon gelar perubahan Anda ke .gitmodules atau stase itu untuk melanjutkan"
 
-#: builtin/rm.c:323
+#: builtin/rm.c:331
 #, c-format
 msgid "not removing '%s' recursively without -r"
-msgstr ""
+msgstr "tidak menghapus '%s' secara rekursif tanpa -r"
 
-#: builtin/rm.c:362
+#: builtin/rm.c:379
 #, c-format
 msgid "git rm: unable to remove %s"
-msgstr ""
+msgstr "git rm: tidak dapat menghapus %s"
 
 #: builtin/send-pack.c:20
 msgid ""
@@ -20495,313 +21214,354 @@ msgstr ""
 msgid "show refs from stdin that aren't in local repository"
 msgstr ""
 
-#: builtin/sparse-checkout.c:21
+#: builtin/sparse-checkout.c:22
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
 msgstr ""
 
-#: builtin/sparse-checkout.c:45
+#: builtin/sparse-checkout.c:46
 msgid "git sparse-checkout list"
 msgstr ""
 
-#: builtin/sparse-checkout.c:71
+#: builtin/sparse-checkout.c:72
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 
-#: builtin/sparse-checkout.c:223
+#: builtin/sparse-checkout.c:227
 msgid "failed to create directory for sparse-checkout file"
 msgstr ""
 
-#: builtin/sparse-checkout.c:264
+#: builtin/sparse-checkout.c:268
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 
-#: builtin/sparse-checkout.c:266
+#: builtin/sparse-checkout.c:270
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr ""
 
-#: builtin/sparse-checkout.c:283
-msgid "git sparse-checkout init [--cone]"
+#: builtin/sparse-checkout.c:290
+msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 msgstr ""
 
-#: builtin/sparse-checkout.c:302
+#: builtin/sparse-checkout.c:310
 msgid "initialize the sparse-checkout in cone mode"
 msgstr ""
 
-#: builtin/sparse-checkout.c:339
+#: builtin/sparse-checkout.c:312
+msgid "toggle the use of a sparse index"
+msgstr ""
+
+#: builtin/sparse-checkout.c:340
+msgid "failed to modify sparse-index config"
+msgstr ""
+
+#: builtin/sparse-checkout.c:361
 #, c-format
 msgid "failed to open '%s'"
 msgstr ""
 
-#: builtin/sparse-checkout.c:396
+#: builtin/sparse-checkout.c:419
 #, c-format
 msgid "could not normalize path %s"
 msgstr ""
 
-#: builtin/sparse-checkout.c:408
+#: builtin/sparse-checkout.c:431
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr ""
 
-#: builtin/sparse-checkout.c:433
+#: builtin/sparse-checkout.c:456
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr ""
 
-#: builtin/sparse-checkout.c:487 builtin/sparse-checkout.c:511
+#: builtin/sparse-checkout.c:510 builtin/sparse-checkout.c:534
 msgid "unable to load existing sparse-checkout patterns"
 msgstr ""
 
-#: builtin/sparse-checkout.c:556
+#: builtin/sparse-checkout.c:579
 msgid "read patterns from standard in"
 msgstr ""
 
-#: builtin/sparse-checkout.c:571
+#: builtin/sparse-checkout.c:594
 msgid "git sparse-checkout reapply"
 msgstr ""
 
-#: builtin/sparse-checkout.c:590
+#: builtin/sparse-checkout.c:613
 msgid "git sparse-checkout disable"
 msgstr ""
 
-#: builtin/sparse-checkout.c:618
+#: builtin/sparse-checkout.c:644
 msgid "error while refreshing working directory"
 msgstr ""
 
-#: builtin/stash.c:22 builtin/stash.c:38
+#: builtin/stash.c:24 builtin/stash.c:40
 msgid "git stash list [<options>]"
-msgstr ""
+msgstr "git stash list [<opsi>]"
 
-#: builtin/stash.c:23 builtin/stash.c:43
+#: builtin/stash.c:25 builtin/stash.c:45
 msgid "git stash show [<options>] [<stash>]"
-msgstr ""
+msgstr "git stash show [<opsi>] [<stase>]"
 
-#: builtin/stash.c:24 builtin/stash.c:48
+#: builtin/stash.c:26 builtin/stash.c:50
 msgid "git stash drop [-q|--quiet] [<stash>]"
-msgstr ""
+msgstr "git stash drop [-q|--quiet] [<stase>]"
 
-#: builtin/stash.c:25
+#: builtin/stash.c:27
 msgid "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
-msgstr ""
+msgstr "git stash ( pop | apply ) [--index] [-q|--quiet] [<stase>]"
 
-#: builtin/stash.c:26 builtin/stash.c:63
+#: builtin/stash.c:28 builtin/stash.c:65
 msgid "git stash branch <branchname> [<stash>]"
-msgstr ""
+msgstr "git stash branch <nama cabang> [<stase>]"
 
-#: builtin/stash.c:27 builtin/stash.c:68
+#: builtin/stash.c:29 builtin/stash.c:70
 msgid "git stash clear"
-msgstr ""
+msgstr "git stash clear"
 
-#: builtin/stash.c:28
+#: builtin/stash.c:30
 msgid ""
 "git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
 "          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
+"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [-m|--message <pesan>]\n"
+"          [--pathspec-from-file=<berkas> [--pathspec-file-nul]]\n"
+"          [--] [<spek jalur>...]]"
 
-#: builtin/stash.c:32 builtin/stash.c:85
+#: builtin/stash.c:34 builtin/stash.c:87
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
 msgstr ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [<pesan>]"
 
-#: builtin/stash.c:53
+#: builtin/stash.c:55
 msgid "git stash pop [--index] [-q|--quiet] [<stash>]"
-msgstr ""
+msgstr "git stash pop [--index] [-q|--quiet] [<stase>]"
 
-#: builtin/stash.c:58
+#: builtin/stash.c:60
 msgid "git stash apply [--index] [-q|--quiet] [<stash>]"
-msgstr ""
+msgstr "git stash apply [--index] [-q|--quiet] [<stase>]"
 
-#: builtin/stash.c:73
+#: builtin/stash.c:75
 msgid "git stash store [-m|--message <message>] [-q|--quiet] <commit>"
-msgstr ""
+msgstr "git stash store [-m|--message <pesan>] [-q|--quiet] <komit>"
 
-#: builtin/stash.c:78
+#: builtin/stash.c:80
 msgid ""
 "git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
+"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [-m|--message <pesan>]\n"
+"          [--] [<spek jalur>...]"
 
-#: builtin/stash.c:128
+#: builtin/stash.c:130
 #, c-format
 msgid "'%s' is not a stash-like commit"
-msgstr ""
+msgstr "'%s' bukan komit mirip stase"
 
-#: builtin/stash.c:148
+#: builtin/stash.c:150
 #, c-format
 msgid "Too many revisions specified:%s"
-msgstr ""
+msgstr "Terlalu banyak revisi disebutkan:%s"
 
-#: builtin/stash.c:162
+#: builtin/stash.c:164
 msgid "No stash entries found."
-msgstr ""
+msgstr "Tidak ada entri stase ditemukan."
 
-#: builtin/stash.c:176
+#: builtin/stash.c:178
 #, c-format
 msgid "%s is not a valid reference"
-msgstr ""
+msgstr "%s bukan referensi valid"
 
-#: builtin/stash.c:225
+#: builtin/stash.c:227
 msgid "git stash clear with arguments is unimplemented"
-msgstr ""
+msgstr "git stash clear dengan argument tak diimplementasikan"
 
-#: builtin/stash.c:429
+#: builtin/stash.c:431
 #, c-format
 msgid ""
 "WARNING: Untracked file in way of tracked file!  Renaming\n"
 "            %s -> %s\n"
 "         to make room.\n"
 msgstr ""
+"PERINGATAN: Berkas tak terlacak dengan cara berkas terlacak! Menamakan "
+"ulang\n"
+"            %s -> %s\n"
+"         untuk buat ruang.\n"
 
-#: builtin/stash.c:490
+#: builtin/stash.c:492
 msgid "cannot apply a stash in the middle of a merge"
-msgstr ""
+msgstr "tidak dapat menerapkan stase di tengah-tengah penggabungan"
 
-#: builtin/stash.c:501
+#: builtin/stash.c:503
 #, c-format
 msgid "could not generate diff %s^!."
-msgstr ""
+msgstr "tidak dapat membuat diff %s^!."
 
-#: builtin/stash.c:508
+#: builtin/stash.c:510
 msgid "conflicts in index. Try without --index."
-msgstr ""
+msgstr "konflik dalam indeks. Coba tanpa --index."
 
-#: builtin/stash.c:514
+#: builtin/stash.c:516
 msgid "could not save index tree"
-msgstr ""
+msgstr "tidak dapat menyimpan pohon indeks"
 
-#: builtin/stash.c:523
+#: builtin/stash.c:525
 msgid "could not restore untracked files from stash"
-msgstr ""
+msgstr "tidak dapat mengembalikan berkas tak terlacak dari stase"
 
-#: builtin/stash.c:537
+#: builtin/stash.c:539
 #, c-format
 msgid "Merging %s with %s"
-msgstr ""
+msgstr "Menggabungkan %s dengan %s"
 
-#: builtin/stash.c:547
+#: builtin/stash.c:549
 msgid "Index was not unstashed."
-msgstr ""
+msgstr "Indeks tak dibatal-stasekan."
 
-#: builtin/stash.c:589 builtin/stash.c:687
+#: builtin/stash.c:591 builtin/stash.c:689
 msgid "attempt to recreate the index"
-msgstr ""
+msgstr "coba membuat ulang indeks"
 
-#: builtin/stash.c:633
+#: builtin/stash.c:635
 #, c-format
 msgid "Dropped %s (%s)"
-msgstr ""
+msgstr "%s (%s) dijatuhkan"
 
-#: builtin/stash.c:636
+#: builtin/stash.c:638
 #, c-format
 msgid "%s: Could not drop stash entry"
-msgstr ""
+msgstr "%s: Tidak dapat menjatuhkan entri stase"
 
-#: builtin/stash.c:649
+#: builtin/stash.c:651
 #, c-format
 msgid "'%s' is not a stash reference"
-msgstr ""
+msgstr "'%s' bukan referensi stase"
 
-#: builtin/stash.c:699
+#: builtin/stash.c:701
 msgid "The stash entry is kept in case you need it again."
-msgstr ""
+msgstr "Entri stase disimpan jika Anda butuh itu lagi."
 
-#: builtin/stash.c:722
+#: builtin/stash.c:724
 msgid "No branch name specified"
-msgstr ""
+msgstr "Tidak ada nama cabang yang disebutkan"
 
-#: builtin/stash.c:866 builtin/stash.c:903
+#: builtin/stash.c:808
+msgid "failed to parse tree"
+msgstr "gagal menguraikan pohon"
+
+#: builtin/stash.c:819
+msgid "failed to unpack trees"
+msgstr "gagal membongkar pohon"
+
+#: builtin/stash.c:839
+msgid "include untracked files in the stash"
+msgstr "masukkan berkas tak terlacak ke dalam stase"
+
+#: builtin/stash.c:842
+msgid "only show untracked files in the stash"
+msgstr "hanya perlihatkan berkas tak terlacak dalam stase"
+
+#: builtin/stash.c:932 builtin/stash.c:969
 #, c-format
 msgid "Cannot update %s with %s"
-msgstr ""
+msgstr "Tidak dapat memperbarui %s dengan %s"
 
-#: builtin/stash.c:884 builtin/stash.c:1538 builtin/stash.c:1603
+#: builtin/stash.c:950 builtin/stash.c:1606 builtin/stash.c:1671
 msgid "stash message"
-msgstr ""
+msgstr "pesan stase"
 
-#: builtin/stash.c:894
+#: builtin/stash.c:960
 msgid "\"git stash store\" requires one <commit> argument"
-msgstr ""
+msgstr "\"git stash store\" butuh satu argumen <komit>"
 
-#: builtin/stash.c:1109
+#: builtin/stash.c:1175
 msgid "No changes selected"
-msgstr ""
+msgstr "Tidak ada perubahan yang dipilih"
 
-#: builtin/stash.c:1209
+#: builtin/stash.c:1275
 msgid "You do not have the initial commit yet"
-msgstr ""
+msgstr "Anda belum punya komit awal"
 
-#: builtin/stash.c:1236
+#: builtin/stash.c:1302
 msgid "Cannot save the current index state"
-msgstr ""
+msgstr "Tidak dapat menyimpan keadaan indeks saat ini"
 
-#: builtin/stash.c:1245
+#: builtin/stash.c:1311
 msgid "Cannot save the untracked files"
-msgstr ""
+msgstr "Tidak dapat menyimpan berkas tak terlacak"
 
-#: builtin/stash.c:1256 builtin/stash.c:1265
+#: builtin/stash.c:1322 builtin/stash.c:1331
 msgid "Cannot save the current worktree state"
-msgstr ""
+msgstr "Tidak dapat menyimpang keadaan pohon kerja saat ini"
 
-#: builtin/stash.c:1293
+#: builtin/stash.c:1359
 msgid "Cannot record working tree state"
-msgstr ""
+msgstr "Tidak dapat merekam keadaan pohon kerja"
 
-#: builtin/stash.c:1342
+#: builtin/stash.c:1408
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
+"Tidak dapat menggunakan --patch dan --include-untracked atau --all pada "
+"waktu yang bersamaan"
 
-#: builtin/stash.c:1358
+#: builtin/stash.c:1426
 msgid "Did you forget to 'git add'?"
-msgstr ""
+msgstr "Anda lupa untuk 'git add'?"
 
-#: builtin/stash.c:1373
+#: builtin/stash.c:1441
 msgid "No local changes to save"
-msgstr ""
+msgstr "Tidak ada perubahan lokal untuk disimpan"
 
-#: builtin/stash.c:1380
+#: builtin/stash.c:1448
 msgid "Cannot initialize stash"
-msgstr ""
+msgstr "Tidak dapat menginisialisasi stase"
 
-#: builtin/stash.c:1395
+#: builtin/stash.c:1463
 msgid "Cannot save the current status"
-msgstr ""
+msgstr "Tidak dapat menyimpan status saat ini"
 
-#: builtin/stash.c:1400
+#: builtin/stash.c:1468
 #, c-format
 msgid "Saved working directory and index state %s"
-msgstr ""
+msgstr "Direktori kerja dan keadaan indeks %s disimpan"
 
-#: builtin/stash.c:1490
+#: builtin/stash.c:1558
 msgid "Cannot remove worktree changes"
-msgstr ""
+msgstr "Tidak dapat menghapus perubahaan pohon kerja"
 
-#: builtin/stash.c:1529 builtin/stash.c:1594
+#: builtin/stash.c:1597 builtin/stash.c:1662
 msgid "keep index"
-msgstr ""
+msgstr "jaga indeks"
 
-#: builtin/stash.c:1531 builtin/stash.c:1596
+#: builtin/stash.c:1599 builtin/stash.c:1664
 msgid "stash in patch mode"
-msgstr ""
+msgstr "stase dalam mode tambalan"
 
-#: builtin/stash.c:1532 builtin/stash.c:1597
+#: builtin/stash.c:1600 builtin/stash.c:1665
 msgid "quiet mode"
-msgstr ""
+msgstr "mode hening"
 
-#: builtin/stash.c:1534 builtin/stash.c:1599
+#: builtin/stash.c:1602 builtin/stash.c:1667
 msgid "include untracked files in stash"
-msgstr ""
+msgstr "masukkan berkas tak terlacak ke dalam stase"
 
-#: builtin/stash.c:1536 builtin/stash.c:1601
+#: builtin/stash.c:1604 builtin/stash.c:1669
 msgid "include ignore files"
-msgstr ""
+msgstr "masukkan berkas ignore"
 
-#: builtin/stash.c:1636
+#: builtin/stash.c:1704
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
 msgstr ""
+"Dukungan untuk stash.useBuiltin sudah dihapus!\n"
+"Lihat entri itu di 'git help config' untuk selengkapnya."
 
 #: builtin/stripspace.c:18
 msgid "git stripspace [-s | --strip-comments]"
@@ -20819,503 +21579,532 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr ""
 
-#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:2423
+#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:2424
 #, c-format
 msgid "Expecting a full ref name, got %s"
-msgstr ""
+msgstr "Mengharapkan nama referensi penuh, dapat %s"
 
 #: builtin/submodule--helper.c:64
 msgid "submodule--helper print-default-remote takes no arguments"
-msgstr ""
+msgstr "submodule--helper print-default-remote tidak membutuhkan argumen"
 
 #: builtin/submodule--helper.c:102
 #, c-format
 msgid "cannot strip one component off url '%s'"
-msgstr ""
+msgstr "tidak dapat mencopot satu komponen dari url '%s'"
 
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1819
+#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1820
 msgid "alternative anchor for relative paths"
-msgstr ""
+msgstr "jangkar alternatif untuk jalur relatif"
 
 #: builtin/submodule--helper.c:415
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
-msgstr ""
+msgstr "git submodule--helper list [--prefix=<jalur>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:472 builtin/submodule--helper.c:629
-#: builtin/submodule--helper.c:652
+#: builtin/submodule--helper.c:473 builtin/submodule--helper.c:630
+#: builtin/submodule--helper.c:653
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr ""
+"Tidak ada url yang ditemukan untuk jalur submodul '%s' dalam .gitmodules"
 
-#: builtin/submodule--helper.c:524
+#: builtin/submodule--helper.c:525
 #, c-format
 msgid "Entering '%s'\n"
-msgstr ""
+msgstr "Memasuki '%s'\n"
 
-#: builtin/submodule--helper.c:527
+#: builtin/submodule--helper.c:528
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
 "."
 msgstr ""
+"run_command mengembalikan status bukan nol untuk %s\n"
+"."
 
-#: builtin/submodule--helper.c:549
+#: builtin/submodule--helper.c:550
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
 "submodules of %s\n"
 "."
 msgstr ""
+"run_command mengembalikan status bukan nol ketika merekursi dalam submodul "
+"bersarang %s\n"
+"."
 
-#: builtin/submodule--helper.c:565
+#: builtin/submodule--helper.c:566
 msgid "suppress output of entering each submodule command"
-msgstr ""
+msgstr "sembunyikan keluaran memasuki setiap perintah submodul"
 
-#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:888
-#: builtin/submodule--helper.c:1487
+#: builtin/submodule--helper.c:568 builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:1488
 msgid "recurse into nested submodules"
-msgstr ""
+msgstr "rekursi ke dalam submodul bersarang"
 
-#: builtin/submodule--helper.c:572
+#: builtin/submodule--helper.c:573
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr ""
+"git submodule--helper foreach [--quiet] [--recursive] [--] [<perintah>]"
 
-#: builtin/submodule--helper.c:599
+#: builtin/submodule--helper.c:600
 #, c-format
 msgid ""
 "could not look up configuration '%s'. Assuming this repository is its own "
 "authoritative upstream."
 msgstr ""
+"tidak dapat mencari konfigurasi '%s'. Asumsi bahwa repositori ini adalah "
+"hulu otoritatif tersendiri."
 
-#: builtin/submodule--helper.c:666
+#: builtin/submodule--helper.c:667
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
-msgstr ""
+msgstr "Gagal mendaftarkan url untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:670
+#: builtin/submodule--helper.c:671
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
-msgstr ""
+msgstr "Submodul '%s' (%s) didaftarkan untuk jalur '%s'\n"
 
-#: builtin/submodule--helper.c:680
+#: builtin/submodule--helper.c:681
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
-msgstr ""
+msgstr "peringatan: perintah mode pembaruan disarankan untuk submodul '%s'\n"
 
-#: builtin/submodule--helper.c:687
+#: builtin/submodule--helper.c:688
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
-msgstr ""
+msgstr "Gagal mendaftarkan mode pembaruan untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:709
+#: builtin/submodule--helper.c:710
 msgid "suppress output for initializing a submodule"
-msgstr ""
+msgstr "sembunyikan keluaran menginisialisasi submodul"
 
-#: builtin/submodule--helper.c:714
+#: builtin/submodule--helper.c:715
 msgid "git submodule--helper init [<options>] [<path>]"
-msgstr ""
+msgstr "git submodule--helper init [<opsi>] [<jalur>]"
 
-#: builtin/submodule--helper.c:787 builtin/submodule--helper.c:922
+#: builtin/submodule--helper.c:788 builtin/submodule--helper.c:923
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
-msgstr ""
+msgstr "tidak ada pemetaan submodul ditemukan di .gitmodules untuk jalur '%s'"
 
-#: builtin/submodule--helper.c:835
+#: builtin/submodule--helper.c:836
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
-msgstr ""
+msgstr "tidak dapat menguraikan referensi HEAD di dalam submodul '%s'"
 
-#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1457
+#: builtin/submodule--helper.c:863 builtin/submodule--helper.c:1458
 #, c-format
 msgid "failed to recurse into submodule '%s'"
-msgstr ""
+msgstr "gagal merekursi ke dalam submodul '%s'"
 
-#: builtin/submodule--helper.c:886 builtin/submodule--helper.c:1623
+#: builtin/submodule--helper.c:887 builtin/submodule--helper.c:1624
 msgid "suppress submodule status output"
-msgstr ""
+msgstr "sembunyikan keluaran status submodul"
 
-#: builtin/submodule--helper.c:887
+#: builtin/submodule--helper.c:888
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
+"gunakan komit yang disimpan di dalam indeks daripada yang disimpan di dalam "
+"HEAD"
 
-#: builtin/submodule--helper.c:893
+#: builtin/submodule--helper.c:894
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
-msgstr ""
+msgstr "git submodule status [--quiet] [--cached] [--recursive] [<jalur>...]"
 
-#: builtin/submodule--helper.c:917
+#: builtin/submodule--helper.c:918
 msgid "git submodule--helper name <path>"
-msgstr ""
+msgstr "git submodule==helper name <jalur>"
 
-#: builtin/submodule--helper.c:989
+#: builtin/submodule--helper.c:990
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
-msgstr ""
+msgstr "* %s %s(blob)->%s(submodul)"
 
-#: builtin/submodule--helper.c:992
+#: builtin/submodule--helper.c:993
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
-msgstr ""
+msgstr "* %s %s(submodul)->%s(blob)"
 
-#: builtin/submodule--helper.c:1005
+#: builtin/submodule--helper.c:1006
 #, c-format
 msgid "%s"
-msgstr ""
+msgstr "%s"
 
-#: builtin/submodule--helper.c:1055
+#: builtin/submodule--helper.c:1056
 #, c-format
 msgid "couldn't hash object from '%s'"
-msgstr ""
+msgstr "tidak dapat hash objek dari '%s'"
 
-#: builtin/submodule--helper.c:1059
+#: builtin/submodule--helper.c:1060
 #, c-format
 msgid "unexpected mode %o\n"
-msgstr ""
+msgstr "mode tidak diharapkan %o\n"
 
-#: builtin/submodule--helper.c:1300
+#: builtin/submodule--helper.c:1301
 msgid "use the commit stored in the index instead of the submodule HEAD"
-msgstr ""
+msgstr "gunakan komit yang disimpan di dalam indeks daripada HEAD submodul"
 
-#: builtin/submodule--helper.c:1302
+#: builtin/submodule--helper.c:1303
 msgid "to compare the commit in the index with that in the submodule HEAD"
 msgstr ""
+"untuk membandingkan komit di dalam indeks dengan yang di dalam HEAD submodul"
 
-#: builtin/submodule--helper.c:1304
+#: builtin/submodule--helper.c:1305
 msgid "skip submodules with 'ignore_config' value set to 'all'"
-msgstr ""
+msgstr "lewatkan submodul dengan nilai 'ignore_config' disetel ke 'all'"
 
-#: builtin/submodule--helper.c:1306
+#: builtin/submodule--helper.c:1307
 msgid "limit the summary size"
-msgstr ""
+msgstr "batasi ukuran ringkasan"
 
-#: builtin/submodule--helper.c:1311
+#: builtin/submodule--helper.c:1312
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
-msgstr ""
+msgstr "git submodule--helper summary [<opsi>] [<commit>] -- [<jalur>]"
 
-#: builtin/submodule--helper.c:1335
+#: builtin/submodule--helper.c:1336
 msgid "could not fetch a revision for HEAD"
-msgstr ""
+msgstr "tidak dapat mengambil revisi untuk HEAD"
 
-#: builtin/submodule--helper.c:1340
+#: builtin/submodule--helper.c:1341
 msgid "--cached and --files are mutually exclusive"
-msgstr ""
+msgstr "--cached dan --files saling eksklusif"
 
-#: builtin/submodule--helper.c:1407
+#: builtin/submodule--helper.c:1408
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
-msgstr ""
+msgstr "Mensinkronisasi url submodul untuk '%s'\n"
 
-#: builtin/submodule--helper.c:1413
+#: builtin/submodule--helper.c:1414
 #, c-format
 msgid "failed to register url for submodule path '%s'"
-msgstr ""
+msgstr "gagal mendaftarkan url untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1427
+#: builtin/submodule--helper.c:1428
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
-msgstr ""
+msgstr "gagal mendapatkan remote asali untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:1438
+#: builtin/submodule--helper.c:1439
 #, c-format
 msgid "failed to update remote for submodule '%s'"
-msgstr ""
+msgstr "gagal memperbarui remote untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:1485
+#: builtin/submodule--helper.c:1486
 msgid "suppress output of synchronizing submodule url"
-msgstr ""
+msgstr "sembunyikan keluaran mensinkronisasi url submodul"
 
-#: builtin/submodule--helper.c:1492
+#: builtin/submodule--helper.c:1493
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
-msgstr ""
+msgstr "git submodule--helper sync [--quiet] [--recursive] [<jalur>]"
 
-#: builtin/submodule--helper.c:1546
+#: builtin/submodule--helper.c:1547
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
 "really want to remove it including all of its history)"
 msgstr ""
+"Pohon kerja submodul '%s' berisi direktori .git (gunakan 'rm -rf' bila Anda "
+"benar-benar ingin menghapus itu termasuk semua riwayatnya)"
 
-#: builtin/submodule--helper.c:1558
+#: builtin/submodule--helper.c:1559
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
 "them"
 msgstr ""
+"Pohon kerja submodul '%s' berisi modifikasi lokal; gunakan '-f' untuk "
+"menyingkirkan itu"
 
-#: builtin/submodule--helper.c:1566
+#: builtin/submodule--helper.c:1567
 #, c-format
 msgid "Cleared directory '%s'\n"
-msgstr ""
+msgstr "Direktori '%s' dibersihkan\n"
 
-#: builtin/submodule--helper.c:1568
+#: builtin/submodule--helper.c:1569
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
-msgstr ""
+msgstr "Tidak dapat menghapus pohon kerja submodul '%s'\n"
 
-#: builtin/submodule--helper.c:1579
+#: builtin/submodule--helper.c:1580
 #, c-format
 msgid "could not create empty submodule directory %s"
-msgstr ""
+msgstr "tidak dapat membuat direktori submodul kosong %s"
 
-#: builtin/submodule--helper.c:1595
+#: builtin/submodule--helper.c:1596
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
-msgstr ""
-
-#: builtin/submodule--helper.c:1624
-msgid "remove submodule working trees even if they contain local changes"
-msgstr ""
+msgstr "Submodul '%s' (%s) tak terdaftar untuk jalur '%s'\n"
 
 #: builtin/submodule--helper.c:1625
-msgid "unregister all submodules"
-msgstr ""
+msgid "remove submodule working trees even if they contain local changes"
+msgstr "hapus pohon kerja submodul bahkan jika itu berisi perubahan lokal"
 
-#: builtin/submodule--helper.c:1630
+#: builtin/submodule--helper.c:1626
+msgid "unregister all submodules"
+msgstr "batal daftar semua submodul"
+
+#: builtin/submodule--helper.c:1631
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
+"git submodule deinit [--quiet] [-f | --force] [--all | [--] [<jalur>...]]"
 
-#: builtin/submodule--helper.c:1644
+#: builtin/submodule--helper.c:1645
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr ""
+"Gunakan '--all' jika Anda benar-benar ingin deinisialisasi semua submodul"
 
-#: builtin/submodule--helper.c:1713
+#: builtin/submodule--helper.c:1714
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
 "submodule.alternateErrorStrategy to 'info' or, equivalently, clone with\n"
 "'--reference-if-able' instead of '--reference'."
 msgstr ""
+"Sebuah pengganti yang dihitung dari pengganti proyek super tidak valid.\n"
+"Untuk memperbolehkan Git untuk kloning tanpa pengganti dalam kasus seperti\n"
+" itu, setel submodule.alternateErrorStrategy ke 'info' atau yang sama,\n"
+"kloning degan '--reference-if-able' daripada '--reference'."
 
-#: builtin/submodule--helper.c:1752 builtin/submodule--helper.c:1755
+#: builtin/submodule--helper.c:1753 builtin/submodule--helper.c:1756
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
-msgstr ""
+msgstr "submodul '%s' tidak dapat menambahkan pengganti: %s"
 
-#: builtin/submodule--helper.c:1791
+#: builtin/submodule--helper.c:1792
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
-msgstr ""
+msgstr "Nilai '%s' untuk submodule.alternateErrorStrategy tidak dikenal"
 
-#: builtin/submodule--helper.c:1798
+#: builtin/submodule--helper.c:1799
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
-msgstr ""
+msgstr "Nilai '%s' untuk submodule.alternateLocation tidak dikenal"
 
-#: builtin/submodule--helper.c:1822
+#: builtin/submodule--helper.c:1823
 msgid "where the new submodule will be cloned to"
-msgstr ""
+msgstr "di mana submodul baru akan dikloning"
 
-#: builtin/submodule--helper.c:1825
+#: builtin/submodule--helper.c:1826
 msgid "name of the new submodule"
-msgstr ""
+msgstr "nama submodul baru"
 
-#: builtin/submodule--helper.c:1828
+#: builtin/submodule--helper.c:1829
 msgid "url where to clone the submodule from"
-msgstr ""
+msgstr "url di mana submodul dikloning"
 
-#: builtin/submodule--helper.c:1836
+#: builtin/submodule--helper.c:1837
 msgid "depth for shallow clones"
-msgstr ""
+msgstr "kedalaman untuk kloning dangkal"
 
-#: builtin/submodule--helper.c:1839 builtin/submodule--helper.c:2348
+#: builtin/submodule--helper.c:1840 builtin/submodule--helper.c:2349
 msgid "force cloning progress"
-msgstr ""
+msgstr "paksa perkembangan kloning"
 
-#: builtin/submodule--helper.c:1841 builtin/submodule--helper.c:2350
+#: builtin/submodule--helper.c:1842 builtin/submodule--helper.c:2351
 msgid "disallow cloning into non-empty directory"
-msgstr ""
+msgstr "tak perbolehkan kloning ke dalam direktori bukan kosong"
 
-#: builtin/submodule--helper.c:1848
+#: builtin/submodule--helper.c:1849
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
 "<url> --path <path>"
 msgstr ""
+"git submodule--helper clone [--prefix=<jalur>] [--quiet] [--reference "
+"<repositori>] [--name <nama>] [--depth <kedalaman>] [--single-branch] --url "
+"<url> --path <jalur>"
 
-#: builtin/submodule--helper.c:1873
+#: builtin/submodule--helper.c:1874
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
+"menolak membuat/menggunakan '%s' di dalam direktori git submodul yang lain"
 
-#: builtin/submodule--helper.c:1884
+#: builtin/submodule--helper.c:1885
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
-msgstr ""
+msgstr "gagal mengkloning '%s' ke dalam jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1888
+#: builtin/submodule--helper.c:1889
 #, c-format
 msgid "directory not empty: '%s'"
-msgstr ""
+msgstr "direktori tidak kosong: '%s'"
 
-#: builtin/submodule--helper.c:1900
+#: builtin/submodule--helper.c:1901
 #, c-format
 msgid "could not get submodule directory for '%s'"
-msgstr ""
+msgstr "tidak dapat mendapatkan direktori submodul untuk '%s'"
 
-#: builtin/submodule--helper.c:1936
+#: builtin/submodule--helper.c:1937
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
-msgstr ""
+msgstr "Mode pembaruan '%s' tidak valid untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1940
+#: builtin/submodule--helper.c:1941
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
-msgstr ""
+msgstr "Mode pembaruan '%s' tidak valid untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:2041
+#: builtin/submodule--helper.c:2042
 #, c-format
 msgid "Submodule path '%s' not initialized"
-msgstr ""
+msgstr "Jalur submodul '%s' tidak diinisialisasi"
 
-#: builtin/submodule--helper.c:2045
+#: builtin/submodule--helper.c:2046
 msgid "Maybe you want to use 'update --init'?"
-msgstr ""
+msgstr "Mungkin Anda ingin menggunakan 'update --init'?"
 
-#: builtin/submodule--helper.c:2075
+#: builtin/submodule--helper.c:2076
 #, c-format
 msgid "Skipping unmerged submodule %s"
-msgstr ""
+msgstr "Melewati submodul tak tergabung %s"
 
-#: builtin/submodule--helper.c:2104
+#: builtin/submodule--helper.c:2105
 #, c-format
 msgid "Skipping submodule '%s'"
-msgstr ""
+msgstr "Melewati submodul '%s'"
 
-#: builtin/submodule--helper.c:2254
+#: builtin/submodule--helper.c:2255
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
-msgstr ""
+msgstr "Gagal mengkloning '%s'. Percobaan ulang dijadwalkan"
 
-#: builtin/submodule--helper.c:2265
+#: builtin/submodule--helper.c:2266
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
-msgstr ""
+msgstr "Gagal mengkloning '%s' untuk kedua kalinya, batalkan"
 
-#: builtin/submodule--helper.c:2327 builtin/submodule--helper.c:2573
+#: builtin/submodule--helper.c:2328 builtin/submodule--helper.c:2574
 msgid "path into the working tree"
-msgstr ""
+msgstr "jalur ke dalam pohon kerja"
 
-#: builtin/submodule--helper.c:2330
+#: builtin/submodule--helper.c:2331
 msgid "path into the working tree, across nested submodule boundaries"
-msgstr ""
+msgstr "jalur ke dalam pohon kerja, melintasi perbatasan submodul bersarang"
 
-#: builtin/submodule--helper.c:2334
+#: builtin/submodule--helper.c:2335
 msgid "rebase, merge, checkout or none"
-msgstr ""
+msgstr "dasarkan ulang, gabungkan, checkout atau tidak sama sekali"
 
-#: builtin/submodule--helper.c:2340
+#: builtin/submodule--helper.c:2341
 msgid "create a shallow clone truncated to the specified number of revisions"
-msgstr ""
+msgstr "buat klon dangkal terpotong hingga sejumlah revisi yang disebutkan"
 
-#: builtin/submodule--helper.c:2343
+#: builtin/submodule--helper.c:2344
 msgid "parallel jobs"
-msgstr ""
-
-#: builtin/submodule--helper.c:2345
-msgid "whether the initial clone should follow the shallow recommendation"
-msgstr ""
+msgstr "pekerjaan paralel"
 
 #: builtin/submodule--helper.c:2346
+msgid "whether the initial clone should follow the shallow recommendation"
+msgstr "apakah klon awal seharusnya mengikuti rekomendasi dangkal"
+
+#: builtin/submodule--helper.c:2347
 msgid "don't print cloning progress"
-msgstr ""
+msgstr "jangan cetak perkembangan pengkloningan"
 
-#: builtin/submodule--helper.c:2357
+#: builtin/submodule--helper.c:2358
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
-msgstr ""
+msgstr "git submodule--helper update-clone [--prefix=<jalur>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:2370
+#: builtin/submodule--helper.c:2371
 msgid "bad value for update parameter"
-msgstr ""
+msgstr "nilai jelek untuk parameter pembaruan"
 
-#: builtin/submodule--helper.c:2418
+#: builtin/submodule--helper.c:2419
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
 "the superproject is not on any branch"
 msgstr ""
+"Cabang submodul (%s) dikonfigurasikan untuk mewarisi cabang dari proyek "
+"super, tapi proyek super tidak pada cabang apapun"
 
-#: builtin/submodule--helper.c:2541
+#: builtin/submodule--helper.c:2542
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
-msgstr ""
+msgstr "tidak dapat mendapat pegangan repositori untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2575
 msgid "recurse into submodules"
-msgstr ""
+msgstr "rekursi ke dalam submodul"
 
-#: builtin/submodule--helper.c:2580
+#: builtin/submodule--helper.c:2581
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
-msgstr ""
+msgstr "giit submodule--helper absorb-git-dirs [<opsi>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:2636
+#: builtin/submodule--helper.c:2637
 msgid "check if it is safe to write to the .gitmodules file"
-msgstr ""
+msgstr "periksa apakah itu aman untuk menulis ke berkas .gitmodules"
 
-#: builtin/submodule--helper.c:2639
+#: builtin/submodule--helper.c:2640
 msgid "unset the config in the .gitmodules file"
-msgstr ""
-
-#: builtin/submodule--helper.c:2644
-msgid "git submodule--helper config <name> [<value>]"
-msgstr ""
+msgstr "batal setel konfigurasi dalam berkas .gitmodules"
 
 #: builtin/submodule--helper.c:2645
-msgid "git submodule--helper config --unset <name>"
-msgstr ""
+msgid "git submodule--helper config <name> [<value>]"
+msgstr "git submodule--helper config <nama> [<nilai>]"
 
 #: builtin/submodule--helper.c:2646
-msgid "git submodule--helper config --check-writeable"
-msgstr ""
+msgid "git submodule--helper config --unset <name>"
+msgstr "git submodule--helper config --unset <nama>"
 
-#: builtin/submodule--helper.c:2665 git-submodule.sh:150
+#: builtin/submodule--helper.c:2647
+msgid "git submodule--helper config --check-writeable"
+msgstr "git submodule--helper config --check-writeable"
+
+#: builtin/submodule--helper.c:2666 git-submodule.sh:150
 #, sh-format
 msgid "please make sure that the .gitmodules file is in the working tree"
-msgstr ""
+msgstr "mohom pastikan berkas .gitmodules di dalam pohon kerja"
 
-#: builtin/submodule--helper.c:2681
+#: builtin/submodule--helper.c:2682
 msgid "suppress output for setting url of a submodule"
-msgstr ""
+msgstr "sembunyikan keluaran penyetelan url submodule"
 
-#: builtin/submodule--helper.c:2685
+#: builtin/submodule--helper.c:2686
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
-msgstr ""
+msgstr "git submodule--helper set-url [--quiet] <jalur> <url baru>"
 
-#: builtin/submodule--helper.c:2718
+#: builtin/submodule--helper.c:2719
 msgid "set the default tracking branch to master"
-msgstr ""
+msgstr "setel cabang pelacak asali ke master"
 
-#: builtin/submodule--helper.c:2720
+#: builtin/submodule--helper.c:2721
 msgid "set the default tracking branch"
-msgstr ""
-
-#: builtin/submodule--helper.c:2724
-msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
-msgstr ""
+msgstr "setel cabang pelacak asali"
 
 #: builtin/submodule--helper.c:2725
+msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
+msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) <jalur>"
+
+#: builtin/submodule--helper.c:2726
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
+"git submodule--helper set-branch [-q|--quiet] (-b|--branch) <cabang> <jalur>"
 
-#: builtin/submodule--helper.c:2732
+#: builtin/submodule--helper.c:2733
 msgid "--branch or --default required"
-msgstr ""
+msgstr "--branch atau --default dibutuhkan"
 
-#: builtin/submodule--helper.c:2735
+#: builtin/submodule--helper.c:2736
 msgid "--branch and --default are mutually exclusive"
-msgstr ""
+msgstr "--branch dan --default saling eksklusif"
 
-#: builtin/submodule--helper.c:2792 git.c:441 git.c:714
+#: builtin/submodule--helper.c:2793 git.c:449 git.c:724
 #, c-format
 msgid "%s doesn't support --super-prefix"
-msgstr ""
+msgstr "%s tidak mendukung --super-prefix"
 
-#: builtin/submodule--helper.c:2798
+#: builtin/submodule--helper.c:2799
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
-msgstr ""
+msgstr "'%s' bukan subperintah submodule--helper valid"
 
 #: builtin/symbolic-ref.c:8
 msgid "git symbolic-ref [<options>] <name> [<ref>]"
@@ -21325,23 +22114,23 @@ msgstr ""
 msgid "git symbolic-ref -d [-q] <name>"
 msgstr ""
 
-#: builtin/symbolic-ref.c:40
+#: builtin/symbolic-ref.c:42
 msgid "suppress error message for non-symbolic (detached) refs"
 msgstr ""
 
-#: builtin/symbolic-ref.c:41
+#: builtin/symbolic-ref.c:43
 msgid "delete symbolic ref"
 msgstr ""
 
-#: builtin/symbolic-ref.c:42
+#: builtin/symbolic-ref.c:44
 msgid "shorten ref output"
 msgstr ""
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
 msgid "reason"
 msgstr ""
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
 msgid "reason of the update"
 msgstr ""
 
@@ -21350,10 +22139,12 @@ msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
 "\t\t<tagname> [<head>]"
 msgstr ""
+"git tag [-a | -s | -u <id kunci>] [-f] [-m <pesan | -F <berkas>]\n"
+"\t\t<nama tag> [<kepala>]"
 
 #: builtin/tag.c:27
 msgid "git tag -d <tagname>..."
-msgstr ""
+msgstr "git tag -d <nama tag>..."
 
 #: builtin/tag.c:28
 msgid ""
@@ -21362,22 +22153,25 @@ msgid ""
 "\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
 "[<pattern>...]"
 msgstr ""
+"git tag -l [-n[<angka>]] [--contains <komit>] [--no-contains <komit>] [--"
+"points-at <objek>]\n"
+"\t\t[--format=<format>] [--merged <komit>] [--no-merged <komit>] [<pola>...]"
 
 #: builtin/tag.c:30
 msgid "git tag -v [--format=<format>] <tagname>..."
-msgstr ""
+msgstr "git tag -v [--format]<format>] <nama tag>..."
 
-#: builtin/tag.c:89
+#: builtin/tag.c:100
 #, c-format
 msgid "tag '%s' not found."
-msgstr ""
+msgstr "tag '%s' tidak ditemukan."
 
-#: builtin/tag.c:124
+#: builtin/tag.c:135
 #, c-format
 msgid "Deleted tag '%s' (was %s)\n"
-msgstr ""
+msgstr "Tag '%s' (yaitu %s) dihapus\n"
 
-#: builtin/tag.c:159
+#: builtin/tag.c:170
 #, c-format
 msgid ""
 "\n"
@@ -21385,8 +22179,12 @@ msgid ""
 "  %s\n"
 "Lines starting with '%c' will be ignored.\n"
 msgstr ""
+"\n"
+"Tulis pesan untuk tag:\n"
+"  %s\n"
+"Baris yang diawali dengan '%c' akan diabaikan.\n"
 
-#: builtin/tag.c:163
+#: builtin/tag.c:174
 #, c-format
 msgid ""
 "\n"
@@ -21395,12 +22193,17 @@ msgid ""
 "Lines starting with '%c' will be kept; you may remove them yourself if you "
 "want to.\n"
 msgstr ""
+"\n"
+"Tulis pesan untuk tag:\n"
+"  %s\n"
+"Baris yang diawali dengan '%c' akan disimpan; Anda dapat menghapus itu bila "
+"Anda mau.\n"
 
-#: builtin/tag.c:230
+#: builtin/tag.c:241
 msgid "unable to sign the tag"
-msgstr ""
+msgstr "tidak dapat menandatangani tag"
 
-#: builtin/tag.c:248
+#: builtin/tag.c:259
 #, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -21408,140 +22211,145 @@ msgid ""
 "\n"
 "\tgit tag -f %s %s^{}"
 msgstr ""
+"Anda telah membuat tag bersarang. Objek yang dirujuk oleh tag baru Anda\n"
+"sudah menjadi tag. Jika maksud Anda men-tag objek yang ditunjukkannya,\n"
+"gunakan:\n"
+"\n"
+"\tgit tag -f %s %s^{}"
 
-#: builtin/tag.c:264
+#: builtin/tag.c:275
 msgid "bad object type."
-msgstr ""
+msgstr "tipe objek jelek."
 
-#: builtin/tag.c:317
+#: builtin/tag.c:328
 msgid "no tag message?"
-msgstr ""
+msgstr "tidak ada pesan tag?"
 
-#: builtin/tag.c:324
+#: builtin/tag.c:335
 #, c-format
 msgid "The tag message has been left in %s\n"
-msgstr ""
-
-#: builtin/tag.c:435
-msgid "list tag names"
-msgstr ""
-
-#: builtin/tag.c:437
-msgid "print <n> lines of each tag message"
-msgstr ""
-
-#: builtin/tag.c:439
-msgid "delete tags"
-msgstr ""
-
-#: builtin/tag.c:440
-msgid "verify tags"
-msgstr ""
-
-#: builtin/tag.c:442
-msgid "Tag creation options"
-msgstr ""
-
-#: builtin/tag.c:444
-msgid "annotated tag, needs a message"
-msgstr ""
+msgstr "Pesan tag dibiarkan di %s\n"
 
 #: builtin/tag.c:446
-msgid "tag message"
-msgstr ""
+msgid "list tag names"
+msgstr "daftarkan nama tag"
 
 #: builtin/tag.c:448
-msgid "force edit of tag message"
-msgstr ""
+msgid "print <n> lines of each tag message"
+msgstr "cetak <n> baris dari setiap pesan tag"
 
-#: builtin/tag.c:449
-msgid "annotated and GPG-signed tag"
-msgstr ""
+#: builtin/tag.c:450
+msgid "delete tags"
+msgstr "hapus tag"
 
-#: builtin/tag.c:452
-msgid "use another key to sign the tag"
-msgstr ""
+#: builtin/tag.c:451
+msgid "verify tags"
+msgstr "verifikasi tag"
 
 #: builtin/tag.c:453
-msgid "replace the tag if exists"
-msgstr ""
+msgid "Tag creation options"
+msgstr "Opsi pembuatan tag"
 
-#: builtin/tag.c:454 builtin/update-ref.c:505
-msgid "create a reflog"
-msgstr ""
-
-#: builtin/tag.c:456
-msgid "Tag listing options"
-msgstr ""
+#: builtin/tag.c:455
+msgid "annotated tag, needs a message"
+msgstr "tag bercatat, butuh sebuah pesan"
 
 #: builtin/tag.c:457
-msgid "show tag list in columns"
-msgstr ""
+msgid "tag message"
+msgstr "pesan tag"
 
-#: builtin/tag.c:458 builtin/tag.c:460
-msgid "print only tags that contain the commit"
-msgstr ""
+#: builtin/tag.c:459
+msgid "force edit of tag message"
+msgstr "paksa sunting pesan tag"
 
-#: builtin/tag.c:459 builtin/tag.c:461
-msgid "print only tags that don't contain the commit"
-msgstr ""
-
-#: builtin/tag.c:462
-msgid "print only tags that are merged"
-msgstr ""
+#: builtin/tag.c:460
+msgid "annotated and GPG-signed tag"
+msgstr "tag bercatat dan bertandatangan GPG"
 
 #: builtin/tag.c:463
-msgid "print only tags that are not merged"
-msgstr ""
+msgid "use another key to sign the tag"
+msgstr "gunakan kunci yang lain untuk menandatangani tag"
+
+#: builtin/tag.c:464
+msgid "replace the tag if exists"
+msgstr "ganti tag jika ada"
+
+#: builtin/tag.c:465 builtin/update-ref.c:505
+msgid "create a reflog"
+msgstr "buat log referensi"
 
 #: builtin/tag.c:467
+msgid "Tag listing options"
+msgstr "Opsi daftar tag"
+
+#: builtin/tag.c:468
+msgid "show tag list in columns"
+msgstr "perlihatkan daftar tag dalam kolom"
+
+#: builtin/tag.c:469 builtin/tag.c:471
+msgid "print only tags that contain the commit"
+msgstr "hanya cetak tag yang berisi komit"
+
+#: builtin/tag.c:470 builtin/tag.c:472
+msgid "print only tags that don't contain the commit"
+msgstr "hanya cetak tag yang tidak berisi komit"
+
+#: builtin/tag.c:473
+msgid "print only tags that are merged"
+msgstr "hanya cetak tag yang tergabung"
+
+#: builtin/tag.c:474
+msgid "print only tags that are not merged"
+msgstr "hanya cetak tag yang tak tergabung"
+
+#: builtin/tag.c:478
 msgid "print only tags of the object"
-msgstr ""
+msgstr "hanya cetak tag dari objek"
 
-#: builtin/tag.c:515
+#: builtin/tag.c:526
 msgid "--column and -n are incompatible"
-msgstr ""
+msgstr "--column dan -n tidak kompatibel"
 
-#: builtin/tag.c:537
+#: builtin/tag.c:548
 msgid "-n option is only allowed in list mode"
-msgstr ""
+msgstr "opsi -n hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:539
+#: builtin/tag.c:550
 msgid "--contains option is only allowed in list mode"
-msgstr ""
+msgstr "opsi --contains hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:541
+#: builtin/tag.c:552
 msgid "--no-contains option is only allowed in list mode"
-msgstr ""
+msgstr "opsi --no-contains hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:543
+#: builtin/tag.c:554
 msgid "--points-at option is only allowed in list mode"
-msgstr ""
-
-#: builtin/tag.c:545
-msgid "--merged and --no-merged options are only allowed in list mode"
-msgstr ""
+msgstr "opsi --points-at hanya diperbolehkan dalam mode daftar"
 
 #: builtin/tag.c:556
-msgid "only one -F or -m option is allowed."
-msgstr ""
+msgid "--merged and --no-merged options are only allowed in list mode"
+msgstr "opsi --merged dan --no-merged hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:581
+#: builtin/tag.c:567
+msgid "only one -F or -m option is allowed."
+msgstr "hanya satu opsi -F atau -m yang diperbolehkan."
+
+#: builtin/tag.c:592
 #, c-format
 msgid "'%s' is not a valid tag name."
-msgstr ""
+msgstr "'%s' bukan nama tag yang valid."
 
-#: builtin/tag.c:586
+#: builtin/tag.c:597
 #, c-format
 msgid "tag '%s' already exists"
-msgstr ""
+msgstr "tag '%s' sudah ada"
 
-#: builtin/tag.c:617
+#: builtin/tag.c:628
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
-msgstr ""
+msgstr "Tag '%s' diperbarui (yaitu %s)\n"
 
-#: builtin/unpack-objects.c:502
+#: builtin/unpack-objects.c:504
 msgid "Unpacking objects"
 msgstr ""
 
@@ -21602,189 +22410,189 @@ msgstr ""
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr ""
 
-#: builtin/update-index.c:974
+#: builtin/update-index.c:976
 msgid "continue refresh even when index needs update"
 msgstr ""
 
-#: builtin/update-index.c:977
+#: builtin/update-index.c:979
 msgid "refresh: ignore submodules"
 msgstr ""
 
-#: builtin/update-index.c:980
+#: builtin/update-index.c:982
 msgid "do not ignore new files"
 msgstr ""
 
-#: builtin/update-index.c:982
+#: builtin/update-index.c:984
 msgid "let files replace directories and vice-versa"
 msgstr ""
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:986
 msgid "notice files missing from worktree"
 msgstr ""
 
-#: builtin/update-index.c:986
+#: builtin/update-index.c:988
 msgid "refresh even if index contains unmerged entries"
 msgstr ""
 
-#: builtin/update-index.c:989
+#: builtin/update-index.c:991
 msgid "refresh stat information"
 msgstr ""
 
-#: builtin/update-index.c:993
+#: builtin/update-index.c:995
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr ""
 
-#: builtin/update-index.c:997
+#: builtin/update-index.c:999
 msgid "<mode>,<object>,<path>"
 msgstr ""
 
-#: builtin/update-index.c:998
+#: builtin/update-index.c:1000
 msgid "add the specified entry to the index"
 msgstr ""
 
-#: builtin/update-index.c:1008
+#: builtin/update-index.c:1010
 msgid "mark files as \"not changing\""
 msgstr ""
 
-#: builtin/update-index.c:1011
+#: builtin/update-index.c:1013
 msgid "clear assumed-unchanged bit"
 msgstr ""
 
-#: builtin/update-index.c:1014
+#: builtin/update-index.c:1016
 msgid "mark files as \"index-only\""
 msgstr ""
 
-#: builtin/update-index.c:1017
+#: builtin/update-index.c:1019
 msgid "clear skip-worktree bit"
 msgstr ""
 
-#: builtin/update-index.c:1020
+#: builtin/update-index.c:1022
 msgid "do not touch index-only entries"
 msgstr ""
 
-#: builtin/update-index.c:1022
+#: builtin/update-index.c:1024
 msgid "add to index only; do not add content to object database"
 msgstr ""
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1026
 msgid "remove named paths even if present in worktree"
 msgstr ""
 
-#: builtin/update-index.c:1026
+#: builtin/update-index.c:1028
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr ""
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1030
 msgid "read list of paths to be updated from standard input"
 msgstr ""
 
-#: builtin/update-index.c:1032
+#: builtin/update-index.c:1034
 msgid "add entries from standard input to the index"
 msgstr ""
 
-#: builtin/update-index.c:1036
+#: builtin/update-index.c:1038
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr ""
 
-#: builtin/update-index.c:1040
+#: builtin/update-index.c:1042
 msgid "only update entries that differ from HEAD"
 msgstr ""
 
-#: builtin/update-index.c:1044
+#: builtin/update-index.c:1046
 msgid "ignore files missing from worktree"
 msgstr ""
 
-#: builtin/update-index.c:1047
+#: builtin/update-index.c:1049
 msgid "report actions to standard output"
 msgstr ""
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1051
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr ""
 
-#: builtin/update-index.c:1053
+#: builtin/update-index.c:1055
 msgid "write index in this format"
 msgstr ""
 
-#: builtin/update-index.c:1055
+#: builtin/update-index.c:1057
 msgid "enable or disable split index"
 msgstr ""
 
-#: builtin/update-index.c:1057
+#: builtin/update-index.c:1059
 msgid "enable/disable untracked cache"
 msgstr ""
 
-#: builtin/update-index.c:1059
+#: builtin/update-index.c:1061
 msgid "test if the filesystem supports untracked cache"
 msgstr ""
 
-#: builtin/update-index.c:1061
+#: builtin/update-index.c:1063
 msgid "enable untracked cache without testing the filesystem"
 msgstr ""
 
-#: builtin/update-index.c:1063
+#: builtin/update-index.c:1065
 msgid "write out the index even if is not flagged as changed"
 msgstr ""
 
-#: builtin/update-index.c:1065
+#: builtin/update-index.c:1067
 msgid "enable or disable file system monitor"
 msgstr ""
 
-#: builtin/update-index.c:1067
+#: builtin/update-index.c:1069
 msgid "mark files as fsmonitor valid"
 msgstr ""
 
-#: builtin/update-index.c:1070
+#: builtin/update-index.c:1072
 msgid "clear fsmonitor valid bit"
 msgstr ""
 
-#: builtin/update-index.c:1173
+#: builtin/update-index.c:1175
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
 msgstr ""
 
-#: builtin/update-index.c:1182
+#: builtin/update-index.c:1184
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
 msgstr ""
 
-#: builtin/update-index.c:1194
+#: builtin/update-index.c:1196
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
 msgstr ""
 
-#: builtin/update-index.c:1198
+#: builtin/update-index.c:1200
 msgid "Untracked cache disabled"
 msgstr ""
 
-#: builtin/update-index.c:1206
+#: builtin/update-index.c:1208
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
 msgstr ""
 
-#: builtin/update-index.c:1210
+#: builtin/update-index.c:1212
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr ""
 
-#: builtin/update-index.c:1218
+#: builtin/update-index.c:1220
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
 
-#: builtin/update-index.c:1222
+#: builtin/update-index.c:1224
 msgid "fsmonitor enabled"
 msgstr ""
 
-#: builtin/update-index.c:1225
+#: builtin/update-index.c:1227
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
 
-#: builtin/update-index.c:1229
+#: builtin/update-index.c:1231
 msgid "fsmonitor disabled"
 msgstr ""
 
@@ -21904,7 +22712,7 @@ msgstr ""
 msgid "git worktree unlock <path>"
 msgstr ""
 
-#: builtin/worktree.c:61 builtin/worktree.c:933
+#: builtin/worktree.c:61 builtin/worktree.c:935
 #, c-format
 msgid "failed to delete '%s'"
 msgstr ""
@@ -21971,167 +22779,167 @@ msgstr ""
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr ""
 
-#: builtin/worktree.c:480
+#: builtin/worktree.c:482
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 
-#: builtin/worktree.c:483
+#: builtin/worktree.c:485
 msgid "create a new branch"
 msgstr ""
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:487
 msgid "create or reset a branch"
 msgstr ""
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:489
 msgid "populate the new working tree"
 msgstr ""
 
-#: builtin/worktree.c:488
+#: builtin/worktree.c:490
 msgid "keep the new working tree locked"
 msgstr ""
 
-#: builtin/worktree.c:491
+#: builtin/worktree.c:493
 msgid "set up tracking mode (see git-branch(1))"
 msgstr ""
 
-#: builtin/worktree.c:494
+#: builtin/worktree.c:496
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 
-#: builtin/worktree.c:502
+#: builtin/worktree.c:504
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr ""
 
-#: builtin/worktree.c:563
+#: builtin/worktree.c:565
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr ""
 
-#: builtin/worktree.c:680
+#: builtin/worktree.c:682
 msgid "show extended annotations and reasons, if available"
 msgstr ""
 
-#: builtin/worktree.c:682
+#: builtin/worktree.c:684
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:693
 msgid "--verbose and --porcelain are mutually exclusive"
 msgstr ""
 
-#: builtin/worktree.c:718
+#: builtin/worktree.c:720
 msgid "reason for locking"
 msgstr ""
 
-#: builtin/worktree.c:730 builtin/worktree.c:763 builtin/worktree.c:837
-#: builtin/worktree.c:961
+#: builtin/worktree.c:732 builtin/worktree.c:765 builtin/worktree.c:839
+#: builtin/worktree.c:963
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr ""
 
-#: builtin/worktree.c:732 builtin/worktree.c:765
+#: builtin/worktree.c:734 builtin/worktree.c:767
 msgid "The main working tree cannot be locked or unlocked"
-msgstr ""
-
-#: builtin/worktree.c:737
-#, c-format
-msgid "'%s' is already locked, reason: %s"
 msgstr ""
 
 #: builtin/worktree.c:739
 #, c-format
+msgid "'%s' is already locked, reason: %s"
+msgstr ""
+
+#: builtin/worktree.c:741
+#, c-format
 msgid "'%s' is already locked"
 msgstr ""
 
-#: builtin/worktree.c:767
+#: builtin/worktree.c:769
 #, c-format
 msgid "'%s' is not locked"
 msgstr ""
 
-#: builtin/worktree.c:808
+#: builtin/worktree.c:810
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 
-#: builtin/worktree.c:816
+#: builtin/worktree.c:818
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 
-#: builtin/worktree.c:839 builtin/worktree.c:963
+#: builtin/worktree.c:841 builtin/worktree.c:965
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr ""
 
-#: builtin/worktree.c:844
+#: builtin/worktree.c:846
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr ""
 
-#: builtin/worktree.c:857
+#: builtin/worktree.c:859
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:859
+#: builtin/worktree.c:861
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:862
+#: builtin/worktree.c:864
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr ""
 
-#: builtin/worktree.c:867
+#: builtin/worktree.c:869
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr ""
 
-#: builtin/worktree.c:913
+#: builtin/worktree.c:915
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr ""
 
-#: builtin/worktree.c:917
+#: builtin/worktree.c:919
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 
-#: builtin/worktree.c:922
+#: builtin/worktree.c:924
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr ""
 
-#: builtin/worktree.c:945
+#: builtin/worktree.c:947
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 
-#: builtin/worktree.c:968
+#: builtin/worktree.c:970
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:970
+#: builtin/worktree.c:972
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:973
+#: builtin/worktree.c:975
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr ""
 
-#: builtin/worktree.c:997
+#: builtin/worktree.c:999
 #, c-format
 msgid "repair: %s: %s"
 msgstr ""
 
-#: builtin/worktree.c:1000
+#: builtin/worktree.c:1002
 #, c-format
 msgid "error: %s: %s"
 msgstr ""
@@ -22150,48 +22958,6 @@ msgstr ""
 
 #: builtin/write-tree.c:31
 msgid "only useful for debugging"
-msgstr ""
-
-#: http-fetch.c:118
-#, c-format
-msgid "argument to --packfile must be a valid hash (got '%s')"
-msgstr ""
-
-#: http-fetch.c:128
-msgid "not a git repository"
-msgstr ""
-
-#: http-fetch.c:134
-msgid "--packfile requires --index-pack-args"
-msgstr ""
-
-#: http-fetch.c:143
-msgid "--index-pack-args can only be used with --packfile"
-msgstr ""
-
-#: t/helper/test-fast-rebase.c:141
-msgid "unhandled options"
-msgstr ""
-
-#: t/helper/test-fast-rebase.c:146
-msgid "error preparing revisions"
-msgstr ""
-
-#: t/helper/test-reach.c:154
-#, c-format
-msgid "commit %s is not marked reachable"
-msgstr ""
-
-#: t/helper/test-reach.c:164
-msgid "too many commits marked reachable"
-msgstr ""
-
-#: t/helper/test-serve-v2.c:7
-msgid "test-tool serve-v2 [<options>]"
-msgstr ""
-
-#: t/helper/test-serve-v2.c:19
-msgid "exit immediately after advertising capabilities"
 msgstr ""
 
 #: git.c:28
@@ -22238,75 +23004,226 @@ msgstr ""
 msgid "-c expects a configuration string\n"
 msgstr ""
 
-#: git.c:292
+#: git.c:260
+#, c-format
+msgid "no config key given for --config-env\n"
+msgstr ""
+
+#: git.c:300
 #, c-format
 msgid "no directory given for -C\n"
 msgstr ""
 
-#: git.c:318
+#: git.c:326
 #, c-format
 msgid "unknown option: %s\n"
 msgstr ""
 
-#: git.c:367
+#: git.c:375
 #, c-format
 msgid "while expanding alias '%s': '%s'"
 msgstr ""
 
-#: git.c:376
+#: git.c:384
 #, c-format
 msgid ""
 "alias '%s' changes environment variables.\n"
 "You can use '!git' in the alias to do this"
 msgstr ""
 
-#: git.c:383
+#: git.c:391
 #, c-format
 msgid "empty alias for %s"
 msgstr ""
 
-#: git.c:386
+#: git.c:394
 #, c-format
 msgid "recursive alias: %s"
 msgstr ""
 
-#: git.c:468
+#: git.c:476
 msgid "write failure on standard output"
 msgstr ""
 
-#: git.c:470
+#: git.c:478
 msgid "unknown write failure on standard output"
 msgstr ""
 
-#: git.c:472
+#: git.c:480
 msgid "close failed on standard output"
 msgstr ""
 
-#: git.c:823
+#: git.c:833
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr ""
 
-#: git.c:873
+#: git.c:883
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr ""
 
-#: git.c:886
+#: git.c:896
 #, c-format
 msgid ""
 "usage: %s\n"
 "\n"
 msgstr ""
 
-#: git.c:906
+#: git.c:916
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr ""
 
-#: git.c:918
+#: git.c:928
 #, c-format
 msgid "failed to run command '%s': %s\n"
+msgstr ""
+
+#: http-fetch.c:118
+#, c-format
+msgid "argument to --packfile must be a valid hash (got '%s')"
+msgstr ""
+
+#: http-fetch.c:128
+msgid "not a git repository"
+msgstr ""
+
+#: http-fetch.c:134
+msgid "--packfile requires --index-pack-args"
+msgstr ""
+
+#: http-fetch.c:143
+msgid "--index-pack-args can only be used with --packfile"
+msgstr ""
+
+#: t/helper/test-fast-rebase.c:141
+msgid "unhandled options"
+msgstr ""
+
+#: t/helper/test-fast-rebase.c:146
+msgid "error preparing revisions"
+msgstr ""
+
+#: t/helper/test-reach.c:154
+#, c-format
+msgid "commit %s is not marked reachable"
+msgstr ""
+
+#: t/helper/test-reach.c:164
+msgid "too many commits marked reachable"
+msgstr ""
+
+#: t/helper/test-serve-v2.c:7
+msgid "test-tool serve-v2 [<options>]"
+msgstr ""
+
+#: t/helper/test-serve-v2.c:19
+msgid "exit immediately after advertising capabilities"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:262
+#, c-format
+msgid "socket/pipe already in use: '%s'"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:264
+#, c-format
+msgid "could not start server on: '%s'"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
+msgid "could not spawn daemon in the background"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:356
+msgid "waitpid failed"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:376
+msgid "daemon not online yet"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:406
+msgid "daemon failed to start"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:410
+msgid "waitpid is confused"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:541
+msgid "daemon has not shutdown yet"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:682
+msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:683
+msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:684
+msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:685
+msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:686
+msgid "test-helper simple-ipc send         [<name>] [<token>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:687
+msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:688
+msgid ""
+"test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
+"[<batchsize>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:696
+msgid "name or pathname of unix domain socket"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:698
+msgid "named-pipe name"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:700
+msgid "number of threads in server thread pool"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:701
+msgid "seconds to wait for daemon to start or stop"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:703
+msgid "number of bytes"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:704
+msgid "number of requests per thread"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:706
+msgid "byte"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:706
+msgid "ballast character"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:707
+msgid "token"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:707
+msgid "command token to send to the server"
 msgstr ""
 
 #: http.c:399
@@ -22345,7 +23262,7 @@ msgstr ""
 msgid "Could not set SSL backend to '%s': already set"
 msgstr ""
 
-#: http.c:2025
+#: http.c:2035
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -22493,43 +23410,43 @@ msgstr ""
 msgid "no libc information available\n"
 msgstr ""
 
-#: list-objects-filter-options.h:91
+#: list-objects-filter-options.h:94
 msgid "args"
 msgstr ""
 
-#: list-objects-filter-options.h:92
+#: list-objects-filter-options.h:95
 msgid "object filtering"
 msgstr ""
 
-#: parse-options.h:183
+#: parse-options.h:184
 msgid "expiry-date"
 msgstr ""
 
-#: parse-options.h:197
+#: parse-options.h:198
 msgid "no-op (backward compatibility)"
 msgstr ""
 
-#: parse-options.h:309
+#: parse-options.h:310
 msgid "be more verbose"
 msgstr ""
 
-#: parse-options.h:311
+#: parse-options.h:312
 msgid "be more quiet"
 msgstr ""
 
-#: parse-options.h:317
+#: parse-options.h:318
 msgid "use <n> digits to display object names"
 msgstr ""
 
-#: parse-options.h:336
+#: parse-options.h:337
 msgid "how to strip spaces and #comments from message"
 msgstr ""
 
-#: parse-options.h:337
+#: parse-options.h:338
 msgid "read pathspec from file"
 msgstr ""
 
-#: parse-options.h:338
+#: parse-options.h:339
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
@@ -24031,73 +24948,78 @@ msgstr ""
 msgid "local time offset greater than or equal to 24 hours\n"
 msgstr ""
 
-#: git-send-email.perl:223 git-send-email.perl:229
+#: git-send-email.perl:222
+#, perl-format
+msgid "fatal: command '%s' died with exit code %d"
+msgstr ""
+
+#: git-send-email.perl:235
 msgid "the editor exited uncleanly, aborting everything"
 msgstr ""
 
-#: git-send-email.perl:312
+#: git-send-email.perl:321
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr ""
 
-#: git-send-email.perl:317
+#: git-send-email.perl:326
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr ""
 
-#: git-send-email.perl:410
+#: git-send-email.perl:419
 msgid "--dump-aliases incompatible with other options\n"
 msgstr ""
 
-#: git-send-email.perl:484
+#: git-send-email.perl:493
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
 "Set sendemail.forbidSendmailVariables to false to disable this check.\n"
 msgstr ""
 
-#: git-send-email.perl:489 git-send-email.perl:691
+#: git-send-email.perl:498 git-send-email.perl:700
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr ""
 
-#: git-send-email.perl:492
+#: git-send-email.perl:501
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
 msgstr ""
 
-#: git-send-email.perl:505
+#: git-send-email.perl:514
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr ""
 
-#: git-send-email.perl:536
+#: git-send-email.perl:545
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr ""
 
-#: git-send-email.perl:564
+#: git-send-email.perl:573
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr ""
 
-#: git-send-email.perl:566
+#: git-send-email.perl:575
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr ""
 
-#: git-send-email.perl:568
+#: git-send-email.perl:577
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr ""
 
-#: git-send-email.perl:573
+#: git-send-email.perl:582
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr ""
 
-#: git-send-email.perl:657
+#: git-send-email.perl:666
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -24107,36 +25029,29 @@ msgid ""
 "    * Giving --format-patch option if you mean a range.\n"
 msgstr ""
 
-#: git-send-email.perl:678
+#: git-send-email.perl:687
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr ""
 
-#: git-send-email.perl:702
-#, perl-format
-msgid ""
-"fatal: %s: %s\n"
-"warning: no patches were sent\n"
-msgstr ""
-
-#: git-send-email.perl:713
+#: git-send-email.perl:720
 msgid ""
 "\n"
 "No patch files specified!\n"
 "\n"
 msgstr ""
 
-#: git-send-email.perl:726
+#: git-send-email.perl:733
 #, perl-format
 msgid "No subject line in %s?"
 msgstr ""
 
-#: git-send-email.perl:736
+#: git-send-email.perl:743
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr ""
 
-#: git-send-email.perl:747
+#: git-send-email.perl:754
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -24145,37 +25060,37 @@ msgid ""
 "Clear the body content if you don't wish to send a summary.\n"
 msgstr ""
 
-#: git-send-email.perl:771
+#: git-send-email.perl:778
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr ""
 
-#: git-send-email.perl:788
+#: git-send-email.perl:795
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr ""
 
-#: git-send-email.perl:831
+#: git-send-email.perl:838
 msgid "Summary email is empty, skipping it\n"
 msgstr ""
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:866
+#: git-send-email.perl:873
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr ""
 
-#: git-send-email.perl:921
+#: git-send-email.perl:928
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
 msgstr ""
 
-#: git-send-email.perl:926
+#: git-send-email.perl:933
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr ""
 
-#: git-send-email.perl:934
+#: git-send-email.perl:941
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -24184,20 +25099,20 @@ msgid ""
 "want to send.\n"
 msgstr ""
 
-#: git-send-email.perl:953
+#: git-send-email.perl:960
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr ""
 
-#: git-send-email.perl:971
+#: git-send-email.perl:978
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr ""
 
-#: git-send-email.perl:983
+#: git-send-email.perl:990
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
 
-#: git-send-email.perl:1041 git-send-email.perl:1049
+#: git-send-email.perl:1048 git-send-email.perl:1056
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr ""
@@ -24205,16 +25120,16 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1053
+#: git-send-email.perl:1060
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr ""
 
-#: git-send-email.perl:1370
+#: git-send-email.perl:1377
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr ""
 
-#: git-send-email.perl:1453
+#: git-send-email.perl:1460
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -24231,128 +25146,148 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1468
+#: git-send-email.perl:1475
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr ""
 
-#: git-send-email.perl:1471
+#: git-send-email.perl:1478
 msgid "Send this email reply required"
 msgstr ""
 
-#: git-send-email.perl:1499
+#: git-send-email.perl:1506
 msgid "The required SMTP server is not properly defined."
 msgstr ""
 
-#: git-send-email.perl:1546
+#: git-send-email.perl:1553
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr ""
 
-#: git-send-email.perl:1551 git-send-email.perl:1555
+#: git-send-email.perl:1558 git-send-email.perl:1562
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr ""
 
-#: git-send-email.perl:1564
+#: git-send-email.perl:1571
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 
-#: git-send-email.perl:1582
+#: git-send-email.perl:1589
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr ""
 
-#: git-send-email.perl:1585
+#: git-send-email.perl:1592
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr ""
 
-#: git-send-email.perl:1585
+#: git-send-email.perl:1592
 #, perl-format
 msgid "Sent %s\n"
 msgstr ""
 
-#: git-send-email.perl:1587
+#: git-send-email.perl:1594
 msgid "Dry-OK. Log says:\n"
 msgstr ""
 
-#: git-send-email.perl:1587
+#: git-send-email.perl:1594
 msgid "OK. Log says:\n"
 msgstr ""
 
-#: git-send-email.perl:1599
+#: git-send-email.perl:1606
 msgid "Result: "
 msgstr ""
 
-#: git-send-email.perl:1602
+#: git-send-email.perl:1609
 msgid "Result: OK\n"
 msgstr ""
 
-#: git-send-email.perl:1620
+#: git-send-email.perl:1627
 #, perl-format
 msgid "can't open file %s"
 msgstr ""
 
-#: git-send-email.perl:1667 git-send-email.perl:1687
+#: git-send-email.perl:1674 git-send-email.perl:1694
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr ""
 
-#: git-send-email.perl:1673
+#: git-send-email.perl:1680
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr ""
 
-#: git-send-email.perl:1730
+#: git-send-email.perl:1737
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr ""
 
-#: git-send-email.perl:1765
+#: git-send-email.perl:1772
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr ""
 
-#: git-send-email.perl:1876
+#: git-send-email.perl:1883
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr ""
 
-#: git-send-email.perl:1883
+#: git-send-email.perl:1890
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr ""
 
-#: git-send-email.perl:1887
+#: git-send-email.perl:1894
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr ""
 
-#: git-send-email.perl:1917
+#: git-send-email.perl:1924
 msgid "cannot send message as 7bit"
 msgstr ""
 
-#: git-send-email.perl:1925
+#: git-send-email.perl:1932
 msgid "invalid transfer encoding"
 msgstr ""
 
-#: git-send-email.perl:1966 git-send-email.perl:2018 git-send-email.perl:2028
+#: git-send-email.perl:1966
+#, perl-format
+msgid ""
+"fatal: %s: rejected by sendemail-validate hook\n"
+"%s\n"
+"warning: no patches were sent\n"
+msgstr ""
+
+#: git-send-email.perl:1976 git-send-email.perl:2029 git-send-email.perl:2039
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr ""
 
-#: git-send-email.perl:1969
+#: git-send-email.perl:1979
 #, perl-format
-msgid "%s: patch contains a line longer than 998 characters"
+msgid ""
+"fatal: %s:%d is longer than 998 characters\n"
+"warning: no patches were sent\n"
 msgstr ""
 
-#: git-send-email.perl:1986
+#: git-send-email.perl:1997
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr ""
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:1990
+#: git-send-email.perl:2001
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr ""
+
+#~ msgid "Already up to date. Yeeah!"
+#~ msgstr "Sudah terbaru. Ya!"
+
+#~ msgid ""
+#~ "the rebase.useBuiltin support has been removed!\n"
+#~ "See its entry in 'git help config' for details."
+#~ msgstr ""
+#~ "dukungan untuk rebase.useBuiltin sudah dihapus!\n"
+#~ "Lihat entri itu di 'git help config' untuk selengkapnya."


### PR DESCRIPTION
Translate following components:

  * builtin/add.c
  * worktree.c
  * builtin/branch.c
  * builtin/commit.c
  * builtin/merge.c
  * builtin/rebase.c
  * builtin/pull.c
  * diff.c
  * add-interactive.c
  * builtin/log.c
  * builtin/stash.c
  * builtin/tag.c
  * config.c
  * builtin/config.c
  * reset.c
  * builtin/remote.c
  * builtin/rm.c
  * builtin/mv.c
  * builtin/clean.c
  * builtin/help.c
  * archive.c
  * submodule.c
  * builtin/submodule--helper.c
  * submodule-config.c

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>
