### PR TITLE
l10n: fixed typos of mismatched constant strings

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3395,7 +3395,7 @@ msgstr ""
 #: diff.c:410
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
-msgstr "Unbekannter Wert in Konfigurationsvariable 'diff.dirstat': '%s'"
+msgstr "Unbekannter Wert in Konfigurationsvariable 'diff.submodule': '%s'"
 
 #: diff.c:470
 #, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -6368,7 +6368,7 @@ msgstr "no es posible crear hilo load_cache_entries: %s"
 #: read-cache.c:2193
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
-msgstr "no es posible unir hilo load_cache_entires: %s"
+msgstr "no es posible unir hilo load_cache_entries: %s"
 
 #: read-cache.c:2226
 #, c-format
@@ -7957,7 +7957,7 @@ msgstr "revert ya está en progreso"
 #: sequencer.c:3031
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
-msgstr "intenta \"git revert (--continue | --quit | %s --abort)\""
+msgstr "intenta \"git revert (--continue | %s--abort | --quit)\""
 
 #: sequencer.c:3034
 msgid "cherry-pick is already in progress"
@@ -7966,7 +7966,7 @@ msgstr "cherry-pick ya está en progreso"
 #: sequencer.c:3036
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
-msgstr "intenta \"git cherry-pick (--continue | --quit | %s --abort)\""
+msgstr "intenta \"git cherry-pick (--continue | %s--abort | --quit)\""
 
 #: sequencer.c:3050
 #, c-format
@@ -15267,7 +15267,7 @@ msgid ""
 "partialclone"
 msgstr ""
 "--filter solo puede ser usado con el remoto configurado en extensions."
-"partialClone"
+"partialclone"
 
 #: builtin/fetch.c:2083
 msgid "--atomic can only be used when fetching from one remote"
@@ -15684,7 +15684,7 @@ msgstr "reempaquetar todos los otros paquetes excepto el paquete más grande"
 #: builtin/gc.c:576
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
-msgstr "falló al analizar valor %s de gc.logexpirity"
+msgstr "falló al analizar valor %s de gc.logexpiry"
 
 #: builtin/gc.c:587
 #, c-format
@@ -16890,7 +16890,7 @@ msgstr "%s: modo cover from description inválido"
 
 #: builtin/log.c:850
 msgid "format.headers without value"
-msgstr "formate.headers. sin valor"
+msgstr "format.headers sin valor"
 
 #: builtin/log.c:979
 #, c-format
@@ -22474,7 +22474,7 @@ msgstr "Se esperaba un nombre de ref completo, se obtuvo %s"
 
 #: builtin/submodule--helper.c:64
 msgid "submodule--helper print-default-remote takes no arguments"
-msgstr "subomdule--helper print-default-remote no toma argumentos"
+msgstr "submodule--helper print-default-remote no toma argumentos"
 
 #: builtin/submodule--helper.c:102
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -4719,12 +4719,12 @@ msgstr "(mauvais commit)\n"
 #: merge-recursive.c:379
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
-msgstr "échec de addinfo_cache pour le chemin '%s' ; abandon de la fusion."
+msgstr "échec de add_cacheinfo pour le chemin '%s' ; abandon de la fusion."
 
 #: merge-recursive.c:388
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
-msgstr "échec de addinfo_cache pour le chemin '%s' ; abandon de la fusion."
+msgstr "échec de add_cacheinfo pour le chemin '%s' ; abandon de la fusion."
 
 #: merge-recursive.c:876
 #, c-format
@@ -5994,12 +5994,12 @@ msgid "Refresh index"
 msgstr "Rafraîchir l'index"
 
 #: read-cache.c:1700
-#, c-format
+#, c-format, fuzzy
 msgid ""
 "index.version set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
-"version d'index renseignée, mais la valeur est invalide.\n"
+"index.version renseignée, mais la valeur est invalide.\n"
 "Utilisation de la version %i"
 
 #: read-cache.c:1710
@@ -6073,7 +6073,7 @@ msgstr "impossible de créer le fil load_cache_entries : %s"
 #: read-cache.c:2193
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
-msgstr "impossible de joindre le fil load_cach_entries : %s"
+msgstr "impossible de joindre le fil load_cache_entries : %s"
 
 #: read-cache.c:2226
 #, c-format
@@ -8275,7 +8275,7 @@ msgstr "nom de sous-module suspicieux %s ignoré"
 
 #: submodule-config.c:304
 msgid "negative values not allowed for submodule.fetchjobs"
-msgstr "les valeurs négatives ne sont pas permises pour submodule.fetchJobs"
+msgstr "les valeurs négatives ne sont pas permises pour submodule.fetchjobs"
 
 #: submodule-config.c:402
 #, c-format
