### PR TITLE
l10n: sv.po: Fix git-po-helper breakage

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: git 2.33.0\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2021-08-14 07:56+0800\n"
-"PO-Revision-Date: 2021-08-14 21:14+0100\n"
+"PO-Revision-Date: 2021-08-18 07:47+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -10348,7 +10348,7 @@ msgstr "Flaggan --ignore-missing kan endast användas tillsammans med --dry-run"
 #: builtin/add.c:526
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
-msgstr "--chmod parametern \"%s\" måste antingen vara -x eller +x"
+msgstr "\"--chmod\"-parametern \"%s\" måste antingen vara -x eller +x"
 
 #: builtin/add.c:544 builtin/checkout.c:1733 builtin/commit.c:363
 #: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1633
@@ -11534,7 +11534,7 @@ msgstr "visa endast grenar som inte innehåller incheckningen"
 
 #: builtin/branch.c:650
 msgid "Specific git-branch actions:"
-msgstr "Specifika git-branch åtgärder:"
+msgstr "Specifika git-branch-åtgärder:"
 
 #: builtin/branch.c:651
 msgid "list both remote-tracking and local branches"
@@ -21829,7 +21829,7 @@ msgstr "git log --pretty=short | git shortlog [<flaggor>]"
 
 #: builtin/shortlog.c:123
 msgid "using multiple --group options with stdin is not supported"
-msgstr "mer än en --group flagga stöds inte med standard in"
+msgstr "mer än en \"--group\"-flagga stöds inte med standard in"
 
 #: builtin/shortlog.c:133
 msgid "using --group=trailer with stdin is not supported"


### PR DESCRIPTION
Fixes errors introduced in commit efedbb11de27a22cf9d4c75255057716f0b1b8ce
when running git-po-helper.

Signed-off-by: Peter Krefting <peter@softwolves.pp.se>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
