### PR TITLE
[l10n] po/id.po: fix mismatched variable names

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -12822,7 +12822,7 @@ msgstr "gagal memperbarui tembolok pohon utama"
 
 #: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
 msgid "unable to write new_index file"
-msgstr "tidak dapat menulis berkas indeks baru"
+msgstr "tidak dapat menulis berkas new_index"
 
 #: builtin/commit.c:489
 msgid "cannot do a partial commit during a merge."
@@ -13330,7 +13330,7 @@ msgid ""
 "not exceeded, and then \"git restore --staged :/\" to recover."
 msgstr ""
 "repositori sudah diperbarui, tetapi tidak dapat menulis\n"
-"berkas indeks baru. Periksa bahwa disk tidak penuh dan kuota\n"
+"berkas new_index. Periksa bahwa disk tidak penuh dan kuota\n"
 "tidak terlampaui, lalu \"git restore --staged :/\" untuk pulihkan."
 
 #: builtin/config.c:11
@@ -21717,7 +21717,7 @@ msgstr "git submodule status [--quiet] [--cached] [--recursive] [<jalur>...]"
 
 #: builtin/submodule--helper.c:918
 msgid "git submodule--helper name <path>"
-msgstr "git submodule==helper name <jalur>"
+msgstr "git submodule--helper name <jalur>"
 
 #: builtin/submodule--helper.c:990
 #, c-format


### PR DESCRIPTION
Jiang Xin notified me [1] to fix some typos. Running git-po-helper [2]
check, it found following:

  1. git submodule--helper typo (was git submodule==helper)
  2. new_index improper translation (DO NOT translate instead)

Fix them.

[1]:
https://lore.kernel.org/git/20210703111837.14894-1-worldhello.net@gmail.com/
[2]:
https://github.com/git-l10n/git-po-helper/commit/e44df847abb91227771560aca56719031f280068

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>