@@ -10717,7 +10717,7 @@ msgstr "doit finir avec une couleur"
 #: builtin/blame.c:728
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
-msgstr "couleur invalide '%s' dans color.blame.repeatedlines"
+msgstr "couleur invalide '%s' dans color.blame.repeatedLines"
 
 #: builtin/blame.c:746
 msgid "invalid value for blame.coloring"
@@ -13779,7 +13779,7 @@ msgstr "afficher les messages de debug sur stderr"
 
 #: builtin/credential-cache--daemon.c:316
 msgid "credential-cache--daemon unavailable; no unix socket support"
-msgstr "credential-cache-daemon non disponible ; pas de gestion des sockets unix"
+msgstr "credential-cache--daemon non disponible ; pas de gestion des sockets unix"
 
 #: builtin/credential-cache.c:154
 msgid "credential-cache unavailable; no unix socket support"
@@ -14645,7 +14645,7 @@ msgstr "Le protocole ne prend pas en charge --negotiate-only, abandon."
 
 #: builtin/fetch.c:2079
 msgid "--filter can only be used with the remote configured in extensions.partialclone"
-msgstr "--filter ne peut être utilisé qu'avec le dépôt distant configuré dans extensions.partialClone"
+msgstr "--filter ne peut être utilisé qu'avec le dépôt distant configuré dans extensions.partialclone"
 
 #: builtin/fetch.c:2083
 msgid "--atomic can only be used when fetching from one remote"
@@ -23221,7 +23221,7 @@ msgstr "L'épinglage de clé publique n'est pas supporté avec cuRL < 7.44.0"
 
 #: http.c:910
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
-msgstr "CURLSSLOPT_NO_REMOVE n'est pas supporté avec cuRL < 7.44.0"
+msgstr "CURLSSLOPT_NO_REVOKE n'est pas supporté avec cuRL < 7.44.0"
 
 #: http.c:989
 msgid "Protocol restrictions not supported with cURL < 7.19.4"

--- a/po/it.po
+++ b/po/it.po
@@ -14953,7 +14953,7 @@ msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
 msgstr ""
-"--filter può essere usato solo con il remoto configurato nelle estensioni."
+"--filter può essere usato solo con il remoto configurato nelle extensions."
 "partialclone"
 
 #: builtin/fetch.c:1891
@@ -19253,7 +19253,7 @@ msgstr ""
 
 #: builtin/rebase.c:474
 msgid "git rebase--interactive [<options>]"
-msgstr "git rebase --interactive [<opzioni>]"
+msgstr "git rebase--interactive [<opzioni>]"
 
 #: builtin/rebase.c:487 builtin/rebase.c:1382
 msgid "keep commits which start empty"
@@ -21746,7 +21746,7 @@ msgid "could not generate diff %s^!."
 msgstr "impossibile generare il diff %s^!"
 
 #: builtin/stash.c:422
-msgid "conflicts in index.Try without --index."
+msgid "conflicts in index. Try without --index."
 msgstr "ci sono conflitti nell'indice. Prova senza --index."
 
 #: builtin/stash.c:428

--- a/po/ko.po
+++ b/po/ko.po
@@ -1702,7 +1702,7 @@ msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
 "%s"
 msgstr ""
-"'diff.submodule' 설정 변수에 오류:\n"
+"'diff.dirstat' 설정 변수에 오류:\n"
 "%s'"
 
 #: diff.c:3823
@@ -2261,12 +2261,12 @@ msgstr "(잘못된 커밋)\n"
 #: merge-recursive.c:320
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
-msgstr "'%s' 경로에 대해 addinfo_cache 실패. 병합 중지."
+msgstr "'%s' 경로에 대해 add_cacheinfo 실패. 병합 중지."
 
 #: merge-recursive.c:328
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
-msgstr "'%s' 경로에 대해 addinfo_cache 새로 고침 실패. 병합 중지."
+msgstr "'%s' 경로에 대해 add_cacheinfo 새로 고침 실패. 병합 중지."
 
 #: merge-recursive.c:410
 msgid "error building trees"
@@ -10983,7 +10983,7 @@ msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
 msgstr ""
-"커밋 빼오기를 마치지 않았습니다. (COMMIT_PICK_HEAD 있음)\n"
+"커밋 빼오기를 마치지 않았습니다. (CHERRY_PICK_HEAD 있음)\n"
 "병합하기 전에 변경 사항을 커밋하십시오."
 
 #: builtin/merge.c:1257

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -14610,7 +14610,7 @@ msgstr "Referência remota HEAD não encontrada"
 #: builtin/fetch.c:677
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
-msgstr "a configuração fetch.ouput contém o valor inválido %s"
+msgstr "a configuração fetch.output contém o valor inválido %s"
 
 #: builtin/fetch.c:775
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -2734,7 +2734,7 @@ msgstr "Felaktigt %s: \"%s\""
 #: config.c:2512
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
-msgstr "värdet \"%d\" för splitIndex.maxPercentage borde vara mellan 0 och 100"
+msgstr "värdet \"%d\" för splitIndex.maxPercentChange borde vara mellan 0 och 100"
 
 #: config.c:2558
 #, c-format
@@ -4910,7 +4910,7 @@ msgstr "(felaktig incheckning)\n"
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr ""
-"add_cahceinfo misslyckades för sökvägen \"%s\"; avslutar sammanslagningen."
+"add_cacheinfo misslyckades för sökvägen \"%s\"; avslutar sammanslagningen."
 
 #: merge-recursive.c:388
 #, c-format
@@ -6314,12 +6314,12 @@ msgid "index file corrupt"
 msgstr "indexfilen trasig"
 
 #: read-cache.c:2180
-#, c-format
+#, c-format, fuzzy
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "kunde inte läsa in cache_entries-tråden: %s"
 
 #: read-cache.c:2193
-#, c-format
+#, c-format, fuzzy
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "kunde inte utföra join på cache_entries-tråden: %s"
 
@@ -10777,7 +10777,7 @@ msgid ""
 "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
 msgstr ""
-"git-bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
+"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
 
 #: builtin/bisect--helper.c:26

--- a/po/tr.po
+++ b/po/tr.po
@@ -12344,7 +12344,7 @@ msgstr ""
 "\tgit checkout --track origin/<ad>\n"
 "\n"
 "Eğer her zaman belirsiz <ad> çıkışlarının bir uzak konumu tercih etmesini\n"
-"isterseniz, örn. 'origin', yapılandırmanızda checkout.defaultsRemote=origin\n"
+"isterseniz, örn. 'origin', yapılandırmanızda checkout.defaultRemote=origin\n"
 "ayarını yapmayı düşünün."
 
 #: builtin/checkout.c:1201
@@ -14349,7 +14349,7 @@ msgstr "hata ayıklama iletilerini stderr'e yazdır"
 
 #: builtin/credential-cache--daemon.c:316
 msgid "credential-cache--daemon unavailable; no unix socket support"
-msgstr "credential-cache-daemon kullanılamıyor; unix soket desteği yok"
+msgstr "credential-cache--daemon kullanılamıyor; unix soket desteği yok"
 
 #: builtin/credential-cache.c:154
 msgid "credential-cache unavailable; no unix socket support"
@@ -14700,7 +14700,7 @@ msgstr "git_env_*(...)'ın geri çekileceği öntanımlı"
 
 #: builtin/env--helper.c:48
 msgid "be quiet only use git_env_*() value as exit code"
-msgstr "sessiz ol, yalnızca git_env*() değerini çıkış kodu olarak kullan"
+msgstr "sessiz ol, yalnızca git_env_*() değerini çıkış kodu olarak kullan"
 
 #: builtin/env--helper.c:67
 #, c-format
@@ -22911,7 +22911,7 @@ msgstr "%s, --super-prefix desteklemiyor"
 #: builtin/submodule--helper.c:2799
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
-msgstr "'%s' geçerli bir submodule-helper altkomutu değil"
+msgstr "'%s' geçerli bir submodule--helper altkomutu değil"
 
 #: builtin/symbolic-ref.c:8
 msgid "git symbolic-ref [<options>] <name> [<ref>]"
@@ -24179,7 +24179,7 @@ msgstr "uzak sunucu durumsuz ayırıcı gönderdi"
 #: remote-curl.c:724
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
-"rpc sonrası verisi geri sarılamıyor - https.postBuffer'ı artırmayı deneyin"
+"rpc sonrası verisi geri sarılamıyor - http.postBuffer'ı artırmayı deneyin"
 
 #: remote-curl.c:754
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -4907,13 +4907,13 @@ msgstr "(commit sai)\n"
 #: merge-recursive.c:379
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
-msgstr "addinfo_cache gặp lỗi đối với đường dẫn “%s”; việc hòa trộn bị bãi bỏ."
+msgstr "add_cacheinfo gặp lỗi đối với đường dẫn “%s”; việc hòa trộn bị bãi bỏ."
 
 #: merge-recursive.c:388
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
-"addinfo_cache gặp lỗi khi làm mới đối với đường dẫn “%s”; việc hòa trộn bị "
+"add_cacheinfo gặp lỗi khi làm mới đối với đường dẫn “%s”; việc hòa trộn bị "
 "bãi bỏ."
 
 #: merge-recursive.c:876
@@ -8585,7 +8585,7 @@ msgstr "đang lờ đi tên mô-đun-con mập mờ: %s"
 
 #: submodule-config.c:304
 msgid "negative values not allowed for submodule.fetchjobs"
-msgstr "không cho phép giá trị âm ở submodule.fetchJobs"
+msgstr "không cho phép giá trị âm ở submodule.fetchjobs"
 
 #: submodule-config.c:402
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -142,7 +142,7 @@ msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2021-05-17 16:02+0800\n"
-"PO-Revision-Date: 2021-06-05 22:10+0800\n"
+"PO-Revision-Date: 2021-07-01 16:01+0800\n"
 "Last-Translator: Jiang Xin <worldhello.net@gmail.com>\n"
 "Language-Team: GitHub <https://github.com/jiangxin/git/>\n"
 "Language: zh_CN\n"
@@ -3060,7 +3060,7 @@ msgstr "关闭 rev-list 的标准输入失败"
 #: convert.c:183
 #, c-format
 msgid "illegal crlf_action %d"
-msgstr "非法的 crlf 动作 %d"
+msgstr "非法的 crlf_action %d"
 
 #: convert.c:196
 #, c-format
@@ -5373,7 +5373,7 @@ msgstr "不能创建 lazy_name 线程：%s"
 #: name-hash.c:570
 #, c-format
 msgid "unable to join lazy_name thread: %s"
-msgstr "不能加入 lasy_name 线程：%s"
+msgstr "不能加入 lazy_name 线程：%s"
 
 #: notes-merge.c:277
 #, c-format
@@ -15034,7 +15034,7 @@ msgstr "协议不支持 --negotiate-only，退出。"
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
-msgstr "只可以将 --filter 用于在 extensions.partialClone 中配置的远程仓库"
+msgstr "只可以将 --filter 用于在 extensions.partialclone 中配置的远程仓库"
 
 #: builtin/fetch.c:2083
 msgid "--atomic can only be used when fetching from one remote"
@@ -17726,7 +17726,7 @@ msgstr "错误：标签输入未通过 fsck：%s"
 #: builtin/mktag.c:41
 #, c-format
 msgid "%d (FSCK_IGNORE?) should never trigger this callback"
-msgstr "%d（忽略 FSCK?）不应该触发这个调用"
+msgstr "%d (FSCK_IGNORE?) 永远不应该触发这个回调"
 
 #: builtin/mktag.c:56
 #, c-format
@@ -22356,7 +22356,7 @@ msgstr "不能识别 submodule.alternateErrorStrategy 的取值 '%s'"
 #: builtin/submodule--helper.c:1799
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
-msgstr "不能识别 submodule.alternateLocaion 的取值 '%s'"
+msgstr "不能识别 submodule.alternateLocation 的取值 '%s'"
 
 #: builtin/submodule--helper.c:1823
 msgid "where the new submodule will be cloned to"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3199,7 +3199,7 @@ msgstr "關閉 rev-list 的標準輸入失敗"
 #: convert.c:183
 #, c-format
 msgid "illegal crlf_action %d"
-msgstr "非法的 crlf 動作 %d"
+msgstr "非法的 crlf_action %d"
 
 #: convert.c:196
 #, c-format
@@ -5502,7 +5502,7 @@ msgstr "不能建立 lazy_name 執行緒：%s"
 #: name-hash.c:570
 #, c-format
 msgid "unable to join lazy_name thread: %s"
-msgstr "不能加入 lasy_name 執行緒：%s"
+msgstr "不能加入 lazy_name 執行緒：%s"
 
 #: notes-merge.c:277
 #, c-format
@@ -15156,7 +15156,7 @@ msgstr "協定不支援 --negotiate-only，結束。"
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
-msgstr "只可以將 --filter 用於在 extensions.partialClone 中設定的遠端版本庫"
+msgstr "只可以將 --filter 用於在 extensions.partialclone 中設定的遠端版本庫"
 
 #: builtin/fetch.c:2083
 msgid "--atomic can only be used when fetching from one remote"
@@ -22482,7 +22482,7 @@ msgstr "不能識別 submodule.alternateErrorStrategy 的取值 '%s'"
 #: builtin/submodule--helper.c:1799
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
-msgstr "不能識別 submodule.alternateLocaion 的取值 '%s'"
+msgstr "不能識別 submodule.alternateLocation 的取值 '%s'"
 
 #: builtin/submodule--helper.c:1823
 msgid "where the new submodule will be cloned to"


### PR DESCRIPTION
Andrei pointed out a typo in the Swedish translation, where a config
variable name had been copied incorrectly.
    
By introducing typo detection function in "git-po-helper", more typos
were found. All easy-to-fix typos were fixed in this commit.
    
Reported-by: Andrei Rybak
Signed-off-by: Peter Krefting
Signed-off-by: Jiang Xin