### PR TITLE
l10n: po-id for 2.34 (round 1)

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-08-14 07:56+0800\n"
+"POT-Creation-Date: 2021-10-30 09:36+0800\n"
 "PO-Revision-Date: 2021-08-14 09:35+0700\n"
 "Last-Translator: Bagas Sanjaya <bagasdotme@gmail.com>\n"
 "Language-Team: Indonesian\n"
@@ -17,213 +17,213 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: add-interactive.c:376
+#: add-interactive.c:380
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Huh (%s)"
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:64 sequencer.c:3493
-#: sequencer.c:3964 sequencer.c:4119 builtin/rebase.c:1528
-#: builtin/rebase.c:1953
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3510
+#: sequencer.c:3977 sequencer.c:4139 builtin/rebase.c:1233
+#: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "tidak dapat membaca indeks"
 
-#: add-interactive.c:584 git-add--interactive.perl:269
+#: add-interactive.c:588 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "biner"
 
-#: add-interactive.c:642 git-add--interactive.perl:278
+#: add-interactive.c:646 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "tidak ada"
 
-#: add-interactive.c:643 git-add--interactive.perl:314
+#: add-interactive.c:647 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "tak berubah"
 
-#: add-interactive.c:680 git-add--interactive.perl:641
+#: add-interactive.c:684 git-add--interactive.perl:641
 msgid "Update"
 msgstr "Perbarui"
 
-#: add-interactive.c:697 add-interactive.c:885
+#: add-interactive.c:701 add-interactive.c:889
 #, c-format
 msgid "could not stage '%s'"
 msgstr "tidak dapat menggelar '%s'"
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:88 sequencer.c:3707
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3716
 msgid "could not write index"
 msgstr "tidak dapat menulis indeks"
 
-#: add-interactive.c:706 git-add--interactive.perl:626
+#: add-interactive.c:710 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "%d jalur diperbarui\n"
 msgstr[1] "%d jalur diperbarui\n"
 
-#: add-interactive.c:724 git-add--interactive.perl:676
+#: add-interactive.c:728 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "catatan: %s sekarang tak terlacak.\n"
 
-#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:298
-#: builtin/reset.c:145
+#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
+#: builtin/reset.c:151
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry gagal untuk jalur '%s'"
 
-#: add-interactive.c:759 git-add--interactive.perl:653
+#: add-interactive.c:763 git-add--interactive.perl:653
 msgid "Revert"
 msgstr "Kembalikan"
 
-#: add-interactive.c:775
+#: add-interactive.c:779
 msgid "Could not parse HEAD^{tree}"
 msgstr "Tidak dapat menguraikan HEAD^{tree}"
 
-#: add-interactive.c:813 git-add--interactive.perl:629
+#: add-interactive.c:817 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "%d jalur dikembalikan\n"
 msgstr[1] "%d jalur dikembalikan\n"
 
-#: add-interactive.c:864 git-add--interactive.perl:693
+#: add-interactive.c:868 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
 msgstr "Tidak ada berkas tak terlacak.\n"
 
-#: add-interactive.c:868 git-add--interactive.perl:687
+#: add-interactive.c:872 git-add--interactive.perl:687
 msgid "Add untracked"
 msgstr "Tambahkan tak terlacak"
 
-#: add-interactive.c:895 git-add--interactive.perl:623
+#: add-interactive.c:899 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "%d jalur ditambahkan\n"
 msgstr[1] "%d jalur ditambahkan\n"
 
-#: add-interactive.c:925
+#: add-interactive.c:929
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "mengabaikan tak tergabung: %s"
 
-#: add-interactive.c:937 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Hanya berkas biner yang berubah.\n"
 
-#: add-interactive.c:939 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
 #, c-format
 msgid "No changes.\n"
 msgstr "Tidak ada perubahan.\n"
 
-#: add-interactive.c:943 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1379
 msgid "Patch update"
 msgstr "Pembaruan tambalan"
 
-#: add-interactive.c:982 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1792
 msgid "Review diff"
 msgstr "Tinjau diff"
 
-#: add-interactive.c:1010
+#: add-interactive.c:1014
 msgid "show paths with changes"
 msgstr "perlihatkan jalur dengan perubahan"
 
-#: add-interactive.c:1012
+#: add-interactive.c:1016
 msgid "add working tree state to the staged set of changes"
 msgstr "tambahkan keadaan pohon kerja ke set perubahan yang tergelar"
 
-#: add-interactive.c:1014
+#: add-interactive.c:1018
 msgid "revert staged set of changes back to the HEAD version"
 msgstr "kembalikan set perubahan yang tergelar kembali ke versi HEAD"
 
-#: add-interactive.c:1016
+#: add-interactive.c:1020
 msgid "pick hunks and update selectively"
-msgstr "ambil hunk dan perbarui secara selektif"
+msgstr "ambil bingkah dan perbarui secara selektif"
 
-#: add-interactive.c:1018
+#: add-interactive.c:1022
 msgid "view diff between HEAD and index"
 msgstr "lihat diff antara HEAD dan indeks"
 
-#: add-interactive.c:1020
+#: add-interactive.c:1024
 msgid "add contents of untracked files to the staged set of changes"
 msgstr "tambahkan isi berkas tak terlacak ke set perubahan yang tergelar"
 
-#: add-interactive.c:1028 add-interactive.c:1077
+#: add-interactive.c:1032 add-interactive.c:1081
 msgid "Prompt help:"
 msgstr "Permintaan bantuan:"
 
-#: add-interactive.c:1030
+#: add-interactive.c:1034
 msgid "select a single item"
 msgstr "pilih satu item"
 
-#: add-interactive.c:1032
+#: add-interactive.c:1036
 msgid "select a range of items"
 msgstr "pilih kisaran item"
 
-#: add-interactive.c:1034
+#: add-interactive.c:1038
 msgid "select multiple ranges"
 msgstr "pilih banyak kisaran"
 
-#: add-interactive.c:1036 add-interactive.c:1081
+#: add-interactive.c:1040 add-interactive.c:1085
 msgid "select item based on unique prefix"
 msgstr "pilih item berdasarkan prefiks unik"
 
-#: add-interactive.c:1038
+#: add-interactive.c:1042
 msgid "unselect specified items"
 msgstr "batal pilih item yang disebutkan"
 
-#: add-interactive.c:1040
+#: add-interactive.c:1044
 msgid "choose all items"
 msgstr "pilih semua item"
 
-#: add-interactive.c:1042
+#: add-interactive.c:1046
 msgid "(empty) finish selecting"
 msgstr "(kosong) sudah memilih"
 
-#: add-interactive.c:1079
+#: add-interactive.c:1083
 msgid "select a numbered item"
 msgstr "pilih item bernomor"
 
-#: add-interactive.c:1083
+#: add-interactive.c:1087
 msgid "(empty) select nothing"
 msgstr "(empty) tidak pilih apapun"
 
-#: add-interactive.c:1091 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
 msgid "*** Commands ***"
 msgstr "*** Perintah ***"
 
-#: add-interactive.c:1092 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
 msgid "What now"
 msgstr "Apa sekarang"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "staged"
 msgstr "tergelar"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "tak tergelar"
 
-#: add-interactive.c:1144 apply.c:4994 apply.c:4997 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/bugreport.c:135 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:285 builtin/pull.c:190
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1886
-#: builtin/submodule--helper.c:1889 builtin/submodule--helper.c:2343
-#: builtin/submodule--helper.c:2346 builtin/submodule--helper.c:2589
-#: builtin/submodule--helper.c:2890 builtin/submodule--helper.c:2893
+#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
+#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
+#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
+#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
+#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "jalur"
 
-#: add-interactive.c:1151
+#: add-interactive.c:1155
 msgid "could not refresh index"
 msgstr "tidak dapat menyegarkan indeks"
 
-#: add-interactive.c:1165 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
 #, c-format
 msgid "Bye.\n"
 msgstr "Sampai jumpa.\n"
@@ -246,15 +246,15 @@ msgstr "Gelar penambahan [y,n,q,a,d%s,?]? "
 #: add-patch.c:37 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
-msgstr "Gelar hunk ini [y,n,q,a,d%s,?]? "
+msgstr "Gelar bingkah ini [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:39
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "staging."
 msgstr ""
-"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
-"untuk digelar."
+"Jika tambalan diterapkan bersih, bingkah yang disunting akan langsung "
+"ditandai untuk digelar."
 
 #: add-patch.c:42
 msgid ""
@@ -264,11 +264,11 @@ msgid ""
 "a - stage this hunk and all later hunks in the file\n"
 "d - do not stage this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - gelar hunk ini\n"
-"n - jangan gelar hunk ini\n"
-"q - keluar; jangan gelar hunk ini atau yang sisanya\n"
-"a - gelar hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan gelar hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - gelar bingkah ini\n"
+"n - jangan gelar bingkah ini\n"
+"q - keluar; jangan gelar bingkah ini atau yang sisanya\n"
+"a - gelar bingkah ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan gelar bingkah ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:56 git-add--interactive.perl:1437
 #, c-format, perl-format
@@ -288,15 +288,15 @@ msgstr "Stase penambahan [y,n,q,a,d%s,?]? "
 #: add-patch.c:59 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
-msgstr "Stase hunk ini [y,n,q,a,d%s,?]? "
+msgstr "Stase bingkah ini [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:61
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
 msgstr ""
-"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
-"untuk distase."
+"Jika tambalan diterapkan bersih, bingkah yang disunting akan langsung "
+"ditandai untuk distase."
 
 #: add-patch.c:64
 msgid ""
@@ -306,11 +306,11 @@ msgid ""
 "a - stash this hunk and all later hunks in the file\n"
 "d - do not stash this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - stase hunk ini\n"
-"n - jangan stase hunk ini\n"
-"q - keluar; jangan stase hunk ini atau yang sisanya\n"
-"a - stase hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan stase hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - stase bingkah ini\n"
+"n - jangan stase bingkah ini\n"
+"q - keluar; jangan stase bingkah ini atau yang sisanya\n"
+"a - stase bingkah ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan stase bingkah ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:80 git-add--interactive.perl:1443
 #, c-format, perl-format
@@ -330,15 +330,15 @@ msgstr "Batal gelar penambahan [y,n,q,a,d%s,?]? "
 #: add-patch.c:83 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
-msgstr "Batal gelar hunk ini [y,n,q,a,d%s,?]? "
+msgstr "Batal gelar bingkah ini [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:85
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
 msgstr ""
-"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
-"untuk dibatalgelarkan."
+"Jika tambalan diterapkan bersih, bingkah yang disunting akan langsung "
+"ditandai untuk dibatalgelarkan."
 
 #: add-patch.c:88
 msgid ""
@@ -348,11 +348,11 @@ msgid ""
 "a - unstage this hunk and all later hunks in the file\n"
 "d - do not unstage this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - batal gelar hunk ini\n"
-"n - jangan batal gelar hunk ini\n"
-"q - keluar; jangan batal gelar hunk ini atau yang sisanya\n"
-"a - batal gelar hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan batal gelar hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - batal gelar bingkah ini\n"
+"n - jangan batal gelar bingkah ini\n"
+"q - keluar; jangan batal gelar bingkah ini atau yang sisanya\n"
+"a - batal gelar bingkah ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan batal gelar bingkah ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:103 git-add--interactive.perl:1449
 #, c-format, perl-format
@@ -372,15 +372,15 @@ msgstr "Terapkan penambahan ke indeks [y,n,q,a,d%s,?]? "
 #: add-patch.c:106 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
-msgstr "Terapkan hunk ini ke indeks [y,n,q,a,d%s,?]? "
+msgstr "Terapkan bingkah ini ke indeks [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:108 add-patch.c:176 add-patch.c:221
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "applying."
 msgstr ""
-"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
-"untuk diterapkan."
+"Jika tambalan diterapkan bersih, bingkah yang disunting akan langsung "
+"ditandai untuk diterapkan."
 
 #: add-patch.c:111
 msgid ""
@@ -390,11 +390,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - terapkan hunk ini ke indeks\n"
-"n - jangan terapkan hunk ini ke indeks\n"
-"q - keluar; jangan terapkan hunk ini atau yang sisanya\n"
-"a - terapkan hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan terapkan hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - terapkan bingkah ini ke indeks\n"
+"n - jangan terapkan bingkah ini ke indeks\n"
+"q - keluar; jangan terapkan bingkah ini atau yang sisanya\n"
+"a - terapkan bingkah ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan terapkan bingkah ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:126 git-add--interactive.perl:1455
 #: git-add--interactive.perl:1473
@@ -418,15 +418,15 @@ msgstr "Buang penambahan dari pohon kerja [y,n,q,a,d%s,?]? "
 #: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
-msgstr "Buang hunk ini dari pohon kerja [y,n,q,a,d%s,?]? "
+msgstr "Buang bingkah ini dari pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:131 add-patch.c:154 add-patch.c:199
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "discarding."
 msgstr ""
-"Jika tambalan diterapkan bersih, hunk yang disunting akan langsung ditandai "
-"untuk dibuang."
+"Jika tambalan diterapkan bersih, bingkah yang disunting akan langsung "
+"ditandai untuk dibuang."
 
 #: add-patch.c:134 add-patch.c:202
 msgid ""
@@ -436,11 +436,11 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - buang hunk ini dari pohon kerja\n"
-"n - jangan buang hunk ini dari pohon kerja\n"
-"q - keluar; jangan buang hunk ini atau yang sisanya\n"
-"a - buang hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan buang hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - buang bingkah ini dari pohon kerja\n"
+"n - jangan buang bingkah ini dari pohon kerja\n"
+"q - keluar; jangan buang bingkah ini atau yang sisanya\n"
+"a - buang hunk ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan buang hunk ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1461
 #, c-format, perl-format
@@ -460,7 +460,7 @@ msgstr "Buang penambahan dari indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 #: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
-msgstr "Buang hunk ini dari indeks dan pohon kerja [y,n,q,a,d%s,?]? "
+msgstr "Buang bingkah ini dari indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:157
 msgid ""
@@ -470,11 +470,11 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - buang hunk ini dari indeks dan pohon kerja\n"
-"n - jangan buang hunk ini dari indeks dan pohon kerja\n"
-"q - keluar; jangan buang hunk ini atau yang sisanya\n"
-"a - buang hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan buang hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - buang bingkah ini dari indeks dan pohon kerja\n"
+"n - jangan buang bingkah ini dari indeks dan pohon kerja\n"
+"q - keluar; jangan buang bingkah ini atau yang sisanya\n"
+"a - buang bingkah ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan buang bingkah ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1467
 #, c-format, perl-format
@@ -494,7 +494,7 @@ msgstr "Terapkan penambahan ke indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 #: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
-msgstr "Terapkan hunk ini ke indeks dan pohon kerja [y,n,q,a,d%s,?]? "
+msgstr "Terapkan bingkah ini ke indeks dan pohon kerja [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:179
 msgid ""
@@ -504,11 +504,11 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - terapkan hunk ini ke indeks dan pohon kerja\n"
-"n - jangan terapkan hunk ini ke indeks dan pohon kerja\n"
-"q - keluar; jangan terapkan hunk ini atau yang sisanya\n"
-"a - terapkan hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan terapkan hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - terapkan bingkah ini ke indeks dan pohon kerja\n"
+"n - jangan terapkan bingkah ini ke indeks dan pohon kerja\n"
+"q - keluar; jangan terapkan bingkah ini atau yang sisanya\n"
+"a - terapkan bingkah ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan terapkan bingkah ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:224
 msgid ""
@@ -518,21 +518,21 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - terapkan hunk ini ke pohon kerja\n"
-"n - jangan terapkan hunk ini ke pohon kerja\n"
-"q - keluar; jangan terapkan hunk ini atau yang sisanya\n"
-"a - terapkan hunk ini dan semua hunk selanjutnya dalam berkas\n"
-"d - jangan terapkan hunk ini atau hunk selanjutnya dalam berkas\n"
+"y - terapkan bingkah ini ke pohon kerja\n"
+"n - jangan terapkan bingkah ini ke pohon kerja\n"
+"q - keluar; jangan terapkan bingkah ini atau yang sisanya\n"
+"a - terapkan bingkah ini dan semua bingkah selanjutnya dalam berkas\n"
+"d - jangan terapkan bingkah ini atau bingkah selanjutnya dalam berkas\n"
 
 #: add-patch.c:343
 #, c-format
 msgid "could not parse hunk header '%.*s'"
-msgstr "tidak dapat menguraikan kepala hunk '%.*s'"
+msgstr "tidak dapat menguraikan kepala bingkah '%.*s'"
 
 #: add-patch.c:362 add-patch.c:366
 #, c-format
 msgid "could not parse colored hunk header '%.*s'"
-msgstr "tidak dapat menguraikan kepala hunk berwarna '%.*s'"
+msgstr "tidak dapat menguraikan kepala bingkah berwarna '%.*s'"
 
 #: add-patch.c:420
 msgid "could not parse diff"
@@ -576,14 +576,14 @@ msgid ""
 "\tdoes not end with:\n"
 "%.*s"
 msgstr ""
-"hunk tidak tumpang tindih:\n"
+"bingkah tidak tumpang tindih:\n"
 "%.*s\n"
 "tidak berakhir dengan:\n"
 "%.*s"
 
 #: add-patch.c:1082 git-add--interactive.perl:1115
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
-msgstr "Mode sunting hunk manual -- lihat dibawah untuk panduan cepat.\n"
+msgstr "Mode sunting bingkah manual -- lihat dibawah untuk panduan cepat.\n"
 
 #: add-patch.c:1086
 #, c-format
@@ -606,12 +606,12 @@ msgid ""
 "aborted and the hunk is left unchanged.\n"
 msgstr ""
 "Jika itu tidak diterapkan dengan bersih, Anda akan diberikan kesempatan\n"
-"untuk menyunting lagi. Jika semua baris dalam hunk dihapus, suntingan\n"
-"dibatalkan dan hunk tetap tidak berubah.\n"
+"untuk menyunting lagi. Jika semua baris dalam bingkah dihapus, suntingan\n"
+"dibatalkan dan bingkah tetap tidak berubah.\n"
 
 #: add-patch.c:1133
 msgid "could not parse hunk header"
-msgstr "tidak dapat menguraikan kepala hunk"
+msgstr "tidak dapat menguraikan kepala bingkah"
 
 #: add-patch.c:1178
 msgid "'git apply --cached' failed"
@@ -633,12 +633,12 @@ msgstr "'git apply --cached' gagal"
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
-"Hunk Anda tak diterapkan. Sunting lagi (bilang \"n\" untuk \"tidak\" buang!) "
-"[y/n]?"
+"Bingkah Anda tak diterapkan. Sunting lagi (bilang \"n\" untuk \"tidak\" "
+"buang!) [y/n]?"
 
 #: add-patch.c:1290
 msgid "The selected hunks do not apply to the index!"
-msgstr "Hunk yang dipilih tidak diterapkan ke indeks!"
+msgstr "Bingkah yang dipilih tidak diterapkan ke indeks!"
 
 #: add-patch.c:1291 git-add--interactive.perl:1346
 msgid "Apply them to the worktree anyway? "
@@ -660,35 +660,35 @@ msgid ""
 "e - manually edit the current hunk\n"
 "? - print help\n"
 msgstr ""
-"j - biarkan hunk ini ragu, lihat hunk ragu berikutnya\n"
-"J - biarkan hunk ini ragu, lihat hunk berikutnya\n"
-"k - biarkan hunk ini ragu, lihat hunk ragu sebelumnya\n"
-"K - biarkan hunk ini ragu, lihat hunk sebelumnya\n"
-"g - pilih satu hunk untuk dikunjungi\n"
-"/ - cari satu hunk yang cocok dengan regex yang diberikan\n"
-"s - belah hunk saat ini ke dalam hunk yang lebih kecil\n"
-"e - sunting hunk saat ini secara manual\n"
+"j - biarkan bingkah ini ragu, lihat bingkah ragu berikutnya\n"
+"J - biarkan bingkah ini ragu, lihat bingkah berikutnya\n"
+"k - biarkan bingkah ini ragu, lihat bingkah ragu sebelumnya\n"
+"K - biarkan bingkah ini ragu, lihat bingkah sebelumnya\n"
+"g - pilih satu bingkah untuk dikunjungi\n"
+"/ - cari satu bingkah yang cocok dengan regex yang diberikan\n"
+"s - belah bingkah saat ini ke dalam bingkah yang lebih kecil\n"
+"e - sunting bingkah saat ini secara manual\n"
 "? - cetak bantuan\n"
 
 #: add-patch.c:1517 add-patch.c:1527
 msgid "No previous hunk"
-msgstr "Tidak ada hunk sebelumnya"
+msgstr "Tidak ada bingkah sebelumnya"
 
 #: add-patch.c:1522 add-patch.c:1532
 msgid "No next hunk"
-msgstr "Tidak ada hunk selanjutnya"
+msgstr "Tidak ada bingkah selanjutnya"
 
 #: add-patch.c:1538
 msgid "No other hunks to goto"
-msgstr "Tidak ada hunk lainnya untuk dikunjungi"
+msgstr "Tidak ada bingkah lainnya untuk dikunjungi"
 
 #: add-patch.c:1549 git-add--interactive.perl:1606
 msgid "go to which hunk (<ret> to see more)? "
-msgstr "pergi ke hunk yang mana (<ret> untuk lihat lebih)? "
+msgstr "pergi ke bingkah yang mana (<ret> untuk lihat lebih)? "
 
 #: add-patch.c:1550 git-add--interactive.perl:1608
 msgid "go to which hunk? "
-msgstr "pergi ke hunk yang mana?"
+msgstr "pergi ke bingkah yang mana?"
 
 #: add-patch.c:1561
 #, c-format
@@ -699,12 +699,12 @@ msgstr "Angka tidak valid: '%s'"
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
-msgstr[0] "Maaf, hanya %d hunk yang tersedia."
-msgstr[1] "Maaf, hanya %d hunk yang tersedia."
+msgstr[0] "Maaf, hanya %d bingkah yang tersedia."
+msgstr[1] "Maaf, hanya %d bingkah yang tersedia."
 
 #: add-patch.c:1575
 msgid "No other hunks to search"
-msgstr "Tidak ada hunk lainnya untuk dicari"
+msgstr "Tidak ada bingkah lainnya untuk dicari"
 
 #: add-patch.c:1581 git-add--interactive.perl:1661
 msgid "search for regex? "
@@ -717,98 +717,104 @@ msgstr "regexp pencarian %s cacat: %s"
 
 #: add-patch.c:1613
 msgid "No hunk matches the given pattern"
-msgstr "Tidak ada hunk yang cocok dengan pola yang diberikan"
+msgstr "Tidak ada bingkah yang cocok dengan pola yang diberikan"
 
 #: add-patch.c:1620
 msgid "Sorry, cannot split this hunk"
-msgstr "Maaf, tidak dapat membelah hunk ini"
+msgstr "Maaf, tidak dapat membelah bingkah ini"
 
 #: add-patch.c:1624
 #, c-format
 msgid "Split into %d hunks."
-msgstr "Terbelah ke dalam %d hunk."
+msgstr "Terbelah ke dalam %d bingkah."
 
 #: add-patch.c:1628
 msgid "Sorry, cannot edit this hunk"
-msgstr "Maaf, tidak dapat menyunting hunk ini"
+msgstr "Maaf, tidak dapat menyunting bingkah ini"
 
 #: add-patch.c:1680
 msgid "'git apply' failed"
 msgstr "'git apply' gagal"
 
-#: advice.c:145
+#: advice.c:78
 #, c-format
 msgid ""
 "\n"
 "Disable this message with \"git config advice.%s false\""
 msgstr ""
 
-#: advice.c:161
+#: advice.c:94
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr ""
 
-#: advice.c:252
+#: advice.c:178
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:254
+#: advice.c:180
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:256
+#: advice.c:182
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:258
+#: advice.c:184
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:260
+#: advice.c:186
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 
-#: advice.c:262
+#: advice.c:188
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr ""
 
-#: advice.c:270
+#: advice.c:196
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
 msgstr ""
 
-#: advice.c:278
+#: advice.c:204
 msgid "Exiting because of an unresolved conflict."
 msgstr ""
 
-#: advice.c:283 builtin/merge.c:1375
+#: advice.c:209 builtin/merge.c:1379
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr ""
 
-#: advice.c:285
+#: advice.c:211
 msgid "Please, commit your changes before merging."
 msgstr ""
 
-#: advice.c:286
+#: advice.c:212
 msgid "Exiting because of unfinished merge."
 msgstr ""
 
-#: advice.c:296
+#: advice.c:217
+msgid "Not possible to fast-forward, aborting."
+msgstr "Tidak mungkin untuk maju cepat, batalkan."
+
+#: advice.c:227
 #, c-format
 msgid ""
-"The following pathspecs didn't match any eligible path, but they do match "
-"index\n"
-"entries outside the current sparse checkout:\n"
+"The following paths and/or pathspecs matched paths that exist\n"
+"outside of your sparse-checkout definition, so will not be\n"
+"updated in the index:\n"
 msgstr ""
 
-#: advice.c:303
+#: advice.c:234
 msgid ""
-"Disable or modify the sparsity rules if you intend to update such entries."
+"If you intend to update such entries, try one of the following:\n"
+"* Use the --sparse option.\n"
+"* Disable or modify the sparsity rules."
 msgstr ""
 
-#: advice.c:310
+#: advice.c:242
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -842,73 +848,75 @@ msgstr ""
 #: apply.c:70
 #, c-format
 msgid "unrecognized whitespace option '%s'"
-msgstr ""
+msgstr "opsi spasi putih tidak dikenal '%s'"
 
 #: apply.c:86
 #, c-format
 msgid "unrecognized whitespace ignore option '%s'"
-msgstr ""
+msgstr "opsi abai spasi putih tidak dikenal '%s'"
 
 #: apply.c:136
 msgid "--reject and --3way cannot be used together."
-msgstr ""
+msgstr "--reject dan --3way tidak dapat digunakan bersamaan."
 
 #: apply.c:139
 msgid "--3way outside a repository"
-msgstr ""
+msgstr "--3way di luar repositori"
 
 #: apply.c:150
 msgid "--index outside a repository"
-msgstr ""
+msgstr "--index di luar repositori"
 
 #: apply.c:153
 msgid "--cached outside a repository"
-msgstr ""
+msgstr "--cached di luar repositori"
 
 #: apply.c:800
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
-msgstr ""
+msgstr "Tidak dapat menyiapkan ekspresi reguler stempel waktu %s"
 
 #: apply.c:809
 #, c-format
 msgid "regexec returned %d for input: %s"
-msgstr ""
+msgstr "regexec kembalikan %d untuk input: %s"
 
 #: apply.c:883
 #, c-format
 msgid "unable to find filename in patch at line %d"
-msgstr ""
+msgstr "tidak dapat menemukan nama berkas dalam tambalan pada baris %d"
 
 #: apply.c:921
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
-msgstr ""
+msgstr "git apply: git-diff jelek - berharap /dev/null, dapat %s pada baris %d"
 
 #: apply.c:927
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
+"git apply: git-diff jelek - nama berkas baru tidak konsisten pada baris %d"
 
 #: apply.c:928
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr ""
+"git apply: git-diff jelek - nama berkas lama tidak konsisten pada baris %d"
 
 #: apply.c:933
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null on line %d"
-msgstr ""
+msgstr "git apply: git-diff jelek - berharap /dev/null pada baris %d"
 
 #: apply.c:962
 #, c-format
 msgid "invalid mode on line %d: %s"
-msgstr ""
+msgstr "mode tidak valid pada baris %d: %s"
 
 #: apply.c:1281
 #, c-format
 msgid "inconsistent header lines %d and %d"
-msgstr ""
+msgstr "kepala baris %d dan %d tidak konsisten"
 
 #: apply.c:1371
 #, c-format
@@ -919,534 +927,548 @@ msgid_plural ""
 "git diff header lacks filename information when removing %d leading pathname "
 "components (line %d)"
 msgstr[0] ""
+"kepala git diff kekurangan informasi nama berkas ketika menghapus %d "
+"komponen nama jalur terkemuka (baris %d)"
 msgstr[1] ""
+"kepala git diff kekurangan informasi nama berkas ketika menghapus %d "
+"komponen nama jalur terkemuka (baris %d)"
 
 #: apply.c:1384
 #, c-format
 msgid "git diff header lacks filename information (line %d)"
-msgstr ""
+msgstr "kepala git diff kekurangan informasi nama berkas (baris %d)"
 
 #: apply.c:1480
 #, c-format
 msgid "recount: unexpected line: %.*s"
-msgstr ""
+msgstr "recount: baris tidak diharapkan: %.*s"
 
 #: apply.c:1549
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
-msgstr ""
+msgstr "pecahan tambalan tanpa kepala pada baris %d: %.*s"
 
 #: apply.c:1752
 msgid "new file depends on old contents"
-msgstr ""
+msgstr "berkas baru bergantung pada konten yang lama"
 
 #: apply.c:1754
 msgid "deleted file still has contents"
-msgstr ""
+msgstr "berkas terhapus masih ada konten"
 
 #: apply.c:1788
 #, c-format
 msgid "corrupt patch at line %d"
-msgstr ""
+msgstr "tambalan rusak pada baris %d"
 
 #: apply.c:1825
 #, c-format
 msgid "new file %s depends on old contents"
-msgstr ""
+msgstr "berkas baru %s bergantung pada konten yang lama"
 
 #: apply.c:1827
 #, c-format
 msgid "deleted file %s still has contents"
-msgstr ""
+msgstr "berkas yang dihapus %s masih ada konten"
 
 #: apply.c:1830
 #, c-format
 msgid "** warning: file %s becomes empty but is not deleted"
-msgstr ""
+msgstr "** peringatan: berkas %s menjadi kosong tetapi tidak dihapus"
 
-#: apply.c:1977
+#: apply.c:1978
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
-msgstr ""
+msgstr "tambalan biner rusak pada baris %d: %.*s"
 
-#: apply.c:2014
+#: apply.c:2015
 #, c-format
 msgid "unrecognized binary patch at line %d"
-msgstr ""
+msgstr "tambalan biner tidak dikenal pada baris %d"
 
-#: apply.c:2176
+#: apply.c:2177
 #, c-format
 msgid "patch with only garbage at line %d"
-msgstr ""
+msgstr "tambal dengan hanya sampah pada baris %d"
 
-#: apply.c:2262
+#: apply.c:2263
 #, c-format
 msgid "unable to read symlink %s"
-msgstr ""
+msgstr "tidak dapat membaca tautan simbolik %s"
 
-#: apply.c:2266
+#: apply.c:2267
 #, c-format
 msgid "unable to open or read %s"
-msgstr ""
+msgstr "tidak dapat membuka atau membaca %s"
 
-#: apply.c:2935
+#: apply.c:2936
 #, c-format
 msgid "invalid start of line: '%c'"
-msgstr ""
+msgstr "awal baris tidak valid: '%c'"
 
-#: apply.c:3056
+#: apply.c:3057
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Bingkah #%d berhasil pada %d (ganti %d baris)."
+msgstr[1] "Bingkah #%d berhasil pada %d (ganti %d baris)."
 
-#: apply.c:3068
+#: apply.c:3069
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
-msgstr ""
+msgstr "Konteks dikurangi menjadi (%ld/%ld) untuk terapkan pecahan pada %d"
 
-#: apply.c:3074
+#: apply.c:3075
 #, c-format
 msgid ""
 "while searching for:\n"
 "%.*s"
 msgstr ""
+"ketika mencari:\n"
+"%.*s"
 
-#: apply.c:3096
+#: apply.c:3097
 #, c-format
 msgid "missing binary patch data for '%s'"
-msgstr ""
+msgstr "data tambalan biner hilang untuk '%s'"
 
-#: apply.c:3104
+#: apply.c:3105
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
+"tidak dapat menerapkan balik tambalan biner tanpa membalikkan bingkah ke '%s'"
 
-#: apply.c:3151
+#: apply.c:3152
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
-msgstr ""
+msgstr "tidak dapat menerapkan tambalan biner ke '%s' tanpa baris indeks penuh"
 
-#: apply.c:3162
+#: apply.c:3163
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
 msgstr ""
+"tambalan diterapkan ke '%s' (%s), yang tidak cocok dengan konten saat ini."
 
-#: apply.c:3170
+#: apply.c:3171
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
-msgstr ""
+msgstr "tambalan diterapkan ke '%s' kosong tapi tidak kosong"
 
-#: apply.c:3188
+#: apply.c:3189
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
-msgstr ""
+msgstr "pascacitra %s yang diperlukan untuk '%s' tidak dapat dibaca"
 
-#: apply.c:3201
+#: apply.c:3202
 #, c-format
 msgid "binary patch does not apply to '%s'"
-msgstr ""
+msgstr "tambalan biner tidak dapat diterapkan ke '%s'"
 
-#: apply.c:3208
+#: apply.c:3209
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
+"tambalan biner ke '%s' membuat hasil yang salah (diharapkan %s, dapat %s)"
 
-#: apply.c:3229
+#: apply.c:3230
 #, c-format
 msgid "patch failed: %s:%ld"
-msgstr ""
+msgstr "tambalan gagal: %s:%ld"
 
-#: apply.c:3352
+#: apply.c:3353
 #, c-format
 msgid "cannot checkout %s"
-msgstr ""
+msgstr "tidak dapat men-checkout %s"
 
-#: apply.c:3404 apply.c:3415 apply.c:3461 midx.c:98 pack-revindex.c:214
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
-msgstr ""
+msgstr "gagal membaca %s"
 
-#: apply.c:3412
+#: apply.c:3413
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
-msgstr ""
+msgstr "membaca dari '%s' diluar tautan simbolik"
 
-#: apply.c:3441 apply.c:3687
+#: apply.c:3442 apply.c:3709
 #, c-format
 msgid "path %s has been renamed/deleted"
-msgstr ""
+msgstr "jalus %s sudah dinamai ulang/dihapus"
 
-#: apply.c:3527 apply.c:3702
+#: apply.c:3549 apply.c:3724
 #, c-format
 msgid "%s: does not exist in index"
-msgstr ""
+msgstr "%s: tidak ada di indeks"
 
-#: apply.c:3536 apply.c:3710 apply.c:3954
+#: apply.c:3558 apply.c:3732 apply.c:3976
 #, c-format
 msgid "%s: does not match index"
-msgstr ""
+msgstr "%s: tidak cocok dengan indeks"
 
-#: apply.c:3571
+#: apply.c:3593
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
+"repositori kekurangan blob yang diperlukan untuk melakukan penggabungan 3 "
+"arah."
 
-#: apply.c:3574
+#: apply.c:3596
 #, c-format
 msgid "Performing three-way merge...\n"
-msgstr ""
+msgstr "Melakukan penggabungan 3 arah...\n"
 
-#: apply.c:3590 apply.c:3594
+#: apply.c:3612 apply.c:3616
 #, c-format
 msgid "cannot read the current contents of '%s'"
-msgstr ""
+msgstr "tidak dapat membaca konten saat ini dari '%s'"
 
-#: apply.c:3606
+#: apply.c:3628
 #, c-format
 msgid "Failed to perform three-way merge...\n"
-msgstr ""
-
-#: apply.c:3620
-#, c-format
-msgid "Applied patch to '%s' with conflicts.\n"
-msgstr ""
-
-#: apply.c:3625
-#, c-format
-msgid "Applied patch to '%s' cleanly.\n"
-msgstr ""
+msgstr "Gagal melakukan penggabungan 3 arah...\n"
 
 #: apply.c:3642
 #, c-format
+msgid "Applied patch to '%s' with conflicts.\n"
+msgstr "Tambalan diterapkan ke '%s' dengan konflik.\n"
+
+#: apply.c:3647
+#, c-format
+msgid "Applied patch to '%s' cleanly.\n"
+msgstr "Tambalan diterapkan ke '%s' dengan rapi.\n"
+
+#: apply.c:3664
+#, c-format
 msgid "Falling back to direct application...\n"
-msgstr ""
+msgstr "Mundur ke penerapan langsung...\n"
 
-#: apply.c:3654
+#: apply.c:3676
 msgid "removal patch leaves file contents"
-msgstr ""
+msgstr "tambalan penghapusan meninggalkan isi berkas"
 
-#: apply.c:3727
+#: apply.c:3749
 #, c-format
 msgid "%s: wrong type"
-msgstr ""
+msgstr "%s: salah tipe"
 
-#: apply.c:3729
+#: apply.c:3751
 #, c-format
 msgid "%s has type %o, expected %o"
-msgstr ""
+msgstr "%s bertipe %o, diharapkan %o"
 
-#: apply.c:3894 apply.c:3896 read-cache.c:863 read-cache.c:892
-#: read-cache.c:1353
+#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
+#: read-cache.c:1368
 #, c-format
 msgid "invalid path '%s'"
-msgstr ""
+msgstr "jalur tidak valid '%s'"
 
-#: apply.c:3952
+#: apply.c:3974
 #, c-format
 msgid "%s: already exists in index"
-msgstr ""
+msgstr "%s: sudah ada di indeks"
 
-#: apply.c:3956
+#: apply.c:3978
 #, c-format
 msgid "%s: already exists in working directory"
-msgstr ""
+msgstr "%s: sudah ada di direktori kerja"
 
-#: apply.c:3976
+#: apply.c:3998
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
-msgstr ""
+msgstr "mode baru (%o) dari %s tidak cocok dengan mode lama (%o)"
 
-#: apply.c:3981
+#: apply.c:4003
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
-msgstr ""
+msgstr "mode baru (%o) dari %s tidak cocok dengan mode lama (%o) dari %s"
 
-#: apply.c:4001
+#: apply.c:4023
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
-msgstr ""
+msgstr "berkas yang terpengaruh '%s' diluar tautan simbolik"
 
-#: apply.c:4005
+#: apply.c:4027
 #, c-format
 msgid "%s: patch does not apply"
-msgstr ""
+msgstr "%s: tambalan tak diterapkan"
 
-#: apply.c:4020
+#: apply.c:4042
 #, c-format
 msgid "Checking patch %s..."
-msgstr ""
+msgstr "Memeriksa tambalan %s..."
 
-#: apply.c:4112
+#: apply.c:4134
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
-msgstr ""
-
-#: apply.c:4119
-#, c-format
-msgid "mode change for %s, which is not in current HEAD"
-msgstr ""
-
-#: apply.c:4122
-#, c-format
-msgid "sha1 information is lacking or useless (%s)."
-msgstr ""
-
-#: apply.c:4131
-#, c-format
-msgid "could not add %s to temporary index"
-msgstr ""
+msgstr "informasi sha1 kurang atau tidak berguna untuk submodul %s"
 
 #: apply.c:4141
 #, c-format
-msgid "could not write temporary index to %s"
-msgstr ""
+msgid "mode change for %s, which is not in current HEAD"
+msgstr "perubahan mode untuk %s, yang bukan dalam HEAD saat ini"
 
-#: apply.c:4279
+#: apply.c:4144
+#, c-format
+msgid "sha1 information is lacking or useless (%s)."
+msgstr "informasi sha1 kurang atau tidak berguna (%s)"
+
+#: apply.c:4153
+#, c-format
+msgid "could not add %s to temporary index"
+msgstr "tidak dapat menambahkan %s ke indeks sementara"
+
+#: apply.c:4163
+#, c-format
+msgid "could not write temporary index to %s"
+msgstr "tidak dapat menulis indeks sementara ke %s"
+
+#: apply.c:4301
 #, c-format
 msgid "unable to remove %s from index"
-msgstr ""
+msgstr "tidak dapat menghapus %s dari indeks"
 
-#: apply.c:4313
+#: apply.c:4335
 #, c-format
 msgid "corrupt patch for submodule %s"
-msgstr ""
+msgstr "tambalan rusak untuk submodul %s"
 
-#: apply.c:4319
+#: apply.c:4341
 #, c-format
 msgid "unable to stat newly created file '%s'"
-msgstr ""
+msgstr "tidak dapat men-stat berkas yang baru dibuat '%s'"
 
-#: apply.c:4327
+#: apply.c:4349
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
+"tidak dapat membuat simpanan pendukung untuk berkas yang baru dibuat %s"
 
-#: apply.c:4333 apply.c:4478
+#: apply.c:4355 apply.c:4500
 #, c-format
 msgid "unable to add cache entry for %s"
-msgstr ""
+msgstr "tidak dapat menambahkan entri tembolok untuk %s"
 
-#: apply.c:4376 builtin/bisect--helper.c:525
+#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2242
+#: builtin/gc.c:2277
 #, c-format
 msgid "failed to write to '%s'"
-msgstr ""
+msgstr "gagal menulis ke '%s'"
 
-#: apply.c:4380
+#: apply.c:4402
 #, c-format
 msgid "closing file '%s'"
-msgstr ""
+msgstr "menutup berkas '%s'"
 
-#: apply.c:4450
+#: apply.c:4472
 #, c-format
 msgid "unable to write file '%s' mode %o"
-msgstr ""
-
-#: apply.c:4548
-#, c-format
-msgid "Applied patch %s cleanly."
-msgstr ""
-
-#: apply.c:4556
-msgid "internal error"
-msgstr ""
-
-#: apply.c:4559
-#, c-format
-msgid "Applying patch %%s with %d reject..."
-msgid_plural "Applying patch %%s with %d rejects..."
-msgstr[0] ""
-msgstr[1] ""
+msgstr "tidak dapat menulis berkas '%s' mode %o"
 
 #: apply.c:4570
 #, c-format
-msgid "truncating .rej filename to %.*s.rej"
-msgstr ""
+msgid "Applied patch %s cleanly."
+msgstr "Tambalan %s diterapkan dengan rapi."
 
-#: apply.c:4578 builtin/fetch.c:993 builtin/fetch.c:1394
+#: apply.c:4578
+msgid "internal error"
+msgstr "kesalahan internal"
+
+#: apply.c:4581
 #, c-format
-msgid "cannot open %s"
-msgstr ""
+msgid "Applying patch %%s with %d reject..."
+msgid_plural "Applying patch %%s with %d rejects..."
+msgstr[0] "Menerapkan tambalan %%s dengan %d penolakan..."
+msgstr[1] "Menerapkan tambalan %%s dengan %d penolakan..."
 
 #: apply.c:4592
 #, c-format
-msgid "Hunk #%d applied cleanly."
-msgstr ""
+msgid "truncating .rej filename to %.*s.rej"
+msgstr "memotong nama berkas .rej ke %.*s.rej"
 
-#: apply.c:4596
+#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
+#, c-format
+msgid "cannot open %s"
+msgstr "tidak dapat membuka %s"
+
+#: apply.c:4614
+#, c-format
+msgid "Hunk #%d applied cleanly."
+msgstr "Bingkah #%d diterapkan dengan rapi."
+
+#: apply.c:4618
 #, c-format
 msgid "Rejected hunk #%d."
-msgstr ""
+msgstr "Bingkah #%d ditolak."
 
-#: apply.c:4725
+#: apply.c:4747
 #, c-format
 msgid "Skipped patch '%s'."
-msgstr ""
+msgstr "Tambalan '%s' dilewatkan."
 
-#: apply.c:4733
+#: apply.c:4755
 msgid "unrecognized input"
-msgstr ""
+msgstr "masukan tidak dikenal"
 
-#: apply.c:4753
+#: apply.c:4775
 msgid "unable to read index file"
-msgstr ""
+msgstr "tidak dapa membaca berkas indeks"
 
-#: apply.c:4910
+#: apply.c:4932
 #, c-format
 msgid "can't open patch '%s': %s"
-msgstr ""
+msgstr "tidak dapat membuka tambalan '%s': %s"
 
-#: apply.c:4937
+#: apply.c:4959
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d kesalahan spasi putih dipadamkan"
+msgstr[1] "%d kesalahan spasi putih dipadamkan"
 
-#: apply.c:4943 apply.c:4958
+#: apply.c:4965 apply.c:4980
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d baris menambahkan kesalahan spasi putih."
+msgstr[1] "%d baris menambahkan kesalahan spasi putih."
 
-#: apply.c:4951
+#: apply.c:4973
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d baris diterapkan setelah memperbaiki kesalahan spasi putih."
+msgstr[1] "%d baris diterapkan setelah memperbaiki kesalahan spasi putih."
 
-#: apply.c:4967 builtin/add.c:678 builtin/mv.c:304 builtin/rm.c:423
+#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
 msgid "Unable to write new index file"
-msgstr ""
+msgstr "Tidak dapat menulis berkas indeks baru"
 
-#: apply.c:4995
+#: apply.c:5017
 msgid "don't apply changes matching the given path"
-msgstr ""
-
-#: apply.c:4998
-msgid "apply changes matching the given path"
-msgstr ""
-
-#: apply.c:5000 builtin/am.c:2318
-msgid "num"
-msgstr ""
-
-#: apply.c:5001
-msgid "remove <num> leading slashes from traditional diff paths"
-msgstr ""
-
-#: apply.c:5004
-msgid "ignore additions made by the patch"
-msgstr ""
-
-#: apply.c:5006
-msgid "instead of applying the patch, output diffstat for the input"
-msgstr ""
-
-#: apply.c:5010
-msgid "show number of added and deleted lines in decimal notation"
-msgstr ""
-
-#: apply.c:5012
-msgid "instead of applying the patch, output a summary for the input"
-msgstr ""
-
-#: apply.c:5014
-msgid "instead of applying the patch, see if the patch is applicable"
-msgstr ""
-
-#: apply.c:5016
-msgid "make sure the patch is applicable to the current index"
-msgstr ""
-
-#: apply.c:5018
-msgid "mark new files with `git add --intent-to-add`"
-msgstr ""
+msgstr "jangan terapkan perubahan yang cocok dengan jalur yang diberikan"
 
 #: apply.c:5020
-msgid "apply a patch without touching the working tree"
-msgstr ""
+msgid "apply changes matching the given path"
+msgstr "terapkan perubahan yang cocok dengan jalur yang diberikan"
 
-#: apply.c:5022
-msgid "accept a patch that touches outside the working area"
-msgstr ""
+#: apply.c:5022 builtin/am.c:2320
+msgid "num"
+msgstr "jumlah"
 
-#: apply.c:5025
-msgid "also apply the patch (use with --stat/--summary/--check)"
-msgstr ""
+#: apply.c:5023
+msgid "remove <num> leading slashes from traditional diff paths"
+msgstr "hapus <jumlah> garis miring terkemuka dari jalur diff tradisional"
 
-#: apply.c:5027
-msgid "attempt three-way merge, fall back on normal patch if that fails"
-msgstr ""
+#: apply.c:5026
+msgid "ignore additions made by the patch"
+msgstr "abaikan penambahan yang dibuat oleh tambalan"
 
-#: apply.c:5029
-msgid "build a temporary index based on embedded index information"
-msgstr ""
+#: apply.c:5028
+msgid "instead of applying the patch, output diffstat for the input"
+msgstr "daripada menerapkan tambalan, keluarkan diffstat untuk masukan"
 
-#: apply.c:5032 builtin/checkout-index.c:196 builtin/ls-files.c:617
-msgid "paths are separated with NUL character"
+#: apply.c:5032
+msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
+"perlihatkan jumlah baris yang ditambahkan dan dihapuskan dalam notasi desimal"
 
 #: apply.c:5034
-msgid "ensure at least <n> lines of context match"
-msgstr ""
-
-#: apply.c:5035 builtin/am.c:2294 builtin/am.c:2297
-#: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
-#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3991
-#: builtin/rebase.c:1347
-msgid "action"
-msgstr ""
+msgid "instead of applying the patch, output a summary for the input"
+msgstr "daripada menerapkan tambalan, keluarkan ringkasan untuk masukan"
 
 #: apply.c:5036
-msgid "detect new or modified lines that have whitespace errors"
-msgstr ""
+msgid "instead of applying the patch, see if the patch is applicable"
+msgstr "daripada menerapkan tambalan, lihat jika tambalan bisa diterapkan"
 
-#: apply.c:5039 apply.c:5042
-msgid "ignore changes in whitespace when finding context"
-msgstr ""
+#: apply.c:5038
+msgid "make sure the patch is applicable to the current index"
+msgstr "pastikan tambalan bisa diterapkan ke indeks saat ini"
 
-#: apply.c:5045
-msgid "apply the patch in reverse"
-msgstr ""
+#: apply.c:5040
+msgid "mark new files with `git add --intent-to-add`"
+msgstr "tandai berkas baru dengan `git add --intent-to-add`"
+
+#: apply.c:5042
+msgid "apply a patch without touching the working tree"
+msgstr "terapkan sebuah tambalan tanpa menyentuh pohon kerja"
+
+#: apply.c:5044
+msgid "accept a patch that touches outside the working area"
+msgstr "terima sebuah tambalan yang menyentuh di luar area kerja"
 
 #: apply.c:5047
-msgid "don't expect at least one line of context"
-msgstr ""
+msgid "also apply the patch (use with --stat/--summary/--check)"
+msgstr "juga terapkan tambalan (gunakan dengan --stat/--summary/--check)"
 
 #: apply.c:5049
-msgid "leave the rejected hunks in corresponding *.rej files"
-msgstr ""
+msgid "attempt three-way merge, fall back on normal patch if that fails"
+msgstr "coba penggabungan tiga arah, mundur ke penambalan normal jika gagal"
 
 #: apply.c:5051
+msgid "build a temporary index based on embedded index information"
+msgstr "bangun sebuah indeks sementara berdasarkan informasi indeks tertanam"
+
+#: apply.c:5054 builtin/checkout-index.c:196
+msgid "paths are separated with NUL character"
+msgstr "jalur dipisahkan dengan karakter NUL"
+
+#: apply.c:5056
+msgid "ensure at least <n> lines of context match"
+msgstr "pastikan setidaknya <n> baris dari konteks cocokan"
+
+#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
+#: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
+#: builtin/rebase.c:1051
+msgid "action"
+msgstr "aksi"
+
+#: apply.c:5058
+msgid "detect new or modified lines that have whitespace errors"
+msgstr "deteksi baris baru atau yang diubah yang ada kesalahan spasi putih"
+
+#: apply.c:5061 apply.c:5064
+msgid "ignore changes in whitespace when finding context"
+msgstr "abaikan perubahan spasi putih ketika menemukan konteks"
+
+#: apply.c:5067
+msgid "apply the patch in reverse"
+msgstr "terapkan tambalan terbalik"
+
+#: apply.c:5069
+msgid "don't expect at least one line of context"
+msgstr "jangan harap setidaknya satu baris konteks"
+
+#: apply.c:5071
+msgid "leave the rejected hunks in corresponding *.rej files"
+msgstr "tinggalkan bingkah yang ditolak pada berkas *.rej yang bersesuaian"
+
+#: apply.c:5073
 msgid "allow overlapping hunks"
-msgstr ""
+msgstr "perbolehkan bingkah yang tumpang tindih"
 
-#: apply.c:5052 builtin/add.c:364 builtin/check-ignore.c:22
-#: builtin/commit.c:1481 builtin/count-objects.c:98 builtin/fsck.c:756
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
+#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
+#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
 msgid "be verbose"
-msgstr ""
+msgstr "jadi berkata-kata"
 
-#: apply.c:5054
+#: apply.c:5076
 msgid "tolerate incorrectly detected missing new-line at the end of file"
-msgstr ""
+msgstr "tolerir baris baru hilang yang salah dideteksi pada akhir berkas"
 
-#: apply.c:5057
+#: apply.c:5079
 msgid "do not trust the line counts in the hunk headers"
-msgstr ""
+msgstr "jangan percaya hitungan baris pada kepala bingkah"
 
-#: apply.c:5059 builtin/am.c:2306
+#: apply.c:5081 builtin/am.c:2308
 msgid "root"
-msgstr ""
+msgstr "akar"
 
-#: apply.c:5060
+#: apply.c:5082
 msgid "prepend <root> to all filenames"
-msgstr ""
+msgstr "tambahkan <akar> di depan semua nama berkas"
 
 #: archive-tar.c:125 archive-zip.c:345
 #, c-format
@@ -1516,173 +1538,172 @@ msgstr "git archive --remote <repo> [--exec <perintah>] --list"
 msgid "cannot read %s"
 msgstr "Tidak dapat membaca %s"
 
-#: archive.c:342 sequencer.c:460 sequencer.c:1915 sequencer.c:3095
-#: sequencer.c:3537 sequencer.c:3665 builtin/am.c:262 builtin/commit.c:833
-#: builtin/merge.c:1144
+#: archive.c:341 sequencer.c:473 sequencer.c:1930 sequencer.c:3112
+#: sequencer.c:3554 sequencer.c:3682 builtin/am.c:263 builtin/commit.c:834
+#: builtin/merge.c:1145
 #, c-format
 msgid "could not read '%s'"
 msgstr "tidak dapat membaca '%s'"
 
-#: archive.c:427 builtin/add.c:205 builtin/add.c:645 builtin/rm.c:328
+#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "spek jalur '%s' tidak cocok dengan berkas apapun"
 
-#: archive.c:451
+#: archive.c:450
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "tidak ada referensi seperti: %.*s"
 
-#: archive.c:457
+#: archive.c:456
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "bukan nama objek valid: %s"
 
-#: archive.c:470
+#: archive.c:469
 #, c-format
 msgid "not a tree object: %s"
 msgstr "bukan objek pohon: %s"
 
-#: archive.c:482
+#: archive.c:481
 msgid "current working directory is untracked"
 msgstr "direktori kerja saat ini tak terlacak"
 
-#: archive.c:523
+#: archive.c:522
 #, c-format
 msgid "File not found: %s"
 msgstr "Berkas tidak ditemukan: %s"
 
-#: archive.c:525
+#: archive.c:524
 #, c-format
 msgid "Not a regular file: %s"
 msgstr "Bukan berkas reguler: %s"
 
-#: archive.c:552
+#: archive.c:551
 msgid "fmt"
 msgstr "fmt"
 
-#: archive.c:552
+#: archive.c:551
 msgid "archive format"
 msgstr "format arsip"
 
-#: archive.c:553 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1775
 msgid "prefix"
 msgstr "prefiks"
 
-#: archive.c:554
+#: archive.c:553
 msgid "prepend prefix to each pathname in the archive"
 msgstr "tambahkan prefiks di depan setiap nama jalur dalam arsip"
 
-#: archive.c:555 archive.c:558 builtin/blame.c:884 builtin/blame.c:888
-#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
-#: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:921 builtin/hash-object.c:105
-#: builtin/ls-files.c:653 builtin/ls-files.c:656 builtin/notes.c:412
-#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:191
+#: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
+#: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
+#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
+#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "berkas"
 
-#: archive.c:556
+#: archive.c:555
 msgid "add untracked file to archive"
 msgstr "tambahkan berkas tak terlacak ke arsip"
 
-#: archive.c:559 builtin/archive.c:90
+#: archive.c:558 builtin/archive.c:88
 msgid "write the archive to this file"
 msgstr "tulis arsip ke berkas ini"
 
-#: archive.c:561
+#: archive.c:560
 msgid "read .gitattributes in working directory"
 msgstr "baca .gitattributes dalam direktori kerja"
 
-#: archive.c:562
+#: archive.c:561
 msgid "report archived files on stderr"
 msgstr "laporkan berkas terarsip ke error standar"
 
-#: archive.c:564
+#: archive.c:563
 msgid "set compression level"
 msgstr "setel level kompresi"
 
-#: archive.c:567
+#: archive.c:566
 msgid "list supported archive formats"
 msgstr "daftar format arsip yang didukung"
 
-#: archive.c:569 builtin/archive.c:91 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1898 builtin/submodule--helper.c:2352
-#: builtin/submodule--helper.c:2902
+#: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
+#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
 msgid "repo"
 msgstr "repositori"
 
-#: archive.c:570 builtin/archive.c:92
+#: archive.c:569 builtin/archive.c:90
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "ambil arsip dari repositori remote <repo>"
 
-#: archive.c:571 builtin/archive.c:93 builtin/difftool.c:717
-#: builtin/notes.c:498
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: builtin/notes.c:496
 msgid "command"
 msgstr "perintah"
 
-#: archive.c:572 builtin/archive.c:94
+#: archive.c:571 builtin/archive.c:92
 msgid "path to the remote git-upload-archive command"
 msgstr "jalur ke perintah git-upload-archive remote"
 
-#: archive.c:579
+#: archive.c:578
 msgid "Unexpected option --remote"
 msgstr "Opsi --remote tak diharapkan"
 
-#: archive.c:581
+#: archive.c:580
 msgid "Option --exec can only be used together with --remote"
 msgstr "Opsi --exec hanya dapat digunakan bersamaan dengan --remote"
 
-#: archive.c:583
+#: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Opsi --output tak diharapkan"
 
-#: archive.c:585
+#: archive.c:584
 msgid "Options --add-file and --remote cannot be used together"
 msgstr "Opsi --add-file dan --remote tidak dapat digunakan bersamaan"
 
-#: archive.c:607
+#: archive.c:606
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Format arsip tidak dikenal '%s'"
 
-#: archive.c:616
+#: archive.c:615
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argumen tidak didukung untuk format '%s': -%d"
 
-#: attr.c:202
+#: attr.c:203
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr ""
 
-#: attr.c:363
+#: attr.c:364
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr ""
 
-#: attr.c:403
+#: attr.c:404
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
 msgstr ""
 
-#: bisect.c:489
+#: bisect.c:488
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Kontent terkutip jelek dalam berkas '%s': %s"
 
-#: bisect.c:699
+#: bisect.c:698
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Kami tidak dapat membagi dua lagi!\n"
 
-#: bisect.c:766
+#: bisect.c:764
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "Bukan sebuah nama komit yang valid %s"
 
-#: bisect.c:791
+#: bisect.c:789
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1691,7 +1712,7 @@ msgstr ""
 "Dasar penggabungan %s jelek.\n"
 "Ini berarti bug telah diperbaiki antara %s dan [%s].\n"
 
-#: bisect.c:796
+#: bisect.c:794
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1700,7 +1721,7 @@ msgstr ""
 "Dasar penggabungan %s baru.\n"
 "Properti telah berubah antara %s dan [%s].\n"
 
-#: bisect.c:801
+#: bisect.c:799
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1709,7 +1730,7 @@ msgstr ""
 "Dasar penggabungan %s adalah %s.\n"
 "Ini berarti komit '%s' pertama adalah di antara %s dan [%s].\n"
 
-#: bisect.c:809
+#: bisect.c:807
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1720,7 +1741,7 @@ msgstr ""
 "git bisect tidak dapat bekerja dengan benar pada kasus ini.\n"
 "Mungkin Anda salah mengira revisi %s dan %s?\n"
 
-#: bisect.c:822
+#: bisect.c:820
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1731,36 +1752,36 @@ msgstr ""
 "Jadi kami tidak dapat yakin komit %s pertama di antara %s dan %s.\n"
 "Kami tetap lanjutkan."
 
-#: bisect.c:861
+#: bisect.c:859
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Membagi dua: dasar penggabungan harus diuji\n"
 
-#: bisect.c:911
+#: bisect.c:909
 #, c-format
 msgid "a %s revision is needed"
 msgstr "sebuah revisi %s diperlukan"
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:298
+#: bisect.c:939
 #, c-format
 msgid "could not create file '%s'"
 msgstr "tidak dapat membuat berkas '%s'"
 
-#: bisect.c:987 builtin/merge.c:153
+#: bisect.c:985 builtin/merge.c:154
 #, c-format
 msgid "could not read file '%s'"
 msgstr "tidak dapat membaca berkas '%s'"
 
-#: bisect.c:1027
+#: bisect.c:1025
 msgid "reading bisect refs failed"
 msgstr "gagal membaca berkas referensi bagi dua"
 
-#: bisect.c:1057
+#: bisect.c:1055
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s sama-sama %s dan %s\n"
 
-#: bisect.c:1066
+#: bisect.c:1064
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1769,7 +1790,7 @@ msgstr ""
 "Tidak ada komit yang bisa diuji ditemukan.\n"
 "Mungkin Anda mulai dengan argumen jalur jelek?\n"
 
-#: bisect.c:1095
+#: bisect.c:1093
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1779,7 +1800,7 @@ msgstr[1] "(kira-kira %d langkah)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1101
+#: bisect.c:1099
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
@@ -1799,11 +1820,12 @@ msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "--reverse dan --first-parent bersama-sama butuh komit terbaru yang disebutkan"
 
-#: blame.c:2820 bundle.c:224 ref-filter.c:2278 remote.c:2041 sequencer.c:2333
-#: sequencer.c:4865 submodule.c:844 builtin/commit.c:1113 builtin/log.c:414
-#: builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056 builtin/log.c:2346
-#: builtin/merge.c:428 builtin/pack-objects.c:3343 builtin/pack-objects.c:3806
-#: builtin/pack-objects.c:3821 builtin/shortlog.c:255
+#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
+#: sequencer.c:2348 sequencer.c:4900 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
+#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
+#: builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "persiapan jalan revisi gagal"
 
@@ -1951,99 +1973,99 @@ msgstr ""
 #: bundle.c:44
 #, c-format
 msgid "unrecognized bundle hash algorithm: %s"
-msgstr ""
+msgstr "algoritma hash bundel tidak dikenal: %s"
 
 #: bundle.c:48
 #, c-format
 msgid "unknown capability '%s'"
-msgstr ""
+msgstr "kapabilitas '%s' tidak dikenal"
 
 #: bundle.c:74
 #, c-format
 msgid "'%s' does not look like a v2 or v3 bundle file"
-msgstr ""
+msgstr "'%s' tidak terlihat seperti berkas bundel v2 atau v3"
 
 #: bundle.c:113
 #, c-format
 msgid "unrecognized header: %s%s (%d)"
-msgstr ""
+msgstr "kepala tidak dikenal: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2593 sequencer.c:3385
-#: builtin/commit.c:861
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2616 sequencer.c:3402
+#: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
-msgstr ""
+msgstr "tidak dapat membuka '%s'"
 
 #: bundle.c:198
 msgid "Repository lacks these prerequisite commits:"
-msgstr ""
+msgstr "Repositori kekurangan komit prasyarat berikut:"
 
 #: bundle.c:201
 msgid "need a repository to verify a bundle"
-msgstr ""
+msgstr "perlu sebuah repositori untuk verifikasi bundel"
 
 #: bundle.c:257
 #, c-format
 msgid "The bundle contains this ref:"
 msgid_plural "The bundle contains these %d refs:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Bundel berisi referensi ini:"
+msgstr[1] "Bundel berisi %d referensi berikut:"
 
 #: bundle.c:264
 msgid "The bundle records a complete history."
-msgstr ""
+msgstr "Bundel merekam riwayat penuh."
 
 #: bundle.c:266
 #, c-format
 msgid "The bundle requires this ref:"
 msgid_plural "The bundle requires these %d refs:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Bundel membutuhkan referensi ini:"
+msgstr[1] "Bundel membutuhkan %d referensi berikut:"
 
 #: bundle.c:333
 msgid "unable to dup bundle descriptor"
-msgstr ""
+msgstr "tidak dapat men-dup pendeskripsi bundel"
 
 #: bundle.c:340
 msgid "Could not spawn pack-objects"
-msgstr ""
+msgstr "Tidak dapat menghidupkan pack-objects"
 
 #: bundle.c:351
 msgid "pack-objects died"
-msgstr ""
+msgstr "pack-objects mati"
 
 #: bundle.c:400
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
-msgstr ""
+msgstr "referensi '%s' dikecualikan oleh opsi rev-list"
 
 #: bundle.c:504
 #, c-format
 msgid "unsupported bundle version %d"
-msgstr ""
+msgstr "versi bundle %d tidak didukung"
 
 #: bundle.c:506
 #, c-format
 msgid "cannot write bundle version %d with algorithm %s"
-msgstr ""
+msgstr "tidak dapat menulis versi bundel %d dengan algoritma %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:396
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
-msgstr ""
+msgstr "argumen tidak dikenal: %s"
 
 #: bundle.c:553
 msgid "Refusing to create empty bundle."
-msgstr ""
+msgstr "Menolak memuat bundel kosong."
 
 #: bundle.c:563
 #, c-format
 msgid "cannot create '%s'"
-msgstr ""
+msgstr "tidak dapat membuat '%s'"
 
 #: bundle.c:588
 msgid "index-pack died"
-msgstr ""
+msgstr "index-pack mati"
 
 #: chunk-format.c:117
 msgid "terminating chunk id appears earlier than expected"
@@ -2069,7 +2091,7 @@ msgstr ""
 msgid "invalid color value: %.*s"
 msgstr ""
 
-#: commit-graph.c:204 midx.c:47
+#: commit-graph.c:204 midx.c:51
 msgid "invalid hash version"
 msgstr ""
 
@@ -2114,217 +2136,217 @@ msgstr ""
 msgid "unable to find all commit-graph files"
 msgstr ""
 
-#: commit-graph.c:745 commit-graph.c:782
+#: commit-graph.c:746 commit-graph.c:783
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:766
+#: commit-graph.c:767
 #, c-format
 msgid "could not find commit %s"
 msgstr ""
 
-#: commit-graph.c:799
+#: commit-graph.c:800
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 
-#: commit-graph.c:1075 builtin/am.c:1341
+#: commit-graph.c:1105 builtin/am.c:1342
 #, c-format
 msgid "unable to parse commit %s"
 msgstr ""
 
-#: commit-graph.c:1337 builtin/pack-objects.c:3057
+#: commit-graph.c:1367 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr ""
 
-#: commit-graph.c:1368
+#: commit-graph.c:1398
 msgid "Loading known commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1385
+#: commit-graph.c:1415
 msgid "Expanding reachable commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1405
+#: commit-graph.c:1435
 msgid "Clearing commit marks in commit graph"
 msgstr ""
 
-#: commit-graph.c:1424
+#: commit-graph.c:1454
 msgid "Computing commit graph topological levels"
 msgstr ""
 
-#: commit-graph.c:1477
+#: commit-graph.c:1507
 msgid "Computing commit graph generation numbers"
 msgstr ""
 
-#: commit-graph.c:1558
+#: commit-graph.c:1588
 msgid "Computing commit changed paths Bloom filters"
 msgstr ""
 
-#: commit-graph.c:1635
+#: commit-graph.c:1665
 msgid "Collecting referenced commits"
 msgstr ""
 
-#: commit-graph.c:1660
+#: commit-graph.c:1690
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:1673
+#: commit-graph.c:1703
 #, c-format
 msgid "error adding pack %s"
 msgstr ""
 
-#: commit-graph.c:1677
+#: commit-graph.c:1707
 #, c-format
 msgid "error opening index for %s"
 msgstr ""
 
-#: commit-graph.c:1714
+#: commit-graph.c:1744
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 
-#: commit-graph.c:1732
+#: commit-graph.c:1762
 msgid "Finding extra edges in commit graph"
 msgstr ""
 
-#: commit-graph.c:1781
+#: commit-graph.c:1811
 msgid "failed to write correct number of base graph ids"
 msgstr ""
 
-#: commit-graph.c:1812 midx.c:911
+#: commit-graph.c:1842 midx.c:1146
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr ""
 
-#: commit-graph.c:1825
+#: commit-graph.c:1855
 msgid "unable to create temporary graph layer"
 msgstr ""
 
-#: commit-graph.c:1830
+#: commit-graph.c:1860
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr ""
 
-#: commit-graph.c:1887
+#: commit-graph.c:1917
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:1923
+#: commit-graph.c:1953
 msgid "unable to open commit-graph chain file"
 msgstr ""
 
-#: commit-graph.c:1939
+#: commit-graph.c:1969
 msgid "failed to rename base commit-graph file"
 msgstr ""
 
-#: commit-graph.c:1959
+#: commit-graph.c:1989
 msgid "failed to rename temporary commit-graph file"
 msgstr ""
 
-#: commit-graph.c:2092
+#: commit-graph.c:2122
 msgid "Scanning merged commits"
 msgstr ""
 
-#: commit-graph.c:2136
+#: commit-graph.c:2166
 msgid "Merging commit-graph"
 msgstr ""
 
-#: commit-graph.c:2244
+#: commit-graph.c:2274
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 
-#: commit-graph.c:2351
+#: commit-graph.c:2381
 msgid "too many commits to write graph"
 msgstr ""
 
-#: commit-graph.c:2449
+#: commit-graph.c:2479
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:2459
+#: commit-graph.c:2489
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr ""
 
-#: commit-graph.c:2469 commit-graph.c:2484
+#: commit-graph.c:2499 commit-graph.c:2514
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 
-#: commit-graph.c:2476
+#: commit-graph.c:2506
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr ""
 
-#: commit-graph.c:2494
+#: commit-graph.c:2524
 msgid "Verifying commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:2509
+#: commit-graph.c:2539
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 
-#: commit-graph.c:2516
+#: commit-graph.c:2546
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2526
+#: commit-graph.c:2556
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 
-#: commit-graph.c:2535
+#: commit-graph.c:2565
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2549
+#: commit-graph.c:2579
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 
-#: commit-graph.c:2554
+#: commit-graph.c:2584
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2558
+#: commit-graph.c:2588
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2575
+#: commit-graph.c:2605
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 
-#: commit-graph.c:2581
+#: commit-graph.c:2611
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 
-#: commit.c:52 sequencer.c:3088 builtin/am.c:372 builtin/am.c:417
-#: builtin/am.c:422 builtin/am.c:1420 builtin/am.c:2067 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3105 builtin/am.c:373 builtin/am.c:418
+#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr ""
 
-#: commit.c:54
+#: commit.c:55
 #, c-format
 msgid "%s %s is not a commit!"
 msgstr ""
 
-#: commit.c:194
+#: commit.c:196
 msgid ""
 "Support for <GIT_DIR>/info/grafts is deprecated\n"
 "and will be removed in a future Git version.\n"
@@ -2336,27 +2358,27 @@ msgid ""
 "\"git config advice.graftFileDeprecated false\""
 msgstr ""
 
-#: commit.c:1237
+#: commit.c:1239
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 
-#: commit.c:1241
+#: commit.c:1243
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr ""
 
-#: commit.c:1244
+#: commit.c:1246
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr ""
 
-#: commit.c:1247
+#: commit.c:1249
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr ""
 
-#: commit.c:1501
+#: commit.c:1503
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2367,7 +2389,7 @@ msgstr ""
 msgid "memory exhausted"
 msgstr ""
 
-#: config.c:126
+#: config.c:125
 #, c-format
 msgid ""
 "exceeded maximum include depth (%d) while including\n"
@@ -2382,35 +2404,35 @@ msgstr ""
 "\t%s\n"
 "Ini mungkin disebabkan oleh include sirkular."
 
-#: config.c:142
+#: config.c:141
 #, c-format
 msgid "could not expand include path '%s'"
 msgstr "tidak dapat menjabarkan jalur include '%s'"
 
-#: config.c:153
+#: config.c:152
 msgid "relative config includes must come from files"
 msgstr "include konfigurasi relatif harus dari berkas"
 
-#: config.c:199
+#: config.c:201
 msgid "relative config include conditionals must come from files"
 msgstr "kondisional include konfigurasi relative harus dari berkas"
 
-#: config.c:396
+#: config.c:398
 #, c-format
 msgid "invalid config format: %s"
 msgstr "format konfigurasi tidak valid: %s"
 
-#: config.c:400
+#: config.c:402
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
 msgstr "nama variabel lingkungan untuk konfigurasi hilang '%.*s'"
 
-#: config.c:405
+#: config.c:407
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
 msgstr "variabel lingkungan '%s' untuk konfigurasi '%.*s'"
 
-#: config.c:442
+#: config.c:443
 #, c-format
 msgid "key does not contain a section: %s"
 msgstr "kunci tidak berisi bagian: %s"
@@ -2420,298 +2442,298 @@ msgstr "kunci tidak berisi bagian: %s"
 msgid "key does not contain variable name: %s"
 msgstr "kunci tidak berisi nama variabel: %s"
 
-#: config.c:472 sequencer.c:2785
+#: config.c:470 sequencer.c:2802
 #, c-format
 msgid "invalid key: %s"
 msgstr "kunci tidak valid: %s"
 
-#: config.c:478
+#: config.c:475
 #, c-format
 msgid "invalid key (newline): %s"
 msgstr "kunci tidak valid (barisbaru): %s"
 
-#: config.c:511
+#: config.c:495
 msgid "empty config key"
 msgstr "kunci konfigurasi kosong"
 
-#: config.c:529 config.c:541
+#: config.c:513 config.c:525
 #, c-format
 msgid "bogus config parameter: %s"
 msgstr "parameter konfigurasi gadungan: %s"
 
-#: config.c:555 config.c:572 config.c:579 config.c:588
+#: config.c:539 config.c:556 config.c:563 config.c:572
 #, c-format
 msgid "bogus format in %s"
 msgstr "format gadungan dalam %s"
 
-#: config.c:622
+#: config.c:606
 #, c-format
 msgid "bogus count in %s"
 msgstr "hitungan gadungan dalam %s"
 
-#: config.c:626
+#: config.c:610
 #, c-format
 msgid "too many entries in %s"
 msgstr "terlalu banyak entri di %s"
 
-#: config.c:636
+#: config.c:620
 #, c-format
 msgid "missing config key %s"
 msgstr "kunci konfigurasi %s hilang"
 
-#: config.c:644
+#: config.c:628
 #, c-format
 msgid "missing config value %s"
 msgstr "nilai konfigurasi %s hilang"
 
-#: config.c:995
+#: config.c:979
 #, c-format
 msgid "bad config line %d in blob %s"
 msgstr "baris konfigurasi %d jelek dalam blob %s"
 
-#: config.c:999
+#: config.c:983
 #, c-format
 msgid "bad config line %d in file %s"
 msgstr "baris konfigurasi %d jelek dalam berkas %s"
 
-#: config.c:1003
+#: config.c:987
 #, c-format
 msgid "bad config line %d in standard input"
 msgstr "baris konfigurasi %d jelek pada masukan standar"
 
-#: config.c:1007
+#: config.c:991
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
 msgstr "baris konfigurasi %d jelek dalam blob submodul %s"
 
-#: config.c:1011
+#: config.c:995
 #, c-format
 msgid "bad config line %d in command line %s"
 msgstr "baris konfigurasi %d jelek pada baris perintah %s"
 
-#: config.c:1015
+#: config.c:999
 #, c-format
 msgid "bad config line %d in %s"
 msgstr "baris konfigurasi %d jelek dalam %s"
 
-#: config.c:1152
+#: config.c:1136
 msgid "out of range"
 msgstr "di luar rentang"
 
-#: config.c:1152
+#: config.c:1136
 msgid "invalid unit"
 msgstr "satuan tidak valid"
 
-#: config.c:1153
+#: config.c:1137
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s': %s"
 
-#: config.c:1163
+#: config.c:1147
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam blob %s: %s"
 
-#: config.c:1166
+#: config.c:1150
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam berkas %s: %s"
 
-#: config.c:1169
+#: config.c:1153
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr ""
 "nilai konfigurasi numerik '%s' jelek untuk '%s' pada masukan standar: %s"
 
-#: config.c:1172
+#: config.c:1156
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr ""
 "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam blob submodul %s: %s"
 
-#: config.c:1175
+#: config.c:1159
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr ""
 "nilai konfigurasi numerik '%s' jelek untuk '%s' pada baris perintah %s: %s"
 
-#: config.c:1178
+#: config.c:1162
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam %s: %s"
 
-#: config.c:1257
+#: config.c:1241
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
 msgstr "nilai konfigurasi boolean '%s' jelek untuk '%s'"
 
-#: config.c:1275
+#: config.c:1259
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "gagal menjabarkan direktori pengguna di: '%s'"
 
-#: config.c:1284
+#: config.c:1268
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "'%s' untuk '%s' bukan stempel waktu valid"
 
-#: config.c:1377
+#: config.c:1361
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "panjang singkatan di luar rentang: %d"
 
-#: config.c:1391 config.c:1402
+#: config.c:1375 config.c:1386
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "level kompresi zlib jelek %d"
 
-#: config.c:1494
+#: config.c:1476
 msgid "core.commentChar should only be one character"
 msgstr "core.commentChar harusnya hanya satu karakter"
 
-#: config.c:1527
+#: config.c:1509
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "mode tidak valid untuk pembuatan objek: %s"
 
-#: config.c:1599
+#: config.c:1581
 #, c-format
 msgid "malformed value for %s"
 msgstr "nilai rusak untuk %s"
 
-#: config.c:1625
+#: config.c:1607
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "nilai rusak untuk %s: %s"
 
-#: config.c:1626
+#: config.c:1608
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "harus salah satu dari nothing, matching, simple, upstream atau current"
 
-#: config.c:1687 builtin/pack-objects.c:4084
+#: config.c:1669 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "level kompresi pak jelek %d"
 
-#: config.c:1809
+#: config.c:1792
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "tidak dapat memuat objek blob konfigurasi '%s'"
 
-#: config.c:1812
+#: config.c:1795
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "referensi '%s' tidak menunjuk pada sebuah blob"
 
-#: config.c:1829
+#: config.c:1813
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "tidak dapat menguraikan blob konfigurasi '%s'"
 
-#: config.c:1874
+#: config.c:1858
 #, c-format
 msgid "failed to parse %s"
 msgstr "gagal menguraikan %s"
 
-#: config.c:1930
+#: config.c:1914
 msgid "unable to parse command-line config"
 msgstr "gagal menguraikan konfigurasi baris perintah"
 
-#: config.c:2294
+#: config.c:2282
 msgid "unknown error occurred while reading the configuration files"
 msgstr "error tidak diketahui ketika membaca berkas konfigurasi"
 
-#: config.c:2468
+#: config.c:2456
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s tidak valid: '%s'"
 
-#: config.c:2513
+#: config.c:2501
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr "nilai splitIndex.maxPercentChange '%d' harusnya diantara 0 dan 100"
 
-#: config.c:2559
+#: config.c:2547
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "tidak dapat menguraikan '%s' dari konfigurasi baris perintah"
 
-#: config.c:2561
+#: config.c:2549
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "variabel konfigurasi '%s' jelek dalam berkas '%s' pada baris %d"
 
-#: config.c:2645
+#: config.c:2633
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "nama bagian '%s' tidak valid"
 
-#: config.c:2677
+#: config.c:2665
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s punya banyak nilai"
 
-#: config.c:2706
+#: config.c:2694
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "gagal menulis berkas konfigurasi baru %s"
 
-#: config.c:2958 config.c:3285
+#: config.c:2946 config.c:3273
 #, c-format
 msgid "could not lock config file %s"
 msgstr "tidak dapat mengunci berkas konfigurasi %s"
 
-#: config.c:2969
+#: config.c:2957
 #, c-format
 msgid "opening %s"
 msgstr "membuka %s"
 
-#: config.c:3006 builtin/config.c:361
+#: config.c:2994 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "pola tidak valid: %s"
 
-#: config.c:3031
+#: config.c:3019
 #, c-format
 msgid "invalid config file %s"
 msgstr "berkas konfigurasi %s tidak valid"
 
-#: config.c:3044 config.c:3298
+#: config.c:3032 config.c:3286
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat pada %s gagal"
 
-#: config.c:3055
+#: config.c:3043
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "tidak dapat me-mmap '%s'%s"
 
-#: config.c:3065 config.c:3303
+#: config.c:3053 config.c:3291
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod pada %s gagal"
 
-#: config.c:3150 config.c:3400
+#: config.c:3138 config.c:3388
 #, c-format
 msgid "could not write config file %s"
 msgstr "tidak dapat menulis berkas konfigurasi %s"
 
-#: config.c:3184
+#: config.c:3172
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "tidak dapat menyetel '%s' ke '%s'"
 
-#: config.c:3186 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "tidak dapat mem-batal setel '%s'"
 
-#: config.c:3276
+#: config.c:3264
 #, c-format
 msgid "invalid section name: %s"
 msgstr "nama bagian tidak valid: %s"
 
-#: config.c:3443
+#: config.c:3431
 #, c-format
 msgid "missing value for '%s'"
 msgstr "nilai hilang untuk '%s'"
@@ -2742,79 +2764,79 @@ msgstr ""
 msgid "expected flush after capabilities"
 msgstr ""
 
-#: connect.c:263
+#: connect.c:265
 #, c-format
 msgid "ignoring capabilities after first line '%s'"
 msgstr ""
 
-#: connect.c:284
+#: connect.c:286
 msgid "protocol error: unexpected capabilities^{}"
 msgstr ""
 
-#: connect.c:306
+#: connect.c:308
 #, c-format
 msgid "protocol error: expected shallow sha-1, got '%s'"
 msgstr ""
 
-#: connect.c:308
+#: connect.c:310
 msgid "repository on the other end cannot be shallow"
 msgstr ""
 
-#: connect.c:347
+#: connect.c:349
 msgid "invalid packet"
 msgstr ""
 
-#: connect.c:367
+#: connect.c:369
 #, c-format
 msgid "protocol error: unexpected '%s'"
 msgstr ""
 
-#: connect.c:497
+#: connect.c:499
 #, c-format
 msgid "unknown object format '%s' specified by server"
 msgstr ""
 
-#: connect.c:526
+#: connect.c:528
 #, c-format
 msgid "invalid ls-refs response: %s"
 msgstr ""
 
-#: connect.c:530
+#: connect.c:532
 msgid "expected flush after ref listing"
 msgstr ""
 
-#: connect.c:533
+#: connect.c:535
 msgid "expected response end packet after ref listing"
 msgstr ""
 
-#: connect.c:666
+#: connect.c:670
 #, c-format
 msgid "protocol '%s' is not supported"
 msgstr ""
 
-#: connect.c:717
+#: connect.c:721
 msgid "unable to set SO_KEEPALIVE on socket"
 msgstr ""
 
-#: connect.c:757 connect.c:820
+#: connect.c:761 connect.c:824
 #, c-format
 msgid "Looking up %s ... "
 msgstr ""
 
-#: connect.c:761
+#: connect.c:765
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
 msgstr ""
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
-#: connect.c:765 connect.c:836
+#: connect.c:769 connect.c:840
 #, c-format
 msgid ""
 "done.\n"
 "Connecting to %s (port %s) ... "
 msgstr ""
 
-#: connect.c:787 connect.c:864
+#: connect.c:791 connect.c:868
 #, c-format
 msgid ""
 "unable to connect to %s:\n"
@@ -2822,77 +2844,77 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#: connect.c:793 connect.c:870
+#: connect.c:797 connect.c:874
 msgid "done."
 msgstr ""
 
-#: connect.c:824
+#: connect.c:828
 #, c-format
 msgid "unable to look up %s (%s)"
 msgstr ""
 
-#: connect.c:830
+#: connect.c:834
 #, c-format
 msgid "unknown port %s"
 msgstr ""
 
-#: connect.c:967 connect.c:1299
+#: connect.c:971 connect.c:1303
 #, c-format
 msgid "strange hostname '%s' blocked"
 msgstr ""
 
-#: connect.c:969
+#: connect.c:973
 #, c-format
 msgid "strange port '%s' blocked"
 msgstr ""
 
-#: connect.c:979
+#: connect.c:983
 #, c-format
 msgid "cannot start proxy %s"
 msgstr ""
 
-#: connect.c:1050
+#: connect.c:1054
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr ""
 
-#: connect.c:1190
+#: connect.c:1194
 msgid "newline is forbidden in git:// hosts and repo paths"
 msgstr ""
 
-#: connect.c:1247
+#: connect.c:1251
 msgid "ssh variant 'simple' does not support -4"
 msgstr ""
 
-#: connect.c:1259
+#: connect.c:1263
 msgid "ssh variant 'simple' does not support -6"
 msgstr ""
 
-#: connect.c:1276
+#: connect.c:1280
 msgid "ssh variant 'simple' does not support setting port"
 msgstr ""
 
-#: connect.c:1388
+#: connect.c:1392
 #, c-format
 msgid "strange pathname '%s' blocked"
 msgstr ""
 
-#: connect.c:1436
+#: connect.c:1440
 msgid "unable to fork"
 msgstr ""
 
-#: connected.c:108 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr ""
 
-#: connected.c:120
+#: connected.c:122
 msgid "Could not run 'git rev-list'"
 msgstr ""
 
-#: connected.c:144
+#: connected.c:146
 msgid "failed write to rev-list"
 msgstr ""
 
-#: connected.c:149
+#: connected.c:151
 msgid "failed to close rev-list's stdin"
 msgstr ""
 
@@ -3026,17 +3048,17 @@ msgstr ""
 msgid "refusing to work with credential missing protocol field"
 msgstr ""
 
-#: credential.c:394
+#: credential.c:395
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr ""
 
-#: credential.c:438
+#: credential.c:439
 #, c-format
 msgid "url has no scheme: %s"
 msgstr ""
 
-#: credential.c:511
+#: credential.c:512
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr ""
@@ -3138,23 +3160,23 @@ msgstr ""
 msgid "unknown value for --diff-merges: %s"
 msgstr ""
 
-#: diff-lib.c:557
+#: diff-lib.c:561
 msgid "--merge-base does not work with ranges"
 msgstr ""
 
-#: diff-lib.c:559
+#: diff-lib.c:563
 msgid "--merge-base only works with commits"
 msgstr ""
 
-#: diff-lib.c:576
+#: diff-lib.c:580
 msgid "unable to get HEAD"
 msgstr ""
 
-#: diff-lib.c:583
+#: diff-lib.c:587
 msgid "no merge base found"
 msgstr ""
 
-#: diff-lib.c:585
+#: diff-lib.c:589
 msgid "multiple merge bases found"
 msgstr ""
 
@@ -3168,17 +3190,17 @@ msgid ""
 "tree"
 msgstr ""
 
-#: diff.c:156
+#: diff.c:157
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr "  Gagal mengurai persentase potongan dirstat '%s'\n"
 
-#: diff.c:161
+#: diff.c:162
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Parameter dirstat tidak ditketahui '%s'\n"
 
-#: diff.c:297
+#: diff.c:298
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3186,7 +3208,7 @@ msgstr ""
 "Setelan warna berpindah harus salah satu dari 'no', 'default', 'blocks', "
 "'dimmed-zebra', 'plain'"
 
-#: diff.c:325
+#: diff.c:326
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3196,7 +3218,7 @@ msgstr ""
 "space-change', 'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-"
 "change'"
 
-#: diff.c:333
+#: diff.c:334
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3204,12 +3226,12 @@ msgstr ""
 "color-moved-ws: allow-indentation-change tidak dapat digabungkan dengan mode "
 "spasi yang lainnya"
 
-#: diff.c:410
+#: diff.c:411
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Nilai tidak dikenal untuk variabel konfigurasi 'diff.submodule': '%s'"
 
-#: diff.c:470
+#: diff.c:471
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3218,26 +3240,26 @@ msgstr ""
 "Ditemukan error dalam variable konfigurasi 'diff.dirstat':\n"
 "%s"
 
-#: diff.c:4282
+#: diff.c:4290
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "diff eksternal mati, berhenti pada %s"
 
-#: diff.c:4634
+#: diff.c:4642
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr "--name-only, --name-status, --check dan -s saling eksklusif"
 
-#: diff.c:4637
+#: diff.c:4645
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S dan --find-object saling eksklusif"
 
-#: diff.c:4640
+#: diff.c:4648
 msgid ""
 "-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
 msgstr ""
 "-G dan --pickaxe-regex saling eksklusif, gunakan --pickaxe-regex dengan -S"
 
-#: diff.c:4643
+#: diff.c:4651
 msgid ""
 "--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
 "with -G and -S"
@@ -3245,22 +3267,22 @@ msgstr ""
 "--pickaxe-all dan --find-object saling eksklusif, gunakan --pickaxe-all "
 "dengan -G dan -S"
 
-#: diff.c:4722
+#: diff.c:4730
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow butuh tepatnya satu spek jalur"
 
-#: diff.c:4770
+#: diff.c:4778
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "nilai --stat tidak valid: %s"
 
-#: diff.c:4775 diff.c:4780 diff.c:4785 diff.c:4790 diff.c:5318
-#: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
+#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s harap nilai numerik"
 
-#: diff.c:4807
+#: diff.c:4815
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3269,42 +3291,42 @@ msgstr ""
 "Gagal menguraikan parameter opsi --dirstat/-X:\n"
 "%s"
 
-#: diff.c:4892
+#: diff.c:4900
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "kelas perubahan '%c' tidak dikenal dalam --diff-filter=%s"
 
-#: diff.c:4916
+#: diff.c:4924
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "nilai tidak dikenal setelah ws-error-highlight=%.*s"
 
-#: diff.c:4930
+#: diff.c:4938
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "tidak dapat menguraikan '%s'"
 
-#: diff.c:4980 diff.c:4986
+#: diff.c:4988 diff.c:4994
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s butuh bentuk <n>/<m>"
 
-#: diff.c:4998
+#: diff.c:5006
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s butuh sebuah karakter, dapat '%s'"
 
-#: diff.c:5019
+#: diff.c:5027
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "argumen --color-moved jelek: %s"
 
-#: diff.c:5038
+#: diff.c:5046
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "mode tidak valid '%s' dalam --color-moved-ws"
 
-#: diff.c:5078
+#: diff.c:5086
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3312,162 +3334,162 @@ msgstr ""
 "opsi diff-algorithm terima \"myers\", \"minimal\", \"patience\" dan "
 "\"histogram\""
 
-#: diff.c:5114 diff.c:5134
+#: diff.c:5122 diff.c:5142
 #, c-format
 msgid "invalid argument to %s"
 msgstr "argumen tidak valid ke %s"
 
-#: diff.c:5238
+#: diff.c:5246
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "regex tidak valid diberikan ke -I: '%s'"
 
-#: diff.c:5287
+#: diff.c:5295
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "gagal menguraikan parameter opsi --submodule: '%s'"
 
-#: diff.c:5343
+#: diff.c:5351
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "argumen --word-diff jelek: %s"
 
-#: diff.c:5379
+#: diff.c:5387
 msgid "Diff output format options"
 msgstr "Opsi format keluaran diff"
 
-#: diff.c:5381 diff.c:5387
+#: diff.c:5389 diff.c:5395
 msgid "generate patch"
 msgstr "buat tambalan"
 
-#: diff.c:5384 builtin/log.c:179
+#: diff.c:5392 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "sembunyikan keluaran diff"
 
-#: diff.c:5389 diff.c:5503 diff.c:5510
+#: diff.c:5397 diff.c:5511 diff.c:5518
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5390 diff.c:5393
+#: diff.c:5398 diff.c:5401
 msgid "generate diffs with <n> lines context"
 msgstr "buat diff dengan <n> baris konteks"
 
-#: diff.c:5395
+#: diff.c:5403
 msgid "generate the diff in raw format"
 msgstr "buat diff dalam format mentah"
 
-#: diff.c:5398
+#: diff.c:5406
 msgid "synonym for '-p --raw'"
 msgstr "sinonim untuk '-p --raw'"
 
-#: diff.c:5402
+#: diff.c:5410
 msgid "synonym for '-p --stat'"
 msgstr "sinonim untuk '-p --stat'"
 
-#: diff.c:5406
+#: diff.c:5414
 msgid "machine friendly --stat"
 msgstr "--stat yang ramah mesin"
 
-#: diff.c:5409
+#: diff.c:5417
 msgid "output only the last line of --stat"
 msgstr "keluarkan hanya baris terakhir --stat"
 
-#: diff.c:5411 diff.c:5419
+#: diff.c:5419 diff.c:5427
 msgid "<param1,param2>..."
 msgstr "<parameter 1,parameter 2>..."
 
-#: diff.c:5412
+#: diff.c:5420
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "keluarkan distribusi jumlah perubahan relatif untuk setiap subdirektori"
 
-#: diff.c:5416
+#: diff.c:5424
 msgid "synonym for --dirstat=cumulative"
 msgstr "sinonim untuk --dirstat=cumulative"
 
-#: diff.c:5420
+#: diff.c:5428
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "sinonim untuk --dirstat=files,param1,param2..."
 
-#: diff.c:5424
+#: diff.c:5432
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "peringatkan bila perubahan memasukkan penanda konflik atau kesalahan spasi"
 
-#: diff.c:5427
+#: diff.c:5435
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "ringkasan singkat seperti pembuatan, penggantian nama dan perubahan mode"
 
-#: diff.c:5430
+#: diff.c:5438
 msgid "show only names of changed files"
 msgstr "perlihatkan hanya nama berkas yang berubah"
 
-#: diff.c:5433
+#: diff.c:5441
 msgid "show only names and status of changed files"
 msgstr "perlihatkan hanya nama dan status berkas yang berubah"
 
-#: diff.c:5435
+#: diff.c:5443
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<lebar>[,<nama lebar>[,<hitungan>]]"
 
-#: diff.c:5436
+#: diff.c:5444
 msgid "generate diffstat"
 msgstr "buat diffstat"
 
-#: diff.c:5438 diff.c:5441 diff.c:5444
+#: diff.c:5446 diff.c:5449 diff.c:5452
 msgid "<width>"
 msgstr "<lebar>"
 
-#: diff.c:5439
+#: diff.c:5447
 msgid "generate diffstat with a given width"
 msgstr "buat diffstat dengan lebar yang diberikan"
 
-#: diff.c:5442
+#: diff.c:5450
 msgid "generate diffstat with a given name width"
 msgstr "buat diffstat dengan nama lebar yang diberikan"
 
-#: diff.c:5445
+#: diff.c:5453
 msgid "generate diffstat with a given graph width"
 msgstr "buat diffstat dengan lebar grafik yang diberikan"
 
-#: diff.c:5447
+#: diff.c:5455
 msgid "<count>"
 msgstr "<hitungan>"
 
-#: diff.c:5448
+#: diff.c:5456
 msgid "generate diffstat with limited lines"
 msgstr "buat diffstat dengan baris yang terbatas"
 
-#: diff.c:5451
+#: diff.c:5459
 msgid "generate compact summary in diffstat"
 msgstr "buat ringkasan singkat dalam diffstat"
 
-#: diff.c:5454
+#: diff.c:5462
 msgid "output a binary diff that can be applied"
 msgstr "keluarkan diff biner yang dapat diterapkan"
 
-#: diff.c:5457
+#: diff.c:5465
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "perlihatkan objek pra- dan pasca-citra penuh pada baris \"index\""
 
-#: diff.c:5459
+#: diff.c:5467
 msgid "show colored diff"
 msgstr "perlihatkan diff berwarna"
 
-#: diff.c:5460
+#: diff.c:5468
 msgid "<kind>"
 msgstr "<tipe>"
 
-#: diff.c:5461
+#: diff.c:5469
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
 msgstr ""
 "soroti kesalahan spasi dalam baris 'context', 'old' atau 'new' dalam diff"
 
-#: diff.c:5464
+#: diff.c:5472
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3475,91 +3497,91 @@ msgstr ""
 "jangan tengkar jalur nama dan gunakan NUL sebagai pembatas bidang keluaran "
 "pada --raw atau --numstat"
 
-#: diff.c:5467 diff.c:5470 diff.c:5473 diff.c:5582
+#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
 msgid "<prefix>"
 msgstr "<prefiks>"
 
-#: diff.c:5468
+#: diff.c:5476
 msgid "show the given source prefix instead of \"a/\""
 msgstr "perlihatkan prefiks sumber yang diberikan daripada \"a/\""
 
-#: diff.c:5471
+#: diff.c:5479
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "perlihatkan prefiks tujuan daripada \"b/\""
 
-#: diff.c:5474
+#: diff.c:5482
 msgid "prepend an additional prefix to every line of output"
 msgstr "tambah depan prefiks tambahan pada setiap baris keluaran"
 
-#: diff.c:5477
+#: diff.c:5485
 msgid "do not show any source or destination prefix"
 msgstr "jangan perlihatkan prefiks sumber atau tujuan apapun"
 
-#: diff.c:5480
+#: diff.c:5488
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
-"perlihatkan konteks diantara hunk diff hingga jumlah baris yang disebutkan"
+"perlihatkan konteks diantara bingkah diff hingga jumlah baris yang disebutkan"
 
-#: diff.c:5484 diff.c:5489 diff.c:5494
+#: diff.c:5492 diff.c:5497 diff.c:5502
 msgid "<char>"
 msgstr "<karakter>"
 
-#: diff.c:5485
+#: diff.c:5493
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "sebutkan karakter yang menandai baris baru daripada '+'"
 
-#: diff.c:5490
+#: diff.c:5498
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "sebutkan karakter yang menandai baris lama daripada '-'"
 
-#: diff.c:5495
+#: diff.c:5503
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "sebutkan karakter yang menandai konteks daripada ' '"
 
-#: diff.c:5498
+#: diff.c:5506
 msgid "Diff rename options"
 msgstr "Opsi penamaan ulang diff"
 
-#: diff.c:5499
+#: diff.c:5507
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5500
+#: diff.c:5508
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "pisahkan perubahan penulisan ulang penuh kedalam pasangan penghapusan dan "
 "pembuatan"
 
-#: diff.c:5504
+#: diff.c:5512
 msgid "detect renames"
 msgstr "deteksi penamaan ulang"
 
-#: diff.c:5508
+#: diff.c:5516
 msgid "omit the preimage for deletes"
 msgstr "lewati pracitra untuk penghapusan"
 
-#: diff.c:5511
+#: diff.c:5519
 msgid "detect copies"
 msgstr "deteksi penyalinan"
 
-#: diff.c:5515
+#: diff.c:5523
 msgid "use unmodified files as source to find copies"
 msgstr ""
 "gunakan berkas tak termodifikasi sebagai sumber untuk menemukan salinan"
 
-#: diff.c:5517
+#: diff.c:5525
 msgid "disable rename detection"
 msgstr "nonaktifkan deteksi penamaan ulang"
 
-#: diff.c:5520
+#: diff.c:5528
 msgid "use empty blobs as rename source"
 msgstr "gunakan blob kosong sebagai sumber penamaan ulang"
 
-#: diff.c:5522
+#: diff.c:5530
 msgid "continue listing the history of a file beyond renames"
 msgstr "lanjutkan daftarkan riwayat berkas di luar penamaan ulang"
 
-#: diff.c:5525
+#: diff.c:5533
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3567,231 +3589,232 @@ msgstr ""
 "cegah pendeteksian penamaan ulang/penyalinan jika jumlah target penamaan "
 "ulang/penyalinan melebihi batas yang diberikan"
 
-#: diff.c:5527
+#: diff.c:5535
 msgid "Diff algorithm options"
 msgstr "Opsi algoritma diff"
 
-#: diff.c:5529
+#: diff.c:5537
 msgid "produce the smallest possible diff"
 msgstr "hasilkan diff yang paling kecil yang dimungkinkan"
 
-#: diff.c:5532
+#: diff.c:5540
 msgid "ignore whitespace when comparing lines"
 msgstr "abaikan spasi saat membandingkan baris"
 
-#: diff.c:5535
+#: diff.c:5543
 msgid "ignore changes in amount of whitespace"
 msgstr "abaikan perubahan dalam jumlah spasi"
 
-#: diff.c:5538
+#: diff.c:5546
 msgid "ignore changes in whitespace at EOL"
 msgstr "abaikan perubahan spasi pada EOL"
 
-#: diff.c:5541
+#: diff.c:5549
 msgid "ignore carrier-return at the end of line"
 msgstr "abaikan kembalian-kurir pada akhir baris"
 
-#: diff.c:5544
+#: diff.c:5552
 msgid "ignore changes whose lines are all blank"
 msgstr "abaikan perubahan yang semua baris kosong"
 
-#: diff.c:5546 diff.c:5568 diff.c:5571 diff.c:5616
+#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
 msgid "<regex>"
 msgstr "<regex>"
 
-#: diff.c:5547
+#: diff.c:5555
 msgid "ignore changes whose all lines match <regex>"
 msgstr "abaikan perubahan yang semua baris cocok dengan <regex>"
 
-#: diff.c:5550
+#: diff.c:5558
 msgid "heuristic to shift diff hunk boundaries for easy reading"
-msgstr "heuristik untuk geser perbatasan hunk diff untuk pembacaan yang mudah"
+msgstr ""
+"heuristik untuk geser perbatasan bingkah diff untuk pembacaan yang mudah"
 
-#: diff.c:5553
+#: diff.c:5561
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "buat diff menggunakan algoritma \"diff sabar\""
 
-#: diff.c:5557
+#: diff.c:5565
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "buat diff menggunakan algoritma \"diff histogram\""
 
-#: diff.c:5559
+#: diff.c:5567
 msgid "<algorithm>"
 msgstr "<algoritma>"
 
-#: diff.c:5560
+#: diff.c:5568
 msgid "choose a diff algorithm"
 msgstr "pilih algoritma diff"
 
-#: diff.c:5562
+#: diff.c:5570
 msgid "<text>"
 msgstr "<teks>"
 
-#: diff.c:5563
+#: diff.c:5571
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "buat diff menggunakan algoritma \"diff terlabuh\""
 
-#: diff.c:5565 diff.c:5574 diff.c:5577
+#: diff.c:5573 diff.c:5582 diff.c:5585
 msgid "<mode>"
 msgstr "<mode>"
 
-#: diff.c:5566
+#: diff.c:5574
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "perlihatkan diff kata, menggunakan <mode> untuk batasi kata yang berubah"
 
-#: diff.c:5569
+#: diff.c:5577
 msgid "use <regex> to decide what a word is"
 msgstr "gunakan <regex> untuk menentukan apa itu kata"
 
-#: diff.c:5572
+#: diff.c:5580
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "sama dengan --word-diff=color --word-diff-regex=<regex>"
 
-#: diff.c:5575
+#: diff.c:5583
 msgid "moved lines of code are colored differently"
 msgstr "baris kode yang berpindah diwarnai berbeda"
 
-#: diff.c:5578
+#: diff.c:5586
 msgid "how white spaces are ignored in --color-moved"
 msgstr "bagaimana spasi diabaikan di --color-moved"
 
-#: diff.c:5581
+#: diff.c:5589
 msgid "Other diff options"
 msgstr "Opsi diff yang lainnya"
 
-#: diff.c:5583
+#: diff.c:5591
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "ketika dijalankan dari subdirektori, kecualikan perubahan diluar dan "
 "perlihatkan jalur relatif"
 
-#: diff.c:5587
+#: diff.c:5595
 msgid "treat all files as text"
 msgstr "perlakukan semua berkas sebagai teks"
 
-#: diff.c:5589
+#: diff.c:5597
 msgid "swap two inputs, reverse the diff"
 msgstr "tukar dua masukkan, balikkan diff"
 
-#: diff.c:5591
+#: diff.c:5599
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr "keluar dengan 1 jika ada perbedaan, selain itu 0"
 
-#: diff.c:5593
+#: diff.c:5601
 msgid "disable all output of the program"
 msgstr "nonaktifkan semua keluaran program"
 
-#: diff.c:5595
+#: diff.c:5603
 msgid "allow an external diff helper to be executed"
 msgstr "perbolehkan pembantu diff eksternal untuk dieksekusi"
 
-#: diff.c:5597
+#: diff.c:5605
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "jalankan saringan konversi teks eksternal ketika membandingkan berkas biner"
 
-#: diff.c:5599
+#: diff.c:5607
 msgid "<when>"
 msgstr "<kapan>"
 
-#: diff.c:5600
+#: diff.c:5608
 msgid "ignore changes to submodules in the diff generation"
 msgstr "abaikan perubahan submodul dalam pembuatan diff"
 
-#: diff.c:5603
+#: diff.c:5611
 msgid "<format>"
 msgstr "<format>"
 
-#: diff.c:5604
+#: diff.c:5612
 msgid "specify how differences in submodules are shown"
 msgstr "sebutkan bagaimana perbedaan dalam submodul diperlihatkan"
 
-#: diff.c:5608
+#: diff.c:5616
 msgid "hide 'git add -N' entries from the index"
 msgstr "sembunyikan entri 'git add -N' dari indeks"
 
-#: diff.c:5611
+#: diff.c:5619
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "perlakukan entri 'git add -N' sebagai nyata dalam indeks"
 
-#: diff.c:5613
+#: diff.c:5621
 msgid "<string>"
 msgstr "<untai>"
 
-#: diff.c:5614
+#: diff.c:5622
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr "cari perbedaan yang mengubah jumlah kemunculan untai yang disebutkan"
 
-#: diff.c:5617
+#: diff.c:5625
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
 msgstr "cari perbedaan yang mengubah jumlah kemunculan regex yang disebutkan"
 
-#: diff.c:5620
+#: diff.c:5628
 msgid "show all changes in the changeset with -S or -G"
 msgstr "perlihatkan semua perubahan dalam set perubahan dengan -S atau -G"
 
-#: diff.c:5623
+#: diff.c:5631
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "perlakukan <string> di -S sebagai ekspresi reguler POSIX yang diperluas"
 
-#: diff.c:5626
+#: diff.c:5634
 msgid "control the order in which files appear in the output"
 msgstr "kontrol urutan berkas yang muncul dalam keluaran"
 
-#: diff.c:5627 diff.c:5630
+#: diff.c:5635 diff.c:5638
 msgid "<path>"
 msgstr "<jalur>"
 
-#: diff.c:5628
+#: diff.c:5636
 msgid "show the change in the specified path first"
 msgstr "perlihatkan perubahan dalam jalur yang disebutkan terlebih dahulu"
 
-#: diff.c:5631
+#: diff.c:5639
 msgid "skip the output to the specified path"
 msgstr "lewati keluaran ke jalur yang disebutkan"
 
-#: diff.c:5633
+#: diff.c:5641
 msgid "<object-id>"
 msgstr "<id objek>"
 
-#: diff.c:5634
+#: diff.c:5642
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
 msgstr "cari perubahan yang mengubah jumlah kemunculan objek yang disebutkan"
 
-#: diff.c:5636
+#: diff.c:5644
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5637
+#: diff.c:5645
 msgid "select files by diff type"
 msgstr "pilih berkas oleh tipe diff"
 
-#: diff.c:5639
+#: diff.c:5647
 msgid "<file>"
 msgstr "<berkas>"
 
-#: diff.c:5640
+#: diff.c:5648
 msgid "Output to a specific file"
 msgstr "Keluarkan ke berkas yang disebutkan"
 
-#: diff.c:6298
+#: diff.c:6306
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr "deteksi penamaan ulang lengkap dilewati karena terlalu banyak berkas."
 
-#: diff.c:6301
+#: diff.c:6309
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "hanya ditemukan salinan dari jalur yang berubah karena terlalu banyak berkas."
 
-#: diff.c:6304
+#: diff.c:6312
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3804,7 +3827,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr ""
 
-#: diffcore-rename.c:1514
+#: diffcore-rename.c:1564
 msgid "Performing inexact rename detection"
 msgstr ""
 
@@ -3842,56 +3865,59 @@ msgstr ""
 msgid "cannot use %s as an exclude file"
 msgstr ""
 
-#: dir.c:2351
+#: dir.c:2464
 #, c-format
 msgid "could not open directory '%s'"
 msgstr ""
 
-#: dir.c:2653
+#: dir.c:2766
 msgid "failed to get kernel name and information"
 msgstr ""
 
-#: dir.c:2777
+#: dir.c:2890
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 
-#: dir.c:3610
+#: dir.c:3158
+msgid ""
+"No directory name could be guessed.\n"
+"Please specify a directory on the command line"
+msgstr ""
+"Nama direktori tidak dapat ditebak.\n"
+"Mohon sebutkan direktori pada baris perintah"
+
+#: dir.c:3837
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr ""
 
-#: dir.c:3657 dir.c:3662
+#: dir.c:3884 dir.c:3889
 #, c-format
 msgid "could not create directories for %s"
 msgstr ""
 
-#: dir.c:3691
+#: dir.c:3918
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr ""
 
-#: editor.c:74
+#: editor.c:77
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr ""
 
-#: entry.c:176
+#: entry.c:177
 msgid "Filtering content"
 msgstr ""
 
-#: entry.c:497
+#: entry.c:498
 #, c-format
 msgid "could not stat file '%s'"
 msgstr ""
 
-#: environment.c:152
+#: environment.c:143
 #, c-format
 msgid "bad git namespace path \"%s\""
-msgstr ""
-
-#: environment.c:334
-#, c-format
-msgid "could not set GIT_DIR to '%s'"
 msgstr ""
 
 #: exec-cmd.c:363
@@ -3899,272 +3925,340 @@ msgstr ""
 msgid "too many args to run %s"
 msgstr ""
 
-#: fetch-pack.c:182
+#: fetch-pack.c:193
 msgid "git fetch-pack: expected shallow list"
 msgstr ""
 
-#: fetch-pack.c:185
+#: fetch-pack.c:196
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr ""
 
-#: fetch-pack.c:196
+#: fetch-pack.c:207
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr ""
 
-#: fetch-pack.c:216
+#: fetch-pack.c:227
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr ""
 
-#: fetch-pack.c:227
+#: fetch-pack.c:238
 msgid "unable to write to remote"
 msgstr ""
 
-#: fetch-pack.c:288
+#: fetch-pack.c:299
 msgid "--stateless-rpc requires multi_ack_detailed"
-msgstr ""
-
-#: fetch-pack.c:383 fetch-pack.c:1423
-#, c-format
-msgid "invalid shallow line: %s"
-msgstr ""
-
-#: fetch-pack.c:389 fetch-pack.c:1429
-#, c-format
-msgid "invalid unshallow line: %s"
-msgstr ""
-
-#: fetch-pack.c:391 fetch-pack.c:1431
-#, c-format
-msgid "object not found: %s"
 msgstr ""
 
 #: fetch-pack.c:394 fetch-pack.c:1434
 #, c-format
+msgid "invalid shallow line: %s"
+msgstr ""
+
+#: fetch-pack.c:400 fetch-pack.c:1440
+#, c-format
+msgid "invalid unshallow line: %s"
+msgstr ""
+
+#: fetch-pack.c:402 fetch-pack.c:1442
+#, c-format
+msgid "object not found: %s"
+msgstr ""
+
+#: fetch-pack.c:405 fetch-pack.c:1445
+#, c-format
 msgid "error in object: %s"
 msgstr ""
 
-#: fetch-pack.c:396 fetch-pack.c:1436
+#: fetch-pack.c:407 fetch-pack.c:1447
 #, c-format
 msgid "no shallow found: %s"
 msgstr ""
 
-#: fetch-pack.c:399 fetch-pack.c:1440
+#: fetch-pack.c:410 fetch-pack.c:1451
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr ""
 
-#: fetch-pack.c:439
+#: fetch-pack.c:450
 #, c-format
 msgid "got %s %d %s"
 msgstr ""
 
-#: fetch-pack.c:456
+#: fetch-pack.c:467
 #, c-format
 msgid "invalid commit %s"
 msgstr ""
 
-#: fetch-pack.c:487
+#: fetch-pack.c:498
 msgid "giving up"
 msgstr ""
 
-#: fetch-pack.c:500 progress.c:339
+#: fetch-pack.c:511 progress.c:339
 msgid "done"
 msgstr ""
 
-#: fetch-pack.c:512
+#: fetch-pack.c:523
 #, c-format
 msgid "got %s (%d) %s"
 msgstr ""
 
-#: fetch-pack.c:548
+#: fetch-pack.c:559
 #, c-format
 msgid "Marking %s as complete"
 msgstr ""
 
-#: fetch-pack.c:763
+#: fetch-pack.c:774
 #, c-format
 msgid "already have %s (%s)"
 msgstr ""
 
-#: fetch-pack.c:849
+#: fetch-pack.c:860
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr ""
 
-#: fetch-pack.c:857
+#: fetch-pack.c:868
 msgid "protocol error: bad pack header"
 msgstr ""
 
-#: fetch-pack.c:951
+#: fetch-pack.c:962
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr ""
 
-#: fetch-pack.c:957
+#: fetch-pack.c:968
 msgid "fetch-pack: invalid index-pack output"
 msgstr ""
 
-#: fetch-pack.c:974
+#: fetch-pack.c:985
 #, c-format
 msgid "%s failed"
 msgstr ""
 
-#: fetch-pack.c:976
+#: fetch-pack.c:987
 msgid "error in sideband demultiplexer"
 msgstr ""
 
-#: fetch-pack.c:1019
+#: fetch-pack.c:1030
 #, c-format
 msgid "Server version is %.*s"
 msgstr ""
 
-#: fetch-pack.c:1027 fetch-pack.c:1033 fetch-pack.c:1036 fetch-pack.c:1042
-#: fetch-pack.c:1046 fetch-pack.c:1050 fetch-pack.c:1054 fetch-pack.c:1058
-#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
-#: fetch-pack.c:1080 fetch-pack.c:1086 fetch-pack.c:1091 fetch-pack.c:1096
+#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
+#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
+#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
+#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
 #, c-format
 msgid "Server supports %s"
 msgstr ""
 
-#: fetch-pack.c:1029
+#: fetch-pack.c:1040
 msgid "Server does not support shallow clients"
 msgstr ""
 
-#: fetch-pack.c:1089
+#: fetch-pack.c:1100
 msgid "Server does not support --shallow-since"
 msgstr ""
 
-#: fetch-pack.c:1094
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-exclude"
 msgstr ""
 
-#: fetch-pack.c:1098
+#: fetch-pack.c:1109
 msgid "Server does not support --deepen"
 msgstr ""
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1111
 msgid "Server does not support this repository's object format"
 msgstr ""
 
-#: fetch-pack.c:1113
+#: fetch-pack.c:1124
 msgid "no common commits"
 msgstr ""
 
-#: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
+#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr ""
 
-#: fetch-pack.c:1128 fetch-pack.c:1660
+#: fetch-pack.c:1139 fetch-pack.c:1671
 msgid "git fetch-pack: fetch failed."
 msgstr ""
 
-#: fetch-pack.c:1242
+#: fetch-pack.c:1253
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr ""
 
-#: fetch-pack.c:1246
+#: fetch-pack.c:1257
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr ""
 
-#: fetch-pack.c:1279
+#: fetch-pack.c:1290
 msgid "Server does not support shallow requests"
 msgstr ""
 
-#: fetch-pack.c:1286
+#: fetch-pack.c:1297
 msgid "Server supports filter"
 msgstr ""
 
-#: fetch-pack.c:1329 fetch-pack.c:2043
+#: fetch-pack.c:1340 fetch-pack.c:2053
 msgid "unable to write request to remote"
 msgstr ""
 
-#: fetch-pack.c:1347
+#: fetch-pack.c:1358
 #, c-format
 msgid "error reading section header '%s'"
 msgstr ""
 
-#: fetch-pack.c:1353
+#: fetch-pack.c:1364
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr ""
 
-#: fetch-pack.c:1387
+#: fetch-pack.c:1398
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr ""
 
-#: fetch-pack.c:1392
+#: fetch-pack.c:1403
 #, c-format
 msgid "error processing acks: %d"
 msgstr ""
 
-#: fetch-pack.c:1402
+#: fetch-pack.c:1413
 msgid "expected packfile to be sent after 'ready'"
 msgstr ""
 
-#: fetch-pack.c:1404
+#: fetch-pack.c:1415
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 
-#: fetch-pack.c:1445
+#: fetch-pack.c:1456
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr ""
 
-#: fetch-pack.c:1494
+#: fetch-pack.c:1505
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr ""
 
-#: fetch-pack.c:1499
+#: fetch-pack.c:1510
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr ""
 
-#: fetch-pack.c:1504
+#: fetch-pack.c:1515
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr ""
 
-#: fetch-pack.c:1534
+#: fetch-pack.c:1545
 msgid "git fetch-pack: expected response end packet"
 msgstr ""
 
-#: fetch-pack.c:1939
+#: fetch-pack.c:1949
 msgid "no matching remote head"
 msgstr ""
 
-#: fetch-pack.c:1962 builtin/clone.c:697
+#: fetch-pack.c:1972 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr ""
 
-#: fetch-pack.c:2065
+#: fetch-pack.c:2075
 msgid "unexpected 'ready' from remote"
 msgstr ""
 
-#: fetch-pack.c:2088
+#: fetch-pack.c:2098
 #, c-format
 msgid "no such remote ref %s"
 msgstr ""
 
-#: fetch-pack.c:2091
+#: fetch-pack.c:2101
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr ""
 
-#: gpg-interface.c:273
+#: gpg-interface.c:329 gpg-interface.c:449 gpg-interface.c:900
+#: gpg-interface.c:916
 msgid "could not create temporary file"
 msgstr ""
 
-#: gpg-interface.c:276
+#: gpg-interface.c:332 gpg-interface.c:452
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr ""
 
-#: gpg-interface.c:470
+#: gpg-interface.c:443
+msgid ""
+"gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
+"signature verification"
+msgstr ""
+
+#: gpg-interface.c:467
+msgid ""
+"ssh-keygen -Y find-principals/verify is needed for ssh signature "
+"verification (available in openssh version 8.2p1+)"
+msgstr ""
+
+#: gpg-interface.c:521
+#, c-format
+msgid "ssh signing revocation file configured but not found: %s"
+msgstr ""
+
+#: gpg-interface.c:574
+#, c-format
+msgid "bad/incompatible signature '%s'"
+msgstr "tanda tangan '%s' jelek/tidak kompatibel"
+
+#: gpg-interface.c:733 gpg-interface.c:738
+#, c-format
+msgid "failed to get the ssh fingerprint for key '%s'"
+msgstr "gagal mendapatkan sidik jari ssh untuk kunci '%s'"
+
+#: gpg-interface.c:760
+msgid ""
+"either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
+msgstr ""
+
+#: gpg-interface.c:778
+#, c-format
+msgid "gpg.ssh.defaultKeycommand succeeded but returned no keys: %s %s"
+msgstr ""
+
+#: gpg-interface.c:784
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
+msgstr ""
+
+#: gpg-interface.c:872
 msgid "gpg failed to sign the data"
+msgstr ""
+
+#: gpg-interface.c:893
+msgid "user.signingkey needs to be set for ssh signing"
+msgstr ""
+
+#: gpg-interface.c:904
+#, c-format
+msgid "failed writing ssh signing key to '%s'"
+msgstr "gagal menulis kunci penandatanganan ssh ke '%s'"
+
+#: gpg-interface.c:922
+#, c-format
+msgid "failed writing ssh signing key buffer to '%s'"
+msgstr "gagal menulis penyangga kunci penandatanganan ssh ke '%s'"
+
+#: gpg-interface.c:940
+msgid ""
+"ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
+"8.2p1+)"
+msgstr ""
+
+#: gpg-interface.c:952
+#, c-format
+msgid "failed reading ssh signing data buffer from '%s'"
 msgstr ""
 
 #: graph.c:98
@@ -4180,109 +4274,109 @@ msgstr ""
 "pola yang diberikan berisi bita NULL (via -f <berkas>). Hal ini hanya "
 "didukung dengan -P di bawah PCRE v2"
 
-#: grep.c:1895
+#: grep.c:1907
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': tidak dapat membaca %s"
 
-#: grep.c:1912 setup.c:176 builtin/clone.c:416 builtin/diff.c:90
+#: grep.c:1924 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "gagal men-stat '%s'"
 
-#: grep.c:1923
+#: grep.c:1935
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': baca pendek"
 
-#: help.c:23
+#: help.c:24
 msgid "start a working area (see also: git help tutorial)"
 msgstr "mulai area kerja (lihat pula: git help tutorial)"
 
-#: help.c:24
+#: help.c:25
 msgid "work on the current change (see also: git help everyday)"
 msgstr "bekerja pada perubahan saat ini (lihat pula: git help everyday)"
 
-#: help.c:25
+#: help.c:26
 msgid "examine the history and state (see also: git help revisions)"
 msgstr "periksa riwayat dan keadaan (lihat pula: git help revisions)"
 
-#: help.c:26
+#: help.c:27
 msgid "grow, mark and tweak your common history"
 msgstr "tumbuhkan, tandai, dan cubit riwayat umum Anda"
 
-#: help.c:27
+#: help.c:28
 msgid "collaborate (see also: git help workflows)"
 msgstr "kolaborasi (lihat pula: git help workflows)"
 
-#: help.c:31
+#: help.c:32
 msgid "Main Porcelain Commands"
 msgstr "Perintah Porselen Utama"
 
-#: help.c:32
+#: help.c:33
 msgid "Ancillary Commands / Manipulators"
 msgstr "Perintah Tambahan / Peubah"
 
-#: help.c:33
+#: help.c:34
 msgid "Ancillary Commands / Interrogators"
 msgstr "Perintah Tambahan / Pemeriksa"
 
-#: help.c:34
+#: help.c:35
 msgid "Interacting with Others"
 msgstr "Berinteraksi dengan yang Lain"
 
-#: help.c:35
+#: help.c:36
 msgid "Low-level Commands / Manipulators"
 msgstr "Perintah Tingkat Rendah / Peubah"
 
-#: help.c:36
+#: help.c:37
 msgid "Low-level Commands / Interrogators"
 msgstr "Perintah Tingkat Rendah / Pemeriksa"
 
-#: help.c:37
+#: help.c:38
 msgid "Low-level Commands / Syncing Repositories"
 msgstr "Perintah Tingkat Rendah / Sinkronisasi Repositori"
 
-#: help.c:38
+#: help.c:39
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Perintah Tingak Rendah / Pembantu Internal"
 
-#: help.c:300
+#: help.c:313
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "perintah git yang tersedia di '%s'"
 
-#: help.c:307
+#: help.c:320
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "perintah git yang tersedia dari tempat lain pada $PATH Anda"
 
-#: help.c:316
+#: help.c:329
 msgid "These are common Git commands used in various situations:"
 msgstr "Berikut ini perintah Git umum yang digunakan dalam beragam situasi:"
 
-#: help.c:365 git.c:100
+#: help.c:378 git.c:100
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "tipe daftar perintah '%s' tidak didukung"
 
-#: help.c:405
+#: help.c:418
 msgid "The Git concept guides are:"
 msgstr "Panduan konsep Git adalah:"
 
-#: help.c:429
+#: help.c:442
 msgid "See 'git help <command>' to read about a specific subcommand"
 msgstr "Lihat 'git help <perintah>' untuk baca tentang subperintah spesifik"
 
-#: help.c:434
+#: help.c:447
 msgid "External commands"
 msgstr "Perintah eksternal"
 
-#: help.c:449
+#: help.c:462
 msgid "Command aliases"
 msgstr "Alias perintah"
 
-#: help.c:527
+#: help.c:543
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4291,31 +4385,36 @@ msgstr ""
 "'%s' sepertinya perintah git, tetapi kami tidak dapat\n"
 "menjalankannya. Mungkin git-%s rusak?"
 
-#: help.c:543 help.c:631
+#: help.c:565 help.c:662
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: '%s' bukan perintah git. Lihat 'git --help'."
 
-#: help.c:591
+#: help.c:613
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Eh oh. Sistem Anda melaporkan tidak ada perintah Git sama sekali."
 
-#: help.c:613
+#: help.c:635
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr "PERINGATAN: Anda memanggil perintah Git bernama '%s' yang tidak ada."
 
-#: help.c:618
+#: help.c:640
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Melanjutkan di bawah asumsi bahwa maksud Anda '%s'."
 
-#: help.c:623
+#: help.c:646
+#, c-format
+msgid "Run '%s' instead? (y/N)"
+msgstr ""
+
+#: help.c:654
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Melanjutkan dalam %0.1f detik, mengasumsikan bahwa maksud Anda '%s'."
 
-#: help.c:635
+#: help.c:666
 msgid ""
 "\n"
 "The most similar command is"
@@ -4329,16 +4428,16 @@ msgstr[1] ""
 "\n"
 "Perintah paling mirip adalah"
 
-#: help.c:675
+#: help.c:706
 msgid "git version [<options>]"
 msgstr "git version [<opsi>]"
 
-#: help.c:730
+#: help.c:761
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:734
+#: help.c:765
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4351,6 +4450,13 @@ msgstr[0] ""
 msgstr[1] ""
 "\n"
 "Mungkin maksud Anda salah satu dari yang ini?"
+
+#: hook.c:27
+#, c-format
+msgid ""
+"The '%s' hook was ignored because it's not set as executable.\n"
+"You can disable this warning with `git config advice.ignoredHook false`."
+msgstr ""
 
 #: ident.c:353
 msgid "Author identity unknown\n"
@@ -4403,7 +4509,7 @@ msgstr ""
 msgid "name consists only of disallowed characters: %s"
 msgstr ""
 
-#: ident.c:454 builtin/commit.c:647
+#: ident.c:454 builtin/commit.c:648
 #, c-format
 msgid "invalid date format: %s"
 msgstr ""
@@ -4490,7 +4596,12 @@ msgstr ""
 msgid "invalid value '%s' for lsrefs.unborn"
 msgstr ""
 
-#: ls-refs.c:167
+#: ls-refs.c:174
+#, c-format
+msgid "unexpected line: '%s'"
+msgstr ""
+
+#: ls-refs.c:178
 msgid "expected flush after ls-refs arguments"
 msgstr ""
 
@@ -4498,44 +4609,44 @@ msgstr ""
 msgid "quoted CRLF detected"
 msgstr ""
 
-#: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr ""
 
-#: merge-ort.c:1569 merge-recursive.c:1201
+#: merge-ort.c:1584 merge-recursive.c:1211
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr ""
 
-#: merge-ort.c:1578 merge-recursive.c:1208
+#: merge-ort.c:1593 merge-recursive.c:1218
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr ""
 
-#: merge-ort.c:1587 merge-recursive.c:1215
+#: merge-ort.c:1602 merge-recursive.c:1225
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 
-#: merge-ort.c:1597 merge-ort.c:1604
+#: merge-ort.c:1612 merge-ort.c:1620
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr ""
 
-#: merge-ort.c:1625
+#: merge-ort.c:1642
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr ""
 
-#: merge-ort.c:1632
+#: merge-ort.c:1649
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
 "%s\n"
 msgstr ""
 
-#: merge-ort.c:1636 merge-recursive.c:1269
+#: merge-ort.c:1653 merge-recursive.c:1281
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4546,42 +4657,42 @@ msgid ""
 "which will accept this suggestion.\n"
 msgstr ""
 
-#: merge-ort.c:1649
+#: merge-ort.c:1666
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
 
-#: merge-ort.c:1868 merge-recursive.c:1358
+#: merge-ort.c:1887 merge-recursive.c:1372
 msgid "Failed to execute internal merge"
 msgstr ""
 
-#: merge-ort.c:1873 merge-recursive.c:1363
+#: merge-ort.c:1892 merge-recursive.c:1377
 #, c-format
 msgid "Unable to add %s to database"
 msgstr ""
 
-#: merge-ort.c:1880 merge-recursive.c:1396
+#: merge-ort.c:1899 merge-recursive.c:1410
 #, c-format
 msgid "Auto-merging %s"
 msgstr ""
 
-#: merge-ort.c:2019 merge-recursive.c:2118
+#: merge-ort.c:2038 merge-recursive.c:2132
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
 "implicit directory rename(s) putting the following path(s) there: %s."
 msgstr ""
 
-#: merge-ort.c:2029 merge-recursive.c:2128
+#: merge-ort.c:2048 merge-recursive.c:2142
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
 "implicit directory renames tried to put these paths there: %s"
 msgstr ""
 
-#: merge-ort.c:2087
+#: merge-ort.c:2106
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4589,47 +4700,47 @@ msgid ""
 "majority of the files."
 msgstr ""
 
-#: merge-ort.c:2241 merge-recursive.c:2464
+#: merge-ort.c:2260 merge-recursive.c:2478
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
 "renamed."
 msgstr ""
 
-#: merge-ort.c:2385 merge-recursive.c:3247
+#: merge-ort.c:2400 merge-recursive.c:3261
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
 "moving it to %s."
 msgstr ""
 
-#: merge-ort.c:2392 merge-recursive.c:3254
+#: merge-ort.c:2407 merge-recursive.c:3268
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
 "%s; moving it to %s."
 msgstr ""
 
-#: merge-ort.c:2405 merge-recursive.c:3250
+#: merge-ort.c:2420 merge-recursive.c:3264
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
 "in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
 
-#: merge-ort.c:2413 merge-recursive.c:3257
+#: merge-ort.c:2428 merge-recursive.c:3271
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
 "was renamed in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
 
-#: merge-ort.c:2569
+#: merge-ort.c:2584
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 
-#: merge-ort.c:2664
+#: merge-ort.c:2679
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4637,67 +4748,67 @@ msgid ""
 "markers."
 msgstr ""
 
-#: merge-ort.c:2683 merge-ort.c:2707
+#: merge-ort.c:2698 merge-ort.c:2722
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 
-#: merge-ort.c:3182 merge-recursive.c:3008
+#: merge-ort.c:3212 merge-recursive.c:3022
 #, c-format
 msgid "cannot read object %s"
 msgstr ""
 
-#: merge-ort.c:3185 merge-recursive.c:3011
+#: merge-ort.c:3215 merge-recursive.c:3025
 #, c-format
 msgid "object %s is not a blob"
 msgstr ""
 
-#: merge-ort.c:3613
+#: merge-ort.c:3644
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
 msgstr ""
 
-#: merge-ort.c:3689
+#: merge-ort.c:3721
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
 "of them so each can be recorded somewhere."
 msgstr ""
 
-#: merge-ort.c:3696
+#: merge-ort.c:3728
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
 "of them so each can be recorded somewhere."
 msgstr ""
 
-#: merge-ort.c:3796 merge-recursive.c:3087
+#: merge-ort.c:3819 merge-recursive.c:3101
 msgid "content"
 msgstr ""
 
-#: merge-ort.c:3798 merge-recursive.c:3091
+#: merge-ort.c:3821 merge-recursive.c:3105
 msgid "add/add"
 msgstr ""
 
-#: merge-ort.c:3800 merge-recursive.c:3136
+#: merge-ort.c:3823 merge-recursive.c:3150
 msgid "submodule"
 msgstr ""
 
-#: merge-ort.c:3802 merge-recursive.c:3137
+#: merge-ort.c:3825 merge-recursive.c:3151
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr ""
 
-#: merge-ort.c:3833
+#: merge-ort.c:3856
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
 "of %s left in tree."
 msgstr ""
 
-#: merge-ort.c:4120
+#: merge-ort.c:4152
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -4707,192 +4818,192 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4487
+#: merge-ort.c:4521
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3702
+#: merge-ort-wrappers.c:13 merge-recursive.c:3716
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "  %s"
 msgstr ""
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3468 builtin/merge.c:402
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
 msgid "Already up to date."
 msgstr "Sudah terbaru."
 
-#: merge-recursive.c:352
+#: merge-recursive.c:353
 msgid "(bad commit)\n"
 msgstr ""
 
-#: merge-recursive.c:375
+#: merge-recursive.c:381
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr ""
 
-#: merge-recursive.c:384
+#: merge-recursive.c:390
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
 
-#: merge-recursive.c:872
+#: merge-recursive.c:881
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr ""
 
-#: merge-recursive.c:883
+#: merge-recursive.c:892
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr ""
 
-#: merge-recursive.c:897 merge-recursive.c:916
+#: merge-recursive.c:906 merge-recursive.c:925
 msgid ": perhaps a D/F conflict?"
 msgstr ""
 
-#: merge-recursive.c:906
+#: merge-recursive.c:915
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr ""
 
-#: merge-recursive.c:947 builtin/cat-file.c:41
+#: merge-recursive.c:956 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr ""
 
-#: merge-recursive.c:952
+#: merge-recursive.c:961
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr ""
 
-#: merge-recursive.c:977
+#: merge-recursive.c:986
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr ""
 
-#: merge-recursive.c:988
+#: merge-recursive.c:997
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr ""
 
-#: merge-recursive.c:993
+#: merge-recursive.c:1002
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr ""
 
-#: merge-recursive.c:1223 merge-recursive.c:1235
+#: merge-recursive.c:1233 merge-recursive.c:1246
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr ""
 
-#: merge-recursive.c:1226 merge-recursive.c:1238
+#: merge-recursive.c:1236 merge-recursive.c:1249
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr ""
 
-#: merge-recursive.c:1261
+#: merge-recursive.c:1273
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 
-#: merge-recursive.c:1265
+#: merge-recursive.c:1277
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr ""
 
-#: merge-recursive.c:1266
+#: merge-recursive.c:1278
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr ""
 
-#: merge-recursive.c:1278
+#: merge-recursive.c:1290
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr ""
 
-#: merge-recursive.c:1420
+#: merge-recursive.c:1434
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
 
-#: merge-recursive.c:1492
+#: merge-recursive.c:1506
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
 "in tree."
 msgstr ""
 
-#: merge-recursive.c:1497
+#: merge-recursive.c:1511
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
 "left in tree."
 msgstr ""
 
-#: merge-recursive.c:1504
+#: merge-recursive.c:1518
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
 "in tree at %s."
 msgstr ""
 
-#: merge-recursive.c:1509
+#: merge-recursive.c:1523
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
 "left in tree at %s."
 msgstr ""
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "rename"
 msgstr ""
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "renamed"
 msgstr ""
 
-#: merge-recursive.c:1595 merge-recursive.c:2501 merge-recursive.c:3164
+#: merge-recursive.c:1609 merge-recursive.c:2515 merge-recursive.c:3178
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr ""
 
-#: merge-recursive.c:1605
+#: merge-recursive.c:1619
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 
-#: merge-recursive.c:1663
+#: merge-recursive.c:1677
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 
-#: merge-recursive.c:1694
+#: merge-recursive.c:1708
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr ""
 
-#: merge-recursive.c:1699
+#: merge-recursive.c:1713
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
 
-#: merge-recursive.c:1726
+#: merge-recursive.c:1740
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
 "\"->\"%s\" in \"%s\"%s"
 msgstr ""
 
-#: merge-recursive.c:1731
+#: merge-recursive.c:1745
 msgid " (left unresolved)"
 msgstr ""
 
-#: merge-recursive.c:1823
+#: merge-recursive.c:1837
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 
-#: merge-recursive.c:2086
+#: merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -4900,86 +5011,86 @@ msgid ""
 "getting a majority of the files."
 msgstr ""
 
-#: merge-recursive.c:2220
+#: merge-recursive.c:2234
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
 ">%s in %s"
 msgstr ""
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modify"
 msgstr ""
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modified"
 msgstr ""
 
-#: merge-recursive.c:3114
+#: merge-recursive.c:3128
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr ""
 
-#: merge-recursive.c:3167
+#: merge-recursive.c:3181
 #, c-format
 msgid "Adding as %s instead"
 msgstr ""
 
-#: merge-recursive.c:3371
+#: merge-recursive.c:3385
 #, c-format
 msgid "Removing %s"
 msgstr ""
 
-#: merge-recursive.c:3394
+#: merge-recursive.c:3408
 msgid "file/directory"
 msgstr ""
 
-#: merge-recursive.c:3399
+#: merge-recursive.c:3413
 msgid "directory/file"
 msgstr ""
 
-#: merge-recursive.c:3406
+#: merge-recursive.c:3420
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 
-#: merge-recursive.c:3415
+#: merge-recursive.c:3429
 #, c-format
 msgid "Adding %s"
 msgstr ""
 
-#: merge-recursive.c:3424
+#: merge-recursive.c:3438
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr ""
 
-#: merge-recursive.c:3477
+#: merge-recursive.c:3491
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr ""
 
-#: merge-recursive.c:3571
+#: merge-recursive.c:3585
 msgid "Merging:"
 msgstr ""
 
-#: merge-recursive.c:3584
+#: merge-recursive.c:3598
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: merge-recursive.c:3634
+#: merge-recursive.c:3648
 msgid "merge returned no commit"
 msgstr ""
 
-#: merge-recursive.c:3799
+#: merge-recursive.c:3816
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr ""
 
-#: merge-recursive.c:3817 builtin/merge.c:717 builtin/merge.c:901
-#: builtin/stash.c:473
+#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr ""
 
@@ -4987,189 +5098,221 @@ msgstr ""
 msgid "failed to read the cache"
 msgstr ""
 
-#: merge.c:108 rerere.c:704 builtin/am.c:1932 builtin/am.c:1966
-#: builtin/checkout.c:590 builtin/checkout.c:844 builtin/clone.c:821
-#: builtin/stash.c:267
+#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
+#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr ""
 
-#: midx.c:74
+#: midx.c:78
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr ""
 
-#: midx.c:105
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr ""
 
-#: midx.c:121
+#: midx.c:125
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 
-#: midx.c:126
+#: midx.c:130
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr ""
 
-#: midx.c:131
+#: midx.c:135
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 
-#: midx.c:148
+#: midx.c:152
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr ""
 
-#: midx.c:150
+#: midx.c:154
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr ""
 
-#: midx.c:152
+#: midx.c:156
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr ""
 
-#: midx.c:154
+#: midx.c:158
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr ""
 
-#: midx.c:170
+#: midx.c:174
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 
-#: midx.c:214
+#: midx.c:221
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr ""
 
-#: midx.c:264
+#: midx.c:271
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 
-#: midx.c:490
+#: midx.c:502
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr ""
 
-#: midx.c:496
+#: midx.c:508
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr ""
 
-#: midx.c:564
+#: midx.c:576
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr ""
 
-#: midx.c:880 builtin/index-pack.c:1533
+#: midx.c:892
 msgid "cannot store reverse index file"
 msgstr "tidak dapat menyimpan berkas indeks balik"
 
-#: midx.c:920
+#: midx.c:990
+#, c-format
+msgid "could not parse line: %s"
+msgstr "tidak dapat menguraikan baris: %s"
+
+#: midx.c:992
+#, c-format
+msgid "malformed line: %s"
+msgstr "baris jelek '%s'."
+
+#: midx.c:1159
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr ""
 
-#: midx.c:943
+#: midx.c:1184
+msgid "could not load pack"
+msgstr ""
+
+#: midx.c:1190
+#, c-format
+msgid "could not open index for %s"
+msgstr "tidak dapat membuka indeks untuk %s"
+
+#: midx.c:1201
 msgid "Adding packfiles to multi-pack-index"
 msgstr ""
 
-#: midx.c:989
-#, c-format
-msgid "did not see pack-file %s to drop"
-msgstr ""
-
-#: midx.c:1034
+#: midx.c:1244
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr ""
 
-#: midx.c:1039
+#: midx.c:1289
+#, c-format
+msgid "cannot select preferred pack %s with no objects"
+msgstr ""
+
+#: midx.c:1321
+#, c-format
+msgid "did not see pack-file %s to drop"
+msgstr ""
+
+#: midx.c:1367
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr ""
 
-#: midx.c:1055
+#: midx.c:1380
 msgid "no pack files to index."
 msgstr ""
 
-#: midx.c:1135 builtin/clean.c:37
+#: midx.c:1417
+msgid "could not write multi-pack bitmap"
+msgstr ""
+
+#: midx.c:1427
+msgid "could not write multi-pack-index"
+msgstr "gagal menulis indeks multipak"
+
+#: midx.c:1486 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "gagal menghapus %s"
 
-#: midx.c:1166
+#: midx.c:1517
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr ""
 
-#: midx.c:1225
+#: midx.c:1577
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr ""
 
-#: midx.c:1233
+#: midx.c:1585
 msgid "incorrect checksum"
 msgstr ""
 
-#: midx.c:1236
+#: midx.c:1588
 msgid "Looking for referenced packfiles"
 msgstr ""
 
-#: midx.c:1251
+#: midx.c:1603
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 
-#: midx.c:1256
+#: midx.c:1608
 msgid "the midx contains no oid"
 msgstr ""
 
-#: midx.c:1265
+#: midx.c:1617
 msgid "Verifying OID order in multi-pack-index"
 msgstr ""
 
-#: midx.c:1274
+#: midx.c:1626
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr ""
 
-#: midx.c:1294
+#: midx.c:1646
 msgid "Sorting objects by packfile"
 msgstr ""
 
-#: midx.c:1301
+#: midx.c:1653
 msgid "Verifying object offsets"
 msgstr ""
 
-#: midx.c:1317
+#: midx.c:1669
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr ""
 
-#: midx.c:1323
+#: midx.c:1675
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr ""
 
-#: midx.c:1332
+#: midx.c:1684
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr ""
 
-#: midx.c:1357
+#: midx.c:1709
 msgid "Counting referenced objects"
 msgstr ""
 
-#: midx.c:1367
+#: midx.c:1719
 msgid "Finding and deleting unreferenced packfiles"
 msgstr ""
 
-#: midx.c:1558
+#: midx.c:1911
 msgid "could not start pack-objects"
 msgstr ""
 
-#: midx.c:1578
+#: midx.c:1931
 msgid "could not finish pack-objects"
 msgstr ""
 
@@ -5224,257 +5367,257 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr ""
 
-#: object-file.c:526
+#: object-file.c:459
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 
-#: object-file.c:584
+#: object-file.c:517
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr ""
 
-#: object-file.c:658
+#: object-file.c:591
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr ""
 
-#: object-file.c:665
+#: object-file.c:598
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr ""
 
-#: object-file.c:708
+#: object-file.c:641
 msgid "unable to fdopen alternates lockfile"
 msgstr ""
 
-#: object-file.c:726
+#: object-file.c:659
 msgid "unable to read alternates file"
 msgstr ""
 
-#: object-file.c:733
+#: object-file.c:666
 msgid "unable to move new alternates file into place"
 msgstr ""
 
-#: object-file.c:768
+#: object-file.c:701
 #, c-format
 msgid "path '%s' does not exist"
 msgstr ""
 
-#: object-file.c:789
+#: object-file.c:722
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 
-#: object-file.c:795
+#: object-file.c:728
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr ""
 
-#: object-file.c:801
+#: object-file.c:734
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr ""
 
-#: object-file.c:809
+#: object-file.c:742
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr ""
 
-#: object-file.c:869
+#: object-file.c:773
+#, c-format
+msgid "could not find object directory matching %s"
+msgstr ""
+
+#: object-file.c:823
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr ""
 
-#: object-file.c:1019
+#: object-file.c:973
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr ""
 
-#: object-file.c:1054
+#: object-file.c:1008
 #, c-format
 msgid "mmap failed%s"
 msgstr ""
 
-#: object-file.c:1218
+#: object-file.c:1174
 #, c-format
 msgid "object file %s is empty"
 msgstr ""
 
-#: object-file.c:1353 object-file.c:2548
+#: object-file.c:1293 object-file.c:2499
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr ""
 
-#: object-file.c:1355 object-file.c:2552
+#: object-file.c:1295 object-file.c:2503
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr ""
 
-#: object-file.c:1397
-msgid "invalid object type"
-msgstr ""
-
-#: object-file.c:1481
-#, c-format
-msgid "unable to unpack %s header with --allow-unknown-type"
-msgstr ""
-
-#: object-file.c:1484
-#, c-format
-msgid "unable to unpack %s header"
-msgstr ""
-
-#: object-file.c:1490
-#, c-format
-msgid "unable to parse %s header with --allow-unknown-type"
-msgstr ""
-
-#: object-file.c:1493
+#: object-file.c:1417
 #, c-format
 msgid "unable to parse %s header"
 msgstr ""
 
-#: object-file.c:1717
+#: object-file.c:1419
+msgid "invalid object type"
+msgstr ""
+
+#: object-file.c:1430
+#, c-format
+msgid "unable to unpack %s header"
+msgstr ""
+
+#: object-file.c:1434
+#, c-format
+msgid "header for %s too long, exceeds %d bytes"
+msgstr ""
+
+#: object-file.c:1664
 #, c-format
 msgid "failed to read object %s"
 msgstr ""
 
-#: object-file.c:1721
+#: object-file.c:1668
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr ""
 
-#: object-file.c:1725
+#: object-file.c:1672
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr ""
 
-#: object-file.c:1729
+#: object-file.c:1676
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr ""
 
-#: object-file.c:1834
+#: object-file.c:1781
 #, c-format
 msgid "unable to write file %s"
 msgstr ""
 
-#: object-file.c:1841
+#: object-file.c:1788
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr ""
 
-#: object-file.c:1848
+#: object-file.c:1795
 msgid "file write error"
 msgstr ""
 
-#: object-file.c:1868
+#: object-file.c:1815
 msgid "error when closing loose object file"
 msgstr ""
 
-#: object-file.c:1933
+#: object-file.c:1882
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 
-#: object-file.c:1935
+#: object-file.c:1884
 msgid "unable to create temporary file"
 msgstr ""
 
-#: object-file.c:1959
+#: object-file.c:1908
 msgid "unable to write loose object file"
 msgstr ""
 
-#: object-file.c:1965
+#: object-file.c:1914
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr ""
 
-#: object-file.c:1969
+#: object-file.c:1918
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr ""
 
-#: object-file.c:1973
+#: object-file.c:1922
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr ""
 
-#: object-file.c:1983 builtin/pack-objects.c:1237
+#: object-file.c:1933 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr ""
 
-#: object-file.c:2060
+#: object-file.c:2011
 #, c-format
 msgid "cannot read object for %s"
 msgstr ""
 
-#: object-file.c:2111
+#: object-file.c:2062
 msgid "corrupt commit"
 msgstr ""
 
-#: object-file.c:2119
+#: object-file.c:2070
 msgid "corrupt tag"
 msgstr ""
 
-#: object-file.c:2219
+#: object-file.c:2170
 #, c-format
 msgid "read error while indexing %s"
 msgstr ""
 
-#: object-file.c:2222
+#: object-file.c:2173
 #, c-format
 msgid "short read while indexing %s"
 msgstr ""
 
-#: object-file.c:2295 object-file.c:2305
+#: object-file.c:2246 object-file.c:2256
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr ""
 
-#: object-file.c:2311
+#: object-file.c:2262
 #, c-format
 msgid "%s: unsupported file type"
 msgstr ""
 
-#: object-file.c:2335
+#: object-file.c:2286 builtin/fetch.c:1445
 #, c-format
 msgid "%s is not a valid object"
 msgstr ""
 
-#: object-file.c:2337
+#: object-file.c:2288
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr ""
 
-#: object-file.c:2364 builtin/index-pack.c:192
+#: object-file.c:2315
 #, c-format
 msgid "unable to open %s"
 msgstr "tidak dapat membuka %s"
 
-#: object-file.c:2559 object-file.c:2612
+#: object-file.c:2510
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr ""
 
-#: object-file.c:2583
+#: object-file.c:2533
 #, c-format
 msgid "unable to mmap %s"
 msgstr ""
 
-#: object-file.c:2588
+#: object-file.c:2539
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr ""
 
-#: object-file.c:2594
+#: object-file.c:2544
 #, c-format
 msgid "unable to parse header of %s"
 msgstr ""
 
-#: object-file.c:2605
+#: object-file.c:2555
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr ""
@@ -5586,12 +5729,25 @@ msgstr ""
 msgid "hash mismatch %s"
 msgstr ""
 
-#: pack-bitmap.c:868 pack-bitmap.c:874 builtin/pack-objects.c:2411
+#: pack-bitmap.c:348
+msgid "multi-pack bitmap is missing required reverse index"
+msgstr ""
+
+#: pack-bitmap.c:424
+msgid "load_reverse_index: could not open pack"
+msgstr ""
+
+#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr ""
 
-#: pack-bitmap.c:1571 builtin/rev-list.c:92
+#: pack-bitmap.c:1916
+#, c-format
+msgid "could not find %s in pack %s at offset %<PRIuMAX>"
+msgstr ""
+
+#: pack-bitmap.c:1952 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr ""
@@ -5621,45 +5777,45 @@ msgstr ""
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
 msgstr ""
 
-#: pack-write.c:250
+#: pack-write.c:251
 msgid "cannot both write and verify reverse index"
 msgstr ""
 
-#: pack-write.c:271
+#: pack-write.c:270
 #, c-format
 msgid "could not stat: %s"
 msgstr ""
 
-#: pack-write.c:283
+#: pack-write.c:282
 #, c-format
 msgid "failed to make %s readable"
 msgstr ""
 
-#: pack-write.c:522
+#: pack-write.c:520
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr ""
 
-#: packfile.c:625
+#: packfile.c:626
 msgid "offset before end of packfile (broken .idx?)"
 msgstr ""
 
-#: packfile.c:655
+#: packfile.c:656
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr ""
 
-#: packfile.c:1934
+#: packfile.c:1923
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 
-#: packfile.c:1938
+#: packfile.c:1927
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 
-#: parse-options-cb.c:20 parse-options-cb.c:24
+#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr ""
@@ -5679,71 +5835,71 @@ msgstr ""
 msgid "malformed object name '%s'"
 msgstr ""
 
-#: parse-options.c:38
+#: parse-options.c:58
 #, c-format
 msgid "%s requires a value"
 msgstr ""
 
-#: parse-options.c:73
+#: parse-options.c:93
 #, c-format
 msgid "%s is incompatible with %s"
 msgstr ""
 
-#: parse-options.c:78
+#: parse-options.c:98
 #, c-format
 msgid "%s : incompatible with something else"
 msgstr ""
 
-#: parse-options.c:92 parse-options.c:96 parse-options.c:317
+#: parse-options.c:112 parse-options.c:116
 #, c-format
 msgid "%s takes no value"
 msgstr ""
 
-#: parse-options.c:94
+#: parse-options.c:114
 #, c-format
 msgid "%s isn't available"
 msgstr ""
 
-#: parse-options.c:217
+#: parse-options.c:237
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr ""
 
-#: parse-options.c:386
+#: parse-options.c:393
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr ""
 
-#: parse-options.c:420 parse-options.c:428
+#: parse-options.c:427 parse-options.c:435
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr ""
 
-#: parse-options.c:668 parse-options.c:988
+#: parse-options.c:677 parse-options.c:1053
 #, c-format
 msgid "alias of --%s"
 msgstr ""
 
-#: parse-options.c:879
+#: parse-options.c:891
 #, c-format
 msgid "unknown option `%s'"
 msgstr ""
 
-#: parse-options.c:881
+#: parse-options.c:893
 #, c-format
 msgid "unknown switch `%c'"
 msgstr ""
 
-#: parse-options.c:883
+#: parse-options.c:895
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr ""
 
-#: parse-options.c:907
+#: parse-options.c:919
 msgid "..."
 msgstr ""
 
-#: parse-options.c:926
+#: parse-options.c:933
 #, c-format
 msgid "usage: %s"
 msgstr ""
@@ -5751,97 +5907,121 @@ msgstr ""
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:932
+#: parse-options.c:948
 #, c-format
 msgid "   or: %s"
 msgstr ""
 
-#: parse-options.c:935
+#. TRANSLATORS: You should only need to translate this format
+#. string if your language is a RTL language (e.g. Arabic,
+#. Hebrew etc.), not if it's a LTR language (e.g. German,
+#. Russian, Chinese etc.).
+#. *
+#. When a translated usage string has an embedded "\n" it's
+#. because options have wrapped to the next line. The line
+#. after the "\n" will then be padded to align with the
+#. command name, such as N_("git cmd [opt]\n<8
+#. spaces>[opt2]"), where the 8 spaces are the same length as
+#. "git cmd ".
+#. *
+#. This format string prints out that already-translated
+#. line. The "%*s" is whitespace padding to account for the
+#. padding at the start of the line that we add in this
+#. function. The "%s" is a line in the (hopefully already
+#. translated) N_() usage string, which contained embedded
+#. newlines before we split it up.
+#.
+#: parse-options.c:969
+#, c-format
+msgid "%*s%s"
+msgstr ""
+
+#: parse-options.c:992
 #, c-format
 msgid "    %s"
 msgstr ""
 
-#: parse-options.c:974
+#: parse-options.c:1039
 msgid "-NUM"
 msgstr ""
 
-#: path.c:915
+#: path.c:922
 #, c-format
 msgid "Could not make %s writable by group"
 msgstr ""
 
-#: pathspec.c:151
+#: pathspec.c:150
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr ""
 
-#: pathspec.c:169
+#: pathspec.c:168
 msgid "Only one 'attr:' specification is allowed."
 msgstr ""
 
-#: pathspec.c:172
+#: pathspec.c:171
 msgid "attr spec must not be empty"
 msgstr ""
 
-#: pathspec.c:215
+#: pathspec.c:214
 #, c-format
 msgid "invalid attribute name %s"
 msgstr ""
 
-#: pathspec.c:280
+#: pathspec.c:279
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr ""
 
-#: pathspec.c:287
+#: pathspec.c:286
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
 msgstr ""
 
-#: pathspec.c:327
+#: pathspec.c:326
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr ""
 
-#: pathspec.c:348
+#: pathspec.c:347
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr ""
 
-#: pathspec.c:353
+#: pathspec.c:352
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr ""
 
-#: pathspec.c:391
+#: pathspec.c:390
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr ""
 
-#: pathspec.c:450
+#: pathspec.c:449
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr ""
 
-#: pathspec.c:466
+#: pathspec.c:465
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
 msgstr ""
 
-#: pathspec.c:542
+#: pathspec.c:541
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr ""
 
-#: pathspec.c:552
+#: pathspec.c:551
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr ""
 
-#: pathspec.c:619
+#: pathspec.c:618
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr ""
 
-#: pathspec.c:664
+#: pathspec.c:663
 #, c-format
 msgid "line is badly quoted: %s"
 msgstr ""
@@ -5862,7 +6042,7 @@ msgstr ""
 msgid "flush packet write failed"
 msgstr ""
 
-#: pkt-line.c:153 pkt-line.c:265
+#: pkt-line.c:153
 msgid "protocol error: impossibly long line"
 msgstr ""
 
@@ -5870,7 +6050,7 @@ msgstr ""
 msgid "packet write with format failed"
 msgstr ""
 
-#: pkt-line.c:204
+#: pkt-line.c:204 pkt-line.c:252
 msgid "packet write failed - data exceeds max packet size"
 msgstr ""
 
@@ -5879,25 +6059,25 @@ msgstr ""
 msgid "packet write failed: %s"
 msgstr ""
 
-#: pkt-line.c:328 pkt-line.c:329
+#: pkt-line.c:349 pkt-line.c:350
 msgid "read error"
 msgstr ""
 
-#: pkt-line.c:339 pkt-line.c:340
+#: pkt-line.c:360 pkt-line.c:361
 msgid "the remote end hung up unexpectedly"
 msgstr ""
 
-#: pkt-line.c:369 pkt-line.c:371
+#: pkt-line.c:390 pkt-line.c:392
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr ""
 
-#: pkt-line.c:386 pkt-line.c:388 pkt-line.c:394 pkt-line.c:396
+#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr ""
 
-#: pkt-line.c:413 sideband.c:165
+#: pkt-line.c:434 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr ""
@@ -5940,32 +6120,32 @@ msgstr ""
 msgid "Removing duplicate objects"
 msgstr ""
 
-#: range-diff.c:78
+#: range-diff.c:67
 msgid "could not start `log`"
 msgstr ""
 
-#: range-diff.c:80
+#: range-diff.c:69
 msgid "could not read `log` output"
 msgstr ""
 
-#: range-diff.c:101 sequencer.c:5550
+#: range-diff.c:97 sequencer.c:5603
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr ""
 
-#: range-diff.c:115
+#: range-diff.c:111
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
 "'%s'"
 msgstr ""
 
-#: range-diff.c:140
+#: range-diff.c:137
 #, c-format
 msgid "could not parse git header '%.*s'"
 msgstr ""
 
-#: range-diff.c:307
+#: range-diff.c:304
 msgid "failed to generate diff"
 msgstr ""
 
@@ -5992,7 +6172,7 @@ msgstr ""
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 
-#: read-cache.c:753
+#: read-cache.c:753 builtin/submodule--helper.c:3241
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr ""
@@ -6012,166 +6192,166 @@ msgstr ""
 msgid "unable to stat '%s'"
 msgstr ""
 
-#: read-cache.c:1358
+#: read-cache.c:1373
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr ""
 
-#: read-cache.c:1573
+#: read-cache.c:1588
 msgid "Refresh index"
 msgstr ""
 
-#: read-cache.c:1705
+#: read-cache.c:1720
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1715
+#: read-cache.c:1730
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1771
+#: read-cache.c:1786
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr ""
 
-#: read-cache.c:1774
+#: read-cache.c:1789
 #, c-format
 msgid "bad index version %d"
 msgstr ""
 
-#: read-cache.c:1783
+#: read-cache.c:1798
 msgid "bad index file sha1 signature"
 msgstr ""
 
-#: read-cache.c:1817
+#: read-cache.c:1832
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr ""
 
-#: read-cache.c:1819
+#: read-cache.c:1834
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr ""
 
-#: read-cache.c:1856
+#: read-cache.c:1871
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr ""
 
-#: read-cache.c:1872
+#: read-cache.c:1887
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr ""
 
-#: read-cache.c:1929
+#: read-cache.c:1944
 msgid "unordered stage entries in index"
 msgstr ""
 
-#: read-cache.c:1932
+#: read-cache.c:1947
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr ""
 
-#: read-cache.c:1935
+#: read-cache.c:1950
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr ""
 
-#: read-cache.c:2041 read-cache.c:2339 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1622 builtin/add.c:575 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:706 builtin/clean.c:987
-#: builtin/commit.c:377 builtin/diff-tree.c:122 builtin/grep.c:505
-#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:291
-#: builtin/submodule--helper.c:333
+#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
+#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
+#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
 msgid "index file corrupt"
 msgstr ""
 
-#: read-cache.c:2185
+#: read-cache.c:2209
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2198
+#: read-cache.c:2222
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2231
+#: read-cache.c:2255
 #, c-format
 msgid "%s: index file open failed"
 msgstr ""
 
-#: read-cache.c:2235
+#: read-cache.c:2259
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr ""
 
-#: read-cache.c:2239
+#: read-cache.c:2263
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr ""
 
-#: read-cache.c:2243
+#: read-cache.c:2267
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr ""
 
-#: read-cache.c:2286
+#: read-cache.c:2310
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2313
+#: read-cache.c:2337
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2351
+#: read-cache.c:2375
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr ""
 
-#: read-cache.c:2398
+#: read-cache.c:2434
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr ""
 
-#: read-cache.c:3032 strbuf.c:1173 wrapper.c:633 builtin/merge.c:1146
+#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
 #, c-format
 msgid "could not close '%s'"
 msgstr ""
 
-#: read-cache.c:3075
+#: read-cache.c:3108
 msgid "failed to convert to a sparse-index"
 msgstr ""
 
-#: read-cache.c:3146 sequencer.c:2684 sequencer.c:4440
+#: read-cache.c:3179
 #, c-format
 msgid "could not stat '%s'"
 msgstr ""
 
-#: read-cache.c:3159
+#: read-cache.c:3192
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr ""
 
-#: read-cache.c:3171
+#: read-cache.c:3204
 #, c-format
 msgid "unable to unlink: %s"
 msgstr ""
 
-#: read-cache.c:3200
+#: read-cache.c:3233
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr ""
 
-#: read-cache.c:3349
+#: read-cache.c:3390
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr ""
@@ -6221,19 +6401,19 @@ msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:218
+#: rebase-interactive.c:75
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
 msgstr ""
 
-#: rebase-interactive.c:78 git-rebase--preserve-merges.sh:222
+#: rebase-interactive.c:78
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
 msgstr ""
 
-#: rebase-interactive.c:84 git-rebase--preserve-merges.sh:861
+#: rebase-interactive.c:84
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -6242,21 +6422,21 @@ msgid ""
 "\n"
 msgstr ""
 
-#: rebase-interactive.c:89 git-rebase--preserve-merges.sh:938
+#: rebase-interactive.c:89
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
 "\n"
 msgstr ""
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3836
-#: sequencer.c:3862 sequencer.c:5656 builtin/fsck.c:328 builtin/rebase.c:271
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3886
+#: sequencer.c:3912 sequencer.c:5709 builtin/fsck.c:328 builtin/gc.c:1790
+#: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
 msgstr ""
 
-#: rebase-interactive.c:119 builtin/rebase.c:203 builtin/rebase.c:229
-#: builtin/rebase.c:253
+#: rebase-interactive.c:119
 #, c-format
 msgid "could not write '%s'."
 msgstr ""
@@ -6279,11 +6459,9 @@ msgid ""
 "\n"
 msgstr ""
 
-#: rebase-interactive.c:236 rebase-interactive.c:241 sequencer.c:2597
-#: builtin/rebase.c:189 builtin/rebase.c:214 builtin/rebase.c:240
-#: builtin/rebase.c:265
+#: rebase.c:29
 #, c-format
-msgid "could not read '%s'."
+msgid "%s: 'preserve' superseded by 'merges'"
 msgstr ""
 
 #: ref-filter.c:42 wt-status.c:2036
@@ -6305,257 +6483,277 @@ msgstr ""
 msgid "ahead %d, behind %d"
 msgstr ""
 
-#: ref-filter.c:230
+#: ref-filter.c:235
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr ""
 
-#: ref-filter.c:232
+#: ref-filter.c:237
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr ""
 
-#: ref-filter.c:254
+#: ref-filter.c:259
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr ""
 
-#: ref-filter.c:258
+#: ref-filter.c:263
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr ""
 
-#: ref-filter.c:260
+#: ref-filter.c:265
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr ""
 
-#: ref-filter.c:315
+#: ref-filter.c:320
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr ""
 
-#: ref-filter.c:339
+#: ref-filter.c:344
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr ""
 
-#: ref-filter.c:347
+#: ref-filter.c:352
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr ""
 
-#: ref-filter.c:359
+#: ref-filter.c:364
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr ""
 
-#: ref-filter.c:372
+#: ref-filter.c:377
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr ""
 
-#: ref-filter.c:391
+#: ref-filter.c:396
 #, c-format
 msgid "expected %%(trailers:key=<value>)"
 msgstr ""
 
-#: ref-filter.c:393
+#: ref-filter.c:398
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr ""
 
-#: ref-filter.c:424
+#: ref-filter.c:429
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr ""
 
-#: ref-filter.c:426
+#: ref-filter.c:431
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr ""
 
-#: ref-filter.c:441
+#: ref-filter.c:443
+#, c-format
+msgid "unrecognized %%(raw) argument: %s"
+msgstr ""
+
+#: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr ""
 
-#: ref-filter.c:445
+#: ref-filter.c:462
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr ""
 
-#: ref-filter.c:459
+#: ref-filter.c:476
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr ""
 
-#: ref-filter.c:489
+#: ref-filter.c:506
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr ""
 
-#: ref-filter.c:501
+#: ref-filter.c:518
 #, c-format
 msgid "unrecognized position:%s"
 msgstr ""
 
-#: ref-filter.c:508
+#: ref-filter.c:525
 #, c-format
 msgid "unrecognized width:%s"
 msgstr ""
 
-#: ref-filter.c:517
+#: ref-filter.c:534
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr ""
 
-#: ref-filter.c:525
+#: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr ""
 
-#: ref-filter.c:543
+#: ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr ""
 
-#: ref-filter.c:645
+#: ref-filter.c:568
+#, c-format
+msgid "%%(rest) does not take arguments"
+msgstr ""
+
+#: ref-filter.c:680
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr ""
 
-#: ref-filter.c:672
+#: ref-filter.c:707
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr ""
 
-#: ref-filter.c:676
+#: ref-filter.c:711
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 
-#: ref-filter.c:801
+#: ref-filter.c:844
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr ""
 
-#: ref-filter.c:865
+#: ref-filter.c:910
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr ""
 
-#: ref-filter.c:867
+#: ref-filter.c:912
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr ""
 
-#: ref-filter.c:869
+#: ref-filter.c:914
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr ""
 
-#: ref-filter.c:897
+#: ref-filter.c:946
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr ""
 
-#: ref-filter.c:899
+#: ref-filter.c:948
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr ""
 
-#: ref-filter.c:901
+#: ref-filter.c:950
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr ""
 
-#: ref-filter.c:916
+#: ref-filter.c:965
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr ""
 
-#: ref-filter.c:973
+#: ref-filter.c:1027
 #, c-format
 msgid "malformed format string %s"
 msgstr ""
 
-#: ref-filter.c:1621
+#: ref-filter.c:1033
+#, c-format
+msgid "this command reject atom %%(%.*s)"
+msgstr ""
+
+#: ref-filter.c:1040
+#, c-format
+msgid "--format=%.*s cannot be used with--python, --shell, --tcl"
+msgstr ""
+
+#: ref-filter.c:1706
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr ""
 
-#: ref-filter.c:1624
+#: ref-filter.c:1709
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr ""
 
-#: ref-filter.c:1627
+#: ref-filter.c:1712
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr ""
 
-#: ref-filter.c:1631
+#: ref-filter.c:1716
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr ""
 
-#: ref-filter.c:1634
+#: ref-filter.c:1719
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr ""
 
-#: ref-filter.c:1637
+#: ref-filter.c:1722
 msgid "(no branch)"
 msgstr ""
 
-#: ref-filter.c:1669 ref-filter.c:1880
+#: ref-filter.c:1754 ref-filter.c:1972
 #, c-format
 msgid "missing object %s for %s"
 msgstr ""
 
-#: ref-filter.c:1679
+#: ref-filter.c:1764
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr ""
 
-#: ref-filter.c:2064
+#: ref-filter.c:2155
 #, c-format
 msgid "malformed object at '%s'"
 msgstr ""
 
-#: ref-filter.c:2153
+#: ref-filter.c:2245
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr ""
 
-#: ref-filter.c:2158 refs.c:676
+#: ref-filter.c:2250 refs.c:673
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr ""
 
-#: ref-filter.c:2502
+#: ref-filter.c:2623
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr ""
 
-#: ref-filter.c:2596
+#: ref-filter.c:2726
 #, c-format
 msgid "malformed object name %s"
 msgstr ""
 
-#: ref-filter.c:2601
+#: ref-filter.c:2731
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr ""
 
-#: refs.c:264
+#: refs.c:261
 #, c-format
 msgid "%s does not point to a valid object!"
 msgstr ""
 
-#: refs.c:566
+#: refs.c:563
 #, c-format
 msgid ""
 "Using '%s' as the name for the initial branch. This default branch name\n"
@@ -6570,81 +6768,81 @@ msgid ""
 "\tgit branch -m <name>\n"
 msgstr ""
 
-#: refs.c:588
+#: refs.c:585
 #, c-format
 msgid "could not retrieve `%s`"
 msgstr ""
 
-#: refs.c:598
+#: refs.c:595
 #, c-format
 msgid "invalid branch name: %s = %s"
 msgstr ""
 
-#: refs.c:674
+#: refs.c:671
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr ""
 
-#: refs.c:922
+#: refs.c:920
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr ""
 
-#: refs.c:929
+#: refs.c:927
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr ""
 
-#: refs.c:994
+#: refs.c:992
 #, c-format
 msgid "log for %s is empty"
 msgstr ""
 
-#: refs.c:1086
+#: refs.c:1084
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr ""
 
-#: refs.c:1157
+#: refs.c:1155
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr ""
 
-#: refs.c:2051
+#: refs.c:2062
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr ""
 
-#: refs.c:2131
+#: refs.c:2142
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 
-#: refs.c:2142
+#: refs.c:2153
 msgid "ref updates aborted by hook"
 msgstr ""
 
-#: refs.c:2242 refs.c:2272
+#: refs.c:2253 refs.c:2283
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr ""
 
-#: refs.c:2248 refs.c:2283
+#: refs.c:2259 refs.c:2294
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr ""
 
-#: refs/files-backend.c:1228
+#: refs/files-backend.c:1271
 #, c-format
 msgid "could not remove reference %s"
 msgstr ""
 
-#: refs/files-backend.c:1242 refs/packed-backend.c:1542
-#: refs/packed-backend.c:1552
+#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr ""
 
-#: refs/files-backend.c:1245 refs/packed-backend.c:1555
+#: refs/files-backend.c:1288 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr ""
@@ -6930,137 +7128,134 @@ msgstr ""
 
 #: rerere.c:201 rerere.c:210 rerere.c:213
 msgid "corrupt MERGE_RR"
-msgstr ""
+msgstr "MERGE_RR rusak"
 
 #: rerere.c:248 rerere.c:253
 msgid "unable to write rerere record"
-msgstr ""
+msgstr "tidak dapat menulis rekaman rerere"
 
 #: rerere.c:479
 #, c-format
 msgid "there were errors while writing '%s' (%s)"
-msgstr ""
+msgstr "ada kesalahan saat menulis '%s' (%s)"
 
-#: rerere.c:482
+#: rerere.c:482 builtin/gc.c:2247 builtin/gc.c:2282
 #, c-format
 msgid "failed to flush '%s'"
-msgstr ""
+msgstr "gagal membilas '%s'"
 
 #: rerere.c:487 rerere.c:1023
 #, c-format
 msgid "could not parse conflict hunks in '%s'"
-msgstr ""
+msgstr "tidak dapat mengurai bingkah konflik di '%s'"
 
 #: rerere.c:668
 #, c-format
 msgid "failed utime() on '%s'"
-msgstr ""
+msgstr "utime() gagal pada '%s'"
 
 #: rerere.c:678
 #, c-format
 msgid "writing '%s' failed"
-msgstr ""
+msgstr "gagal menulis '%s'"
 
 #: rerere.c:698
 #, c-format
 msgid "Staged '%s' using previous resolution."
-msgstr ""
+msgstr "'%s' digelarkan menggunakan resolusi sebelumnya."
 
 #: rerere.c:737
 #, c-format
 msgid "Recorded resolution for '%s'."
-msgstr ""
+msgstr "Resolusi direkam untuk '%s'."
 
 #: rerere.c:772
 #, c-format
 msgid "Resolved '%s' using previous resolution."
-msgstr ""
+msgstr "'%s' diselesaikan menggunakan resolusi sebelumnya."
 
 #: rerere.c:787
 #, c-format
 msgid "cannot unlink stray '%s'"
-msgstr ""
+msgstr "tidak dapat batal taut simpangan '%s'"
 
 #: rerere.c:791
 #, c-format
 msgid "Recorded preimage for '%s'"
-msgstr ""
+msgstr "Pracitra direkam untuk '%s'"
 
-#: rerere.c:865 submodule.c:2076 builtin/log.c:2002
-#: builtin/submodule--helper.c:1805 builtin/submodule--helper.c:1848
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
+#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
 #, c-format
 msgid "could not create directory '%s'"
-msgstr ""
+msgstr "tidak dapat membuat direktori '%s'"
 
 #: rerere.c:1041
 #, c-format
 msgid "failed to update conflicted state in '%s'"
-msgstr ""
+msgstr "gagal memperbarui keadaan konflik di '%s'"
 
 #: rerere.c:1052 rerere.c:1059
 #, c-format
 msgid "no remembered resolution for '%s'"
-msgstr ""
+msgstr "tidak ada resolusi yang diingat untuk '%s'"
 
 #: rerere.c:1061
 #, c-format
 msgid "cannot unlink '%s'"
-msgstr ""
+msgstr "tidak dapat batal taut '%s'"
 
 #: rerere.c:1071
 #, c-format
 msgid "Updated preimage for '%s'"
-msgstr ""
+msgstr "Pracitra diperbarui untuk '%s'"
 
 #: rerere.c:1080
 #, c-format
 msgid "Forgot resolution for '%s'\n"
-msgstr ""
+msgstr "Resolusi dilupakan untuk '%s'\n"
 
 #: rerere.c:1191
 msgid "unable to open rr-cache directory"
-msgstr ""
+msgstr "tidak dapat membuka direktori rr-cache"
 
 #: reset.c:42
 msgid "could not determine HEAD revision"
 msgstr "tidak dapat menentukan revisi HEAD"
 
-#: reset.c:69 reset.c:75 sequencer.c:3689
+#: reset.c:70 reset.c:76 sequencer.c:3703
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "gagal menemukan pohon %s"
 
-#: revision.c:2344
+#: revision.c:2259
+msgid "--unsorted-input is incompatible with --no-walk"
+msgstr ""
+
+#: revision.c:2346
 msgid "--unpacked=<packfile> no longer supported"
 msgstr ""
 
-#: revision.c:2684
+#: revision.c:2655 revision.c:2659
+msgid "--no-walk is incompatible with --unsorted-input"
+msgstr ""
+
+#: revision.c:2690
 msgid "your current branch appears to be broken"
 msgstr ""
 
-#: revision.c:2687
+#: revision.c:2693
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr ""
 
-#: revision.c:2893
+#: revision.c:2895
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr ""
 
-#: run-command.c:766
-msgid "open /dev/null failed"
-msgstr ""
-
-#: run-command.c:1274
+#: run-command.c:1278
 #, c-format
 msgid "cannot create async thread: %s"
-msgstr ""
-
-#: run-command.c:1344
-#, c-format
-msgid ""
-"The '%s' hook was ignored because it's not set as executable.\n"
-"You can disable this warning with `git config advice.ignoredHook false`."
 msgstr ""
 
 #: send-pack.c:150
@@ -7081,118 +7276,132 @@ msgstr ""
 msgid "failed to sign the push certificate"
 msgstr ""
 
-#: send-pack.c:433
+#: send-pack.c:435
 msgid "send-pack: unable to fork off fetch subprocess"
 msgstr ""
 
-#: send-pack.c:455
+#: send-pack.c:457
 msgid "push negotiation failed; proceeding anyway with push"
 msgstr ""
 
-#: send-pack.c:526
+#: send-pack.c:528
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr ""
 
-#: send-pack.c:535
+#: send-pack.c:537
 msgid "the receiving end does not support --signed push"
 msgstr ""
 
-#: send-pack.c:537
+#: send-pack.c:539
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
 msgstr ""
 
-#: send-pack.c:544
+#: send-pack.c:546
 msgid "the receiving end does not support --atomic push"
 msgstr ""
 
-#: send-pack.c:549
+#: send-pack.c:551
 msgid "the receiving end does not support push options"
 msgstr ""
 
-#: sequencer.c:196
+#: sequencer.c:197
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr ""
 
-#: sequencer.c:324
+#: sequencer.c:325
 #, c-format
 msgid "could not delete '%s'"
 msgstr ""
 
-#: sequencer.c:344 builtin/rebase.c:757 builtin/rebase.c:1592 builtin/rm.c:402
+#: sequencer.c:345 sequencer.c:4752 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:408
 #, c-format
 msgid "could not remove '%s'"
 msgstr ""
 
-#: sequencer.c:354
+#: sequencer.c:355
 msgid "revert"
 msgstr ""
 
-#: sequencer.c:356
+#: sequencer.c:357
 msgid "cherry-pick"
 msgstr ""
 
-#: sequencer.c:358
+#: sequencer.c:359
 msgid "rebase"
 msgstr ""
 
-#: sequencer.c:360
+#: sequencer.c:361
 #, c-format
 msgid "unknown action: %d"
 msgstr ""
 
-#: sequencer.c:419
+#: sequencer.c:420
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
 msgstr ""
 
-#: sequencer.c:422
+#: sequencer.c:423
 msgid ""
-"after resolving the conflicts, mark the corrected paths\n"
-"with 'git add <paths>' or 'git rm <paths>'\n"
-"and commit the result with 'git commit'"
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git cherry-pick --continue\".\n"
+"You can instead skip this commit with \"git cherry-pick --skip\".\n"
+"To abort and get back to the state before \"git cherry-pick\",\n"
+"run \"git cherry-pick --abort\"."
 msgstr ""
 
-#: sequencer.c:435 sequencer.c:3271
+#: sequencer.c:430
+msgid ""
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git revert --continue\".\n"
+"You can instead skip this commit with \"git revert --skip\".\n"
+"To abort and get back to the state before \"git revert\",\n"
+"run \"git revert --abort\"."
+msgstr ""
+
+#: sequencer.c:448 sequencer.c:3288
 #, c-format
 msgid "could not lock '%s'"
 msgstr ""
 
-#: sequencer.c:437 sequencer.c:3070 sequencer.c:3275 sequencer.c:3289
-#: sequencer.c:3547 sequencer.c:5566 strbuf.c:1170 wrapper.c:631
+#: sequencer.c:450 sequencer.c:3087 sequencer.c:3292 sequencer.c:3306
+#: sequencer.c:3564 sequencer.c:5619 strbuf.c:1176 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr ""
 
-#: sequencer.c:442
+#: sequencer.c:455
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr ""
 
-#: sequencer.c:447 sequencer.c:3075 sequencer.c:3277 sequencer.c:3291
-#: sequencer.c:3555
+#: sequencer.c:460 sequencer.c:3092 sequencer.c:3294 sequencer.c:3308
+#: sequencer.c:3572
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr ""
 
-#: sequencer.c:486
+#: sequencer.c:499
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr ""
 
-#: sequencer.c:490
+#: sequencer.c:503
 msgid "commit your changes or stash them to proceed."
 msgstr ""
 
-#: sequencer.c:522
+#: sequencer.c:535
 #, c-format
 msgid "%s: fast-forward"
 msgstr ""
 
-#: sequencer.c:561 builtin/tag.c:609
+#: sequencer.c:574 builtin/tag.c:610
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr ""
@@ -7200,65 +7409,65 @@ msgstr ""
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:671
+#: sequencer.c:685
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr ""
 
-#: sequencer.c:685
+#: sequencer.c:699
 msgid "unable to update cache tree"
 msgstr ""
 
-#: sequencer.c:699
+#: sequencer.c:713
 msgid "could not resolve HEAD commit"
 msgstr ""
 
-#: sequencer.c:779
+#: sequencer.c:793
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr ""
 
-#: sequencer.c:790
+#: sequencer.c:804
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr ""
 
-#: sequencer.c:827 wrapper.c:201 wrapper.c:371 builtin/am.c:729
-#: builtin/am.c:821 builtin/merge.c:1141 builtin/rebase.c:910
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
+#: builtin/am.c:822 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr ""
 
-#: sequencer.c:837
+#: sequencer.c:851
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr ""
 
-#: sequencer.c:842
+#: sequencer.c:856
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr ""
 
-#: sequencer.c:847
+#: sequencer.c:861
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr ""
 
-#: sequencer.c:851
+#: sequencer.c:865
 #, c-format
 msgid "unknown variable '%s'"
 msgstr ""
 
-#: sequencer.c:856
+#: sequencer.c:870
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr ""
 
-#: sequencer.c:858
+#: sequencer.c:872
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr ""
 
-#: sequencer.c:860
+#: sequencer.c:874
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr ""
 
-#: sequencer.c:925
+#: sequencer.c:939
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7275,11 +7484,11 @@ msgid ""
 "  git rebase --continue\n"
 msgstr ""
 
-#: sequencer.c:1212
+#: sequencer.c:1227
 msgid "'prepare-commit-msg' hook failed"
 msgstr ""
 
-#: sequencer.c:1218
+#: sequencer.c:1233
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7294,7 +7503,7 @@ msgid ""
 "    git commit --amend --reset-author\n"
 msgstr ""
 
-#: sequencer.c:1231
+#: sequencer.c:1246
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7308,359 +7517,364 @@ msgid ""
 "    git commit --amend --reset-author\n"
 msgstr ""
 
-#: sequencer.c:1273
+#: sequencer.c:1288
 msgid "couldn't look up newly created commit"
 msgstr ""
 
-#: sequencer.c:1275
+#: sequencer.c:1290
 msgid "could not parse newly created commit"
 msgstr ""
 
-#: sequencer.c:1321
+#: sequencer.c:1336
 msgid "unable to resolve HEAD after creating commit"
 msgstr ""
 
-#: sequencer.c:1323
+#: sequencer.c:1338
 msgid "detached HEAD"
 msgstr ""
 
-#: sequencer.c:1327
+#: sequencer.c:1342
 msgid " (root-commit)"
 msgstr ""
 
-#: sequencer.c:1348
+#: sequencer.c:1363
 msgid "could not parse HEAD"
 msgstr ""
 
-#: sequencer.c:1350
+#: sequencer.c:1365
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr ""
 
-#: sequencer.c:1354 sequencer.c:1432 builtin/commit.c:1705
+#: sequencer.c:1369 sequencer.c:1447 builtin/commit.c:1707
 msgid "could not parse HEAD commit"
 msgstr ""
 
-#: sequencer.c:1410 sequencer.c:2295
+#: sequencer.c:1425 sequencer.c:2310
 msgid "unable to parse commit author"
 msgstr ""
 
-#: sequencer.c:1421 builtin/am.c:1615 builtin/merge.c:707
+#: sequencer.c:1436 builtin/am.c:1616 builtin/merge.c:708
 msgid "git write-tree failed to write a tree"
 msgstr ""
 
-#: sequencer.c:1454 sequencer.c:1574
+#: sequencer.c:1469 sequencer.c:1589
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr ""
 
-#: sequencer.c:1485 sequencer.c:1517
+#: sequencer.c:1500 sequencer.c:1532
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr ""
 
-#: sequencer.c:1491
+#: sequencer.c:1506
 msgid "corrupt author: missing date information"
 msgstr ""
 
-#: sequencer.c:1530 builtin/am.c:1642 builtin/commit.c:1819 builtin/merge.c:910
-#: builtin/merge.c:935 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1545 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
+#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr ""
 
-#: sequencer.c:1557 sequencer.c:4492 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1572 sequencer.c:4524 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr ""
 
-#: sequencer.c:1606
+#: sequencer.c:1621
 #, c-format
 msgid "could not parse commit %s"
 msgstr ""
 
-#: sequencer.c:1611
+#: sequencer.c:1626
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr ""
 
-#: sequencer.c:1694 sequencer.c:1975
+#: sequencer.c:1709 sequencer.c:1990
 #, c-format
 msgid "unknown command: %d"
 msgstr ""
 
-#: sequencer.c:1736 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1751
 msgid "This is the 1st commit message:"
 msgstr ""
 
-#: sequencer.c:1737
+#: sequencer.c:1752
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr ""
 
-#: sequencer.c:1738
+#: sequencer.c:1753
 msgid "The 1st commit message will be skipped:"
 msgstr ""
 
-#: sequencer.c:1739
+#: sequencer.c:1754
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr ""
 
-#: sequencer.c:1740
+#: sequencer.c:1755
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr ""
 
-#: sequencer.c:1887 sequencer.c:1944
+#: sequencer.c:1902 sequencer.c:1959
 #, c-format
 msgid "cannot write '%s'"
 msgstr ""
 
-#: sequencer.c:1934
+#: sequencer.c:1949
 msgid "need a HEAD to fixup"
 msgstr ""
 
-#: sequencer.c:1936 sequencer.c:3582
+#: sequencer.c:1951 sequencer.c:3599
 msgid "could not read HEAD"
 msgstr ""
 
-#: sequencer.c:1938
+#: sequencer.c:1953
 msgid "could not read HEAD's commit message"
 msgstr ""
 
-#: sequencer.c:1962
+#: sequencer.c:1977
 #, c-format
 msgid "could not read commit message of %s"
 msgstr ""
 
-#: sequencer.c:2072
+#: sequencer.c:2087
 msgid "your index file is unmerged."
 msgstr ""
 
-#: sequencer.c:2079
+#: sequencer.c:2094
 msgid "cannot fixup root commit"
 msgstr ""
 
-#: sequencer.c:2098
+#: sequencer.c:2113
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr ""
 
-#: sequencer.c:2106 sequencer.c:2114
+#: sequencer.c:2121 sequencer.c:2129
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr ""
 
-#: sequencer.c:2120
+#: sequencer.c:2135
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr ""
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2139
+#: sequencer.c:2154
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr ""
 
-#: sequencer.c:2205
+#: sequencer.c:2220
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr ""
 
-#: sequencer.c:2265
+#: sequencer.c:2280
 #, c-format
 msgid "could not revert %s... %s"
 msgstr ""
 
-#: sequencer.c:2266
+#: sequencer.c:2281
 #, c-format
 msgid "could not apply %s... %s"
 msgstr ""
 
-#: sequencer.c:2287
+#: sequencer.c:2302
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr ""
 
-#: sequencer.c:2345
+#: sequencer.c:2360
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr ""
 
-#: sequencer.c:2352
+#: sequencer.c:2368
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr ""
 
-#: sequencer.c:2425
+#: sequencer.c:2448
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr ""
 
-#: sequencer.c:2434
+#: sequencer.c:2457
 #, c-format
 msgid "missing arguments for %s"
 msgstr ""
 
-#: sequencer.c:2477
+#: sequencer.c:2500
 #, c-format
 msgid "could not parse '%s'"
 msgstr ""
 
-#: sequencer.c:2538
+#: sequencer.c:2561
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr ""
 
-#: sequencer.c:2549
+#: sequencer.c:2572
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr ""
 
-#: sequencer.c:2635
+#: sequencer.c:2620 builtin/rebase.c:184
+#, c-format
+msgid "could not read '%s'."
+msgstr ""
+
+#: sequencer.c:2658
 msgid "cancelling a cherry picking in progress"
 msgstr ""
 
-#: sequencer.c:2644
+#: sequencer.c:2667
 msgid "cancelling a revert in progress"
 msgstr ""
 
-#: sequencer.c:2690
+#: sequencer.c:2707
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
 
-#: sequencer.c:2692
+#: sequencer.c:2709
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr ""
 
-#: sequencer.c:2697
+#: sequencer.c:2714
 msgid "no commits parsed."
 msgstr ""
 
-#: sequencer.c:2708
+#: sequencer.c:2725
 msgid "cannot cherry-pick during a revert."
 msgstr ""
 
-#: sequencer.c:2710
+#: sequencer.c:2727
 msgid "cannot revert during a cherry-pick."
 msgstr ""
 
-#: sequencer.c:2788
+#: sequencer.c:2805
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr ""
 
-#: sequencer.c:2897
+#: sequencer.c:2914
 msgid "unusable squash-onto"
 msgstr ""
 
-#: sequencer.c:2917
+#: sequencer.c:2934
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr ""
 
-#: sequencer.c:3012 sequencer.c:4868
+#: sequencer.c:3029 sequencer.c:4903
 msgid "empty commit set passed"
 msgstr ""
 
-#: sequencer.c:3029
+#: sequencer.c:3046
 msgid "revert is already in progress"
 msgstr ""
 
-#: sequencer.c:3031
+#: sequencer.c:3048
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr ""
 
-#: sequencer.c:3034
+#: sequencer.c:3051
 msgid "cherry-pick is already in progress"
 msgstr ""
 
-#: sequencer.c:3036
+#: sequencer.c:3053
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr ""
 
-#: sequencer.c:3050
+#: sequencer.c:3067
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr ""
 
-#: sequencer.c:3065
+#: sequencer.c:3082
 msgid "could not lock HEAD"
 msgstr ""
 
-#: sequencer.c:3125 sequencer.c:4581
+#: sequencer.c:3142 sequencer.c:4613
 msgid "no cherry-pick or revert in progress"
 msgstr ""
 
-#: sequencer.c:3127 sequencer.c:3138
+#: sequencer.c:3144 sequencer.c:3155
 msgid "cannot resolve HEAD"
 msgstr ""
 
-#: sequencer.c:3129 sequencer.c:3173
+#: sequencer.c:3146 sequencer.c:3190
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 
-#: sequencer.c:3159 builtin/grep.c:758
+#: sequencer.c:3176 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr ""
 
-#: sequencer.c:3161
+#: sequencer.c:3178
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr ""
 
-#: sequencer.c:3162
+#: sequencer.c:3179
 msgid "unexpected end of file"
 msgstr ""
 
-#: sequencer.c:3168
+#: sequencer.c:3185
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr ""
 
-#: sequencer.c:3179
+#: sequencer.c:3196
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 
-#: sequencer.c:3220
+#: sequencer.c:3237
 msgid "no revert in progress"
 msgstr ""
 
-#: sequencer.c:3229
+#: sequencer.c:3246
 msgid "no cherry-pick in progress"
 msgstr ""
 
-#: sequencer.c:3239
+#: sequencer.c:3256
 msgid "failed to skip the commit"
 msgstr ""
 
-#: sequencer.c:3246
+#: sequencer.c:3263
 msgid "there is nothing to skip"
 msgstr ""
 
-#: sequencer.c:3249
+#: sequencer.c:3266
 #, c-format
 msgid ""
 "have you committed already?\n"
 "try \"git %s --continue\""
 msgstr ""
 
-#: sequencer.c:3411 sequencer.c:4472
+#: sequencer.c:3428 sequencer.c:4504
 msgid "cannot read HEAD"
 msgstr ""
 
-#: sequencer.c:3428
+#: sequencer.c:3445
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr ""
 
-#: sequencer.c:3436
+#: sequencer.c:3453
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -7672,27 +7886,27 @@ msgid ""
 "  git rebase --continue\n"
 msgstr ""
 
-#: sequencer.c:3446
+#: sequencer.c:3463
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr ""
 
-#: sequencer.c:3453
+#: sequencer.c:3470
 #, c-format
 msgid "Could not merge %.*s"
 msgstr ""
 
-#: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
+#: sequencer.c:3484 sequencer.c:3488 builtin/difftool.c:639
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr ""
 
-#: sequencer.c:3483
+#: sequencer.c:3500
 #, c-format
 msgid "Executing: %s\n"
 msgstr ""
 
-#: sequencer.c:3498
+#: sequencer.c:3515
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -7702,11 +7916,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: sequencer.c:3504
+#: sequencer.c:3521
 msgid "and made changes to the index and/or the working tree\n"
 msgstr ""
 
-#: sequencer.c:3510
+#: sequencer.c:3527
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -7717,90 +7931,90 @@ msgid ""
 "\n"
 msgstr ""
 
-#: sequencer.c:3572
+#: sequencer.c:3589
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr ""
 
-#: sequencer.c:3645
+#: sequencer.c:3662
 msgid "writing fake root commit"
 msgstr ""
 
-#: sequencer.c:3650
+#: sequencer.c:3667
 msgid "writing squash-onto"
 msgstr ""
 
-#: sequencer.c:3734
+#: sequencer.c:3746
 #, c-format
 msgid "could not resolve '%s'"
 msgstr ""
 
-#: sequencer.c:3767
+#: sequencer.c:3778
 msgid "cannot merge without a current revision"
 msgstr ""
 
-#: sequencer.c:3789
+#: sequencer.c:3800
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr ""
 
-#: sequencer.c:3798
+#: sequencer.c:3809
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr ""
 
-#: sequencer.c:3810
+#: sequencer.c:3821
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
 
-#: sequencer.c:3826
+#: sequencer.c:3876
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr ""
 
-#: sequencer.c:4009
+#: sequencer.c:4022
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr ""
 
-#: sequencer.c:4025
+#: sequencer.c:4038
 msgid "merge: Unable to write new index file"
 msgstr ""
 
-#: sequencer.c:4099
+#: sequencer.c:4119
 msgid "Cannot autostash"
 msgstr ""
 
-#: sequencer.c:4102
+#: sequencer.c:4122
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr ""
 
-#: sequencer.c:4108
+#: sequencer.c:4128
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr ""
 
-#: sequencer.c:4111
+#: sequencer.c:4131
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr ""
 
-#: sequencer.c:4115
+#: sequencer.c:4135
 msgid "could not reset --hard"
 msgstr ""
 
-#: sequencer.c:4140
+#: sequencer.c:4160
 #, c-format
 msgid "Applied autostash.\n"
 msgstr ""
 
-#: sequencer.c:4152
+#: sequencer.c:4172
 #, c-format
 msgid "cannot store %s"
 msgstr ""
 
-#: sequencer.c:4155
+#: sequencer.c:4175
 #, c-format
 msgid ""
 "%s\n"
@@ -7808,29 +8022,29 @@ msgid ""
 "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
 msgstr ""
 
-#: sequencer.c:4160
+#: sequencer.c:4180
 msgid "Applying autostash resulted in conflicts."
 msgstr ""
 
-#: sequencer.c:4161
+#: sequencer.c:4181
 msgid "Autostash exists; creating a new stash entry."
 msgstr ""
 
-#: sequencer.c:4233 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4253
 msgid "could not detach HEAD"
 msgstr ""
 
-#: sequencer.c:4248
+#: sequencer.c:4268
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr ""
 
-#: sequencer.c:4250
+#: sequencer.c:4270
 #, c-format
 msgid "Stopped at %s\n"
 msgstr ""
 
-#: sequencer.c:4258
+#: sequencer.c:4302
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -7843,108 +8057,117 @@ msgid ""
 "    git rebase --continue\n"
 msgstr ""
 
-#: sequencer.c:4304
+#: sequencer.c:4348
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr ""
 
-#: sequencer.c:4350
+#: sequencer.c:4394
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr ""
 
-#: sequencer.c:4421
+#: sequencer.c:4464
 #, c-format
 msgid "unknown command %d"
 msgstr ""
 
-#: sequencer.c:4480
+#: sequencer.c:4512
 msgid "could not read orig-head"
 msgstr ""
 
-#: sequencer.c:4485
+#: sequencer.c:4517
 msgid "could not read 'onto'"
 msgstr ""
 
-#: sequencer.c:4499
+#: sequencer.c:4531
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr ""
 
-#: sequencer.c:4559
+#: sequencer.c:4591
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr ""
 
-#: sequencer.c:4611
+#: sequencer.c:4643
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 
-#: sequencer.c:4620
+#: sequencer.c:4652
 msgid "cannot amend non-existing commit"
 msgstr ""
 
-#: sequencer.c:4622
+#: sequencer.c:4654
 #, c-format
 msgid "invalid file: '%s'"
 msgstr ""
 
-#: sequencer.c:4624
+#: sequencer.c:4656
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr ""
 
-#: sequencer.c:4627
+#: sequencer.c:4659
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
 "first and then run 'git rebase --continue' again."
 msgstr ""
 
-#: sequencer.c:4663 sequencer.c:4702
+#: sequencer.c:4695 sequencer.c:4734
 #, c-format
 msgid "could not write file: '%s'"
 msgstr ""
 
-#: sequencer.c:4718
+#: sequencer.c:4750
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr ""
 
-#: sequencer.c:4725
+#: sequencer.c:4760
 msgid "could not commit staged changes."
 msgstr ""
 
-#: sequencer.c:4845
+#: sequencer.c:4880
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr ""
 
-#: sequencer.c:4849
+#: sequencer.c:4884
 #, c-format
 msgid "%s: bad revision"
 msgstr ""
 
-#: sequencer.c:4884
+#: sequencer.c:4919
 msgid "can't revert as initial commit"
 msgstr ""
 
-#: sequencer.c:5361
+#: sequencer.c:5190 sequencer.c:5419
+#, c-format
+msgid "skipped previously applied commit %s"
+msgstr ""
+
+#: sequencer.c:5260 sequencer.c:5435
+msgid "use --reapply-cherry-picks to include skipped commits"
+msgstr ""
+
+#: sequencer.c:5406
 msgid "make_script: unhandled options"
 msgstr ""
 
-#: sequencer.c:5364
+#: sequencer.c:5409
 msgid "make_script: error preparing revisions"
 msgstr ""
 
-#: sequencer.c:5614 sequencer.c:5631
+#: sequencer.c:5667 sequencer.c:5684
 msgid "nothing to do"
 msgstr ""
 
-#: sequencer.c:5650
+#: sequencer.c:5703
 msgid "could not skip unnecessary pick commands"
 msgstr ""
 
-#: sequencer.c:5750
+#: sequencer.c:5803
 msgid "the script was already rearranged."
 msgstr ""
 
@@ -8088,27 +8311,15 @@ msgid ""
 "The owner of files must always have read and write permissions."
 msgstr ""
 
-#: setup.c:1430
-msgid "open /dev/null or dup failed"
-msgstr ""
-
-#: setup.c:1445
+#: setup.c:1443
 msgid "fork failed"
 msgstr ""
 
-#: setup.c:1450 t/helper/test-simple-ipc.c:285
+#: setup.c:1448
 msgid "setsid failed"
 msgstr ""
 
-#: sparse-index.c:162
-msgid "attempting to use sparse-index without cone mode"
-msgstr ""
-
-#: sparse-index.c:176
-msgid "unable to update cache-tree, staying full"
-msgstr ""
-
-#: sparse-index.c:263
+#: sparse-index.c:273
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr ""
@@ -8165,13 +8376,13 @@ msgid_plural "%u bytes/s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: strbuf.c:1168 wrapper.c:199 wrapper.c:369 builtin/am.c:738
-#: builtin/rebase.c:866
+#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr ""
 
-#: strbuf.c:1177
+#: strbuf.c:1183
 #, c-format
 msgid "could not edit '%s'"
 msgstr ""
@@ -8195,7 +8406,7 @@ msgstr "abaikan '%s' yang mungkin ditafsirkan sebagai opsi baris perintah: %s"
 msgid "invalid value for %s"
 msgstr "nilai tidak valid untuk %s"
 
-#: submodule-config.c:766
+#: submodule-config.c:767
 #, c-format
 msgid "Could not update .gitmodules entry %s"
 msgstr "Tidak dapat memperbarui entri .gitmodules %s"
@@ -8220,22 +8431,22 @@ msgstr "Tidak dapat menghapus entri .gitmodules untuk %s"
 msgid "staging updated .gitmodules failed"
 msgstr "gagal menggelar .gitmodules terbarui"
 
-#: submodule.c:328
+#: submodule.c:358
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "dalam submodul tak terisi '%s'"
 
-#: submodule.c:359
+#: submodule.c:389
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Spek jalur '%s' di dalam submodul '%.*s'"
 
-#: submodule.c:436
+#: submodule.c:466
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "argumen --ignore-submodules jelek: %s"
 
-#: submodule.c:805
+#: submodule.c:844
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8244,12 +8455,12 @@ msgstr ""
 "Submodul dalam komit %s pada jalur '%s' bertabrakan dengan submodul yang "
 "bernama sama. Melewati itu."
 
-#: submodule.c:908
+#: submodule.c:954
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "entri submodul '%s' (%s) adalah %s, bukan komit"
 
-#: submodule.c:993
+#: submodule.c:1042
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8258,36 +8469,36 @@ msgstr ""
 "Tidak dapat menjalankan perintah 'git rev-list <komit> --not --remotes -n 1' "
 "dalam submodul %s"
 
-#: submodule.c:1116
+#: submodule.c:1165
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "proses untuk submodul '%s' gagal"
 
-#: submodule.c:1145 builtin/branch.c:691 builtin/submodule--helper.c:2486
+#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Gagal menguraikan HEAD sebagai referensi valid."
 
-#: submodule.c:1156
+#: submodule.c:1205
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Mendorong submodul '%s'\n"
 
-#: submodule.c:1159
+#: submodule.c:1208
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Tidak dapat mendorong submodul '%s'\n"
 
-#: submodule.c:1451
+#: submodule.c:1491
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Mengambil submodul %s%s\n"
 
-#: submodule.c:1485
+#: submodule.c:1525
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Tidak dapat mengakses submodul '%s'\n"
 
-#: submodule.c:1640
+#: submodule.c:1680
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8296,61 +8507,61 @@ msgstr ""
 "Kesalahan saat pengambilan submodul:\n"
 "%s"
 
-#: submodule.c:1665
+#: submodule.c:1705
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' tak dikenal sebagai repositori git"
 
-#: submodule.c:1682
+#: submodule.c:1722
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Tidak dapat menjalankan 'git status --porcelain=2' dalam submodul %s"
 
-#: submodule.c:1723
+#: submodule.c:1763
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "'git status --porcelain=2' gagal dalam submodul %s"
 
-#: submodule.c:1798
+#: submodule.c:1838
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "Tidak dalat memulai 'git status' dalam submodul '%s'"
 
-#: submodule.c:1811
+#: submodule.c:1851
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "tidak dapat menjalankan 'git status' dalam submodul '%s'"
 
-#: submodule.c:1826
+#: submodule.c:1868
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Tidak dapat batal setel setelan core.worktree dalam submodul '%s'"
 
-#: submodule.c:1853 submodule.c:2163
+#: submodule.c:1895 submodule.c:2210
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "tidak dapat rekursi ke dalam submodul '%s'"
 
-#: submodule.c:1874
+#: submodule.c:1917
 msgid "could not reset submodule index"
 msgstr "tidak dapat reset indeks submodul"
 
-#: submodule.c:1916
+#: submodule.c:1959
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "submodul '%s' punya indeks kotor"
 
-#: submodule.c:1968
+#: submodule.c:2013
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Submodul '%s' tidak dapat diperbarui."
 
-#: submodule.c:2036
+#: submodule.c:2081
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr "direktori submodul git '%s' di dalam direktori git '%.*s'"
 
-#: submodule.c:2057
+#: submodule.c:2102
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8358,17 +8569,17 @@ msgstr ""
 "relocate_gitdir untuk submodul '%s' dengan lebih dari satu pohon kerja tidak "
 "didukung"
 
-#: submodule.c:2069 submodule.c:2128
+#: submodule.c:2114 submodule.c:2174
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "tidak dapat mencari nama untuk submodul '%s'"
 
-#: submodule.c:2073
+#: submodule.c:2118
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "menolak memindahkan '%s' ke dalam direktori git yang ada"
 
-#: submodule.c:2080
+#: submodule.c:2124
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8379,11 +8590,11 @@ msgstr ""
 "'%s' ke\n"
 "'%s'\n"
 
-#: submodule.c:2208
+#: submodule.c:2255
 msgid "could not start ls-files in .."
 msgstr "tidak dapat memulai ls-files dalam .."
 
-#: submodule.c:2248
+#: submodule.c:2295
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree kembalikan kode kembali %d yang tak diharapkan"
@@ -8405,7 +8616,7 @@ msgid "unknown value '%s' for key '%s'"
 msgstr ""
 
 #: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
-#: builtin/remote.c:324
+#: builtin/remote.c:327
 #, c-format
 msgid "more than one %s"
 msgstr ""
@@ -8420,11 +8631,11 @@ msgstr ""
 msgid "could not read input file '%s'"
 msgstr ""
 
-#: trailer.c:766 builtin/mktag.c:88 imap-send.c:1577
+#: trailer.c:766 builtin/mktag.c:89 imap-send.c:1573
 msgid "could not read from stdin"
 msgstr ""
 
-#: trailer.c:1024 wrapper.c:676
+#: trailer.c:1024 wrapper.c:684
 #, c-format
 msgid "could not stat %s"
 msgstr ""
@@ -8490,7 +8701,7 @@ msgstr ""
 msgid "error while running fast-import"
 msgstr ""
 
-#: transport-helper.c:549 transport-helper.c:1247
+#: transport-helper.c:549 transport-helper.c:1251
 #, c-format
 msgid "could not read ref %s"
 msgstr ""
@@ -8508,7 +8719,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr ""
 
-#: transport-helper.c:661 transport.c:1477
+#: transport-helper.c:661 transport.c:1475
 msgid "operation not supported by protocol"
 msgstr ""
 
@@ -8517,7 +8728,7 @@ msgstr ""
 msgid "can't connect to subservice %s"
 msgstr ""
 
-#: transport-helper.c:693 transport.c:400
+#: transport-helper.c:693 transport.c:404
 msgid "--negotiate-only requires protocol v2"
 msgstr ""
 
@@ -8530,111 +8741,111 @@ msgstr ""
 msgid "expected ok/error, helper said '%s'"
 msgstr ""
 
-#: transport-helper.c:855
+#: transport-helper.c:859
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr ""
 
-#: transport-helper.c:938
+#: transport-helper.c:942
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr ""
 
-#: transport-helper.c:941
+#: transport-helper.c:945
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr ""
 
-#: transport-helper.c:944
+#: transport-helper.c:948
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr ""
 
-#: transport-helper.c:949
+#: transport-helper.c:953
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr ""
 
-#: transport-helper.c:953
+#: transport-helper.c:957
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr ""
 
-#: transport-helper.c:960
+#: transport-helper.c:964
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr ""
 
-#: transport-helper.c:1060
+#: transport-helper.c:1064
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr ""
 
-#: transport-helper.c:1065
+#: transport-helper.c:1069
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr ""
 
-#: transport-helper.c:1112
+#: transport-helper.c:1116
 msgid "couldn't run fast-export"
 msgstr ""
 
-#: transport-helper.c:1117
+#: transport-helper.c:1121
 msgid "error while running fast-export"
 msgstr ""
 
-#: transport-helper.c:1142
+#: transport-helper.c:1146
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
 "Perhaps you should specify a branch.\n"
 msgstr ""
 
-#: transport-helper.c:1224
+#: transport-helper.c:1228
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr ""
 
-#: transport-helper.c:1233
+#: transport-helper.c:1237
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr ""
 
-#: transport-helper.c:1385
+#: transport-helper.c:1389
 #, c-format
 msgid "read(%s) failed"
 msgstr ""
 
-#: transport-helper.c:1412
+#: transport-helper.c:1416
 #, c-format
 msgid "write(%s) failed"
 msgstr ""
 
-#: transport-helper.c:1461
+#: transport-helper.c:1465
 #, c-format
 msgid "%s thread failed"
 msgstr ""
 
-#: transport-helper.c:1465
+#: transport-helper.c:1469
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr ""
 
-#: transport-helper.c:1484 transport-helper.c:1488
+#: transport-helper.c:1488 transport-helper.c:1492
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr ""
 
-#: transport-helper.c:1525
+#: transport-helper.c:1529
 #, c-format
 msgid "%s process failed to wait"
 msgstr ""
 
-#: transport-helper.c:1529
+#: transport-helper.c:1533
 #, c-format
 msgid "%s process failed"
 msgstr ""
 
-#: transport-helper.c:1547 transport-helper.c:1556
+#: transport-helper.c:1551 transport-helper.c:1560
 msgid "can't start thread for copying data"
 msgstr ""
 
@@ -8648,53 +8859,53 @@ msgstr ""
 msgid "could not read bundle '%s'"
 msgstr ""
 
-#: transport.c:223
+#: transport.c:227
 #, c-format
 msgid "transport: invalid depth option '%s'"
 msgstr ""
 
-#: transport.c:275
+#: transport.c:279
 msgid "see protocol.version in 'git help config' for more details"
 msgstr ""
 
-#: transport.c:276
+#: transport.c:280
 msgid "server options require protocol version 2 or later"
 msgstr ""
 
-#: transport.c:403
+#: transport.c:407
 msgid "server does not support wait-for-done"
 msgstr ""
 
-#: transport.c:755
+#: transport.c:759
 msgid "could not parse transport.color.* config"
 msgstr ""
 
-#: transport.c:830
+#: transport.c:834
 msgid "support for protocol v2 not implemented yet"
 msgstr ""
 
-#: transport.c:965
+#: transport.c:967
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr ""
 
-#: transport.c:1031
+#: transport.c:1033
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr ""
 
-#: transport.c:1084
+#: transport.c:1082
 msgid "git-over-rsync is no longer supported"
 msgstr ""
 
-#: transport.c:1187
+#: transport.c:1185
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
 "not be found on any remote:\n"
 msgstr ""
 
-#: transport.c:1191
+#: transport.c:1189
 #, c-format
 msgid ""
 "\n"
@@ -8710,11 +8921,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: transport.c:1199
+#: transport.c:1197
 msgid "Aborting."
 msgstr ""
 
-#: transport.c:1346
+#: transport.c:1344
 msgid "failed to push all needed submodules"
 msgstr ""
 
@@ -8927,16 +9138,16 @@ msgid ""
 "colliding group is in the working tree:\n"
 msgstr ""
 
-#: unpack-trees.c:1618
+#: unpack-trees.c:1620
 msgid "Updating index flags"
 msgstr ""
 
-#: unpack-trees.c:2718
+#: unpack-trees.c:2772
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 
-#: upload-pack.c:1548
+#: upload-pack.c:1561
 msgid "expected flush after fetch arguments"
 msgstr ""
 
@@ -8973,7 +9184,7 @@ msgstr ""
 msgid "Fetching objects"
 msgstr ""
 
-#: worktree.c:236 builtin/am.c:2152
+#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "gagal membaca '%s'"
@@ -9070,17 +9281,27 @@ msgstr "berkas gitdir tidak valid"
 msgid "gitdir file points to non-existent location"
 msgstr "berkas gitdir menunjuk ke lokasi yang tidak ada"
 
-#: wrapper.c:197 wrapper.c:367
+#: wrapper.c:151
+#, c-format
+msgid "could not setenv '%s'"
+msgstr ""
+
+#: wrapper.c:203
+#, c-format
+msgid "unable to create '%s'"
+msgstr "tidak dapat membuat '%s'"
+
+#: wrapper.c:205 wrapper.c:375
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr ""
 
-#: wrapper.c:398 wrapper.c:599
+#: wrapper.c:406 wrapper.c:607
 #, c-format
 msgid "unable to access '%s'"
 msgstr ""
 
-#: wrapper.c:607
+#: wrapper.c:615
 msgid "unable to get current working directory"
 msgstr ""
 
@@ -9625,25 +9846,25 @@ msgstr "juga indeks Anda berisi perubahan yang belum dikomit."
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "tidak dapat %s: indeks Anda berisi perubahan yang belum dikomit."
 
-#: compat/simple-ipc/ipc-unix-socket.c:182
+#: compat/simple-ipc/ipc-unix-socket.c:183
 msgid "could not send IPC command"
 msgstr ""
 
-#: compat/simple-ipc/ipc-unix-socket.c:189
+#: compat/simple-ipc/ipc-unix-socket.c:190
 msgid "could not read IPC response"
 msgstr ""
 
-#: compat/simple-ipc/ipc-unix-socket.c:866
+#: compat/simple-ipc/ipc-unix-socket.c:870
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr ""
 
-#: compat/simple-ipc/ipc-unix-socket.c:878
+#: compat/simple-ipc/ipc-unix-socket.c:882
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr ""
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:461
+#: compat/precompose_utf8.c:58 builtin/clone.c:347
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr ""
@@ -9652,131 +9873,130 @@ msgstr ""
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<opsi>] [--] <pathspec>..."
 
-#: builtin/add.c:61
+#: builtin/add.c:64
 #, c-format
 msgid "cannot chmod %cx '%s'"
 msgstr "tidak dapat chmod %cx '%s'"
 
-#: builtin/add.c:99
+#: builtin/add.c:106
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "status diff tak diharapkan %c"
 
-#: builtin/add.c:104 builtin/commit.c:297
+#: builtin/add.c:111 builtin/commit.c:298
 msgid "updating files failed"
 msgstr "gagal memperbarui berkas"
 
-#: builtin/add.c:114
+#: builtin/add.c:121
 #, c-format
 msgid "remove '%s'\n"
 msgstr "hapus '%s'\n"
 
-#: builtin/add.c:198
+#: builtin/add.c:205
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Perubahan tak tergelar setelah menyegarkan indeks:"
 
-#: builtin/add.c:307 builtin/rev-parse.c:993
+#: builtin/add.c:317 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Tidak dapat membaca indeks"
 
-#: builtin/add.c:318
-#, c-format
-msgid "Could not open '%s' for writing."
-msgstr "Tidak dapat membuka '%s' untuk ditulis."
-
-#: builtin/add.c:322
+#: builtin/add.c:330
 msgid "Could not write patch"
 msgstr "Tidak dapat menulis tambalan"
 
-#: builtin/add.c:325
+#: builtin/add.c:333
 msgid "editing patch failed"
 msgstr "Gagal menyunting tambalan"
 
-#: builtin/add.c:328
+#: builtin/add.c:336
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Tidak dapat men-stat '%s'"
 
-#: builtin/add.c:330
+#: builtin/add.c:338
 msgid "Empty patch. Aborted."
 msgstr "Tambalan kosong. Dibatalkan."
 
-#: builtin/add.c:335
+#: builtin/add.c:343
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Tidak dapat terapkan '%s'"
 
-#: builtin/add.c:343
+#: builtin/add.c:351
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "Jalur berikut diabaikan oleh salah satu dari berkas .gitignore Anda:\n"
 
-#: builtin/add.c:363 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
-#: builtin/remote.c:1427 builtin/rm.c:243 builtin/send-pack.c:190
+#: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "latihan"
 
-#: builtin/add.c:366
+#: builtin/add.c:374
 msgid "interactive picking"
 msgstr "pengambilan interaktif"
 
-#: builtin/add.c:367 builtin/checkout.c:1562 builtin/reset.c:308
+#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
 msgid "select hunks interactively"
 msgstr "pilih bingkah secara interaktif"
 
-#: builtin/add.c:368
+#: builtin/add.c:376
 msgid "edit current diff and apply"
 msgstr "sunting diff saat ini dan terapkan"
 
-#: builtin/add.c:369
+#: builtin/add.c:377
 msgid "allow adding otherwise ignored files"
 msgstr "perbolehkan tambah berkas yang diabaikan"
 
-#: builtin/add.c:370
+#: builtin/add.c:378
 msgid "update tracked files"
 msgstr "perbarui berkas terlacak"
 
-#: builtin/add.c:371
+#: builtin/add.c:379
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "normalisasi ulang EOL berkas terlacak (menyiratkan -u)"
 
-#: builtin/add.c:372
+#: builtin/add.c:380
 msgid "record only the fact that the path will be added later"
 msgstr "rekam hanya fakta bahwa jalur akan ditambahkan nanti"
 
-#: builtin/add.c:373
+#: builtin/add.c:381
 msgid "add changes from all tracked and untracked files"
 msgstr "tambahkan perubahan dari semua berkas terlacak dan tak terlacak"
 
-#: builtin/add.c:376
+#: builtin/add.c:384
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "abaikan jalur yang terhapus dari pohon kerja (sama dengan --no-all)"
 
-#: builtin/add.c:378
+#: builtin/add.c:386
 msgid "don't add, only refresh the index"
 msgstr "jangan tambahkan, hanya segarkan indeks"
 
-#: builtin/add.c:379
+#: builtin/add.c:387
 msgid "just skip files which cannot be added because of errors"
 msgstr "hanya lewatkan berkas yang tidak dapat ditambah karena error"
 
-#: builtin/add.c:380
+#: builtin/add.c:388
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "periksa bahwa berkas yang - bahkan hilang - diabaikan dalam latihan"
 
-#: builtin/add.c:382 builtin/update-index.c:1006
+#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+msgid "allow updating entries outside of the sparse-checkout cone"
+msgstr ""
+
+#: builtin/add.c:391 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "timpa bit yang dapat dieksekusi dari berkas terdaftar"
 
-#: builtin/add.c:384
+#: builtin/add.c:393
 msgid "warn when adding an embedded repository"
 msgstr "peringatkan ketika menambahkan repositori tertanam"
 
-#: builtin/add.c:386
+#: builtin/add.c:395
 msgid "backend for `git stash -p`"
 msgstr "tulang belakang untuk `git stash -p`"
 
-#: builtin/add.c:404
+#: builtin/add.c:413
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -9807,12 +10027,12 @@ msgstr ""
 "\n"
 "Lihat \"git help submodule\" untuk selengkapnya."
 
-#: builtin/add.c:432
+#: builtin/add.c:442
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "menambahkan repositori git tertanam: %s"
 
-#: builtin/add.c:451
+#: builtin/add.c:462
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -9822,51 +10042,51 @@ msgstr ""
 "Matikan pesan ini dengan menjalankan\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:460
+#: builtin/add.c:477
 msgid "adding files failed"
 msgstr "gagal menambahkan berkas"
 
-#: builtin/add.c:488
+#: builtin/add.c:513
 msgid "--dry-run is incompatible with --interactive/--patch"
 msgstr "--dry-run tidak kompatibel dengan --interactive/--patch"
 
-#: builtin/add.c:490 builtin/commit.c:357
+#: builtin/add.c:515 builtin/commit.c:358
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr "--pathspec-from-file tidak kompatibel dengan --interactive/--patch"
 
-#: builtin/add.c:507
+#: builtin/add.c:532
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "--pathspec-from-file tidak kompatibel dengan --edit"
 
-#: builtin/add.c:519
+#: builtin/add.c:544
 msgid "-A and -u are mutually incompatible"
 msgstr "-A dan -u saling tak kompatibel"
 
-#: builtin/add.c:522
+#: builtin/add.c:547
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr "Opsi --ignore-missing hanya dapat digunakan bersama dengan --dry-run"
 
-#: builtin/add.c:526
+#: builtin/add.c:551
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod param '%s' harus berupa -x atau +x"
 
-#: builtin/add.c:544 builtin/checkout.c:1733 builtin/commit.c:363
-#: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1633
+#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
+#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr "--pathspec-from-file tidak kompatibel dengan argumen pathspec"
 
-#: builtin/add.c:551 builtin/checkout.c:1745 builtin/commit.c:369
-#: builtin/reset.c:334 builtin/rm.c:279 builtin/stash.c:1639
+#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
+#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul butuh --pathspec-from-file"
 
-#: builtin/add.c:555
+#: builtin/add.c:583
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Tidak ada yang disebutkan, tidak ada yang ditambahkan.\n"
 
-#: builtin/add.c:557
+#: builtin/add.c:585
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -9876,166 +10096,178 @@ msgstr ""
 "Matikan pesan ini dengan menjalankan\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:365
+#: builtin/am.c:366
 msgid "could not parse author script"
-msgstr ""
+msgstr "tidak dapat mengurai skrip pengarang"
 
-#: builtin/am.c:455
+#: builtin/am.c:456
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
-msgstr ""
+msgstr "'%s' dihapus oleh kail applypatch-msg"
 
-#: builtin/am.c:497
+#: builtin/am.c:498
 #, c-format
 msgid "Malformed input line: '%s'."
-msgstr ""
+msgstr "Baris masukan salah format: '%s'."
 
-#: builtin/am.c:535
+#: builtin/am.c:536
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
-msgstr ""
+msgstr "Gagal menyalin catatan dari '%s' ke '%s'"
 
-#: builtin/am.c:561
+#: builtin/am.c:562
 msgid "fseek failed"
-msgstr ""
+msgstr "fseek gagal"
 
-#: builtin/am.c:749
+#: builtin/am.c:750
 #, c-format
 msgid "could not parse patch '%s'"
-msgstr ""
+msgstr "tidak dapat mengurai tambalan '%s'"
 
-#: builtin/am.c:814
+#: builtin/am.c:815
 msgid "Only one StGIT patch series can be applied at once"
-msgstr ""
+msgstr "Hanya satu rangkaian tambalan StGIT yang bisa diterapkan sekaligus"
 
-#: builtin/am.c:862
+#: builtin/am.c:863
 msgid "invalid timestamp"
-msgstr ""
+msgstr "stempel waktu tidak valid"
 
-#: builtin/am.c:867 builtin/am.c:879
+#: builtin/am.c:868 builtin/am.c:880
 msgid "invalid Date line"
-msgstr ""
+msgstr "baris Date tidak valid"
 
-#: builtin/am.c:874
+#: builtin/am.c:875
 msgid "invalid timezone offset"
-msgstr ""
+msgstr "offset zona waktu tidak valid"
 
-#: builtin/am.c:967
+#: builtin/am.c:968
 msgid "Patch format detection failed."
-msgstr ""
+msgstr "Pendeteksian format tambalan gagal."
 
-#: builtin/am.c:972 builtin/clone.c:414
+#: builtin/am.c:973 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
-msgstr ""
+msgstr "gagal membuat direktori '%s'"
 
-#: builtin/am.c:977
+#: builtin/am.c:978
 msgid "Failed to split patches."
-msgstr ""
-
-#: builtin/am.c:1126
-#, c-format
-msgid "When you have resolved this problem, run \"%s --continue\"."
-msgstr ""
+msgstr "Gagal memecah tambalan."
 
 #: builtin/am.c:1127
 #, c-format
-msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
-msgstr ""
+msgid "When you have resolved this problem, run \"%s --continue\"."
+msgstr "Saat Anda sudah menyelesaikan masalah ini, jalankan \"%s --continue\"."
 
 #: builtin/am.c:1128
 #, c-format
+msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
+msgstr ""
+"Jika Anda lebih suka melewati tambalan ini, jalankan \"%s --skip\" sebagai "
+"gantinya."
+
+#: builtin/am.c:1129
+#, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
+"Untuk mengembalikan cabang yang asli dan berhenti menambal, jalankan \"%s --"
+"abort\""
 
-#: builtin/am.c:1223
+#: builtin/am.c:1224
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
+"Tambalan dikirimkan dengan format=flowed; spasi pada akhir baris mungkin "
+"hilang."
 
-#: builtin/am.c:1251
+#: builtin/am.c:1252
 msgid "Patch is empty."
-msgstr ""
+msgstr "Tambalan kosong."
 
-#: builtin/am.c:1316
+#: builtin/am.c:1317
 #, c-format
 msgid "missing author line in commit %s"
-msgstr ""
+msgstr "baris pengarang hilang dalam komit %s"
 
-#: builtin/am.c:1319
+#: builtin/am.c:1320
 #, c-format
 msgid "invalid ident line: %.*s"
-msgstr ""
+msgstr "baris identitas tidak valid: %.*s"
 
-#: builtin/am.c:1538
+#: builtin/am.c:1539
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
+"Repositori kekurangan blob yang diperlukan untuk mundur ke penggabungan 3 "
+"arah."
 
-#: builtin/am.c:1540
+#: builtin/am.c:1541
 msgid "Using index info to reconstruct a base tree..."
-msgstr ""
+msgstr "Menggunakan info indeks untuk membangun ulang sebuah pohon dasar..."
 
-#: builtin/am.c:1559
+#: builtin/am.c:1560
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
 msgstr ""
+"Apakah Anda menyunting tambalan Anda?\n"
+"Itu tidak diterapkan ke blob yang direkam dalam indeksnya."
 
-#: builtin/am.c:1565
+#: builtin/am.c:1566
 msgid "Falling back to patching base and 3-way merge..."
-msgstr ""
+msgstr "Mundur ke penambalan dasar dan penggabungan 3 arah..."
 
-#: builtin/am.c:1591
+#: builtin/am.c:1592
 msgid "Failed to merge in the changes."
-msgstr ""
+msgstr "Gagal menggabungkan perubahan."
 
-#: builtin/am.c:1623
+#: builtin/am.c:1624
 msgid "applying to an empty history"
-msgstr ""
+msgstr "menerapkan ke sebuah riwayat kosong"
 
-#: builtin/am.c:1675 builtin/am.c:1679
+#: builtin/am.c:1676 builtin/am.c:1680
 #, c-format
 msgid "cannot resume: %s does not exist."
-msgstr ""
+msgstr "tidak dapat melanjutkan: %s tidak ada."
 
-#: builtin/am.c:1697
+#: builtin/am.c:1698
 msgid "Commit Body is:"
-msgstr ""
+msgstr "Badan komit adalah:"
 
 #. TRANSLATORS: Make sure to include [y], [n], [e], [v] and [a]
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1707
+#: builtin/am.c:1708
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
+"Terapkan? [y]a/[n] tidak/[e] sunting/[v] lihat tambalan/terim[a] semua: "
 
-#: builtin/am.c:1753 builtin/commit.c:408
+#: builtin/am.c:1754 builtin/commit.c:409
 msgid "unable to write index file"
-msgstr ""
+msgstr "tidak dapat menulis berkas indeks"
 
-#: builtin/am.c:1757
+#: builtin/am.c:1758
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
-msgstr ""
+msgstr "Indeks kotor: tidak dapat menerapkan tambalan (kotor: %s)"
 
-#: builtin/am.c:1797 builtin/am.c:1865
+#: builtin/am.c:1798 builtin/am.c:1865
 #, c-format
 msgid "Applying: %.*s"
-msgstr ""
+msgstr "Menerapkan: %.*s"
 
-#: builtin/am.c:1814
+#: builtin/am.c:1815
 msgid "No changes -- Patch already applied."
-msgstr ""
+msgstr "Tidak ada perubahan -- tambalan sudah diterapkan"
 
-#: builtin/am.c:1820
+#: builtin/am.c:1821
 #, c-format
 msgid "Patch failed at %s %.*s"
-msgstr ""
+msgstr "Penambalan gagal pada %s %.*s"
 
-#: builtin/am.c:1824
+#: builtin/am.c:1825
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
+"Gunakan 'git am --show-current-patch=diff' untuk melihat tambalan yang gagal"
 
 #: builtin/am.c:1868
 msgid ""
@@ -10043,6 +10275,9 @@ msgid ""
 "If there is nothing left to stage, chances are that something else\n"
 "already introduced the same changes; you might want to skip this patch."
 msgstr ""
+"Tidak ada perubahan - apakah Anda lupa untuk menggunakan 'git add'?\n"
+"Jika tidak ada lagi yang diterapkan, sepertinya sesuatu yang lain sudah \n"
+"memasukkan perubahan yang sama; mungkin Anda ingin melewatkan tambalan ini."
 
 #: builtin/am.c:1875
 msgid ""
@@ -10051,248 +10286,250 @@ msgid ""
 "such.\n"
 "You might run `git rm` on a file to accept \"deleted by them\" for it."
 msgstr ""
+"Anda masih punya jalur yang belum digabung pada indeks Anda.\n"
+"Anda harus 'git add' setiap berkas dengan konflik terselesai untuk "
+"menandainya.\n"
+"Anda mungkin jalankan `git rm` pada berkas untuk menerima \"penghapusan oleh "
+"mereka\" untuk itu."
 
-#: builtin/am.c:1982 builtin/am.c:1986 builtin/am.c:1998 builtin/reset.c:347
-#: builtin/reset.c:355
+#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
+#: builtin/reset.c:361
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Tidak dapat mengurai objek '%s'."
 
-#: builtin/am.c:2034
+#: builtin/am.c:2035 builtin/am.c:2111
 msgid "failed to clean index"
-msgstr ""
+msgstr "gagal membersihkan indeks"
 
-#: builtin/am.c:2078
+#: builtin/am.c:2079
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
 msgstr ""
+"Sepertinya Anda telah memindahkan HEAD sejak kegagalan 'am' terakhir.\n"
+"Tidak memutar ulang ke ORIG_HEAD"
 
-#: builtin/am.c:2185
+#: builtin/am.c:2187
 #, c-format
 msgid "Invalid value for --patch-format: %s"
-msgstr ""
+msgstr "Nilai tidak valid untuk --patch-format: %s"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2229
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
-msgstr ""
+msgstr "Nilai tidak valid untuk --show-current-patch: %s"
 
-#: builtin/am.c:2231
+#: builtin/am.c:2233
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
-msgstr ""
+msgstr "--show-current-patch=%s tidak kompatibel untuk --show-current-patch=%s"
 
-#: builtin/am.c:2262
+#: builtin/am.c:2264
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
-msgstr ""
+msgstr "git am [<opsi>] [(<mbox> | <Maildir>)...]"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2265
 msgid "git am [<options>] (--continue | --skip | --abort)"
-msgstr ""
-
-#: builtin/am.c:2269
-msgid "run interactively"
-msgstr ""
+msgstr "git am [<opsi>] (--continue | --skip | --abort)"
 
 #: builtin/am.c:2271
-msgid "historical option -- no-op"
-msgstr ""
+msgid "run interactively"
+msgstr "jalankan secara interaktif"
 
 #: builtin/am.c:2273
+msgid "historical option -- no-op"
+msgstr "opsi bersejarah -- no-op"
+
+#: builtin/am.c:2275
 msgid "allow fall back on 3way merging if needed"
-msgstr ""
+msgstr "perbolehkan mundur ke penggabungan 3 arah jika diperlukan"
 
-#: builtin/am.c:2274 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:472 builtin/stash.c:945
+#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:640 builtin/stash.c:961
 msgid "be quiet"
-msgstr ""
+msgstr "jadi senyap"
 
-#: builtin/am.c:2276
+#: builtin/am.c:2278
 msgid "add a Signed-off-by trailer to the commit message"
-msgstr ""
-
-#: builtin/am.c:2279
-msgid "recode into utf8 (default)"
-msgstr ""
+msgstr "tambahkan trailer Signed-off-by kepada pesan komit"
 
 #: builtin/am.c:2281
-msgid "pass -k flag to git-mailinfo"
-msgstr ""
+msgid "recode into utf8 (default)"
+msgstr "koding ulang ke dalam utf8 (asali)"
 
 #: builtin/am.c:2283
-msgid "pass -b flag to git-mailinfo"
-msgstr ""
+msgid "pass -k flag to git-mailinfo"
+msgstr "lewatkan opsi -k ke git-mailinfo"
 
 #: builtin/am.c:2285
-msgid "pass -m flag to git-mailinfo"
-msgstr ""
+msgid "pass -b flag to git-mailinfo"
+msgstr "lewatkan opsi -b ke git-mailinfo"
 
 #: builtin/am.c:2287
-msgid "pass --keep-cr flag to git-mailsplit for mbox format"
-msgstr ""
+msgid "pass -m flag to git-mailinfo"
+msgstr "lewatkan opsi -m ke git-mailinfo"
 
-#: builtin/am.c:2290
+#: builtin/am.c:2289
+msgid "pass --keep-cr flag to git-mailsplit for mbox format"
+msgstr "lewatkan opsi --keep-cr ke git-mailsplit untuk format mbox"
+
+#: builtin/am.c:2292
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
-
-#: builtin/am.c:2293
-msgid "strip everything before a scissors line"
-msgstr ""
+"jangan lewatkan opsi --keep-cr ke git-mailsplit tak bergantung pada am.keepcr"
 
 #: builtin/am.c:2295
+msgid "strip everything before a scissors line"
+msgstr "copot semuanya sebelum garis gunting"
+
+#: builtin/am.c:2297
 msgid "pass it through git-mailinfo"
-msgstr ""
+msgstr "lewatkannya melalui git-mailinfo"
 
-#: builtin/am.c:2298 builtin/am.c:2301 builtin/am.c:2304 builtin/am.c:2307
-#: builtin/am.c:2310 builtin/am.c:2313 builtin/am.c:2316 builtin/am.c:2319
-#: builtin/am.c:2325
+#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
+#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
+#: builtin/am.c:2327
 msgid "pass it through git-apply"
-msgstr ""
+msgstr "lewatkannya melalui git-apply"
 
-#: builtin/am.c:2315 builtin/commit.c:1512 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:905 builtin/merge.c:261
+#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1342 builtin/repack.c:483 builtin/repack.c:487
-#: builtin/repack.c:489 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:447 parse-options.h:155 parse-options.h:176
-#: parse-options.h:317
+#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
+#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
+#: parse-options.h:316
 msgid "n"
-msgstr ""
+msgstr "n"
 
-#: builtin/am.c:2321 builtin/branch.c:672 builtin/bugreport.c:137
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:481
+#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
-msgstr ""
+msgstr "format"
 
-#: builtin/am.c:2322
+#: builtin/am.c:2324
 msgid "format the patch(es) are in"
-msgstr ""
-
-#: builtin/am.c:2328
-msgid "override error message when patch failure occurs"
-msgstr ""
+msgstr "format tambalan yang ada di"
 
 #: builtin/am.c:2330
+msgid "override error message when patch failure occurs"
+msgstr "timpa pesan error ketika kegagalan penambalan terjadi"
+
+#: builtin/am.c:2332
 msgid "continue applying patches after resolving a conflict"
-msgstr ""
+msgstr "lanjutkan penerapan tambalan setelah menyelesaikan konflik"
 
-#: builtin/am.c:2333
+#: builtin/am.c:2335
 msgid "synonyms for --continue"
-msgstr ""
+msgstr "sinonim untuk --continue"
 
-#: builtin/am.c:2336
+#: builtin/am.c:2338
 msgid "skip the current patch"
-msgstr ""
+msgstr "lewati tambalan saat ini"
 
-#: builtin/am.c:2339
+#: builtin/am.c:2341
 msgid "restore the original branch and abort the patching operation"
-msgstr ""
+msgstr "kembalikan cabang asli dan batalkan operasi penambalan"
 
-#: builtin/am.c:2342
+#: builtin/am.c:2344
 msgid "abort the patching operation but keep HEAD where it is"
-msgstr ""
+msgstr "batalkan operasi penambalan tetapi simpan HEAD dimanapun itu"
 
-#: builtin/am.c:2346
+#: builtin/am.c:2348
 msgid "show the patch being applied"
-msgstr ""
-
-#: builtin/am.c:2351
-msgid "lie about committer date"
-msgstr ""
+msgstr "perlihatkan tambalan yang diterapkan"
 
 #: builtin/am.c:2353
+msgid "lie about committer date"
+msgstr "berbohong soal tanggal pengkomit"
+
+#: builtin/am.c:2355
 msgid "use current timestamp for author date"
-msgstr ""
+msgstr "gunakan stempel waktu saat ini untuk tanggal pengarang"
 
-#: builtin/am.c:2355 builtin/commit-tree.c:120 builtin/commit.c:1640
-#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:537
-#: builtin/rebase.c:1395 builtin/revert.c:117 builtin/tag.c:462
+#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
+#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
-msgstr ""
+msgstr "key-id"
 
-#: builtin/am.c:2356 builtin/rebase.c:538 builtin/rebase.c:1396
+#: builtin/am.c:2358 builtin/rebase.c:1100
 msgid "GPG-sign commits"
-msgstr ""
+msgstr "tandatangani komit dengan GPG"
 
-#: builtin/am.c:2359
+#: builtin/am.c:2361
 msgid "(internal use for git-rebase)"
-msgstr ""
+msgstr "(penggunaan internal untuk git-rebase)"
 
-#: builtin/am.c:2377
+#: builtin/am.c:2379
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
 msgstr ""
+"Opsi -b/--binary telah menjadi no-op untuk waktu yang lama, dan\n"
+"itu akan dihapus. Mohon jangan gunakan itu lagi."
 
-#: builtin/am.c:2384
+#: builtin/am.c:2386
 msgid "failed to read the index"
-msgstr ""
+msgstr "gagal membaca indeks"
 
-#: builtin/am.c:2399
+#: builtin/am.c:2401
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
+"direktori pendasaran ulang sebelumnya %s masih ada tapi mbox diberikan."
 
-#: builtin/am.c:2423
+#: builtin/am.c:2425
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
 "Use \"git am --abort\" to remove it."
 msgstr ""
+"Direktori menyimpang %s ditemukan.\n"
+"Gunakan \"git am --abort\" untuk menghapusnya."
 
-#: builtin/am.c:2429
+#: builtin/am.c:2431
 msgid "Resolve operation not in progress, we are not resuming."
-msgstr ""
+msgstr "Operasi penguraian tidak berjalan, kami tidak melanjutkan."
 
-#: builtin/am.c:2439
+#: builtin/am.c:2441
 msgid "interactive mode requires patches on the command line"
-msgstr ""
+msgstr "mode interaktif butuh tambalan pada baris perintah"
 
 #: builtin/apply.c:8
 msgid "git apply [<options>] [<patch>...]"
-msgstr ""
+msgstr "git apply [<opsi>] [<tambalan>...]"
 
-#: builtin/archive.c:17
-#, c-format
-msgid "could not create archive file '%s'"
-msgstr ""
-
-#: builtin/archive.c:20
+#: builtin/archive.c:18
 msgid "could not redirect output"
-msgstr ""
+msgstr "tidak dapat mengalihkan keluaran"
 
-#: builtin/archive.c:37
+#: builtin/archive.c:35
 msgid "git archive: Remote with no URL"
-msgstr ""
+msgstr "git archive: Remote tanpa URL"
 
-#: builtin/archive.c:61
+#: builtin/archive.c:59
 msgid "git archive: expected ACK/NAK, got a flush packet"
-msgstr ""
+msgstr "git archive: ACK/NAK diharapkan, dapat paket bilasan"
 
-#: builtin/archive.c:64
+#: builtin/archive.c:62
 #, c-format
 msgid "git archive: NACK %s"
-msgstr ""
+msgstr "git archive: NACK %s"
 
-#: builtin/archive.c:65
+#: builtin/archive.c:63
 msgid "git archive: protocol error"
-msgstr ""
+msgstr "git archive: kesalahan protokol"
 
-#: builtin/archive.c:69
+#: builtin/archive.c:67
 msgid "git archive: expected a flush"
-msgstr ""
-
-#: builtin/bisect--helper.c:23
-msgid "git bisect--helper --bisect-reset [<commit>]"
-msgstr "git bisect--helper --bisect-reset [<komit>]"
+msgstr "git archive: sebuah bilasan diharapkan"
 
 #: builtin/bisect--helper.c:24
-msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-msgstr ""
-"git bisect--helper --bisect-next-check <istilah bagus> <istilah jelek> "
-"[<istilah>]"
+msgid "git bisect--helper --bisect-reset [<commit>]"
+msgstr "git bisect--helper --bisect-reset [<komit>]"
 
 #: builtin/bisect--helper.c:25
 msgid ""
@@ -10332,73 +10569,86 @@ msgstr "git bisect--helper --bisect-replay <nama berkas>"
 msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
 msgstr "git bisect--helper --bisect-skip [(<revisi>|<rentang>)...]"
 
-#: builtin/bisect--helper.c:107
+#: builtin/bisect--helper.c:33
+msgid "git bisect--helper --bisect-visualize"
+msgstr "git bisect--helper --bisect-visualize"
+
+#: builtin/bisect--helper.c:34
+msgid "git bisect--helper --bisect-run <cmd>..."
+msgstr "git bisect--helper --bisect-run <perintah>..."
+
+#: builtin/bisect--helper.c:109
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
 msgstr "tidak dapat membuka berkas '%s' dalam mode '%s'"
 
-#: builtin/bisect--helper.c:114
+#: builtin/bisect--helper.c:116
 #, c-format
 msgid "could not write to file '%s'"
 msgstr "tidak dapat menulis ke berkas '%s'"
 
-#: builtin/bisect--helper.c:155
+#: builtin/bisect--helper.c:154
+#, c-format
+msgid "cannot open file '%s' for reading"
+msgstr "tidak dapat membuka berkas '%s' untuk dibaca"
+
+#: builtin/bisect--helper.c:170
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "'%s' bukan istilah yang valid"
 
-#: builtin/bisect--helper.c:159
+#: builtin/bisect--helper.c:174
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "tidak dapat menggunakan perintah bawaan '%s' sebagai istilah"
 
-#: builtin/bisect--helper.c:169
+#: builtin/bisect--helper.c:184
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "tidak dapat mengubah makna istilah '%s'"
 
-#: builtin/bisect--helper.c:179
+#: builtin/bisect--helper.c:194
 msgid "please use two different terms"
 msgstr "mohon gunakan dua istilah yang berbeda"
 
-#: builtin/bisect--helper.c:195
+#: builtin/bisect--helper.c:210
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "Kami tidak sedang membagi dua.\n"
 
-#: builtin/bisect--helper.c:203
+#: builtin/bisect--helper.c:218
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "'%s' bukan sebuah komit yang valid"
 
-#: builtin/bisect--helper.c:212
+#: builtin/bisect--helper.c:227
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
 msgstr ""
 "tidak dapat men-checkout HEAD asli '%s'. Coba 'git bisect reset <komit>'."
 
-#: builtin/bisect--helper.c:256
+#: builtin/bisect--helper.c:271
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "argument bisect_write jelek: %s"
 
-#: builtin/bisect--helper.c:261
+#: builtin/bisect--helper.c:276
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "tidak dapat mendapatkan oid revisi '%s'"
 
-#: builtin/bisect--helper.c:273
+#: builtin/bisect--helper.c:288
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "tidak dapat membuka berkas '%s'"
 
-#: builtin/bisect--helper.c:299
+#: builtin/bisect--helper.c:314
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Perintah tidak valid: sekarang Anda berada dalam pembagian dua %s/%s"
 
-#: builtin/bisect--helper.c:326
+#: builtin/bisect--helper.c:341
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -10407,7 +10657,7 @@ msgstr ""
 "Anda perlu berikan saya setidaknya satu revisi %s dan %s.\n"
 "Untuk itu Anda dapat menggunakan \"git bisect %s\" dan \"git bisect %s\"."
 
-#: builtin/bisect--helper.c:330
+#: builtin/bisect--helper.c:345
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -10418,7 +10668,7 @@ msgstr ""
 "Lalu Anda perlu berikan saya setidaknya satu revisi %s dan %s.\n"
 "Untuk itu Anda dapat menggunakan \"git bisect %s\" dan \"git bisect %s\"."
 
-#: builtin/bisect--helper.c:350
+#: builtin/bisect--helper.c:365
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "membagi dua hanya dengan sebuah komit %s"
@@ -10427,15 +10677,15 @@ msgstr "membagi dua hanya dengan sebuah komit %s"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:358
+#: builtin/bisect--helper.c:373
 msgid "Are you sure [Y/n]? "
 msgstr "Anda yakin [Y/n]?"
 
-#: builtin/bisect--helper.c:419
+#: builtin/bisect--helper.c:434
 msgid "no terms defined"
 msgstr "tidak ada istilah yang didefinisikan"
 
-#: builtin/bisect--helper.c:422
+#: builtin/bisect--helper.c:437
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -10444,7 +10694,7 @@ msgstr ""
 "Istilah Anda saat ini adalah %s untuk keadaan lama\n"
 "dan %s untuk keadaan baru.\n"
 
-#: builtin/bisect--helper.c:432
+#: builtin/bisect--helper.c:447
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -10453,52 +10703,52 @@ msgstr ""
 "argumen %s tidak valid untuk 'git bisect terms'.\n"
 "Opsi yang didukung adalah: --term-good|--term-old dan --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:499 builtin/bisect--helper.c:1023
+#: builtin/bisect--helper.c:514 builtin/bisect--helper.c:1038
 msgid "revision walk setup failed\n"
 msgstr "setup jalan revisi gagal\n"
 
-#: builtin/bisect--helper.c:521
+#: builtin/bisect--helper.c:536
 #, c-format
 msgid "could not open '%s' for appending"
 msgstr "tidak dapat membuka '%s' untuk menambahkan"
 
-#: builtin/bisect--helper.c:640 builtin/bisect--helper.c:653
+#: builtin/bisect--helper.c:655 builtin/bisect--helper.c:668
 msgid "'' is not a valid term"
 msgstr "'' bukan istilah yang valid"
 
-#: builtin/bisect--helper.c:663
+#: builtin/bisect--helper.c:678
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "opsi tidak dikenal: '%s'"
 
-#: builtin/bisect--helper.c:667
+#: builtin/bisect--helper.c:682
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "'%s' sepertinya bukan revisi valid"
 
-#: builtin/bisect--helper.c:698
+#: builtin/bisect--helper.c:713
 msgid "bad HEAD - I need a HEAD"
 msgstr "HEAD jelek - saya butuh HEAD"
 
-#: builtin/bisect--helper.c:713
+#: builtin/bisect--helper.c:728
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr "gagal men-checkout '%s'. Coba 'git bisect start <cabang valid>'."
 
-#: builtin/bisect--helper.c:734
+#: builtin/bisect--helper.c:749
 msgid "won't bisect on cg-seek'ed tree"
 msgstr "tidak akan membagi dua pada pohon yang di-cg-seek"
 
-#: builtin/bisect--helper.c:737
+#: builtin/bisect--helper.c:752
 msgid "bad HEAD - strange symbolic ref"
 msgstr "HEAD jelek - referensi simbolik aneh"
 
-#: builtin/bisect--helper.c:757
+#: builtin/bisect--helper.c:772
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "referensi tidak valid: '%s'"
 
-#: builtin/bisect--helper.c:815
+#: builtin/bisect--helper.c:830
 msgid "You need to start by \"git bisect start\"\n"
 msgstr "Anda perlu memulai dengan \"git bisect start\"\n"
 
@@ -10506,104 +10756,150 @@ msgstr "Anda perlu memulai dengan \"git bisect start\"\n"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:826
+#: builtin/bisect--helper.c:841
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "Anda ingin saya melakukannya untuk Anda [Y/n]"
 
-#: builtin/bisect--helper.c:844
+#: builtin/bisect--helper.c:859
 msgid "Please call `--bisect-state` with at least one argument"
 msgstr "Mohon panggil `--bisect-state` dengan setidaknya satu argumen"
 
-#: builtin/bisect--helper.c:857
+#: builtin/bisect--helper.c:872
 #, c-format
 msgid "'git bisect %s' can take only one argument."
 msgstr "'git bisect %s' hanya dapat mengambil satu argumen."
 
-#: builtin/bisect--helper.c:869 builtin/bisect--helper.c:882
+#: builtin/bisect--helper.c:884 builtin/bisect--helper.c:897
 #, c-format
 msgid "Bad rev input: %s"
 msgstr "Masukan revisi jelek: %s"
 
-#: builtin/bisect--helper.c:889
+#: builtin/bisect--helper.c:904
 #, c-format
 msgid "Bad rev input (not a commit): %s"
 msgstr "Masukan revisi jelek (bukan sebuah komit): %s"
 
-#: builtin/bisect--helper.c:921
+#: builtin/bisect--helper.c:936
 msgid "We are not bisecting."
 msgstr "Kami tidak sedang membagi dua."
 
-#: builtin/bisect--helper.c:971
+#: builtin/bisect--helper.c:986
 #, c-format
 msgid "'%s'?? what are you talking about?"
 msgstr "'%s'?? Anda bilang tentang apa?"
 
-#: builtin/bisect--helper.c:983
+#: builtin/bisect--helper.c:998
 #, c-format
 msgid "cannot read file '%s' for replaying"
 msgstr "tidak dapat membuka berkas '%s' untuk memainkan ulang"
 
-#: builtin/bisect--helper.c:1056
+#: builtin/bisect--helper.c:1107 builtin/bisect--helper.c:1274
+msgid "bisect run failed: no command provided."
+msgstr "bisect run gagal: tidak ada perintah yang diberikan"
+
+#: builtin/bisect--helper.c:1116
+#, c-format
+msgid "running %s\n"
+msgstr "menjalankan %s\n"
+
+#: builtin/bisect--helper.c:1120
+#, c-format
+msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
+msgstr "bisect run gagal: kode keluar %d dari '%s' < 0 atau >= 128"
+
+#: builtin/bisect--helper.c:1136
+#, c-format
+msgid "cannot open file '%s' for writing"
+msgstr "tidak dapat membuka berkas '%s' untuk ditulis"
+
+#: builtin/bisect--helper.c:1152
+msgid "bisect run cannot continue any more"
+msgstr "bisect run tidak dapat dilanjutkan lagi"
+
+#: builtin/bisect--helper.c:1154
+#, c-format
+msgid "bisect run success"
+msgstr "bisect run sukses"
+
+#: builtin/bisect--helper.c:1157
+#, c-format
+msgid "bisect found first bad commit"
+msgstr "pembagian dua menemukan komit jelek pertama"
+
+#: builtin/bisect--helper.c:1160
+#, c-format
+msgid ""
+"bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
+"code %d"
+msgstr ""
+"bisect run gagal: 'git bisect--helper --bisect-state %s' keluar dengan kode "
+"keluar %d"
+
+#: builtin/bisect--helper.c:1192
 msgid "reset the bisection state"
 msgstr "setel ulang keadaan pembagian dua"
 
-#: builtin/bisect--helper.c:1058
+#: builtin/bisect--helper.c:1194
 msgid "check whether bad or good terms exist"
 msgstr "periksa apakah ada istilah jelek atau bagus"
 
-#: builtin/bisect--helper.c:1060
+#: builtin/bisect--helper.c:1196
 msgid "print out the bisect terms"
 msgstr "cetak istilah pembagian dua"
 
-#: builtin/bisect--helper.c:1062
+#: builtin/bisect--helper.c:1198
 msgid "start the bisect session"
 msgstr "mulai sesi pembagian dua"
 
-#: builtin/bisect--helper.c:1064
+#: builtin/bisect--helper.c:1200
 msgid "find the next bisection commit"
 msgstr "temukan komit pembagian dua berikutnya"
 
-#: builtin/bisect--helper.c:1066
+#: builtin/bisect--helper.c:1202
 msgid "mark the state of ref (or refs)"
 msgstr "tandai keadaan referensi"
 
-#: builtin/bisect--helper.c:1068
+#: builtin/bisect--helper.c:1204
 msgid "list the bisection steps so far"
 msgstr "daftar langkah pembagian dua sejauh ini"
 
-#: builtin/bisect--helper.c:1070
+#: builtin/bisect--helper.c:1206
 msgid "replay the bisection process from the given file"
 msgstr "mainkan ulang proses pembagian dua dari berkas yang diberikan"
 
-#: builtin/bisect--helper.c:1072
+#: builtin/bisect--helper.c:1208
 msgid "skip some commits for checkout"
 msgstr "lewati beberapa komit untuk checkout"
 
-#: builtin/bisect--helper.c:1074
+#: builtin/bisect--helper.c:1210
+msgid "visualize the bisection"
+msgstr "visualisasikan pembagian dua"
+
+#: builtin/bisect--helper.c:1212
+msgid "use <cmd>... to automatically bisect."
+msgstr "gunakan <cmd>... untuk bagi dua otomatis."
+
+#: builtin/bisect--helper.c:1214
 msgid "no log for BISECT_WRITE"
 msgstr "tidak ada log untuk BISECT_WRITE"
 
-#: builtin/bisect--helper.c:1089
+#: builtin/bisect--helper.c:1229
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset butuh baik tanpa argumen atau sebuah komit"
 
-#: builtin/bisect--helper.c:1094
-msgid "--bisect-next-check requires 2 or 3 arguments"
-msgstr "--bisect-next-check butuh 2 atau 3 argumen"
-
-#: builtin/bisect--helper.c:1100
+#: builtin/bisect--helper.c:1234
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms butuh 0 atau 1 argumen"
 
-#: builtin/bisect--helper.c:1109
+#: builtin/bisect--helper.c:1243
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next butuh 0 argumen"
 
-#: builtin/bisect--helper.c:1120
+#: builtin/bisect--helper.c:1254
 msgid "--bisect-log requires 0 arguments"
 msgstr "--bisect-log butuh 0 argumen"
 
-#: builtin/bisect--helper.c:1125
+#: builtin/bisect--helper.c:1259
 msgid "no logfile given"
 msgstr "tidak ada berkas log yang diberikan"
 
@@ -10615,149 +10911,151 @@ msgstr "git blame [<opsi>] [<opsi revisi>] [<revisi>] [--] <berkas>"
 msgid "<rev-opts> are documented in git-rev-list(1)"
 msgstr "<opsi revisi> didokumentasikan dalam git-rev-list(1)"
 
-#: builtin/blame.c:410
+#: builtin/blame.c:406
 #, c-format
 msgid "expecting a color: %s"
 msgstr "mengharapkan warna: %s"
 
-#: builtin/blame.c:417
+#: builtin/blame.c:413
 msgid "must end with a color"
 msgstr "harus berakhir dengan warna"
 
-#: builtin/blame.c:728
+#: builtin/blame.c:724
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "warna tidak valid '%s' pada color.blame.repeatedLines"
 
-#: builtin/blame.c:746
+#: builtin/blame.c:742
 msgid "invalid value for blame.coloring"
 msgstr "nilai tidak valid untuk blame.coloring"
 
-#: builtin/blame.c:845
+#: builtin/blame.c:841
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "tidak dapat menemukan revisi %s untuk diabaikan"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:863
 msgid "show blame entries as we find them, incrementally"
 msgstr "perlihatkan entri penyalahan seperti yang kami temukan secara bertahap"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:864
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr "jangan perlihatkan nama objek dari komit perbatasan (asali: off)"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:865
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr "jangan perlakukan komit akar sebagai perbatasan (asali: off)"
 
-#: builtin/blame.c:870
+#: builtin/blame.c:866
 msgid "show work cost statistics"
 msgstr "perlihatkan statistik biaya usaha"
 
-#: builtin/blame.c:871 builtin/checkout.c:1519 builtin/clone.c:94
-#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:179
-#: builtin/merge.c:297 builtin/multi-pack-index.c:55 builtin/pull.c:119
-#: builtin/push.c:566 builtin/send-pack.c:198
+#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
+#: builtin/merge.c:298 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
+#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "paksa laporkan perkembangan"
 
-#: builtin/blame.c:872
+#: builtin/blame.c:868
 msgid "show output score for blame entries"
 msgstr "perlihatkan nilai keluaran untuk entri penyalahan"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:869
 msgid "show original filename (Default: auto)"
 msgstr "perlihatkan nama berkas asli (asali: auto)"
 
-#: builtin/blame.c:874
+#: builtin/blame.c:870
 msgid "show original linenumber (Default: off)"
 msgstr "perlihatkan nomor baris asli (asali: off)"
 
-#: builtin/blame.c:875
+#: builtin/blame.c:871
 msgid "show in a format designed for machine consumption"
 msgstr "perlihatkan dalam format yang didesain untuk konsumsi mesin"
 
-#: builtin/blame.c:876
+#: builtin/blame.c:872
 msgid "show porcelain format with per-line commit information"
 msgstr "perlihatkan format porselen dengan informasi komit per baris"
 
-#: builtin/blame.c:877
+#: builtin/blame.c:873
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr "gunakan mode keluaran yang sama dengan git-annotate (asali: off)"
 
-#: builtin/blame.c:878
+#: builtin/blame.c:874
 msgid "show raw timestamp (Default: off)"
 msgstr "perlihatkan stempel waktu mentah (asali: off)"
 
-#: builtin/blame.c:879
+#: builtin/blame.c:875
 msgid "show long commit SHA1 (Default: off)"
 msgstr "perlihatkan SHA1 komit panjang (asali: off)"
 
-#: builtin/blame.c:880
+#: builtin/blame.c:876
 msgid "suppress author name and timestamp (Default: off)"
 msgstr "sembunyikan nama pengarang dan stempel waktu (asali: off)"
 
-#: builtin/blame.c:881
+#: builtin/blame.c:877
 msgid "show author email instead of name (Default: off)"
 msgstr "perlihatkan email pengarang daripada nama (asali: off)"
 
-#: builtin/blame.c:882
+#: builtin/blame.c:878
 msgid "ignore whitespace differences"
 msgstr "abaikan perbedaan spasi putih"
 
-#: builtin/blame.c:883 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1823
 msgid "rev"
 msgstr "revisi"
 
-#: builtin/blame.c:883
+#: builtin/blame.c:879
 msgid "ignore <rev> when blaming"
 msgstr "abaikan <revisi> ketika menyalahkan"
 
-#: builtin/blame.c:884
+#: builtin/blame.c:880
 msgid "ignore revisions from <file>"
 msgstr "abaikan revisi dari <berkas>"
 
-#: builtin/blame.c:885
+#: builtin/blame.c:881
 msgid "color redundant metadata from previous line differently"
 msgstr "metadata warna berlebihan dari baris sebelumnya secara berbeda"
 
-#: builtin/blame.c:886
+#: builtin/blame.c:882
 msgid "color lines by age"
 msgstr "warnai baris oleh umur"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:883
 msgid "spend extra cycles to find better match"
 msgstr "perlihatkan siklus ekstra untuk menemukan cocokan yang lebih baik"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:884
 msgid "use revisions from <file> instead of calling git-rev-list"
 msgstr "gunakan revisi dari <berkas> daripada memanggil git-rev-list"
 
-#: builtin/blame.c:889
+#: builtin/blame.c:885
 msgid "use <file>'s contents as the final image"
 msgstr "gunakan konten <berkas> sebagai citra final"
 
-#: builtin/blame.c:890 builtin/blame.c:891
+#: builtin/blame.c:886 builtin/blame.c:887
 msgid "score"
 msgstr "nilai"
 
-#: builtin/blame.c:890
+#: builtin/blame.c:886
 msgid "find line copies within and across files"
 msgstr "temukan salinan baris di dalam dan di seluruh berkas"
 
-#: builtin/blame.c:891
+#: builtin/blame.c:887
 msgid "find line movements within and across files"
 msgstr "temukan gerakan baris di dalam dan di seluruh baris"
 
-#: builtin/blame.c:892
+#: builtin/blame.c:888
 msgid "range"
 msgstr "rentang"
 
-#: builtin/blame.c:893
+#: builtin/blame.c:889
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr "hanya proses rentang baris <awal>,<akhir> atau fungsi :<nama fungsi>"
 
-#: builtin/blame.c:945
+#: builtin/blame.c:944
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress tidak dapat digunakan dengan --incremental atau format porselen"
@@ -10770,18 +11068,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:996
+#: builtin/blame.c:995
 msgid "4 years, 11 months ago"
 msgstr "4 tahun, 11 bulan yang lalu"
 
-#: builtin/blame.c:1112
+#: builtin/blame.c:1111
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "berkas %s hanya punya %lu baris"
 msgstr[1] "berkas %s hanya punya %lu baris"
 
-#: builtin/blame.c:1157
+#: builtin/blame.c:1156
 msgid "Blaming lines"
 msgstr "Menyalahkan baris"
 
@@ -10882,74 +11180,74 @@ msgstr "Cabang pelacak remote %s (yaitu %s) dihapus.\n"
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Cabang %s (yaitu %s) dihapus.\n"
 
-#: builtin/branch.c:440 builtin/tag.c:63
+#: builtin/branch.c:441 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "tidak dapat menguraikan untai format"
 
-#: builtin/branch.c:471
+#: builtin/branch.c:472
 msgid "could not resolve HEAD"
 msgstr "tidak dapat menguraikan HEAD"
 
-#: builtin/branch.c:477
+#: builtin/branch.c:478
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) merujuk diluar refs/heads/"
 
-#: builtin/branch.c:492
+#: builtin/branch.c:493
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Cabang %s sedang didasarkan ulang pada %s"
 
-#: builtin/branch.c:496
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Cabang %s sedang dibagi dua pada %s"
 
-#: builtin/branch.c:513
+#: builtin/branch.c:514
 msgid "cannot copy the current branch while not on any."
 msgstr "tidak dapat menyalin cabang saat ini ketika tidak ada."
 
-#: builtin/branch.c:515
+#: builtin/branch.c:516
 msgid "cannot rename the current branch while not on any."
 msgstr "tidak dapat mengganti nama cabang saat ini ketika tidak ada."
 
-#: builtin/branch.c:526
+#: builtin/branch.c:527
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Nama cabang tidak valid: '%s'"
 
-#: builtin/branch.c:555
+#: builtin/branch.c:556
 msgid "Branch rename failed"
 msgstr "Penggantian nama cabang gagal"
 
-#: builtin/branch.c:557
+#: builtin/branch.c:558
 msgid "Branch copy failed"
 msgstr "Penyalinan cabang gagal"
 
-#: builtin/branch.c:561
+#: builtin/branch.c:562
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Salinan cabang salah nama '%s' dibuat"
 
-#: builtin/branch.c:564
+#: builtin/branch.c:565
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Cabang salah nama '%s' berganti nama"
 
-#: builtin/branch.c:570
+#: builtin/branch.c:571
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Cabang berganti nama ke %s, tapi HEAD tidak diperbarui!"
 
-#: builtin/branch.c:579
+#: builtin/branch.c:580
 msgid "Branch is renamed, but update of config-file failed"
 msgstr "Cabang berganti nama, tapi pembaruan berkas konfigurasi gagal"
 
-#: builtin/branch.c:581
+#: builtin/branch.c:582
 msgid "Branch is copied, but update of config-file failed"
 msgstr "Cabang disalin, tapi pembaruan berkas konfigurasi gagal"
 
-#: builtin/branch.c:597
+#: builtin/branch.c:598
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -10960,180 +11258,180 @@ msgstr ""
 "  %s\n"
 "Baris yang diawali dengan '%c' akan dicopot.\n"
 
-#: builtin/branch.c:631
+#: builtin/branch.c:632
 msgid "Generic options"
 msgstr "Opsi generik"
 
-#: builtin/branch.c:633
+#: builtin/branch.c:634
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "perlihatkan hash dan subjek, berikan dua kali untuk cabang hulu"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:635
 msgid "suppress informational messages"
 msgstr "sembunyikan pesan informasi"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:636
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "pasang mode pelacakan (lihat git-pull(1))"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:638
 msgid "do not use"
 msgstr "jangan gunakan"
 
-#: builtin/branch.c:639 builtin/rebase.c:533
+#: builtin/branch.c:640
 msgid "upstream"
 msgstr "hulu"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:640
 msgid "change the upstream info"
 msgstr "ubah info hulu"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:641
 msgid "unset the upstream info"
 msgstr "batal-setel info hulu"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:642
 msgid "use colored output"
 msgstr "gunakan keluaran berwarna"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:643
 msgid "act on remote-tracking branches"
 msgstr "lakukan pada cabang pelacak remote"
 
-#: builtin/branch.c:644 builtin/branch.c:646
+#: builtin/branch.c:645 builtin/branch.c:647
 msgid "print only branches that contain the commit"
 msgstr "cetak hanya cabang yang berisi komit"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:646 builtin/branch.c:648
 msgid "print only branches that don't contain the commit"
 msgstr "cetak hanya cabang yang tak berisi komit"
 
-#: builtin/branch.c:650
+#: builtin/branch.c:651
 msgid "Specific git-branch actions:"
 msgstr "Aksi git-branch spesifik:"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:652
 msgid "list both remote-tracking and local branches"
 msgstr "sebut baik cabang pelacak remote dan cabang lokal"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:654
 msgid "delete fully merged branch"
 msgstr "hapus cabang yang tergabung sepenuhnya"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:655
 msgid "delete branch (even if not merged)"
 msgstr "hapus cabang (walaupun tak tergabung)"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:656
 msgid "move/rename a branch and its reflog"
 msgstr "pindah/ganti nama cabang dan reflog-nya"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:657
 msgid "move/rename a branch, even if target exists"
 msgstr "pindah/ganti nama cabang, walaupun target ada"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:658
 msgid "copy a branch and its reflog"
 msgstr "salin cabang dan reflog-nya"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:659
 msgid "copy a branch, even if target exists"
 msgstr "salin cabang, walapun target ada"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:660
 msgid "list branch names"
 msgstr "sebut nama cabang"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:661
 msgid "show current branch name"
 msgstr "perlihatkan nama cabang saat ini"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:662
 msgid "create the branch's reflog"
 msgstr "buat reflog cabang"
 
-#: builtin/branch.c:663
+#: builtin/branch.c:664
 msgid "edit the description for the branch"
 msgstr "sunting deskripsi cabang"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:665
 msgid "force creation, move/rename, deletion"
 msgstr "paksa buat, pindah/ganti nama, hapus"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:666
 msgid "print only branches that are merged"
 msgstr "cetak hanya cabang yang tergabung"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:667
 msgid "print only branches that are not merged"
 msgstr "cetak hanya cabang yang tak tergabung"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:668
 msgid "list branches in columns"
 msgstr "sebut cabang dalam kolom"
 
-#: builtin/branch.c:669 builtin/for-each-ref.c:44 builtin/notes.c:415
-#: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:477
+#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
+#: builtin/tag.c:475
 msgid "object"
 msgstr "objek"
 
-#: builtin/branch.c:670
+#: builtin/branch.c:671
 msgid "print only branches of the object"
 msgstr "cetak hanya cabang objek"
 
-#: builtin/branch.c:671 builtin/for-each-ref.c:50 builtin/tag.c:484
+#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "pengurutan dan penyaringan tak peka kapital"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:40 builtin/tag.c:482
+#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "format yang digunakan untuk keluaran"
 
-#: builtin/branch.c:695 builtin/clone.c:794
+#: builtin/branch.c:696 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD tidak ditemukan di bawah refs/heads!"
 
-#: builtin/branch.c:719
+#: builtin/branch.c:720
 msgid "--column and --verbose are incompatible"
 msgstr "--column dan --verbose tidak kompatibel"
 
-#: builtin/branch.c:734 builtin/branch.c:790 builtin/branch.c:799
+#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
 msgid "branch name required"
 msgstr "nama cabang diperlukan"
 
-#: builtin/branch.c:766
+#: builtin/branch.c:768
 msgid "Cannot give description to detached HEAD"
 msgstr "Tidak dapat memberikan deskripsi ke HEAD terpisah"
 
-#: builtin/branch.c:771
+#: builtin/branch.c:773
 msgid "cannot edit description of more than one branch"
 msgstr "tidak dapat menyunting deskripsi lebih dari satu cabang"
 
-#: builtin/branch.c:778
+#: builtin/branch.c:780
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Belum ada komit pada cabang '%s'."
 
-#: builtin/branch.c:781
+#: builtin/branch.c:783
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Tidak ada cabang bernama '%s'."
 
-#: builtin/branch.c:796
+#: builtin/branch.c:798
 msgid "too many branches for a copy operation"
 msgstr "terlalu banyak cabang untuk operasi penyalinan"
 
-#: builtin/branch.c:805
+#: builtin/branch.c:807
 msgid "too many arguments for a rename operation"
 msgstr "terlalu banyak argumen untuk operasi penggantian nama"
 
-#: builtin/branch.c:810
+#: builtin/branch.c:812
 msgid "too many arguments to set new upstream"
 msgstr "terlalu banyak argumen untuk menyetel hulu baru"
 
-#: builtin/branch.c:814
+#: builtin/branch.c:816
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11141,32 +11439,32 @@ msgstr ""
 "tidak dapat menyetel hulu HEAD ke %s ketika itu tak menunjuk pada cabang "
 "apapun."
 
-#: builtin/branch.c:817 builtin/branch.c:840
+#: builtin/branch.c:819 builtin/branch.c:842
 #, c-format
 msgid "no such branch '%s'"
 msgstr "tidak ada cabang '%s'"
 
-#: builtin/branch.c:821
+#: builtin/branch.c:823
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "cabang '%s' tidak ada"
 
-#: builtin/branch.c:834
+#: builtin/branch.c:836
 msgid "too many arguments to unset upstream"
 msgstr "terlalu banyak argumen untuk batal-setel hulu"
 
-#: builtin/branch.c:838
+#: builtin/branch.c:840
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "tidak dapat membatal-setel hulu HEAD ketika itu tak menunjuk pada cabang "
 "apapun."
 
-#: builtin/branch.c:844
+#: builtin/branch.c:846
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Cabang '%s' tidak ada informasi hulu"
 
-#: builtin/branch.c:854
+#: builtin/branch.c:856
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11174,7 +11472,7 @@ msgstr ""
 "Opsi -a dan -r tidak mengambil nama cabang.\n"
 "Mungkin maksud Anda gunakan: -a|-r --list <pola>?"
 
-#: builtin/branch.c:858
+#: builtin/branch.c:860
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -11182,32 +11480,32 @@ msgstr ""
 "opsi '--set-upstream' tidak lagi didukung. Mohon gunakan '--track' atau '--"
 "set-upstream-to' sebagai gantinya."
 
-#: builtin/bugreport.c:15
+#: builtin/bugreport.c:16
 msgid "git version:\n"
 msgstr ""
 
-#: builtin/bugreport.c:21
+#: builtin/bugreport.c:22
 #, c-format
 msgid "uname() failed with error '%s' (%d)\n"
 msgstr ""
 
-#: builtin/bugreport.c:31
+#: builtin/bugreport.c:32
 msgid "compiler info: "
 msgstr ""
 
-#: builtin/bugreport.c:34
+#: builtin/bugreport.c:35
 msgid "libc info: "
 msgstr ""
 
-#: builtin/bugreport.c:80
+#: builtin/bugreport.c:49
 msgid "not run from a git repository - no hooks to show\n"
 msgstr ""
 
-#: builtin/bugreport.c:90
+#: builtin/bugreport.c:62
 msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
 msgstr ""
 
-#: builtin/bugreport.c:97
+#: builtin/bugreport.c:69
 msgid ""
 "Thank you for filling out a Git bug report!\n"
 "Please answer the following questions to help us understand your issue.\n"
@@ -11226,183 +11524,184 @@ msgid ""
 "You can delete any lines you don't wish to share.\n"
 msgstr ""
 
-#: builtin/bugreport.c:136
+#: builtin/bugreport.c:108
 msgid "specify a destination for the bugreport file"
 msgstr ""
 
-#: builtin/bugreport.c:138
+#: builtin/bugreport.c:110
 msgid "specify a strftime format suffix for the filename"
 msgstr ""
 
-#: builtin/bugreport.c:160
+#: builtin/bugreport.c:132
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr ""
 
-#: builtin/bugreport.c:167
+#: builtin/bugreport.c:139
 msgid "System Info"
 msgstr ""
 
-#: builtin/bugreport.c:170
+#: builtin/bugreport.c:142
 msgid "Enabled Hooks"
 msgstr ""
 
-#: builtin/bugreport.c:177
-#, c-format
-msgid "couldn't create a new file at '%s'"
-msgstr ""
-
-#: builtin/bugreport.c:180
+#: builtin/bugreport.c:149
 #, c-format
 msgid "unable to write to %s"
 msgstr ""
 
-#: builtin/bugreport.c:190
+#: builtin/bugreport.c:159
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr ""
 
 #: builtin/bundle.c:15 builtin/bundle.c:23
 msgid "git bundle create [<options>] <file> <git-rev-list args>"
-msgstr ""
+msgstr "git bundle create [<opsi>] <berkas> <argumen git-rev-list>"
 
 #: builtin/bundle.c:16 builtin/bundle.c:28
 msgid "git bundle verify [<options>] <file>"
-msgstr ""
+msgstr "git bundle verify [<opsi>] <berkas>"
 
 #: builtin/bundle.c:17 builtin/bundle.c:33
 msgid "git bundle list-heads <file> [<refname>...]"
-msgstr ""
+msgstr "git bundle list-heads <berkas> [<nama referensi>...]"
 
 #: builtin/bundle.c:18 builtin/bundle.c:38
 msgid "git bundle unbundle <file> [<refname>...]"
-msgstr ""
+msgstr "git bundle unbundle <berkas> [<nama referensi>...]"
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3907
+#: builtin/bundle.c:65 builtin/pack-objects.c:3876
 msgid "do not show progress meter"
-msgstr ""
+msgstr "jangan perlihatkan meteran perkembangan"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3909
+#: builtin/bundle.c:67 builtin/bundle.c:167 builtin/pack-objects.c:3878
 msgid "show progress meter"
-msgstr ""
+msgstr "perlihatkan meteran perkembangan"
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3911
+#: builtin/bundle.c:69 builtin/pack-objects.c:3880
 msgid "show progress meter during object writing phase"
-msgstr ""
+msgstr "perlihatkan meteran perkembangan saat fase penulisan objek"
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3914
+#: builtin/bundle.c:72 builtin/pack-objects.c:3883
 msgid "similar to --all-progress when progress meter is shown"
-msgstr ""
+msgstr "sama seperti --all-progress ketika meteran perkembangan diperlihatkan"
 
-#: builtin/bundle.c:76
+#: builtin/bundle.c:74
 msgid "specify bundle format version"
-msgstr ""
+msgstr "sebutkan versi format bundel"
 
-#: builtin/bundle.c:96
+#: builtin/bundle.c:94
 msgid "Need a repository to create a bundle."
-msgstr ""
+msgstr "Perlu sebuah repositori untuk membuat bundel."
 
-#: builtin/bundle.c:109
+#: builtin/bundle.c:107
 msgid "do not show bundle details"
-msgstr ""
+msgstr "jangan perlihatkan detail bundel"
 
-#: builtin/bundle.c:128
+#: builtin/bundle.c:126
 #, c-format
 msgid "%s is okay\n"
-msgstr ""
+msgstr "%s oke \n"
 
-#: builtin/bundle.c:179
+#: builtin/bundle.c:182
 msgid "Need a repository to unbundle."
-msgstr ""
+msgstr "Perlu sebuah repositori untuk membongkar bundel."
 
-#: builtin/bundle.c:191 builtin/remote.c:1700
-msgid "be verbose; must be placed before a subcommand"
-msgstr ""
+#: builtin/bundle.c:185
+msgid "Unbundling objects"
+msgstr "Membongkar bundel objek"
 
-#: builtin/bundle.c:213 builtin/remote.c:1731
+#: builtin/bundle.c:219 builtin/remote.c:1733
 #, c-format
 msgid "Unknown subcommand: %s"
-msgstr ""
+msgstr "Subperintah tidak dikenal: %s"
 
-#: builtin/cat-file.c:596
+#: builtin/cat-file.c:622
 msgid ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <type> | --textconv | --filters) [--path=<path>] <object>"
 msgstr ""
+"git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
+"p | <tipe> | --textconv | --filters) [--path=<jalur>] <objek>"
 
-#: builtin/cat-file.c:597
+#: builtin/cat-file.c:623
 msgid ""
 "git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
 "symlinks] [--textconv | --filters]"
 msgstr ""
+"git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
+"symlinks] [--textconv | --filters]"
 
-#: builtin/cat-file.c:618
+#: builtin/cat-file.c:644
 msgid "only one batch option may be specified"
-msgstr ""
-
-#: builtin/cat-file.c:636
-msgid "<type> can be one of: blob, tree, commit, tag"
-msgstr ""
-
-#: builtin/cat-file.c:637
-msgid "show object type"
-msgstr ""
-
-#: builtin/cat-file.c:638
-msgid "show object size"
-msgstr ""
-
-#: builtin/cat-file.c:640
-msgid "exit with zero when there's no error"
-msgstr ""
-
-#: builtin/cat-file.c:641
-msgid "pretty-print object's content"
-msgstr ""
-
-#: builtin/cat-file.c:643
-msgid "for blob objects, run textconv on object's content"
-msgstr ""
-
-#: builtin/cat-file.c:645
-msgid "for blob objects, run filters on object's content"
-msgstr ""
-
-#: builtin/cat-file.c:646
-msgid "blob"
-msgstr ""
-
-#: builtin/cat-file.c:647
-msgid "use a specific path for --textconv/--filters"
-msgstr ""
-
-#: builtin/cat-file.c:649
-msgid "allow -s and -t to work with broken/corrupt objects"
-msgstr ""
-
-#: builtin/cat-file.c:650
-msgid "buffer --batch output"
-msgstr ""
-
-#: builtin/cat-file.c:652
-msgid "show info and content of objects fed from the standard input"
-msgstr ""
-
-#: builtin/cat-file.c:656
-msgid "show info about objects fed from the standard input"
-msgstr ""
-
-#: builtin/cat-file.c:660
-msgid "follow in-tree symlinks (used with --batch or --batch-check)"
-msgstr ""
+msgstr "hanya satu opsi setumpuk yang mungkin disebutkan"
 
 #: builtin/cat-file.c:662
-msgid "show all objects with --batch or --batch-check"
-msgstr ""
+msgid "<type> can be one of: blob, tree, commit, tag"
+msgstr "<tipe> bisa salah satu dari: blob, tree, commit, tag"
+
+#: builtin/cat-file.c:663
+msgid "show object type"
+msgstr "perlihatkan tipe objek"
 
 #: builtin/cat-file.c:664
-msgid "do not order --batch-all-objects output"
+msgid "show object size"
+msgstr "perlihatkan ukuran objek"
+
+#: builtin/cat-file.c:666
+msgid "exit with zero when there's no error"
+msgstr "keluar dengan nol ketika tidak ada kesalahan"
+
+#: builtin/cat-file.c:667
+msgid "pretty-print object's content"
+msgstr "cetak-cantik isi objek"
+
+#: builtin/cat-file.c:669
+msgid "for blob objects, run textconv on object's content"
+msgstr "untuk objek blob, jalankan textconv pada isi objek"
+
+#: builtin/cat-file.c:671
+msgid "for blob objects, run filters on object's content"
+msgstr "untuk objek blob, jalankan penyaring pada isi objek"
+
+#: builtin/cat-file.c:672
+msgid "blob"
+msgstr "blob"
+
+#: builtin/cat-file.c:673
+msgid "use a specific path for --textconv/--filters"
+msgstr "gunakan jalur spesifik untuk --textconv/--filters"
+
+#: builtin/cat-file.c:675
+msgid "allow -s and -t to work with broken/corrupt objects"
+msgstr "perbolehkan -s dan -t bekerja dengan objek rusak"
+
+#: builtin/cat-file.c:676
+msgid "buffer --batch output"
+msgstr "sannga keluaran --batch"
+
+#: builtin/cat-file.c:678
+msgid "show info and content of objects fed from the standard input"
+msgstr "perlihatkan info dan isi objek yang disuap dari masukan standar"
+
+#: builtin/cat-file.c:682
+msgid "show info about objects fed from the standard input"
+msgstr "perlihatkan info tentang objek yang disuap dari masukan standar"
+
+#: builtin/cat-file.c:686
+msgid "follow in-tree symlinks (used with --batch or --batch-check)"
 msgstr ""
+"ikuti tautan simbolik dalam pohon (digunakan dengan --batch atau --batch-"
+"check)"
+
+#: builtin/cat-file.c:688
+msgid "show all objects with --batch or --batch-check"
+msgstr "perlihatkan semua objek dengan --batch atau --batch-check"
+
+#: builtin/cat-file.c:690
+msgid "do not order --batch-all-objects output"
+msgstr "jangan urutkan keluaran --batch-all-objects"
 
 #: builtin/check-attr.c:13
 msgid "git check-attr [-a | --all | <attr>...] [--] <pathname>..."
@@ -11420,7 +11719,7 @@ msgstr ""
 msgid "use .gitattributes only from the index"
 msgstr ""
 
-#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:102
+#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:100
 msgid "read file names from stdin"
 msgstr ""
 
@@ -11428,8 +11727,8 @@ msgstr ""
 msgid "terminate input and output records by a NUL character"
 msgstr ""
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1515 builtin/gc.c:549
-#: builtin/worktree.c:493
+#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
+#: builtin/worktree.c:494
 msgid "suppress progress reporting"
 msgstr ""
 
@@ -11487,11 +11786,10 @@ msgid "git checkout--worker [<options>]"
 msgstr ""
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/submodule--helper.c:1892
-#: builtin/submodule--helper.c:1895 builtin/submodule--helper.c:1903
-#: builtin/submodule--helper.c:2350 builtin/submodule--helper.c:2896
-#: builtin/submodule--helper.c:2899 builtin/worktree.c:491
-#: builtin/worktree.c:728
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
+#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
+#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "string"
 msgstr ""
 
@@ -11644,11 +11942,11 @@ msgstr "'%s' atau '%s' tidak dapat digunakan untuk %s"
 msgid "path '%s' is unmerged"
 msgstr "jalur '%s' tak tergabung"
 
-#: builtin/checkout.c:734
+#: builtin/checkout.c:736
 msgid "you need to resolve your current index first"
 msgstr "Anda perlu selesaikan dulu indeks Anda saat ini"
 
-#: builtin/checkout.c:788
+#: builtin/checkout.c:786
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -11658,50 +11956,50 @@ msgstr ""
 "berikut:\n"
 "%s"
 
-#: builtin/checkout.c:881
+#: builtin/checkout.c:879
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Tidak dapat melakukan reflog untuk '%s': %s\n"
 
-#: builtin/checkout.c:923
+#: builtin/checkout.c:921
 msgid "HEAD is now at"
 msgstr "HEAD sekarang berada di"
 
-#: builtin/checkout.c:927 builtin/clone.c:725 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "tidak dapat memperbarui HEAD"
 
-#: builtin/checkout.c:931
+#: builtin/checkout.c:929
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Ganti ulang cabang '%s'\n"
 
-#: builtin/checkout.c:934
+#: builtin/checkout.c:932
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Sudah berada pada '%s'\n"
 
-#: builtin/checkout.c:938
+#: builtin/checkout.c:936
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Ganti ke dan ganti cabang '%s'\n"
 
-#: builtin/checkout.c:940 builtin/checkout.c:1371
+#: builtin/checkout.c:938 builtin/checkout.c:1369
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Ganti ke cabang baru '%s'\n"
 
-#: builtin/checkout.c:942
+#: builtin/checkout.c:940
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Ganti ke cabang '%s'\n"
 
-#: builtin/checkout.c:993
+#: builtin/checkout.c:991
 #, c-format
 msgid " ... and %d more.\n"
 msgstr "... dan %d lainnya.\n"
 
-#: builtin/checkout.c:999
+#: builtin/checkout.c:997
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -11724,7 +12022,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1018
+#: builtin/checkout.c:1016
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -11747,19 +12045,19 @@ msgstr[1] ""
 "saat yang tepat untuk dilakukan dengan:\n"
 "git branch <nama-cabang-baru> %s\n"
 
-#: builtin/checkout.c:1053
+#: builtin/checkout.c:1051
 msgid "internal error in revision walk"
 msgstr "kesalahan internal dalam jalan revisi"
 
-#: builtin/checkout.c:1057
+#: builtin/checkout.c:1055
 msgid "Previous HEAD position was"
 msgstr "Posisi HEAD sebelumnya adalah"
 
-#: builtin/checkout.c:1097 builtin/checkout.c:1366
+#: builtin/checkout.c:1095 builtin/checkout.c:1364
 msgid "You are on a branch yet to be born"
 msgstr "Anda berada pada cabang yang belum lahir"
 
-#: builtin/checkout.c:1179
+#: builtin/checkout.c:1177
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -11768,7 +12066,7 @@ msgstr ""
 "'%s' bisa jadi berkas lokal dan cabang pelacak.\n"
 "Mohon gunakan -- (dan secara opsional --no-guess) untuk disambiguasi"
 
-#: builtin/checkout.c:1186
+#: builtin/checkout.c:1184
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -11788,51 +12086,51 @@ msgstr ""
 "seperti remote 'origin', pertimbangkan untuk menyetel\n"
 "checkout.defaultRemote=origin di konfigurasi Anda"
 
-#: builtin/checkout.c:1196
+#: builtin/checkout.c:1194
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' cocok dengan banyak (%d) cabang pelacak remote"
 
-#: builtin/checkout.c:1262
+#: builtin/checkout.c:1260
 msgid "only one reference expected"
 msgstr "hanya satu referensi yang diharapkan"
 
-#: builtin/checkout.c:1279
+#: builtin/checkout.c:1277
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "hanya satu referensi yang diharapkan, %d diberikan"
 
-#: builtin/checkout.c:1325 builtin/worktree.c:268 builtin/worktree.c:436
+#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
 #, c-format
 msgid "invalid reference: %s"
 msgstr "referensi tidak valid: %s"
 
-#: builtin/checkout.c:1338 builtin/checkout.c:1707
+#: builtin/checkout.c:1336 builtin/checkout.c:1705
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "referensi bukan pohon: %s"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1383
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "sebuah cabang diharapkan, dapat tag '%s'"
 
-#: builtin/checkout.c:1387
+#: builtin/checkout.c:1385
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "sebuah cabang diharapkan, dapat cabang remote '%s'"
 
-#: builtin/checkout.c:1388 builtin/checkout.c:1396
+#: builtin/checkout.c:1386 builtin/checkout.c:1394
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "sebuah cabang diharapkan, dapat '%s'"
 
-#: builtin/checkout.c:1391
+#: builtin/checkout.c:1389
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "sebuah cabang diharapkan, dapat komit '%s'"
 
-#: builtin/checkout.c:1407
+#: builtin/checkout.c:1405
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -11841,7 +12139,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git merge --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1411
+#: builtin/checkout.c:1409
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -11849,7 +12147,7 @@ msgstr ""
 "tidak dapat mengganti cabang di tengah sesi am\n"
 "Pertimbangkan untuk menggunakan \"git am --quit\" atau \"git worktree add\"."
 
-#: builtin/checkout.c:1415
+#: builtin/checkout.c:1413
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -11858,7 +12156,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git rebase --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1419
+#: builtin/checkout.c:1417
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -11867,7 +12165,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git cherry-pick --quit\" atau \"git "
 "worktree add\"."
 
-#: builtin/checkout.c:1423
+#: builtin/checkout.c:1421
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -11876,138 +12174,138 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git revert --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1427
+#: builtin/checkout.c:1425
 msgid "you are switching branch while bisecting"
 msgstr "Anda mengganti cabang saat pembagian dua"
 
-#: builtin/checkout.c:1434
+#: builtin/checkout.c:1432
 msgid "paths cannot be used with switching branches"
 msgstr "jalur tidak dapat digunakan dengan mengganti cabang"
 
-#: builtin/checkout.c:1437 builtin/checkout.c:1441 builtin/checkout.c:1445
+#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' tidak dapat digunakan dengan mengganti cabang"
 
-#: builtin/checkout.c:1449 builtin/checkout.c:1452 builtin/checkout.c:1455
-#: builtin/checkout.c:1460 builtin/checkout.c:1465
+#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
+#: builtin/checkout.c:1458 builtin/checkout.c:1463
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' tidak dapat digunakan dengan '%s'"
 
-#: builtin/checkout.c:1462
+#: builtin/checkout.c:1460
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' tidak bisa mengambil <titik-awal>"
 
-#: builtin/checkout.c:1470
+#: builtin/checkout.c:1468
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Tidak dapat mengganti cabang ke bukan komit '%s'"
 
-#: builtin/checkout.c:1477
+#: builtin/checkout.c:1475
 msgid "missing branch or commit argument"
 msgstr "kehilangan argumen cabang atau komit"
 
-#: builtin/checkout.c:1520
+#: builtin/checkout.c:1518
 msgid "perform a 3-way merge with the new branch"
 msgstr "lakukan penggabungan 3 arah dengan cabang baru"
 
-#: builtin/checkout.c:1521 builtin/log.c:1810 parse-options.h:323
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
 msgid "style"
 msgstr "gaya"
 
-#: builtin/checkout.c:1522
+#: builtin/checkout.c:1520
 msgid "conflict style (merge or diff3)"
 msgstr "gaya konflik (merge atau diff3)"
 
-#: builtin/checkout.c:1534 builtin/worktree.c:488
+#: builtin/checkout.c:1532 builtin/worktree.c:489
 msgid "detach HEAD at named commit"
 msgstr "lepas HEAD pada komit bernama"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1533
 msgid "set upstream info for new branch"
 msgstr "setel info hulu untuk cabang baru"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1535
 msgid "force checkout (throw away local modifications)"
 msgstr "paksa checkout (buang modifikasi lokal)"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new-branch"
 msgstr "cabang baru"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new unparented branch"
 msgstr "cabang baru tanpa induk"
 
-#: builtin/checkout.c:1541 builtin/merge.c:301
+#: builtin/checkout.c:1539 builtin/merge.c:302
 msgid "update ignored files (default)"
 msgstr "perbarui berkas yang diabaikan (default)"
 
-#: builtin/checkout.c:1544
+#: builtin/checkout.c:1542
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "jangan periksa jika pohon kerja yang lain mempunyai referensi yang diberikan"
 
-#: builtin/checkout.c:1557
+#: builtin/checkout.c:1555
 msgid "checkout our version for unmerged files"
 msgstr "checkout versi kami untuk berkas yang tak tergabung"
 
-#: builtin/checkout.c:1560
+#: builtin/checkout.c:1558
 msgid "checkout their version for unmerged files"
 msgstr "checkout versi mereka untuk berkas yang tak tergabung"
 
-#: builtin/checkout.c:1564
+#: builtin/checkout.c:1562
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "jangan batasi jalur spek hanya ke entri tipis"
 
-#: builtin/checkout.c:1622
+#: builtin/checkout.c:1620
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "-%c, -%c dan --orphan saling eksklusif"
 
-#: builtin/checkout.c:1626
+#: builtin/checkout.c:1624
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p dan --overlay saling eksklusif"
 
-#: builtin/checkout.c:1663
+#: builtin/checkout.c:1661
 msgid "--track needs a branch name"
 msgstr "--track butuh nama cabang"
 
-#: builtin/checkout.c:1668
+#: builtin/checkout.c:1666
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kehilangan nama cabang; coba -%c"
 
-#: builtin/checkout.c:1700
+#: builtin/checkout.c:1698
 #, c-format
 msgid "could not resolve %s"
 msgstr "tidak dapat menyelesaikan %s"
 
-#: builtin/checkout.c:1716
+#: builtin/checkout.c:1714
 msgid "invalid path specification"
 msgstr "spesifikasi jalur tidak valid"
 
-#: builtin/checkout.c:1723
+#: builtin/checkout.c:1721
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "'%s' bukanlah commit dan cabang '%s' tidak dapat dibuat dari itu"
 
-#: builtin/checkout.c:1727
+#: builtin/checkout.c:1725
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach tidak mengambil argumen jalur '%s'"
 
-#: builtin/checkout.c:1736
+#: builtin/checkout.c:1734
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file tidak kompatible dengan --detach"
 
-#: builtin/checkout.c:1739 builtin/reset.c:325 builtin/stash.c:1630
+#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file tidak kompatibel dengan --patch"
 
-#: builtin/checkout.c:1752
+#: builtin/checkout.c:1750
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12015,71 +12313,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force dan --merge tidak kompatibel saat\n"
 "men-checkout index"
 
-#: builtin/checkout.c:1757
+#: builtin/checkout.c:1755
 msgid "you must specify path(s) to restore"
 msgstr "Anda harus sebutkan jalur untuk dipulihkan"
 
-#: builtin/checkout.c:1783 builtin/checkout.c:1785 builtin/checkout.c:1834
-#: builtin/checkout.c:1836 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2736
-#: builtin/submodule--helper.c:2887 builtin/worktree.c:484
-#: builtin/worktree.c:486
+#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
+#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2958
+#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
+#: builtin/worktree.c:487
 msgid "branch"
 msgstr "cabang"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1782
 msgid "create and checkout a new branch"
 msgstr "buat dan checkout cabang baru"
 
-#: builtin/checkout.c:1786
+#: builtin/checkout.c:1784
 msgid "create/reset and checkout a branch"
 msgstr "buat/setel ulang dan checkout cabang"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1785
 msgid "create reflog for new branch"
 msgstr "buat reflog untuk cabang baru"
 
-#: builtin/checkout.c:1789
+#: builtin/checkout.c:1787
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "tebakan kedua 'git checkout <tidak-ada-cabang-seperti-itu>' (default)"
 
-#: builtin/checkout.c:1790
+#: builtin/checkout.c:1788
 msgid "use overlay mode (default)"
 msgstr "gunakan mode hamparan (default)"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1833
 msgid "create and switch to a new branch"
 msgstr "buat dan ganti ke cabang baru"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1835
 msgid "create/reset and switch to a branch"
 msgstr "buat/setel ulang dan ganti ke cabang"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1837
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "tebakan kedua 'git switch <tidak-ada-cabang-seperti-itu>'"
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1839
 msgid "throw away local modifications"
 msgstr "buang modifikasi lokal"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1873
 msgid "which tree-ish to checkout from"
 msgstr "mana mirip-cabang untuk di-checkout"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1875
 msgid "restore the index"
 msgstr "pulihkan indeks"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1877
 msgid "restore the working tree (default)"
 msgstr "pulihkan pohon kerja (default)"
 
-#: builtin/checkout.c:1881
+#: builtin/checkout.c:1879
 msgid "ignore unmerged entries"
 msgstr "abaikan entri yang tak tergabung"
 
-#: builtin/checkout.c:1882
+#: builtin/checkout.c:1880
 msgid "use overlay mode"
 msgstr "gunakan mode hamparan"
 
@@ -12219,8 +12517,8 @@ msgid "remove whole directories"
 msgstr "hapus keseluruhan direktori"
 
 #: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:923 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:650 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "pola"
@@ -12309,19 +12607,20 @@ msgstr "direktori templat"
 msgid "directory from which templates will be used"
 msgstr "direktori dimana templat akan digunakan"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1899
-#: builtin/submodule--helper.c:2353 builtin/submodule--helper.c:2903
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
+#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
 msgid "reference repository"
 msgstr "repositori rujukan"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1901
-#: builtin/submodule--helper.c:2355 builtin/submodule--helper.c:2905
+#: builtin/clone.c:123 builtin/submodule--helper.c:1872
+#: builtin/submodule--helper.c:2515
 msgid "use --reference only while cloning"
 msgstr "gunakan --reference hanya pada saat kloning"
 
 #: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3975 builtin/repack.c:495
-#: t/helper/test-simple-ipc.c:696 t/helper/test-simple-ipc.c:698
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
+#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "nama"
 
@@ -12337,7 +12636,7 @@ msgstr "checkout <cabang> daripada HEAD remote"
 msgid "path to git-upload-pack on the remote"
 msgstr "jalur ke git-upload-pack pada remote"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:862
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "kedalaman"
@@ -12346,7 +12645,7 @@ msgstr "kedalaman"
 msgid "create a shallow clone of that depth"
 msgstr "buat klon dangkal sedalam kedalaman tersebut"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3964
+#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
 #: builtin/pull.c:211
 msgid "time"
 msgstr "waktu"
@@ -12356,7 +12655,7 @@ msgid "create a shallow clone since a specific time"
 msgstr "buat klon dangkal sejak waktu yang disebutkan"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1318
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
 msgid "revision"
 msgstr "revisi"
 
@@ -12364,8 +12663,8 @@ msgstr "revisi"
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "perdalam riwayat klon dangkal, tidak termasuk rev"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1911
-#: builtin/submodule--helper.c:2369
+#: builtin/clone.c:137 builtin/submodule--helper.c:1882
+#: builtin/submodule--helper.c:2529
 msgid "clone only one branch, HEAD or --branch"
 msgstr "klon hanya satu cabang, HEAD atau --branch"
 
@@ -12394,12 +12693,12 @@ msgid "set config inside the new repository"
 msgstr "setel konfigurasi di dalam repositori baru"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:196
+#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "spesifik ke server"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:197
+#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "opsi untuk transmisi"
 
@@ -12422,50 +12721,42 @@ msgid "initialize sparse-checkout file to include only files at root"
 msgstr ""
 "inisialisasi berkas checkout tipis agar memasukkan hanya berkas pada akar"
 
-#: builtin/clone.c:292
-msgid ""
-"No directory name could be guessed.\n"
-"Please specify a directory on the command line"
-msgstr ""
-"Nama direktori tidak dapat ditebak.\n"
-"Mohon sebutkan direktori pada baris perintah"
-
-#: builtin/clone.c:345
+#: builtin/clone.c:231
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: Tidak dapat menambahkan alternatif untuk '%s': %s\n"
 
-#: builtin/clone.c:418
+#: builtin/clone.c:304
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s ada dan bukan direktori"
 
-#: builtin/clone.c:436
+#: builtin/clone.c:322
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "gagal memulai iterator pada '%s'"
 
-#: builtin/clone.c:467
+#: builtin/clone.c:353
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "gagal membuat tautan '%s'"
 
-#: builtin/clone.c:471
+#: builtin/clone.c:357
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "gagal menyalin berkas ke '%s'"
 
-#: builtin/clone.c:476
+#: builtin/clone.c:362
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "gagal iterasi pada '%s'"
 
-#: builtin/clone.c:503
+#: builtin/clone.c:389
 #, c-format
 msgid "done.\n"
 msgstr "selesai.\n"
 
-#: builtin/clone.c:517
+#: builtin/clone.c:403
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -12475,105 +12766,105 @@ msgstr ""
 "Anda dapat periksa apa yang dicheckout dengan 'git status'\n"
 "dan coba lagi dengan 'git restore --source=HEAD :/'\n"
 
-#: builtin/clone.c:594
+#: builtin/clone.c:480
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Tidak dapat menemukan cabang remote %s untuk diklon."
 
-#: builtin/clone.c:713
+#: builtin/clone.c:597
 #, c-format
 msgid "unable to update %s"
 msgstr "tidak dapat memperbarui %s"
 
-#: builtin/clone.c:761
+#: builtin/clone.c:645
 msgid "failed to initialize sparse-checkout"
 msgstr "gagal menginisalisasi checkout tipis"
 
-#: builtin/clone.c:784
+#: builtin/clone.c:668
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "HEAD remote merujuk pada ref yang tidak ada, tidak dapat men-checkout.\n"
 
-#: builtin/clone.c:816
+#: builtin/clone.c:701
 msgid "unable to checkout working tree"
 msgstr "tidak dapat men-checkout pohon kerja"
 
-#: builtin/clone.c:894
+#: builtin/clone.c:779
 msgid "unable to write parameters to config file"
 msgstr "tidak dapat menulis parameter ke berkas konfigurasi"
 
-#: builtin/clone.c:957
+#: builtin/clone.c:842
 msgid "cannot repack to clean up"
 msgstr "tidak dapat memaket ulang untuk pembersihan"
 
-#: builtin/clone.c:959
+#: builtin/clone.c:844
 msgid "cannot unlink temporary alternates file"
 msgstr "tidak dapat batal-taut berkas alternatif sementara"
 
-#: builtin/clone.c:1001 builtin/receive-pack.c:2490
+#: builtin/clone.c:886 builtin/receive-pack.c:2493
 msgid "Too many arguments."
 msgstr "Terlalu banyak argumen."
 
-#: builtin/clone.c:1005
+#: builtin/clone.c:890
 msgid "You must specify a repository to clone."
 msgstr "Anda harus sebutkan repositori untuk diklon."
 
-#: builtin/clone.c:1018
+#: builtin/clone.c:903
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "--bare dan --origin %s tidak kompatibel."
 
-#: builtin/clone.c:1021
+#: builtin/clone.c:906
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "--bare dan --separate-git-dir tidak kompatibel."
 
-#: builtin/clone.c:1035
+#: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "repositori '%s' tidak ada"
 
-#: builtin/clone.c:1039 builtin/fetch.c:2014
+#: builtin/clone.c:924 builtin/fetch.c:2029
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "kedalaman %s bukan bilangan positif"
 
-#: builtin/clone.c:1049
+#: builtin/clone.c:934
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "jalur tujuan '%s' sudah ada dan bukan direktori kosong"
 
-#: builtin/clone.c:1055
+#: builtin/clone.c:940
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr "jalur repositori '%s' sudah ada dan bukan direktori kosong"
 
-#: builtin/clone.c:1069
+#: builtin/clone.c:954
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "pohon kerja '%s' sudah ada."
 
-#: builtin/clone.c:1084 builtin/clone.c:1105 builtin/difftool.c:272
-#: builtin/log.c:1997 builtin/worktree.c:280 builtin/worktree.c:312
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
+#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "tidak dapat membuat direktori pendahulu '%s'"
 
-#: builtin/clone.c:1089
+#: builtin/clone.c:974
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "tidak dapat membuat direktori pohon kerja '%s'"
 
-#: builtin/clone.c:1109
+#: builtin/clone.c:994
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Kloning ke repositori bare '%s'...\n"
 
-#: builtin/clone.c:1111
+#: builtin/clone.c:996
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Kloning ke '%s'...\n"
 
-#: builtin/clone.c:1135
+#: builtin/clone.c:1025
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -12581,47 +12872,47 @@ msgstr ""
 "clone --recursive tidak kompatibel dengan baik --reference dan --reference-"
 "if-able"
 
-#: builtin/clone.c:1188 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1080 builtin/remote.c:200 builtin/remote.c:710
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' bukan nama remote yang valid"
 
-#: builtin/clone.c:1229
+#: builtin/clone.c:1121
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "--depth diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1231
+#: builtin/clone.c:1123
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1233
+#: builtin/clone.c:1125
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1235
+#: builtin/clone.c:1127
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr "--filter diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1240
+#: builtin/clone.c:1132
 msgid "source repository is shallow, ignoring --local"
 msgstr "repositori sumber dangkal, abaikan --local"
 
-#: builtin/clone.c:1245
+#: builtin/clone.c:1137
 msgid "--local is ignored"
 msgstr "--local diabaikan"
 
-#: builtin/clone.c:1324 builtin/clone.c:1383
+#: builtin/clone.c:1216 builtin/clone.c:1276
 msgid "remote transport reported error"
 msgstr "transportasi remote melaporkan kesalahan"
 
-#: builtin/clone.c:1336 builtin/clone.c:1344
+#: builtin/clone.c:1228 builtin/clone.c:1239
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Cabang remote %s tidak ditemukan di hulu %s"
 
-#: builtin/clone.c:1347
+#: builtin/clone.c:1242
 msgid "You appear to have cloned an empty repository."
 msgstr "Anda tampaknya mengklon repositori kosong."
 
@@ -12657,103 +12948,101 @@ msgstr ""
 msgid "--command must be the first argument"
 msgstr ""
 
-#: builtin/commit-graph.c:13 builtin/commit-graph.c:22
+#: builtin/commit-graph.c:13
 msgid ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 msgstr ""
 
-#: builtin/commit-graph.c:14 builtin/commit-graph.c:27
+#: builtin/commit-graph.c:16
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] <split options>"
 msgstr ""
 
-#: builtin/commit-graph.c:64
-#, c-format
-msgid "could not find object directory matching %s"
-msgstr ""
-
-#: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
 msgid "dir"
 msgstr ""
 
-#: builtin/commit-graph.c:81 builtin/commit-graph.c:211
-#: builtin/commit-graph.c:317
+#: builtin/commit-graph.c:52
 msgid "the object directory to store the graph"
 msgstr ""
 
-#: builtin/commit-graph.c:83
+#: builtin/commit-graph.c:73
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr ""
 
-#: builtin/commit-graph.c:106
+#: builtin/commit-graph.c:100
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr ""
 
-#: builtin/commit-graph.c:142
+#: builtin/commit-graph.c:137
 #, c-format
 msgid "unrecognized --split argument, %s"
 msgstr ""
 
-#: builtin/commit-graph.c:155
+#: builtin/commit-graph.c:150
 #, c-format
 msgid "unexpected non-hex object ID: %s"
 msgstr ""
 
-#: builtin/commit-graph.c:160
+#: builtin/commit-graph.c:155
 #, c-format
 msgid "invalid object: %s"
 msgstr ""
 
-#: builtin/commit-graph.c:213
+#: builtin/commit-graph.c:205
 msgid "start walk at all refs"
 msgstr ""
 
-#: builtin/commit-graph.c:215
+#: builtin/commit-graph.c:207
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr ""
 
-#: builtin/commit-graph.c:217
+#: builtin/commit-graph.c:209
 msgid "start walk at commits listed by stdin"
 msgstr ""
 
-#: builtin/commit-graph.c:219
+#: builtin/commit-graph.c:211
 msgid "include all commits already in the commit-graph file"
 msgstr ""
 
-#: builtin/commit-graph.c:221
+#: builtin/commit-graph.c:213
 msgid "enable computation for changed paths"
 msgstr ""
 
-#: builtin/commit-graph.c:224
+#: builtin/commit-graph.c:215
 msgid "allow writing an incremental commit-graph file"
 msgstr ""
 
-#: builtin/commit-graph.c:228
+#: builtin/commit-graph.c:219
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr ""
 
-#: builtin/commit-graph.c:230
+#: builtin/commit-graph.c:221
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr ""
 
-#: builtin/commit-graph.c:232
+#: builtin/commit-graph.c:223
 msgid "only expire files older than a given date-time"
 msgstr ""
 
-#: builtin/commit-graph.c:234
+#: builtin/commit-graph.c:225
 msgid "maximum number of changed-path Bloom filters to compute"
 msgstr ""
 
-#: builtin/commit-graph.c:255
+#: builtin/commit-graph.c:251
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
 
-#: builtin/commit-graph.c:287
+#: builtin/commit-graph.c:283
 msgid "Collecting commits from input"
+msgstr ""
+
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#, c-format
+msgid "unrecognized subcommand: %s"
 msgstr ""
 
 #: builtin/commit-tree.c:18
@@ -12761,76 +13050,73 @@ msgid ""
 "git commit-tree [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...] [(-F "
 "<file>)...] <tree>"
 msgstr ""
+"git commit-tree [(-p <induk>)...] [-S[<id kunci>]] [(-m <pesan>)...] [(-F "
+"<berkas>)...] <pohon>"
 
 #: builtin/commit-tree.c:31
 #, c-format
 msgid "duplicate parent %s ignored"
-msgstr ""
+msgstr "induk duplikat %s diabaikan"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
 #, c-format
 msgid "not a valid object name %s"
-msgstr ""
+msgstr "bukan nama objek valid %s"
 
-#: builtin/commit-tree.c:93
+#: builtin/commit-tree.c:94
 #, c-format
-msgid "git commit-tree: failed to open '%s'"
-msgstr ""
+msgid "git commit-tree: failed to read '%s'"
+msgstr "git commit-tree: gagal membaca '%s'"
 
 #: builtin/commit-tree.c:96
 #, c-format
-msgid "git commit-tree: failed to read '%s'"
-msgstr ""
-
-#: builtin/commit-tree.c:98
-#, c-format
 msgid "git commit-tree: failed to close '%s'"
-msgstr ""
+msgstr "git commit-tree: gagal menutup '%s'"
 
-#: builtin/commit-tree.c:111
+#: builtin/commit-tree.c:109
 msgid "parent"
-msgstr ""
+msgstr "induk"
 
-#: builtin/commit-tree.c:112
+#: builtin/commit-tree.c:110
 msgid "id of a parent commit object"
-msgstr ""
+msgstr "id objek komit induk"
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1624 builtin/merge.c:282
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1601
-#: builtin/tag.c:456
+#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/tag.c:454
 msgid "message"
-msgstr ""
+msgstr "pesan"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1624
+#: builtin/commit-tree.c:113 builtin/commit.c:1626
 msgid "commit message"
-msgstr ""
+msgstr "pesan komit"
 
-#: builtin/commit-tree.c:118
+#: builtin/commit-tree.c:116
 msgid "read commit log message from file"
-msgstr ""
+msgstr "baca pesan log komit dari berkas"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1641 builtin/merge.c:299
+#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
-msgstr ""
+msgstr "Tandatangani komit dengan GPG"
 
-#: builtin/commit-tree.c:133
+#: builtin/commit-tree.c:131
 msgid "must give exactly one tree"
-msgstr ""
+msgstr "harus berikan tepat satu pohon"
 
-#: builtin/commit-tree.c:140
+#: builtin/commit-tree.c:138
 msgid "git commit-tree: failed to read"
-msgstr ""
+msgstr "git commit-tree: gagal membaca"
 
-#: builtin/commit.c:41
+#: builtin/commit.c:42
 msgid "git commit [<options>] [--] <pathspec>..."
 msgstr "git commit [<opsi>] [--] <spek jalur>..."
 
-#: builtin/commit.c:46
+#: builtin/commit.c:47
 msgid "git status [<options>] [--] <pathspec>..."
 msgstr "git status [<opsi>] [--] <spek jalur>..."
 
-#: builtin/commit.c:51
+#: builtin/commit.c:52
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -12841,7 +13127,7 @@ msgstr ""
 "dengan --allow-empty, atau Anda dapat menghapus keseluruhan komit\n"
 "dengan \"git reset HEAD^\".\n"
 
-#: builtin/commit.c:56
+#: builtin/commit.c:57
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -12855,15 +13141,15 @@ msgstr ""
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:63
+#: builtin/commit.c:64
 msgid "Otherwise, please use 'git rebase --skip'\n"
 msgstr "Selain itu, gunakan 'git rebase --skip'\n"
 
-#: builtin/commit.c:66
+#: builtin/commit.c:67
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
 msgstr "Selain itu, gunakan 'git cherry-pick --skip'\n"
 
-#: builtin/commit.c:69
+#: builtin/commit.c:70
 msgid ""
 "and then use:\n"
 "\n"
@@ -12884,73 +13170,73 @@ msgstr ""
 "    git cherry-pick --skip\n"
 "\n"
 
-#: builtin/commit.c:324
+#: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "gagal membuka objek pohon HEAD"
 
-#: builtin/commit.c:360
+#: builtin/commit.c:361
 msgid "--pathspec-from-file with -a does not make sense"
 msgstr "--pathspec-from-file dengan -a tidak masuk akal"
 
-#: builtin/commit.c:374
+#: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
 msgstr "Tanpa jalur dengan --include/--only tidak masuk akal."
 
-#: builtin/commit.c:386
+#: builtin/commit.c:387
 msgid "unable to create temporary index"
 msgstr "tidak dapat membuat indeks sementara"
 
-#: builtin/commit.c:395
+#: builtin/commit.c:396
 msgid "interactive add failed"
 msgstr "penambahan interaktif gagal"
 
-#: builtin/commit.c:410
+#: builtin/commit.c:411
 msgid "unable to update temporary index"
 msgstr "tidak dapat memperbarui indeks sementara"
 
-#: builtin/commit.c:412
+#: builtin/commit.c:413
 msgid "Failed to update main cache tree"
 msgstr "gagal memperbarui tembolok pohon utama"
 
-#: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
+#: builtin/commit.c:438 builtin/commit.c:461 builtin/commit.c:509
 msgid "unable to write new_index file"
 msgstr "tidak dapat menulis berkas new_index"
 
-#: builtin/commit.c:489
+#: builtin/commit.c:490
 msgid "cannot do a partial commit during a merge."
 msgstr "tidak dapat melakukan komit sebagian selama penggabungan."
 
-#: builtin/commit.c:491
+#: builtin/commit.c:492
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr "tidak dapat melakukan komit sebagian selama pemetikan ceri."
 
-#: builtin/commit.c:493
+#: builtin/commit.c:494
 msgid "cannot do a partial commit during a rebase."
 msgstr "tidak dapat melakukan komit sebagian selama pendasaran ulang."
 
-#: builtin/commit.c:501
+#: builtin/commit.c:502
 msgid "cannot read the index"
 msgstr "tidak dapat membaca indeks"
 
-#: builtin/commit.c:520
+#: builtin/commit.c:521
 msgid "unable to write temporary index file"
 msgstr "tidak dapat menulis berkas indeks sementara"
 
-#: builtin/commit.c:618
+#: builtin/commit.c:619
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "komit '%s' kurang kepala pengarang"
 
-#: builtin/commit.c:620
+#: builtin/commit.c:621
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "komit '%s' ada baris pengarang cacat"
 
-#: builtin/commit.c:639
+#: builtin/commit.c:640
 msgid "malformed --author parameter"
 msgstr "parameter --author cacat"
 
-#: builtin/commit.c:692
+#: builtin/commit.c:693
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -12958,43 +13244,43 @@ msgstr ""
 "tidak dapat memilih karakter komentar yang tidak terpakai\n"
 "dalam pesan komit saat ini"
 
-#: builtin/commit.c:746 builtin/commit.c:780 builtin/commit.c:1165
+#: builtin/commit.c:747 builtin/commit.c:781 builtin/commit.c:1166
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "tidak dapat mencari komit %s"
 
-#: builtin/commit.c:758 builtin/shortlog.c:413
+#: builtin/commit.c:759 builtin/shortlog.c:416
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(baca pesan log dari standar masukan)\n"
 
-#: builtin/commit.c:760
+#: builtin/commit.c:761
 msgid "could not read log from standard input"
 msgstr "tidak dapat membaca log dari standar masukan"
 
-#: builtin/commit.c:764
+#: builtin/commit.c:765
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "tidak dapat membaca berkas log '%s'"
 
-#: builtin/commit.c:801
+#: builtin/commit.c:802
 #, c-format
 msgid "cannot combine -m with --fixup:%s"
 msgstr "tidak dapat menggabungkan -m dengan --fixup:%s"
 
-#: builtin/commit.c:813 builtin/commit.c:829
+#: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
 msgstr "tidak dapat membaca SQUASH_MSG"
 
-#: builtin/commit.c:820
+#: builtin/commit.c:821
 msgid "could not read MERGE_MSG"
 msgstr "tidak dapat membaca MERGE_MSG"
 
-#: builtin/commit.c:880
+#: builtin/commit.c:881
 msgid "could not write commit template"
 msgstr "tidak dapat menulis templat komit"
 
-#: builtin/commit.c:893
+#: builtin/commit.c:894
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13003,7 +13289,7 @@ msgstr ""
 "Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
 "dengan '%c' akan diabaikan.\n"
 
-#: builtin/commit.c:895
+#: builtin/commit.c:896
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13012,7 +13298,7 @@ msgstr ""
 "Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
 "dengan '%c' akan diabaikan, dan pesan kosong batalkan komit.\n"
 
-#: builtin/commit.c:899
+#: builtin/commit.c:900
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13021,7 +13307,7 @@ msgstr ""
 "Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
 "dengan '%c' akan tetap; Anda dapat menghapus itu jika Anda mau.\n"
 
-#: builtin/commit.c:903
+#: builtin/commit.c:904
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13032,7 +13318,7 @@ msgstr ""
 "dengan '%c' akan tetap; Anda dapat menghapus itu jika Anda mau.\n"
 "Pesan kosong batalkan komit.\n"
 
-#: builtin/commit.c:915
+#: builtin/commit.c:916
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -13046,7 +13332,7 @@ msgstr ""
 "\tgit update-ref -d MERGE_HEAD\n"
 "dan coba lagi.\n"
 
-#: builtin/commit.c:920
+#: builtin/commit.c:921
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -13060,175 +13346,175 @@ msgstr ""
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "dan coba lagi.\n"
 
-#: builtin/commit.c:947
+#: builtin/commit.c:948
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sPengarang:    %.*s <%.*s>"
 
-#: builtin/commit.c:955
+#: builtin/commit.c:956
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sTanggal:       %s"
 
-#: builtin/commit.c:962
+#: builtin/commit.c:963
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sPengkomit: %.*s <%.*s>"
 
-#: builtin/commit.c:980
+#: builtin/commit.c:981
 msgid "Cannot read index"
 msgstr "Tidak dapat membaca indeks"
 
-#: builtin/commit.c:1025
+#: builtin/commit.c:1026
 msgid "unable to pass trailers to --trailers"
 msgstr "tidak dapat melewatkan trailer ke --trailers"
 
-#: builtin/commit.c:1065
+#: builtin/commit.c:1066
 msgid "Error building trees"
 msgstr "Kesalahan membangun pohon"
 
-#: builtin/commit.c:1079 builtin/tag.c:319
+#: builtin/commit.c:1080 builtin/tag.c:317
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Mohon berikan pesan baik dengan opsi -m atau -F.\n"
 
-#: builtin/commit.c:1123
+#: builtin/commit.c:1124
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' bukan 'Nama <email>' dan tidak cocok dengan pengarang yang ada"
 
-#: builtin/commit.c:1137
+#: builtin/commit.c:1138
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Mode terabaikan '%s' tidak valid"
 
-#: builtin/commit.c:1155 builtin/commit.c:1448
+#: builtin/commit.c:1156 builtin/commit.c:1450
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Mode berkas tak terlacak '%s' tidak valid"
 
-#: builtin/commit.c:1195
+#: builtin/commit.c:1196
 msgid "--long and -z are incompatible"
 msgstr "--long dan -z tidak kompatibel"
 
-#: builtin/commit.c:1226
+#: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
 msgstr "Anda berada di tengah penggabungan -- tidak dapat menulis ulang."
 
-#: builtin/commit.c:1228
+#: builtin/commit.c:1229
 msgid "You are in the middle of a cherry-pick -- cannot reword."
 msgstr "Anda berada di tengah pemetikan ceri -- tidak dapat menulis ulang."
 
-#: builtin/commit.c:1231
+#: builtin/commit.c:1232
 #, c-format
 msgid "cannot combine reword option of --fixup with path '%s'"
 msgstr ""
 "tidak dapat menggabungkan opsi penulisan ulang --fixup dengan jalur '%s'"
 
-#: builtin/commit.c:1233
+#: builtin/commit.c:1234
 msgid ""
 "reword option of --fixup is mutually exclusive with --patch/--interactive/--"
 "all/--include/--only"
 msgstr ""
 
-#: builtin/commit.c:1252
+#: builtin/commit.c:1253
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "Menggunakan baik --reset-author dan --author tidak masuk akal"
 
-#: builtin/commit.c:1261
+#: builtin/commit.c:1260
 msgid "You have nothing to amend."
 msgstr "Anda tidak punya apapun untuk diubah."
 
-#: builtin/commit.c:1264
+#: builtin/commit.c:1263
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Anda berada di tengah penggabungan -- tidak dapat mengubah."
 
-#: builtin/commit.c:1266
+#: builtin/commit.c:1265
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "Anda berada di tengah pemetikan ceri -- tidak dapat mengubah."
 
-#: builtin/commit.c:1268
+#: builtin/commit.c:1267
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Anda berada di tengah pendasaran ulang -- tidak dapat mengubah."
 
-#: builtin/commit.c:1271
+#: builtin/commit.c:1270
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Opsi --squash dan --fixup tidak dapat digunakan bersamaan"
 
-#: builtin/commit.c:1281
+#: builtin/commit.c:1280
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Hanya salah satu dari -c/-C/-F/--fixup yang dapat digunakan."
 
-#: builtin/commit.c:1283
+#: builtin/commit.c:1282
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Opsi -m tidak dapat digabung dengan -c/-C/-F."
 
-#: builtin/commit.c:1292
+#: builtin/commit.c:1291
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset-author hanya dapat digunakan dengan -C, -c atau --amend."
 
-#: builtin/commit.c:1310
+#: builtin/commit.c:1309
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Hanya salah satu dari --include/--only/--all/--interactive/--patch yang "
 "dapat digunakan."
 
-#: builtin/commit.c:1338
+#: builtin/commit.c:1337
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr ""
 
-#: builtin/commit.c:1352
+#: builtin/commit.c:1354
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "jalur '%s ...' dengan -a tidak masuk akal"
 
-#: builtin/commit.c:1483 builtin/commit.c:1652
+#: builtin/commit.c:1485 builtin/commit.c:1654
 msgid "show status concisely"
 msgstr "perlihatkan status dengan ringkas"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1487 builtin/commit.c:1656
 msgid "show branch information"
 msgstr "perlihatkan informasi cabang"
 
-#: builtin/commit.c:1487
+#: builtin/commit.c:1489
 msgid "show stash information"
 msgstr "perlihatkan informasi stase"
 
-#: builtin/commit.c:1489 builtin/commit.c:1656
+#: builtin/commit.c:1491 builtin/commit.c:1658
 msgid "compute full ahead/behind values"
 msgstr "hitung nilai didepan/dibelakang penuh"
 
-#: builtin/commit.c:1491
+#: builtin/commit.c:1493
 msgid "version"
 msgstr "versi"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658 builtin/push.c:551
-#: builtin/worktree.c:690
+#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
+#: builtin/worktree.c:691
 msgid "machine-readable output"
 msgstr "keluaran yang dapat dibaca mesin"
 
-#: builtin/commit.c:1494 builtin/commit.c:1660
+#: builtin/commit.c:1496 builtin/commit.c:1662
 msgid "show status in long format (default)"
 msgstr "perlihatkan status dalam format panjang (asali)"
 
-#: builtin/commit.c:1497 builtin/commit.c:1663
+#: builtin/commit.c:1499 builtin/commit.c:1665
 msgid "terminate entries with NUL"
 msgstr "akhiri entri dengan NUL"
 
-#: builtin/commit.c:1499 builtin/commit.c:1503 builtin/commit.c:1666
-#: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1407 parse-options.h:337
+#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
+#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
 msgid "mode"
 msgstr "mode"
 
-#: builtin/commit.c:1500 builtin/commit.c:1666
+#: builtin/commit.c:1502 builtin/commit.c:1668
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "perlihatkan berkas tak terlacak, mode opsional: all, normal, no. (Asali: all)"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1506
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -13236,11 +13522,11 @@ msgstr ""
 "perlihatkan berkas terabaikan, mode opsional: traditional, matching, no. "
 "(Asali: traditional)"
 
-#: builtin/commit.c:1506 parse-options.h:193
+#: builtin/commit.c:1508 parse-options.h:192
 msgid "when"
 msgstr "bila"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1509
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -13248,192 +13534,192 @@ msgstr ""
 "abaikan perubahan submodul, bila opsional: all, dirty, untracked. (Asali: "
 "all)"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1511
 msgid "list untracked files in columns"
 msgstr "sebut berkas tak terlacak dalam kolom"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1512
 msgid "do not detect renames"
 msgstr "jangan deteksi penggantian nama"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1514
 msgid "detect renames, optionally set similarity index"
 msgstr "deteksi penggantian nama, setel indeks kemiripan secara opsional"
 
-#: builtin/commit.c:1535
+#: builtin/commit.c:1537
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr "Kombinasi argumen berkas terabaikan dan tak terlacak tidak didukung"
 
-#: builtin/commit.c:1617
+#: builtin/commit.c:1619
 msgid "suppress summary after successful commit"
 msgstr "sembunyikan rangkuman setelah komit berhasil"
 
-#: builtin/commit.c:1618
+#: builtin/commit.c:1620
 msgid "show diff in commit message template"
 msgstr "perlihatkan diff dalam templat pesan komit"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1622
 msgid "Commit message options"
 msgstr "Opsi pesan komit"
 
-#: builtin/commit.c:1621 builtin/merge.c:286 builtin/tag.c:458
+#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
 msgid "read message from file"
 msgstr "Baca pesan dari berkas"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "author"
 msgstr "pengarang"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "override author for commit"
 msgstr "timpa pengarang komit"
 
-#: builtin/commit.c:1623 builtin/gc.c:550
+#: builtin/commit.c:1625 builtin/gc.c:550
 msgid "date"
 msgstr "tangal"
 
-#: builtin/commit.c:1623
+#: builtin/commit.c:1625
 msgid "override date for commit"
 msgstr "timpa tanggal komit"
 
-#: builtin/commit.c:1625 builtin/commit.c:1626 builtin/commit.c:1632
-#: parse-options.h:329 ref-filter.h:90
+#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
+#: parse-options.h:328 ref-filter.h:92
 msgid "commit"
 msgstr "komit"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1627
 msgid "reuse and edit message from specified commit"
 msgstr "gunakan kembali dan sunting pesan dari komit tersebut"
 
-#: builtin/commit.c:1626
+#: builtin/commit.c:1628
 msgid "reuse message from specified commit"
 msgstr "gunakan kembali pesan dari komit tersebut"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]komit"
 
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "gunakan pesan terformat autosquash untuk perbaiki atau ubah/tulis ulang "
 "komit yang disebutkan"
 
-#: builtin/commit.c:1632
+#: builtin/commit.c:1634
 msgid "use autosquash formatted message to squash specified commit"
 msgstr "gunakan pesan terformat autosquash untuk lumat komit tersebut"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1635
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "komit sekarang dikarang olehku (gunakan dengan -C/-c/--amend)"
 
-#: builtin/commit.c:1634 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr ""
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1636
 msgid "add custom trailer(s)"
 msgstr ""
 
-#: builtin/commit.c:1635 builtin/log.c:1754 builtin/merge.c:302
+#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "tambahkan trailer Signed-off-by"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1638
 msgid "use specified template file"
 msgstr "gunakan templat berkas tersebut"
 
-#: builtin/commit.c:1637
+#: builtin/commit.c:1639
 msgid "force edit of commit"
 msgstr "paksa sunting komit"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1641
 msgid "include status in commit message template"
 msgstr "masukkan status dalam templat pesaan komit"
 
-#: builtin/commit.c:1644
+#: builtin/commit.c:1646
 msgid "Commit contents options"
 msgstr "Opsi isi komit"
 
-#: builtin/commit.c:1645
+#: builtin/commit.c:1647
 msgid "commit all changed files"
 msgstr "komit semua berkas terubah"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1648
 msgid "add specified files to index for commit"
 msgstr "tambahakn berkas tersebut ke indeks untuk dikomit"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1649
 msgid "interactively add files"
 msgstr "tambah berkas secara interaktif"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1650
 msgid "interactively add changes"
 msgstr "tambah perubahan secara interaktif"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1651
 msgid "commit only specified files"
 msgstr "hanya komit berkas tersebut"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1652
 msgid "bypass pre-commit and commit-msg hooks"
-msgstr "lewati hook pre-commit dan commit-msg"
+msgstr "lewati kail pre-commit dan commit-msg"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1653
 msgid "show what would be committed"
 msgstr "perlihatkan apa yang akan dikomit"
 
-#: builtin/commit.c:1664
+#: builtin/commit.c:1666
 msgid "amend previous commit"
 msgstr "ubah komit sebelumnya"
 
-#: builtin/commit.c:1665
+#: builtin/commit.c:1667
 msgid "bypass post-rewrite hook"
-msgstr "lewati hook post-rewrite"
+msgstr "lewati kail post-rewrite"
 
-#: builtin/commit.c:1672
+#: builtin/commit.c:1674
 msgid "ok to record an empty change"
 msgstr "ok merekam perubahan kosong"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1676
 msgid "ok to record a change with an empty message"
 msgstr "ok merekam perubahan dengan pesan kosong"
 
-#: builtin/commit.c:1750
+#: builtin/commit.c:1752
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Berkas MERGE_HEAD (%s) rusak"
 
-#: builtin/commit.c:1757
+#: builtin/commit.c:1759
 msgid "could not read MERGE_MODE"
 msgstr "tidak dapat membaca MERGE_MODE"
 
-#: builtin/commit.c:1778
+#: builtin/commit.c:1780
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "tidak dapat membaca pesan komit: %s"
 
-#: builtin/commit.c:1785
+#: builtin/commit.c:1787
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Batalkan komit karena pesan komit kosong.\n"
 
-#: builtin/commit.c:1790
+#: builtin/commit.c:1792
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Batalkan komit; Anda tidak menyunting pesan.\n"
 
-#: builtin/commit.c:1801
+#: builtin/commit.c:1803
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr "Batalkan komit karena badan pesan komit kosong.\n"
 
-#: builtin/commit.c:1837
+#: builtin/commit.c:1839
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -13771,11 +14057,11 @@ msgstr "tidak ada bagian seperti: %s"
 
 #: builtin/count-objects.c:90
 msgid "git count-objects [-v] [-H | --human-readable]"
-msgstr ""
+msgstr "git count-objects [-v] [-H | --human-readable]"
 
 #: builtin/count-objects.c:100
 msgid "print sizes in human readable format"
-msgstr ""
+msgstr "cetak ukuran dalam format yang bisa dibaca manusia"
 
 #: builtin/credential-cache--daemon.c:227
 #, c-format
@@ -13794,7 +14080,7 @@ msgstr ""
 msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr ""
 
-#: builtin/credential-cache.c:154
+#: builtin/credential-cache.c:180
 msgid "credential-cache unavailable; no unix socket support"
 msgstr ""
 
@@ -13996,7 +14282,7 @@ msgstr "%s...%s: tidak ada dasar penggabungan"
 msgid "Not a git repository"
 msgstr "bukan repositori git"
 
-#: builtin/diff.c:532 builtin/grep.c:684
+#: builtin/diff.c:532 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "objek yang diberikan '%s' tidak valid"
@@ -14018,119 +14304,123 @@ msgstr "%s...%s: banyak dasar penggabungan, menggunakan %s"
 
 #: builtin/difftool.c:31
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
-msgstr ""
+msgstr "git difftool [<opsi>] [<komit> [<komit>]] [--] [<jalur>...]"
 
-#: builtin/difftool.c:261
+#: builtin/difftool.c:293
 #, c-format
-msgid "failed: %d"
-msgstr ""
+msgid "could not read symlink %s"
+msgstr "tidak dapat membaca tautan simbolik %s"
+
+#: builtin/difftool.c:295
+#, c-format
+msgid "could not read symlink file %s"
+msgstr "tidak dapat membaca berkas tautan simbolik %s"
 
 #: builtin/difftool.c:303
 #, c-format
-msgid "could not read symlink %s"
-msgstr ""
-
-#: builtin/difftool.c:305
-#, c-format
-msgid "could not read symlink file %s"
-msgstr ""
-
-#: builtin/difftool.c:313
-#, c-format
 msgid "could not read object %s for symlink %s"
-msgstr ""
+msgstr "tidak dapat membaca objek %s untuk symlink %s"
 
-#: builtin/difftool.c:413
+#: builtin/difftool.c:427
 msgid ""
-"combined diff formats('-c' and '--cc') are not supported in\n"
-"directory diff mode('-d' and '--dir-diff')."
+"combined diff formats ('-c' and '--cc') are not supported in\n"
+"directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
+"format diff tergabung ('-c' dan '--cc') tidak didukung dalam\n"
+"mode diff direktori ('-d' dan '--dir-diff')."
 
-#: builtin/difftool.c:637
+#: builtin/difftool.c:632
 #, c-format
 msgid "both files modified: '%s' and '%s'."
-msgstr ""
+msgstr "kedua berkas berubah: '%s' dan '%s'."
 
-#: builtin/difftool.c:639
+#: builtin/difftool.c:634
 msgid "working tree file has been left."
-msgstr ""
+msgstr "berkas pohon kerja telah ditinggalkan."
 
-#: builtin/difftool.c:650
+#: builtin/difftool.c:645
 #, c-format
 msgid "temporary files exist in '%s'."
-msgstr ""
+msgstr "berkas sementara ada di '%s'."
+
+#: builtin/difftool.c:646
+msgid "you may want to cleanup or recover these."
+msgstr "mungkin Anda ingin membersihkan atau memulihkan itu."
 
 #: builtin/difftool.c:651
-msgid "you may want to cleanup or recover these."
-msgstr ""
+#, c-format
+msgid "failed: %d"
+msgstr "gagal: %d"
 
-#: builtin/difftool.c:699
+#: builtin/difftool.c:696
 msgid "use `diff.guitool` instead of `diff.tool`"
-msgstr ""
+msgstr "gunakan `diff.guitool` daripada `diff.tool`"
 
-#: builtin/difftool.c:701
+#: builtin/difftool.c:698
 msgid "perform a full-directory diff"
-msgstr ""
+msgstr "lakukan diff direktori penuh"
 
-#: builtin/difftool.c:703
+#: builtin/difftool.c:700
 msgid "do not prompt before launching a diff tool"
-msgstr ""
+msgstr "jangan bisiki sebelum meluncurkan alat diff"
 
-#: builtin/difftool.c:708
+#: builtin/difftool.c:705
 msgid "use symlinks in dir-diff mode"
-msgstr ""
+msgstr "gunakan tautan simbolik dalam mode diff direktori"
+
+#: builtin/difftool.c:706
+msgid "tool"
+msgstr "alat"
+
+#: builtin/difftool.c:707
+msgid "use the specified diff tool"
+msgstr "gunakan alat diff yang disebutkan"
 
 #: builtin/difftool.c:709
-msgid "tool"
-msgstr ""
-
-#: builtin/difftool.c:710
-msgid "use the specified diff tool"
-msgstr ""
+msgid "print a list of diff tools that may be used with `--tool`"
+msgstr "cetak daftar alat diff yang bisa digunakan dengan `--tool`"
 
 #: builtin/difftool.c:712
-msgid "print a list of diff tools that may be used with `--tool`"
-msgstr ""
-
-#: builtin/difftool.c:715
 msgid ""
-"make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
+"make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
 msgstr ""
+"buat 'git-difftool' keluar ketika alat diff yang dijalankan mengembalikan "
+"kode keluar bukan nol"
 
-#: builtin/difftool.c:718
+#: builtin/difftool.c:715
 msgid "specify a custom command for viewing diffs"
-msgstr ""
+msgstr "sebutkan perintah kustom untuk melihat diff"
 
-#: builtin/difftool.c:719
+#: builtin/difftool.c:716
 msgid "passed to `diff`"
-msgstr ""
+msgstr "dilewatkan ke `diff`"
 
-#: builtin/difftool.c:734
+#: builtin/difftool.c:732
 msgid "difftool requires worktree or --no-index"
-msgstr ""
+msgstr "difftool butuh pohon kerja atau --no-index"
 
-#: builtin/difftool.c:741
+#: builtin/difftool.c:739
 msgid "--dir-diff is incompatible with --no-index"
-msgstr ""
+msgstr "--dir-diff tidak kompatibel dengan --no-index"
 
-#: builtin/difftool.c:744
+#: builtin/difftool.c:742
 msgid "--gui, --tool and --extcmd are mutually exclusive"
-msgstr ""
+msgstr "--gui, --tool dan --extcmd saling eksklusif"
 
-#: builtin/difftool.c:752
+#: builtin/difftool.c:750
 msgid "no <tool> given for --tool=<tool>"
-msgstr ""
+msgstr "tidak ada <alat> yang diberikan untuk --tool=<alat>"
 
-#: builtin/difftool.c:759
+#: builtin/difftool.c:757
 msgid "no <cmd> given for --extcmd=<cmd>"
-msgstr ""
+msgstr "tidak ada <perintah> yang diberikan untuk --extcmd=<perintah>"
 
 #: builtin/env--helper.c:6
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
 msgstr ""
 
-#: builtin/env--helper.c:42 builtin/hash-object.c:98
+#: builtin/env--helper.c:42 builtin/hash-object.c:96
 msgid "type"
 msgstr ""
 
@@ -14156,133 +14446,137 @@ msgstr ""
 
 #: builtin/fast-export.c:29
 msgid "git fast-export [rev-list-opts]"
-msgstr ""
+msgstr "git fast-export [opsi rev-list]"
 
-#: builtin/fast-export.c:868
+#: builtin/fast-export.c:869
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
+"Kesalahan: Tidak dapat mengekspor tag bersarang kecuali jika --mark-tags "
+"disebutkan."
 
-#: builtin/fast-export.c:1177
+#: builtin/fast-export.c:1178
 msgid "--anonymize-map token cannot be empty"
-msgstr ""
+msgstr "token --anonymize-map tidak bisa kosong"
 
-#: builtin/fast-export.c:1197
+#: builtin/fast-export.c:1198
 msgid "show progress after <n> objects"
-msgstr ""
+msgstr "perlihatkan perkembangan setelah <n> objek"
 
-#: builtin/fast-export.c:1199
+#: builtin/fast-export.c:1200
 msgid "select handling of signed tags"
-msgstr ""
+msgstr "pilih penanganan tag bertandatangan"
 
-#: builtin/fast-export.c:1202
+#: builtin/fast-export.c:1203
 msgid "select handling of tags that tag filtered objects"
-msgstr ""
+msgstr "pilih penanganan tag yang men-tag objek tersaring"
 
-#: builtin/fast-export.c:1205
+#: builtin/fast-export.c:1206
 msgid "select handling of commit messages in an alternate encoding"
-msgstr ""
+msgstr "pilih penanganan pesan komit dalam pengkodean alternatif"
 
-#: builtin/fast-export.c:1208
+#: builtin/fast-export.c:1209
 msgid "dump marks to this file"
-msgstr ""
+msgstr "buang tanda ke berkas ini"
 
-#: builtin/fast-export.c:1210
+#: builtin/fast-export.c:1211
 msgid "import marks from this file"
-msgstr ""
+msgstr "impor tanda dari berkas ini"
 
-#: builtin/fast-export.c:1214
+#: builtin/fast-export.c:1215
 msgid "import marks from this file if it exists"
-msgstr ""
+msgstr "impor tanda dari berkas ini jika ada"
 
-#: builtin/fast-export.c:1216
+#: builtin/fast-export.c:1217
 msgid "fake a tagger when tags lack one"
-msgstr ""
+msgstr "palsukan pen-tag ketika tidak ada pada tag"
 
-#: builtin/fast-export.c:1218
+#: builtin/fast-export.c:1219
 msgid "output full tree for each commit"
-msgstr ""
-
-#: builtin/fast-export.c:1220
-msgid "use the done feature to terminate the stream"
-msgstr ""
+msgstr "keluarkan pohon penuh untuk setiap komit"
 
 #: builtin/fast-export.c:1221
+msgid "use the done feature to terminate the stream"
+msgstr "gunakan fitur selesai untuk mengakhiri arus"
+
+#: builtin/fast-export.c:1222
 msgid "skip output of blob data"
-msgstr ""
+msgstr "lewati keluaran data blob"
 
-#: builtin/fast-export.c:1222 builtin/log.c:1826
+#: builtin/fast-export.c:1223 builtin/log.c:1826
 msgid "refspec"
-msgstr ""
-
-#: builtin/fast-export.c:1223
-msgid "apply refspec to exported refs"
-msgstr ""
+msgstr "spek referensi"
 
 #: builtin/fast-export.c:1224
-msgid "anonymize output"
-msgstr ""
+msgid "apply refspec to exported refs"
+msgstr "terapkan spek referensi ke referensi terekspor"
 
 #: builtin/fast-export.c:1225
-msgid "from:to"
-msgstr ""
+msgid "anonymize output"
+msgstr "anonimkan keluaran"
 
 #: builtin/fast-export.c:1226
+msgid "from:to"
+msgstr "dari:ke"
+
+#: builtin/fast-export.c:1227
 msgid "convert <from> to <to> in anonymized output"
-msgstr ""
+msgstr "ubah <dari> ke <ke> pada keluaran teranonim"
 
-#: builtin/fast-export.c:1229
+#: builtin/fast-export.c:1230
 msgid "reference parents which are not in fast-export stream by object id"
-msgstr ""
+msgstr "referensikan induk yang tidak ada dalam arus fast-export oleh id objek"
 
-#: builtin/fast-export.c:1231
+#: builtin/fast-export.c:1232
 msgid "show original object ids of blobs/commits"
-msgstr ""
+msgstr "perlihatkan id objek asli dari blob/komit"
 
-#: builtin/fast-export.c:1233
+#: builtin/fast-export.c:1234
 msgid "label tags with mark ids"
-msgstr ""
+msgstr "label tag dengan id tanda"
 
-#: builtin/fast-export.c:1256
+#: builtin/fast-export.c:1257
 msgid "--anonymize-map without --anonymize does not make sense"
-msgstr ""
+msgstr "--anonymize-map tanpa --anonymize tidak masuk akal"
 
-#: builtin/fast-export.c:1271
+#: builtin/fast-export.c:1272
 msgid "Cannot pass both --import-marks and --import-marks-if-exists"
 msgstr ""
+"Tidak dapat melewatkan baik --import-marks dan --import-marks-if-exists"
 
 #: builtin/fast-import.c:3088
 #, c-format
 msgid "Missing from marks for submodule '%s'"
-msgstr ""
+msgstr "Kehilangan tanda dari untuk submodul '%s'"
 
 #: builtin/fast-import.c:3090
 #, c-format
 msgid "Missing to marks for submodule '%s'"
-msgstr ""
+msgstr "Kehilangan tanda ke untuk submodul '%s'"
 
 #: builtin/fast-import.c:3225
 #, c-format
 msgid "Expected 'mark' command, got %s"
-msgstr ""
+msgstr "Perintah 'mark' diharapkan, dapat %s"
 
 #: builtin/fast-import.c:3230
 #, c-format
 msgid "Expected 'to' command, got %s"
-msgstr ""
+msgstr "Perintah 'to' diharapkan, dapat %s"
 
 #: builtin/fast-import.c:3322
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr ""
+"Format nama:nama berkas diharapkan untuk operasi penulisan ulang submodul"
 
 #: builtin/fast-import.c:3377
 #, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
-msgstr ""
+msgstr "fitur '%s' dilarang dalam input tanpa --allow-unsafe-features"
 
 #: builtin/fetch-pack.c:242
 #, c-format
 msgid "Lockfile created but not reported: %s"
-msgstr ""
+msgstr "Berkas kunci dibuat tetapi tidak dilaporkan: %s"
 
 #: builtin/fetch.c:35
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
@@ -14421,6 +14715,7 @@ msgstr ""
 #: builtin/fetch.c:210
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
+"jangan ambil berkas pak; sebagai gantinya cetak leluhur dari ujung negosiasi"
 
 #: builtin/fetch.c:213 builtin/fetch.c:215
 msgid "run 'maintenance --auto' after fetching"
@@ -14442,62 +14737,62 @@ msgstr "terima spek referensi dari masukan standar"
 msgid "Couldn't find remote ref HEAD"
 msgstr "tidak dapat menemukan referensi remote HEAD"
 
-#: builtin/fetch.c:757
+#: builtin/fetch.c:760
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "konfigurasi fetch.output berisi nilai tidak valid %s"
 
-#: builtin/fetch.c:856
+#: builtin/fetch.c:862
 #, c-format
 msgid "object %s not found"
 msgstr "objek %s tidak ditemukan"
 
-#: builtin/fetch.c:860
+#: builtin/fetch.c:866
 msgid "[up to date]"
 msgstr "[terkini]"
 
-#: builtin/fetch.c:873 builtin/fetch.c:889 builtin/fetch.c:961
+#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
 msgid "[rejected]"
 msgstr "[tertolak]"
 
-#: builtin/fetch.c:874
+#: builtin/fetch.c:880
 msgid "can't fetch in current branch"
 msgstr "tidak dapat mengambil di cabang saat ini"
 
-#: builtin/fetch.c:884
+#: builtin/fetch.c:890
 msgid "[tag update]"
 msgstr "[pembaruan tag]"
 
-#: builtin/fetch.c:885 builtin/fetch.c:922 builtin/fetch.c:944
-#: builtin/fetch.c:956
+#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
+#: builtin/fetch.c:962
 msgid "unable to update local ref"
 msgstr "tidak dapat memperbarui referensi lokal"
 
-#: builtin/fetch.c:889
+#: builtin/fetch.c:895
 msgid "would clobber existing tag"
 msgstr "akan klob tag yang ada"
 
-#: builtin/fetch.c:911
+#: builtin/fetch.c:917
 msgid "[new tag]"
 msgstr "[tag baru]"
 
-#: builtin/fetch.c:914
+#: builtin/fetch.c:920
 msgid "[new branch]"
 msgstr "[cabang baru]"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:923
 msgid "[new ref]"
 msgstr "[referensi baru]"
 
-#: builtin/fetch.c:956
+#: builtin/fetch.c:962
 msgid "forced update"
 msgstr "pembaruan terpaksa"
 
-#: builtin/fetch.c:961
+#: builtin/fetch.c:967
 msgid "non-fast-forward"
 msgstr "bukan-maju-cepat"
 
-#: builtin/fetch.c:1065
+#: builtin/fetch.c:1070
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -14508,7 +14803,7 @@ msgstr ""
 "'--show-forced-updates' atau jalankan 'git config fetch.showForcedUpdates "
 "true'."
 
-#: builtin/fetch.c:1069
+#: builtin/fetch.c:1074
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -14521,22 +14816,22 @@ msgstr ""
 "'git config fetch.showForcedUpdates false'\n"
 " untuk menghindari pemeriksaan ini.\n"
 
-#: builtin/fetch.c:1101
+#: builtin/fetch.c:1105
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s tidak mengirim semua objek yang diperlukan\n"
 
-#: builtin/fetch.c:1129
+#: builtin/fetch.c:1134
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "tolak %s karena akar dangkal tidak diperkenankan untuk diperbarui"
 
-#: builtin/fetch.c:1206 builtin/fetch.c:1357
+#: builtin/fetch.c:1223 builtin/fetch.c:1371
 #, c-format
 msgid "From %.*s\n"
 msgstr "Dari %.*s\n"
 
-#: builtin/fetch.c:1228
+#: builtin/fetch.c:1244
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -14545,56 +14840,61 @@ msgstr ""
 "beberapa referensi lokal tidak dapat diperbarui; coba jalankan\n"
 " 'git remote prune %s' untuk hapus cabang yang lama dan berkonflik"
 
-#: builtin/fetch.c:1327
+#: builtin/fetch.c:1341
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s akan menjadi terjuntai)"
 
-#: builtin/fetch.c:1328
+#: builtin/fetch.c:1342
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s telah menjadi terjuntai)"
 
-#: builtin/fetch.c:1360
+#: builtin/fetch.c:1374
 msgid "[deleted]"
 msgstr "[dihapus]"
 
-#: builtin/fetch.c:1361 builtin/remote.c:1118
+#: builtin/fetch.c:1375 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(tidak ada)"
 
-#: builtin/fetch.c:1384
+#: builtin/fetch.c:1398
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr "Tolak mengambil ke cabang saat ini %s dari repositori non-bare"
 
-#: builtin/fetch.c:1403
+#: builtin/fetch.c:1417
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Opsi \"%s\" nilai \"%s\" tidak valid untuk %s"
 
-#: builtin/fetch.c:1406
+#: builtin/fetch.c:1420
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Opsi \"%s\" diabaikan untuk %s\n"
 
-#: builtin/fetch.c:1618
+#: builtin/fetch.c:1447
+#, c-format
+msgid "the object %s does not exist"
+msgstr "objek '%s' tidak ada"
+
+#: builtin/fetch.c:1633
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "banyak cabang terdeteksi, tidak kompatibel dengan --set-upstream"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1648
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "tidak setel hulu untuk cabang remote pelacak remote"
 
-#: builtin/fetch.c:1635
+#: builtin/fetch.c:1650
 msgid "not setting upstream for a remote tag"
 msgstr "tidak setel hulu untuk tag remote"
 
-#: builtin/fetch.c:1637
+#: builtin/fetch.c:1652
 msgid "unknown branch type"
 msgstr "tipe cabang tidak diketahui"
 
-#: builtin/fetch.c:1639
+#: builtin/fetch.c:1654
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -14602,22 +14902,22 @@ msgstr ""
 "cabang sumber tidak ditemukan.\n"
 "Anda harus sebutkan tepat satu cabang dengan opsi --set-upstream."
 
-#: builtin/fetch.c:1768 builtin/fetch.c:1831
+#: builtin/fetch.c:1783 builtin/fetch.c:1846
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Mengambil %s\n"
 
-#: builtin/fetch.c:1778 builtin/fetch.c:1833 builtin/remote.c:101
+#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Tidak dapat mengambil %s"
 
-#: builtin/fetch.c:1790
+#: builtin/fetch.c:1805
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "tidak dapat mengambil '%s' (kode keluar: %d)\n"
 
-#: builtin/fetch.c:1894
+#: builtin/fetch.c:1909
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -14625,56 +14925,56 @@ msgstr ""
 "Repositori remot tidak disebutkan. Mohon sebutkan baik URL atau nama\n"
 "cabang yang mana revisi baru sebaiknya diambil."
 
-#: builtin/fetch.c:1930
+#: builtin/fetch.c:1945
 msgid "You need to specify a tag name."
 msgstr "Anda perlu sebutkan nama tag"
 
-#: builtin/fetch.c:1994
+#: builtin/fetch.c:2009
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only perlu satu atau lebih --negotiate-tip=*"
 
-#: builtin/fetch.c:1998
+#: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"
 msgstr "Kedalaman negatif di --deepen tidak didukung"
 
-#: builtin/fetch.c:2000
+#: builtin/fetch.c:2015
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen dan --depth saling eksklusif"
 
-#: builtin/fetch.c:2005
+#: builtin/fetch.c:2020
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth dan --unshallow tidak dapat digunakan bersamaan"
 
-#: builtin/fetch.c:2007
+#: builtin/fetch.c:2022
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow pada repositori penuh tidak masuk akal"
 
-#: builtin/fetch.c:2024
+#: builtin/fetch.c:2039
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all tidak mengambil argumen repositori"
 
-#: builtin/fetch.c:2026
+#: builtin/fetch.c:2041
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all tidak masuk akal dengan spek referensi"
 
-#: builtin/fetch.c:2035
+#: builtin/fetch.c:2050
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "tidak ada remote atau grup remote seperti itu: %s"
 
-#: builtin/fetch.c:2042
+#: builtin/fetch.c:2057
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr "Ambil grup dan sebutkan spek referensi tidak masuk akal"
 
-#: builtin/fetch.c:2058
+#: builtin/fetch.c:2073
 msgid "must supply remote when using --negotiate-only"
-msgstr ""
+msgstr "harus suplai remote ketika menggunakan --negotiate-only"
 
-#: builtin/fetch.c:2063
+#: builtin/fetch.c:2078
 msgid "Protocol does not support --negotiate-only, exiting."
-msgstr ""
+msgstr "Protokol tidak mendukung --negotiate-only, keluar."
 
-#: builtin/fetch.c:2082
+#: builtin/fetch.c:2097
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -14682,11 +14982,11 @@ msgstr ""
 "--filter hanya dapat digunakan dengan remote yang terkonfigurasi di "
 "extensions.partialclone"
 
-#: builtin/fetch.c:2086
+#: builtin/fetch.c:2101
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic hanya dapat digunakan saat mengambil dari satu remote"
 
-#: builtin/fetch.c:2090
+#: builtin/fetch.c:2105
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin hanya dapat digunakan saat mengambil dari satu remote"
 
@@ -14751,7 +15051,7 @@ msgstr ""
 msgid "show only <n> matched refs"
 msgstr ""
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:483
+#: builtin/for-each-ref.c:41 builtin/tag.c:481
 msgid "respect format colors"
 msgstr ""
 
@@ -14793,28 +15093,28 @@ msgstr ""
 
 #: builtin/fsck.c:69 builtin/fsck.c:128 builtin/fsck.c:129
 msgid "unknown"
-msgstr ""
+msgstr "tidak dikenal"
 
 #. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
 #: builtin/fsck.c:78 builtin/fsck.c:100
 #, c-format
 msgid "error in %s %s: %s"
-msgstr ""
+msgstr "kesalahan pada %s %s: %s"
 
 #. TRANSLATORS: e.g. warning in tree 01bfda: <more explanation>
 #: builtin/fsck.c:94
 #, c-format
 msgid "warning in %s %s: %s"
-msgstr ""
+msgstr "peringatan pada %s %s: %s"
 
 #: builtin/fsck.c:124 builtin/fsck.c:127
 #, c-format
 msgid "broken link from %7s %s"
-msgstr ""
+msgstr "tautan rusak dari %7s %s"
 
 #: builtin/fsck.c:136
 msgid "wrong object type in link"
-msgstr ""
+msgstr "tipe objek salah dalam tautan"
 
 #: builtin/fsck.c:152
 #, c-format
@@ -14822,475 +15122,540 @@ msgid ""
 "broken link from %7s %s\n"
 "              to %7s %s"
 msgstr ""
+"tautan rusak dari %7s %s\n"
+"               ke %7s %s"
 
 #: builtin/fsck.c:264
 #, c-format
 msgid "missing %s %s"
-msgstr ""
+msgstr "kehilangan %s %s"
 
 #: builtin/fsck.c:291
 #, c-format
 msgid "unreachable %s %s"
-msgstr ""
+msgstr "tidak dapat dicapai %s %s"
 
 #: builtin/fsck.c:311
 #, c-format
 msgid "dangling %s %s"
-msgstr ""
+msgstr "teruntai %s %s"
 
 #: builtin/fsck.c:321
 msgid "could not create lost-found"
-msgstr ""
+msgstr "tidak dapat membuat lost-found"
 
 #: builtin/fsck.c:332
 #, c-format
 msgid "could not finish '%s'"
-msgstr ""
+msgstr "tidak dapat menyelesaikan '%s'"
 
 #: builtin/fsck.c:349
 #, c-format
 msgid "Checking %s"
-msgstr ""
+msgstr "Memeriksa %s"
 
 #: builtin/fsck.c:387
 #, c-format
 msgid "Checking connectivity (%d objects)"
-msgstr ""
+msgstr "Memerika konektivitas (%d objek)"
 
 #: builtin/fsck.c:406
 #, c-format
 msgid "Checking %s %s"
-msgstr ""
+msgstr "Memeriksa %s %s"
 
 #: builtin/fsck.c:411
 msgid "broken links"
-msgstr ""
+msgstr "tautan rusak"
 
 #: builtin/fsck.c:420
 #, c-format
 msgid "root %s"
-msgstr ""
+msgstr "akar %s"
 
 #: builtin/fsck.c:428
 #, c-format
 msgid "tagged %s %s (%s) in %s"
-msgstr ""
+msgstr "ter-tag %s %s (%s) di %s"
 
 #: builtin/fsck.c:457
 #, c-format
 msgid "%s: object corrupt or missing"
-msgstr ""
+msgstr "%s: objek rusak atau hilang"
 
 #: builtin/fsck.c:482
 #, c-format
 msgid "%s: invalid reflog entry %s"
-msgstr ""
+msgstr "%s: entri log referensi tidak valid %s"
 
 #: builtin/fsck.c:496
 #, c-format
 msgid "Checking reflog %s->%s"
-msgstr ""
+msgstr "Memeriksa log referensi %s->%s"
 
 #: builtin/fsck.c:530
 #, c-format
 msgid "%s: invalid sha1 pointer %s"
-msgstr ""
+msgstr "%s: penunjuk sha1 tidak valid %s"
 
 #: builtin/fsck.c:537
 #, c-format
 msgid "%s: not a commit"
-msgstr ""
+msgstr "%s: bukan sebuah komit"
 
 #: builtin/fsck.c:591
 msgid "notice: No default references"
+msgstr "catatan: Tidak ada referensi asali"
+
+#: builtin/fsck.c:621
+#, c-format
+msgid "%s: hash-path mismatch, found at: %s"
 msgstr ""
 
-#: builtin/fsck.c:606
+#: builtin/fsck.c:624
 #, c-format
 msgid "%s: object corrupt or missing: %s"
-msgstr ""
+msgstr "%s: objek rusak atau hilang: %s"
 
-#: builtin/fsck.c:619
+#: builtin/fsck.c:628
+#, c-format
+msgid "%s: object is of unknown type '%s': %s"
+msgstr "%s: objek bertipe tidak dikenal '%s': %s"
+
+#: builtin/fsck.c:644
 #, c-format
 msgid "%s: object could not be parsed: %s"
-msgstr ""
+msgstr "%s: objek tidak dapat diuraikan: %s"
 
-#: builtin/fsck.c:639
+#: builtin/fsck.c:664
 #, c-format
 msgid "bad sha1 file: %s"
-msgstr ""
+msgstr "sha1 berkas jelek: %s"
 
-#: builtin/fsck.c:654
+#: builtin/fsck.c:685
 msgid "Checking object directory"
-msgstr ""
+msgstr "Memeriksa direktori objek"
 
-#: builtin/fsck.c:657
+#: builtin/fsck.c:688
 msgid "Checking object directories"
-msgstr ""
+msgstr "Memeriksa direktori objek"
 
-#: builtin/fsck.c:672
+#: builtin/fsck.c:704
 #, c-format
 msgid "Checking %s link"
-msgstr ""
+msgstr "Memeriksa tautan %s"
 
-#: builtin/fsck.c:677 builtin/index-pack.c:864
+#: builtin/fsck.c:709 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "%s tidak valid"
 
-#: builtin/fsck.c:684
+#: builtin/fsck.c:716
 #, c-format
 msgid "%s points to something strange (%s)"
-msgstr ""
+msgstr "%s menunjuk ke sesuatu yang aneh (%s)"
 
-#: builtin/fsck.c:690
+#: builtin/fsck.c:722
 #, c-format
 msgid "%s: detached HEAD points at nothing"
-msgstr ""
+msgstr "%s: HEAD terpisah tidak menunjuk ke apapun"
 
-#: builtin/fsck.c:694
+#: builtin/fsck.c:726
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
-msgstr ""
+msgstr "catatan: %s menunjuk ke cabang yang belum lahir (%s)"
 
-#: builtin/fsck.c:706
+#: builtin/fsck.c:738
 msgid "Checking cache tree"
-msgstr ""
+msgstr "Memeriksa pohon tembolok"
 
-#: builtin/fsck.c:711
+#: builtin/fsck.c:743
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
-msgstr ""
+msgstr "%s: penunjuk sha1 tidak valid pada pohon tembolok"
 
-#: builtin/fsck.c:720
+#: builtin/fsck.c:752
 msgid "non-tree in cache-tree"
-msgstr ""
+msgstr "bukan pohon pada pohon tembolok"
 
-#: builtin/fsck.c:751
+#: builtin/fsck.c:783
 msgid "git fsck [<options>] [<object>...]"
-msgstr ""
+msgstr "git fsck [<opsi>] [<objek>...]"
 
-#: builtin/fsck.c:757
+#: builtin/fsck.c:789
 msgid "show unreachable objects"
-msgstr ""
+msgstr "perlihatkan objek yang tak dapat dicapai"
 
-#: builtin/fsck.c:758
+#: builtin/fsck.c:790
 msgid "show dangling objects"
-msgstr ""
+msgstr "perlihatkan objek teruntai"
 
-#: builtin/fsck.c:759
+#: builtin/fsck.c:791
 msgid "report tags"
-msgstr ""
+msgstr "laporkan tag"
 
-#: builtin/fsck.c:760
+#: builtin/fsck.c:792
 msgid "report root nodes"
-msgstr ""
+msgstr "laporkan simpul akar"
 
-#: builtin/fsck.c:761
+#: builtin/fsck.c:793
 msgid "make index objects head nodes"
-msgstr ""
+msgstr "buat objek indeks simpul kepala"
 
-#: builtin/fsck.c:762
+#: builtin/fsck.c:794
 msgid "make reflogs head nodes (default)"
-msgstr ""
+msgstr "buat log referensi simpul kepala (asali)"
 
-#: builtin/fsck.c:763
+#: builtin/fsck.c:795
 msgid "also consider packs and alternate objects"
-msgstr ""
+msgstr "juga pertimbangkan pak dan objek alternatif"
 
-#: builtin/fsck.c:764
+#: builtin/fsck.c:796
 msgid "check only connectivity"
-msgstr ""
+msgstr "hanya periksa konektivitas"
 
-#: builtin/fsck.c:765 builtin/mktag.c:75
+#: builtin/fsck.c:797 builtin/mktag.c:76
 msgid "enable more strict checking"
-msgstr ""
+msgstr "aktifkan pemeriksaan lebih ketat"
 
-#: builtin/fsck.c:767
+#: builtin/fsck.c:799
 msgid "write dangling objects in .git/lost-found"
-msgstr ""
+msgstr "tulis objek teruntai dalam .git/lost-found"
 
-#: builtin/fsck.c:768 builtin/prune.c:134
+#: builtin/fsck.c:800 builtin/prune.c:134
 msgid "show progress"
-msgstr ""
+msgstr "perlihatkan perkembangan"
 
-#: builtin/fsck.c:769
+#: builtin/fsck.c:801
 msgid "show verbose names for reachable objects"
-msgstr ""
+msgstr "perlihatkan nama lantung untuk objek yang dapat dicapai"
 
-#: builtin/fsck.c:828 builtin/index-pack.c:262
+#: builtin/fsck.c:860 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Memeriksa objek"
 
-#: builtin/fsck.c:856
+#: builtin/fsck.c:888
 #, c-format
 msgid "%s: object missing"
-msgstr ""
+msgstr "%s: objek hilang"
 
-#: builtin/fsck.c:867
+#: builtin/fsck.c:899
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
-msgstr ""
+msgstr "parameter tidak valid: sha1 diharapkan, dapat '%s'"
 
 #: builtin/gc.c:39
 msgid "git gc [<options>]"
-msgstr ""
+msgstr "git gc [<opsi>]"
 
 #: builtin/gc.c:93
 #, c-format
 msgid "Failed to fstat %s: %s"
-msgstr ""
+msgstr "Gagal men-fstat %s: %s"
 
 #: builtin/gc.c:129
 #, c-format
 msgid "failed to parse '%s' value '%s'"
-msgstr ""
+msgstr "gagal menguraikan nilai '%s' '%s'"
 
 #: builtin/gc.c:487 builtin/init-db.c:57
 #, c-format
 msgid "cannot stat '%s'"
-msgstr ""
+msgstr "tidak dapat men-stat '%s'"
 
-#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:573
+#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
 #, c-format
 msgid "cannot read '%s'"
-msgstr ""
+msgstr "tidak dapat membaca '%s'"
 
 #: builtin/gc.c:503
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
-"and remove %s.\n"
+"and remove %s\n"
 "Automatic cleanup will not be performed until the file is removed.\n"
 "\n"
 "%s"
 msgstr ""
+"Aksi gc terakhir melaporkan berikut. Mohon koreksi akar masalah\n"
+"dan hapus %s\n"
+"Pembersihan otomatis tidak akan dilakukan sampai berkas dihapus.\n"
+"\n"
+"%s"
 
 #: builtin/gc.c:551
 msgid "prune unreferenced objects"
-msgstr ""
+msgstr "pangkas objek tak tereferensi"
 
 #: builtin/gc.c:553
 msgid "be more thorough (increased runtime)"
-msgstr ""
+msgstr "jadi lebih cermat (waktu yang dijalankan bertambah)"
 
 #: builtin/gc.c:554
 msgid "enable auto-gc mode"
-msgstr ""
+msgstr "aktifkan mode gc otomatis"
 
 #: builtin/gc.c:557
 msgid "force running gc even if there may be another gc running"
-msgstr ""
+msgstr "paksa jalankan gc bahkan jika mungkin ada gc lain yang berjalan"
 
 #: builtin/gc.c:560
 msgid "repack all other packs except the largest pack"
-msgstr ""
+msgstr "pak ulang semua pak yang lain kecuali pak terbesar"
 
 #: builtin/gc.c:576
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
-msgstr ""
+msgstr "gagal menguraikan nilai gc.logexpiry %s"
 
 #: builtin/gc.c:587
 #, c-format
 msgid "failed to parse prune expiry value %s"
-msgstr ""
+msgstr "gagal menguraikan nilai pangkas kadaluarsa %s"
 
 #: builtin/gc.c:607
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
-msgstr ""
+msgstr "Mempak otomatis repositori di latar belakang untuk performa optimal.\n"
 
 #: builtin/gc.c:609
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
-msgstr ""
+msgstr "Mempak otomatis repositori untuk performa optimal.\n"
 
 #: builtin/gc.c:610
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
-msgstr ""
+msgstr "Lihat \"git help gc\" untuk pembenahan manual.\n"
 
 #: builtin/gc.c:650
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
 msgstr ""
+"gc sudah berjalan pada mesin '%s' pid %<PRIuMAX> (gunakan --force jika tidak)"
 
 #: builtin/gc.c:705
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
+"Ada terlalu banyak objek longgar yang tak dapat dicapai; jalankan 'git "
+"prune' untuk menghapusnya."
 
 #: builtin/gc.c:715
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr ""
+"git maintenance run [--auto] [--[no-]quiet] [--task=<tugas>] [--schedule]"
 
 #: builtin/gc.c:745
 msgid "--no-schedule is not allowed"
-msgstr ""
+msgstr "--no-schedule tidak diperbolehkan"
 
 #: builtin/gc.c:750
 #, c-format
 msgid "unrecognized --schedule argument '%s'"
-msgstr ""
+msgstr "argumen --schedule tidak dikenal '%s'"
 
-#: builtin/gc.c:869
+#: builtin/gc.c:868
 msgid "failed to write commit-graph"
-msgstr ""
+msgstr "gagal menulis grafik komit"
 
-#: builtin/gc.c:905
+#: builtin/gc.c:904
 msgid "failed to prefetch remotes"
-msgstr ""
+msgstr "gagal mem-praambil remote"
 
-#: builtin/gc.c:1022
+#: builtin/gc.c:1020
 msgid "failed to start 'git pack-objects' process"
-msgstr ""
+msgstr "gagal memulai proses 'git pack-objects'"
 
-#: builtin/gc.c:1039
+#: builtin/gc.c:1037
 msgid "failed to finish 'git pack-objects' process"
-msgstr ""
+msgstr "gagal menyelesaikan proses 'git pack-objects'"
 
-#: builtin/gc.c:1091
+#: builtin/gc.c:1089
 msgid "failed to write multi-pack-index"
-msgstr ""
+msgstr "gagal menulis indeks multipak"
 
-#: builtin/gc.c:1109
+#: builtin/gc.c:1105
 msgid "'git multi-pack-index expire' failed"
-msgstr ""
+msgstr "'git multi-pack-index expire' gagal"
 
-#: builtin/gc.c:1170
+#: builtin/gc.c:1164
 msgid "'git multi-pack-index repack' failed"
-msgstr ""
+msgstr "'git multi-pack-index repack' gagal"
 
-#: builtin/gc.c:1179
+#: builtin/gc.c:1173
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
+"melewatkan tugas pengepakan tambahan karena core.multiPackIndex dinonaktifkan"
 
-#: builtin/gc.c:1283
+#: builtin/gc.c:1277
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
-msgstr ""
+msgstr "berkas kunci '%s' ada, melewatkan pemeliharaan"
 
-#: builtin/gc.c:1313
+#: builtin/gc.c:1307
 #, c-format
 msgid "task '%s' failed"
-msgstr ""
+msgstr "tugas '%s' gagal"
 
-#: builtin/gc.c:1395
+#: builtin/gc.c:1389
 #, c-format
 msgid "'%s' is not a valid task"
-msgstr ""
+msgstr "'%s' bukan tugas yang valid"
 
-#: builtin/gc.c:1400
+#: builtin/gc.c:1394
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
-msgstr ""
+msgstr "tugas '%s' tidak dapat dipilih berulang kali"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1409
 msgid "run tasks based on the state of the repository"
-msgstr ""
+msgstr "jalankan tugas berdasarkan keadaan repositori"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1410
 msgid "frequency"
-msgstr ""
+msgstr "frekuensi"
 
-#: builtin/gc.c:1417
+#: builtin/gc.c:1411
 msgid "run tasks based on frequency"
-msgstr ""
+msgstr "jalankan tugas berdasarkan frekuensi"
 
-#: builtin/gc.c:1420
+#: builtin/gc.c:1414
 msgid "do not report progress or other information over stderr"
 msgstr ""
+"jangan laporkan perkembangan atau informasi lainnya ke kesalahan standar"
 
-#: builtin/gc.c:1421
+#: builtin/gc.c:1415
 msgid "task"
-msgstr ""
+msgstr "tugas"
 
-#: builtin/gc.c:1422
+#: builtin/gc.c:1416
 msgid "run a specific task"
-msgstr ""
+msgstr "jalankan tugas spesifik"
 
-#: builtin/gc.c:1439
+#: builtin/gc.c:1433
 msgid "use at most one of --auto and --schedule=<frequency>"
-msgstr ""
+msgstr "gunakan paling banyak satu dari --auto dan --schedule=<frekuensi>"
 
-#: builtin/gc.c:1482
+#: builtin/gc.c:1476
 msgid "failed to run 'git config'"
-msgstr ""
+msgstr "gagal menjalankan 'git config'"
 
-#: builtin/gc.c:1547
+#: builtin/gc.c:1628
 #, c-format
 msgid "failed to expand path '%s'"
-msgstr ""
+msgstr "gagal memperluas jalur '%s'"
 
-#: builtin/gc.c:1576
+#: builtin/gc.c:1655 builtin/gc.c:1693
 msgid "failed to start launchctl"
-msgstr ""
+msgstr "gagal menjalankan launchctl"
 
-#: builtin/gc.c:1613
+#: builtin/gc.c:1768 builtin/gc.c:2221
 #, c-format
 msgid "failed to create directories for '%s'"
-msgstr ""
+msgstr "gagal membuat direktori untuk '%s'"
 
-#: builtin/gc.c:1674
+#: builtin/gc.c:1795
 #, c-format
 msgid "failed to bootstrap service %s"
-msgstr ""
+msgstr "gagal men-tali-botkan layanan %s"
 
-#: builtin/gc.c:1745
+#: builtin/gc.c:1888
 msgid "failed to create temp xml file"
-msgstr ""
+msgstr "gagal membuat berkas xml sementara"
 
-#: builtin/gc.c:1835
+#: builtin/gc.c:1978
 msgid "failed to start schtasks"
-msgstr ""
+msgstr "gagal menjalankan schtasks"
 
-#: builtin/gc.c:1879
+#: builtin/gc.c:2047
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
+"gagal menjalankan 'crontab -l'; sistem Anda mungkin tidak mendukung 'cron'"
 
-#: builtin/gc.c:1896
+#: builtin/gc.c:2064
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
+"gagal menjalankan 'crontab'; sistem Anda mungkin tidak mendukung 'cron'"
 
-#: builtin/gc.c:1900
+#: builtin/gc.c:2068
 msgid "failed to open stdin of 'crontab'"
-msgstr ""
+msgstr "gagal membuka masukan standar dari 'crontab'"
 
-#: builtin/gc.c:1942
+#: builtin/gc.c:2110
 msgid "'crontab' died"
-msgstr ""
+msgstr "'crontab' mati"
 
-#: builtin/gc.c:1976
+#: builtin/gc.c:2175
+msgid "failed to start systemctl"
+msgstr "gagal memulai systemctl"
+
+#: builtin/gc.c:2185
+msgid "failed to run systemctl"
+msgstr "gagal menjalankan systemctl"
+
+#: builtin/gc.c:2194 builtin/gc.c:2199 builtin/worktree.c:62
+#: builtin/worktree.c:945
+#, c-format
+msgid "failed to delete '%s'"
+msgstr "gagal menghapus '%s'"
+
+#: builtin/gc.c:2379
+#, c-format
+msgid "unrecognized --scheduler argument '%s'"
+msgstr "argumen --scheduler tidak dikenal '%s'"
+
+#: builtin/gc.c:2404
+msgid "neither systemd timers nor crontab are available"
+msgstr "baik pewaktu systemd atau crontab tidak tersedia"
+
+#: builtin/gc.c:2419
+#, c-format
+msgid "%s scheduler is not available"
+msgstr "penjadwal %s tidak tersedia"
+
+#: builtin/gc.c:2433
 msgid "another process is scheduling background maintenance"
-msgstr ""
+msgstr "proses lainnya sedang menjadwalkan peme"
 
-#: builtin/gc.c:2000
+#: builtin/gc.c:2455
+msgid "git maintenance start [--scheduler=<scheduler>]"
+msgstr "git maintenance start [--scheduler=<penjadwal>]"
+
+#: builtin/gc.c:2464
+msgid "scheduler"
+msgstr "penjadwal"
+
+#: builtin/gc.c:2465
+msgid "scheduler to trigger git maintenance run"
+msgstr "penjadwal untuk memicu git maintenance run"
+
+#: builtin/gc.c:2479
 msgid "failed to add repo to global config"
-msgstr ""
+msgstr "gagal menambahkan repositori ke konfigurasi global"
 
-#: builtin/gc.c:2010
+#: builtin/gc.c:2488
 msgid "git maintenance <subcommand> [<options>]"
-msgstr ""
+msgstr "git maintenance <subperintah> [<opsi>]"
 
-#: builtin/gc.c:2029
+#: builtin/gc.c:2507
 #, c-format
 msgid "invalid subcommand: %s"
-msgstr ""
+msgstr "subperintah tidak valid: %s"
 
 #: builtin/grep.c:30
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [<opsi>] [-e] <pola> [<revisi>...] [[--] <pola>...]"
 
-#: builtin/grep.c:223
+#: builtin/grep.c:239
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: gagal membuat utas: %s"
 
-#: builtin/grep.c:277
+#: builtin/grep.c:293
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "jumlah utas yang diberikan (%d) tidak valid untuk %s"
@@ -15299,357 +15664,372 @@ msgstr "jumlah utas yang diberikan (%d) tidak valid untuk %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1588 builtin/index-pack.c:1791
-#: builtin/pack-objects.c:3129
+#: builtin/grep.c:301 builtin/index-pack.c:1582 builtin/index-pack.c:1785
+#: builtin/pack-objects.c:3142
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "tidak ada dukungan utas, abaikan %s"
 
-#: builtin/grep.c:473 builtin/grep.c:603 builtin/grep.c:643
+#: builtin/grep.c:488 builtin/grep.c:617 builtin/grep.c:657
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "tidak dapat membaca pohon (%s)"
 
-#: builtin/grep.c:658
+#: builtin/grep.c:672
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "tidak dapan men-grep dari objek dengan tipe %s"
 
-#: builtin/grep.c:738
+#: builtin/grep.c:752
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "saklar '%c' mengharapkan nilai numerik"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:851
 msgid "search in index instead of in the work tree"
 msgstr "cari dalam index daripada dalam pohon kerja"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:853
 msgid "find in contents not managed by git"
 msgstr "temukan dalam konten yang tak dikelola oleh git"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:855
 msgid "search in both tracked and untracked files"
 msgstr "cari dalam berkas terlacak dan tak terlacak"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:857
 msgid "ignore files specified via '.gitignore'"
 msgstr "abaikan berkas yang disebutkan via '.gitignore'"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:859
 msgid "recursively search in each submodule"
 msgstr "cari secara rekursif dalam setiap submodul"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:862
 msgid "show non-matching lines"
 msgstr "perlihatkan baris nir-cocok"
 
-#: builtin/grep.c:850
+#: builtin/grep.c:864
 msgid "case insensitive matching"
 msgstr "pencocokan tak peka kapital"
 
-#: builtin/grep.c:852
+#: builtin/grep.c:866
 msgid "match patterns only at word boundaries"
 msgstr "cocokkan pola hanya pada batas kata"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:868
 msgid "process binary files as text"
 msgstr "proses berkas biner sebagai teks"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:870
 msgid "don't match patterns in binary files"
 msgstr "jangan cocokkan pola pada berkas biner"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:873
 msgid "process binary files with textconv filters"
 msgstr "proses berkas biner dengan saringan textconv"
 
-#: builtin/grep.c:861
+#: builtin/grep.c:875
 msgid "search in subdirectories (default)"
 msgstr "cari dalam subdirektori (asali)"
 
-#: builtin/grep.c:863
+#: builtin/grep.c:877
 msgid "descend at most <depth> levels"
 msgstr "turun paling banyak <kedalaman> tingkat"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:881
 msgid "use extended POSIX regular expressions"
 msgstr "gunakan ekspresi reguler POSIX diperpanjang"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:884
 msgid "use basic POSIX regular expressions (default)"
 msgstr "gunakan ekspresi reguler POSIX dasar (asali)"
 
-#: builtin/grep.c:873
+#: builtin/grep.c:887
 msgid "interpret patterns as fixed strings"
 msgstr "tafsirkan pola sebagai untai tetap"
 
-#: builtin/grep.c:876
+#: builtin/grep.c:890
 msgid "use Perl-compatible regular expressions"
 msgstr "gunakan ekspresi reguler kompatibel dengan Perl"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:893
 msgid "show line numbers"
 msgstr "perlihatkan nomor baris"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:894
 msgid "show column number of first match"
 msgstr "perlihatkan nomor kolom cocokan pertama"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:895
 msgid "don't show filenames"
 msgstr "jangan perlihatkan nama berkas"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:896
 msgid "show filenames"
 msgstr "perlihatkan nama berkas"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:898
 msgid "show filenames relative to top directory"
 msgstr "perlihatkan nama berkas relatif terhadap direktori puncak"
 
-#: builtin/grep.c:886
+#: builtin/grep.c:900
 msgid "show only filenames instead of matching lines"
 msgstr "hanya perlihatkan nama berkas daripada baris yang cocok"
 
-#: builtin/grep.c:888
+#: builtin/grep.c:902
 msgid "synonym for --files-with-matches"
 msgstr "sinonim untuk --files-with-matches"
 
-#: builtin/grep.c:891
+#: builtin/grep.c:905
 msgid "show only the names of files without match"
 msgstr "hanya perlihatkan nama berkas tanpa cocok"
 
-#: builtin/grep.c:893
+#: builtin/grep.c:907
 msgid "print NUL after filenames"
 msgstr "cetak NUL setelah nama berkas"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:910
 msgid "show only matching parts of a line"
 msgstr "hanya perlihatkan bagian cocokan baris"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:912
 msgid "show the number of matches instead of matching lines"
 msgstr "perlihatkan jumlah cocokan daripada baris yang cocok"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:913
 msgid "highlight matches"
 msgstr "sorot cocokan"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:915
 msgid "print empty line between matches from different files"
 msgstr "cetak baris kosong di antara cocokan dari berkas yang berbeda"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:917
 msgid "show filename only once above matches from same file"
 msgstr ""
 "perlihatkan nama berkas hanya sekali di atas cocokan dari berkas yang sama"
 
-#: builtin/grep.c:906
+#: builtin/grep.c:920
 msgid "show <n> context lines before and after matches"
 msgstr "perlihatkan <n> baris konteks sebelum dan sesudah cocokan"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:923
 msgid "show <n> context lines before matches"
 msgstr "perlihatkan <n> baris konteks sebelum cocokan"
 
-#: builtin/grep.c:911
+#: builtin/grep.c:925
 msgid "show <n> context lines after matches"
 msgstr "perlihatkan <n> baris konteks setelah cocokan"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:927
 msgid "use <n> worker threads"
 msgstr "gunakan <n> utas pekerja"
 
-#: builtin/grep.c:914
+#: builtin/grep.c:928
 msgid "shortcut for -C NUM"
 msgstr "pintasan untuk -C NUM"
 
-#: builtin/grep.c:917
+#: builtin/grep.c:931
 msgid "show a line with the function name before matches"
 msgstr "perlihatkan sebuah baris dengan nama fungsi sebelum cocokan"
 
-#: builtin/grep.c:919
+#: builtin/grep.c:933
 msgid "show the surrounding function"
 msgstr "perlihatkan fungsi di sekitar"
 
-#: builtin/grep.c:922
+#: builtin/grep.c:936
 msgid "read patterns from file"
 msgstr "baca pola dari berkas"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:938
 msgid "match <pattern>"
 msgstr "cocokkan <pola>"
 
-#: builtin/grep.c:926
+#: builtin/grep.c:940
 msgid "combine patterns specified with -e"
 msgstr "kombinasikan pola yang disebutkan dengan -e"
 
-#: builtin/grep.c:938
+#: builtin/grep.c:952
 msgid "indicate hit with exit status without output"
 msgstr "tunjukkan kena dengan status keluar tanpa keluaran"
 
-#: builtin/grep.c:940
+#: builtin/grep.c:954
 msgid "show only matches from files that match all patterns"
 msgstr "hanya perlihatkan cocokan dari berkas yang cocok dengan semua pola"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "pager"
 msgstr "penghalaman"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "show matching files in the pager"
 msgstr "perlihatkan berkas yang cocok dalam penghalaman"
 
-#: builtin/grep.c:947
+#: builtin/grep.c:961
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "perbolehkan pemanggilan grep(1) (diabaikan oleh bangunan ini)"
 
-#: builtin/grep.c:1013
+#: builtin/grep.c:1027
 msgid "no pattern given"
 msgstr "tidak ada pola yang diberikan"
 
-#: builtin/grep.c:1049
+#: builtin/grep.c:1063
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index atau --untracked tidak dapat digunakan dengan revisi"
 
-#: builtin/grep.c:1057
+#: builtin/grep.c:1071
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "tidak dapat menguraikan revisi: %s"
 
-#: builtin/grep.c:1087
+#: builtin/grep.c:1101
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked tidak didukung dengan --recurse-submodules"
 
-#: builtin/grep.c:1091
+#: builtin/grep.c:1105
 msgid "invalid option combination, ignoring --threads"
 msgstr "kombinasi opsi tidak valid, abaikan --threads"
 
-#: builtin/grep.c:1094 builtin/pack-objects.c:4090
+#: builtin/grep.c:1108 builtin/pack-objects.c:4059
 msgid "no threads support, ignoring --threads"
 msgstr "tidak ada dukungan utas, abaikan --threads"
 
-#: builtin/grep.c:1097 builtin/index-pack.c:1585 builtin/pack-objects.c:3126
+#: builtin/grep.c:1111 builtin/index-pack.c:1579 builtin/pack-objects.c:3139
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "jumlah utas tersebut (%d) tidak valid"
 
-#: builtin/grep.c:1131
+#: builtin/grep.c:1145
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "--open-files-in-pager hanya bekerja pada pohon kerja"
 
-#: builtin/grep.c:1157
+#: builtin/grep.c:1171
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached atau --untracked tidak dapat digunakan dengan --no-index"
 
-#: builtin/grep.c:1160
+#: builtin/grep.c:1174
 msgid "--untracked cannot be used with --cached"
 msgstr "--untracked tidak dapat digunakan dengan --cached"
 
-#: builtin/grep.c:1166
+#: builtin/grep.c:1180
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr "--[no-]exclude-standard tidak dapat digunakan untuk konten terlacak"
 
-#: builtin/grep.c:1174
+#: builtin/grep.c:1188
 msgid "both --cached and trees are given"
 msgstr "baik --cached dan pohon diberikan"
 
-#: builtin/hash-object.c:85
+#: builtin/hash-object.c:83
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file> | --no-filters] [--stdin] "
 "[--] <file>..."
 msgstr ""
+"git hash-object [-t <tipe>] [-w] [--path=<berkas> | --no-filters] [--stdin] "
+"[--] <berkas>..."
 
-#: builtin/hash-object.c:86
+#: builtin/hash-object.c:84
 msgid "git hash-object  --stdin-paths"
-msgstr ""
+msgstr "git hash-object  --stdin-paths"
 
-#: builtin/hash-object.c:98
+#: builtin/hash-object.c:96
 msgid "object type"
-msgstr ""
+msgstr "tipe objek"
+
+#: builtin/hash-object.c:97
+msgid "write the object into the object database"
+msgstr "tulis objek ke dalam basis data objek"
 
 #: builtin/hash-object.c:99
-msgid "write the object into the object database"
-msgstr ""
+msgid "read the object from stdin"
+msgstr "baca objek dari masukan standar"
 
 #: builtin/hash-object.c:101
-msgid "read the object from stdin"
-msgstr ""
-
-#: builtin/hash-object.c:103
 msgid "store file as is without filters"
-msgstr ""
+msgstr "simpan berkas apa adanya tanpa penyaring"
 
-#: builtin/hash-object.c:104
+#: builtin/hash-object.c:102
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr ""
+"hanya hash sampah acak apapun untuk membuat objek rusak demi menirkutukan Git"
 
-#: builtin/hash-object.c:105
+#: builtin/hash-object.c:103
 msgid "process file as it were from this path"
-msgstr ""
+msgstr "proses berkas seperti dari jalur ini"
 
-#: builtin/help.c:47
+#: builtin/help.c:55
 msgid "print all available commands"
 msgstr "cetak semua perintah yang tersedia"
 
-#: builtin/help.c:48
+#: builtin/help.c:57
 msgid "exclude guides"
 msgstr "kecualikan panduan"
 
-#: builtin/help.c:49
-msgid "print list of useful guides"
-msgstr "cetak daftar panduan berguna"
-
-#: builtin/help.c:50
-msgid "print all configuration variable names"
-msgstr "cetak semua nama variabel konfigurasi"
-
-#: builtin/help.c:52
+#: builtin/help.c:58
 msgid "show man page"
 msgstr "perlihatkan halaman man"
 
-#: builtin/help.c:53
+#: builtin/help.c:59
 msgid "show manual in web browser"
 msgstr "perlihatkan manual dalam penjelajah web"
 
-#: builtin/help.c:55
+#: builtin/help.c:61
 msgid "show info page"
 msgstr "perlihatkan halaman info"
 
-#: builtin/help.c:57
+#: builtin/help.c:63
 msgid "print command description"
 msgstr "perlihatkan deskripsi perintah"
 
-#: builtin/help.c:62
-msgid "git help [--all] [--guides] [--man | --web | --info] [<command>]"
-msgstr "git help [--all] [--guides] [--man | --web | --info] [<command>]"
+#: builtin/help.c:65
+msgid "print list of useful guides"
+msgstr "cetak daftar panduan berguna"
 
-#: builtin/help.c:163
+#: builtin/help.c:67
+msgid "print all configuration variable names"
+msgstr "cetak semua nama variabel konfigurasi"
+
+#: builtin/help.c:78
+msgid ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
+msgstr ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<perintah>]"
+
+#: builtin/help.c:80
+msgid "git help [-g|--guides]"
+msgstr ""
+
+#: builtin/help.c:81
+msgid "git help [-c|--config]"
+msgstr ""
+
+#: builtin/help.c:196
 #, c-format
 msgid "unrecognized help format '%s'"
 msgstr "format bantuan tidak dikenal '%s'"
 
-#: builtin/help.c:190
+#: builtin/help.c:223
 msgid "Failed to start emacsclient."
 msgstr "gagal menjalankan emacsclient."
 
-#: builtin/help.c:203
+#: builtin/help.c:236
 msgid "Failed to parse emacsclient version."
 msgstr "gagal menguraikan versi emacsclient."
 
-#: builtin/help.c:211
+#: builtin/help.c:244
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "versi emacsclient '%d' terlalu usang (< 22)."
 
-#: builtin/help.c:229 builtin/help.c:251 builtin/help.c:261 builtin/help.c:269
+#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "gagal menjalankan '%s'"
 
-#: builtin/help.c:307
+#: builtin/help.c:340
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -15658,7 +16038,7 @@ msgstr ""
 "'%s': jalur untuk pembaca man yang tidak didukung.\n"
 "Mohon gunakan 'man.<tool>.cmd' sebagai gantinya."
 
-#: builtin/help.c:319
+#: builtin/help.c:352
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -15667,331 +16047,322 @@ msgstr ""
 "'%s': cmd untuk pembaca man yang didukung.\n"
 "Mohon gunakan 'man.<tool>.path' sebagai gantinya."
 
-#: builtin/help.c:436
+#: builtin/help.c:467
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "'%s': pembaca man tidak dikenal"
 
-#: builtin/help.c:452
+#: builtin/help.c:483
 msgid "no man viewer handled the request"
 msgstr "tidak ada pembaca man yang menangani permintaan"
 
-#: builtin/help.c:459
+#: builtin/help.c:490
 msgid "no info viewer handled the request"
 msgstr "tidak ada pembaca info yang menangani permintaan"
 
-#: builtin/help.c:517 builtin/help.c:528 git.c:348
+#: builtin/help.c:551 builtin/help.c:562 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "'%s' dialiaskan ke '%s'"
 
-#: builtin/help.c:531 git.c:380
+#: builtin/help.c:565 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "untai alias.%s jelek: %s"
 
-#: builtin/help.c:561 builtin/help.c:591
+#: builtin/help.c:581
+msgid "this option doesn't take any other arguments"
+msgstr "opsi ini tidak mengambil argumen lainnya"
+
+#: builtin/help.c:602 builtin/help.c:629
 #, c-format
 msgid "usage: %s%s"
 msgstr "penggunaan: %s%s"
 
-#: builtin/help.c:575
+#: builtin/help.c:624
 msgid "'git help config' for more information"
 msgstr "'git help config' untuk informasi lebih lanjut"
 
-#: builtin/index-pack.c:222
+#: builtin/index-pack.c:221
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "tipe objek tidak cocok pada %s"
 
-#: builtin/index-pack.c:242
+#: builtin/index-pack.c:241
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "tidak menerima objek yang diharapkan %s"
 
-#: builtin/index-pack.c:245
+#: builtin/index-pack.c:244
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "objek %s: yang diharapkan %s, yang didapat %s"
 
-#: builtin/index-pack.c:295
+#: builtin/index-pack.c:294
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:305
+#: builtin/index-pack.c:304
 msgid "early EOF"
 msgstr "EOF awal"
 
-#: builtin/index-pack.c:306
+#: builtin/index-pack.c:305
 msgid "read error on input"
 msgstr "kesalahan baca pada masukan"
 
-#: builtin/index-pack.c:318
+#: builtin/index-pack.c:317
 msgid "used more bytes than were available"
 msgstr "gunakan lebih banyak pita dari pada yang tersedia"
 
-#: builtin/index-pack.c:325 builtin/pack-objects.c:756
+#: builtin/index-pack.c:324 builtin/pack-objects.c:756
 msgid "pack too large for current definition of off_t"
 msgstr "paket terlalu besar untuk definisi off_t saat ini"
 
-#: builtin/index-pack.c:328 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "paket melebihi ukuran maksimum yang diperbolehkan"
 
-#: builtin/index-pack.c:343
-#, c-format
-msgid "unable to create '%s'"
-msgstr "tidak dapat membuat '%s'"
-
-#: builtin/index-pack.c:349
-#, c-format
-msgid "cannot open packfile '%s'"
-msgstr "tidak dapat membuka berkas paket '%s'"
-
-#: builtin/index-pack.c:363
+#: builtin/index-pack.c:358
 msgid "pack signature mismatch"
 msgstr "tanda tangan paket tidak cocok"
 
-#: builtin/index-pack.c:365
+#: builtin/index-pack.c:360
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "versi paket %<PRIu32> tidak didukung"
 
-#: builtin/index-pack.c:381
+#: builtin/index-pack.c:376
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "paket ada objek jelek pada offset %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:487
+#: builtin/index-pack.c:482
 #, c-format
 msgid "inflate returned %d"
 msgstr "inflate mengembalikan %d"
 
-#: builtin/index-pack.c:536
+#: builtin/index-pack.c:531
 msgid "offset value overflow for delta base object"
 msgstr "nilai offset meluap untuk objek basis delta"
 
-#: builtin/index-pack.c:544
+#: builtin/index-pack.c:539
 msgid "delta base offset is out of bound"
 msgstr "offset basis delta di luar jangkauan"
 
-#: builtin/index-pack.c:552
+#: builtin/index-pack.c:547
 #, c-format
 msgid "unknown object type %d"
 msgstr "tipe objek tidak diketahui %d"
 
-#: builtin/index-pack.c:583
+#: builtin/index-pack.c:578
 msgid "cannot pread pack file"
 msgstr "tidak dapat pread berkas paket"
 
-#: builtin/index-pack.c:585
+#: builtin/index-pack.c:580
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:611
+#: builtin/index-pack.c:606
 msgid "serious inflate inconsistency"
 msgstr "inkonsistensi inflate serius"
 
-#: builtin/index-pack.c:756 builtin/index-pack.c:762 builtin/index-pack.c:786
-#: builtin/index-pack.c:825 builtin/index-pack.c:834
+#: builtin/index-pack.c:751 builtin/index-pack.c:757 builtin/index-pack.c:781
+#: builtin/index-pack.c:820 builtin/index-pack.c:829
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "TUMBUKAN SHA1 DITEMUKAN DENGAN %s !"
 
-#: builtin/index-pack.c:759 builtin/pack-objects.c:292
+#: builtin/index-pack.c:754 builtin/pack-objects.c:292
 #: builtin/pack-objects.c:352 builtin/pack-objects.c:458
 #, c-format
 msgid "unable to read %s"
 msgstr "tidak dapat membaca %s"
 
-#: builtin/index-pack.c:823
+#: builtin/index-pack.c:818
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "tidak dapat membaca info objek yang ada %s"
 
-#: builtin/index-pack.c:831
+#: builtin/index-pack.c:826
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "tidak dapat membaca objek yang ada %s"
 
-#: builtin/index-pack.c:845
+#: builtin/index-pack.c:840
 #, c-format
 msgid "invalid blob object %s"
 msgstr "objek blob tidak valid %s"
 
-#: builtin/index-pack.c:848 builtin/index-pack.c:867
+#: builtin/index-pack.c:843 builtin/index-pack.c:862
 msgid "fsck error in packed object"
 msgstr "kesalahan fsck dalam objek terpaket"
 
-#: builtin/index-pack.c:869
+#: builtin/index-pack.c:864
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Tidak semua objek anak dari %s bisa dicapai"
 
-#: builtin/index-pack.c:930 builtin/index-pack.c:977
+#: builtin/index-pack.c:925 builtin/index-pack.c:972
 msgid "failed to apply delta"
 msgstr "gagal menerapkan delta"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Receiving objects"
 msgstr "Menerima objek"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Indexing objects"
 msgstr "Mengindeks objek"
 
-#: builtin/index-pack.c:1194
+#: builtin/index-pack.c:1190
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "paket rusak (SHA1 tidak cocok)"
 
-#: builtin/index-pack.c:1199
+#: builtin/index-pack.c:1195
 msgid "cannot fstat packfile"
 msgstr "tidak dapat fstat berkas paket"
 
-#: builtin/index-pack.c:1202
+#: builtin/index-pack.c:1198
 msgid "pack has junk at the end"
 msgstr "paket memiliki sampah pada ujung"
 
-#: builtin/index-pack.c:1214
+#: builtin/index-pack.c:1210
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "bingung di luar kegilaan di parse_pack_objects()"
 
-#: builtin/index-pack.c:1237
+#: builtin/index-pack.c:1233
 msgid "Resolving deltas"
 msgstr "Menguraikan delta"
 
-#: builtin/index-pack.c:1248 builtin/pack-objects.c:2892
+#: builtin/index-pack.c:1244 builtin/pack-objects.c:2905
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "tidak dapat membuat utas: %s"
 
-#: builtin/index-pack.c:1281
+#: builtin/index-pack.c:1277
 msgid "confusion beyond insanity"
 msgstr "bingung di luar kegilaan"
 
-#: builtin/index-pack.c:1287
+#: builtin/index-pack.c:1283
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1299
+#: builtin/index-pack.c:1295
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Checksum ekor tidak diharapkan untuk %s (kerusakan disk?)"
 
-#: builtin/index-pack.c:1303
+#: builtin/index-pack.c:1299
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1327
+#: builtin/index-pack.c:1323
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "tidak dapat menggemboskan objek tertambah (%d)"
 
-#: builtin/index-pack.c:1423
+#: builtin/index-pack.c:1419
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "objek lokal %s rusak"
 
-#: builtin/index-pack.c:1444
+#: builtin/index-pack.c:1440
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "nama berkas paket '%s' tidak diakhiri dengan '.%s'"
 
-#: builtin/index-pack.c:1468
+#: builtin/index-pack.c:1464
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "tidak dapat menulis %s berkas '%s'"
 
-#: builtin/index-pack.c:1476
+#: builtin/index-pack.c:1472
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "tidak dapat menutup %s berkas tertulis '%s'"
 
-#: builtin/index-pack.c:1502
+#: builtin/index-pack.c:1489
+#, c-format
+msgid "unable to rename temporary '*.%s' file to '%s"
+msgstr "tidak dapat menamai ulang berkas '*.%s' sementara ke '%s'"
+
+#: builtin/index-pack.c:1514
 msgid "error while closing pack file"
 msgstr "kesalahan menutup berkas paket"
 
-#: builtin/index-pack.c:1516
-msgid "cannot store pack file"
-msgstr "tidak dapat menyimpan berkas paket"
-
-#: builtin/index-pack.c:1524
-msgid "cannot store index file"
-msgstr "tidak dapat menyimpan berkas indeks"
-
-#: builtin/index-pack.c:1579 builtin/pack-objects.c:3137
+#: builtin/index-pack.c:1573 builtin/pack-objects.c:3150
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "pack.indexversion=%<PRIu32> jelek"
 
-#: builtin/index-pack.c:1649
+#: builtin/index-pack.c:1643
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "tidak dapat membuka berkas paket yang ada '%s'"
 
-#: builtin/index-pack.c:1651
+#: builtin/index-pack.c:1645
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "tidak dapat membuka berkas indeks paket untuk '%s'"
 
-#: builtin/index-pack.c:1699
+#: builtin/index-pack.c:1693
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1706
+#: builtin/index-pack.c:1700
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1748
+#: builtin/index-pack.c:1742
 msgid "Cannot come back to cwd"
 msgstr "tidak dapat kembali ke direktori kerja saat ini"
 
-#: builtin/index-pack.c:1802 builtin/index-pack.c:1805
-#: builtin/index-pack.c:1821 builtin/index-pack.c:1825
+#: builtin/index-pack.c:1796 builtin/index-pack.c:1799
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1823
 #, c-format
 msgid "bad %s"
 msgstr "%s jelek"
 
-#: builtin/index-pack.c:1831 builtin/init-db.c:379 builtin/init-db.c:614
+#: builtin/index-pack.c:1829 builtin/init-db.c:379 builtin/init-db.c:614
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algoritma hash tak dikenal '%s'"
 
-#: builtin/index-pack.c:1850
+#: builtin/index-pack.c:1848
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin tidak dapat digunakan tanpa --stdin"
 
-#: builtin/index-pack.c:1852
+#: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "--stdin memerlukan repositori git"
 
-#: builtin/index-pack.c:1854
+#: builtin/index-pack.c:1852
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format tidak dapat digunakan dengan --stdin"
 
-#: builtin/index-pack.c:1869
+#: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
 msgstr "--verify tanpa nama berkas paket diberikan"
 
-#: builtin/index-pack.c:1935 builtin/unpack-objects.c:584
+#: builtin/index-pack.c:1933 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "kesalahan fsck dalam objek paket"
 
@@ -16631,192 +17002,203 @@ msgstr ""
 "Tidak dapat menemukan cabang remote terlacak, mohon sebutkan <hulu>\n"
 "secara manual.\n"
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:561
 msgid "git ls-files [<options>] [<file>...]"
-msgstr ""
+msgstr "git ls-files [<opsi>] [<berkas>...]"
+
+#: builtin/ls-files.c:615
+msgid "separate paths with the NUL character"
+msgstr "pisahkan jalur dengan karakter NUL"
+
+#: builtin/ls-files.c:617
+msgid "identify the file status with tags"
+msgstr "identifikasi status berkas dengan tag"
 
 #: builtin/ls-files.c:619
-msgid "identify the file status with tags"
-msgstr ""
+msgid "use lowercase letters for 'assume unchanged' files"
+msgstr "gunakan huruf kecil untuk berkas 'asumsikan tak berubah'"
 
 #: builtin/ls-files.c:621
-msgid "use lowercase letters for 'assume unchanged' files"
-msgstr ""
+msgid "use lowercase letters for 'fsmonitor clean' files"
+msgstr "gunakan huruf kecil untuk berkas 'fsmonitor bersih'"
 
 #: builtin/ls-files.c:623
-msgid "use lowercase letters for 'fsmonitor clean' files"
-msgstr ""
+msgid "show cached files in the output (default)"
+msgstr "perlihatkan berkas tertembolok di dalam keluaran (asali)"
 
 #: builtin/ls-files.c:625
-msgid "show cached files in the output (default)"
-msgstr ""
+msgid "show deleted files in the output"
+msgstr "perlihatkan berkas yang dihapus di dalam keluaran"
 
 #: builtin/ls-files.c:627
-msgid "show deleted files in the output"
-msgstr ""
+msgid "show modified files in the output"
+msgstr "perlihatkan berkas yang berubah di dalam keluaran"
 
 #: builtin/ls-files.c:629
-msgid "show modified files in the output"
-msgstr ""
+msgid "show other files in the output"
+msgstr "perlihatkan berkas lainnya di dalam keluaran"
 
 #: builtin/ls-files.c:631
-msgid "show other files in the output"
-msgstr ""
-
-#: builtin/ls-files.c:633
 msgid "show ignored files in the output"
-msgstr ""
+msgstr "perlihatkan berkas terabaikan di dalam keluaran"
+
+#: builtin/ls-files.c:634
+msgid "show staged contents' object name in the output"
+msgstr "perlihatkan nama objek dari konten tergelar di dalam keluaran"
 
 #: builtin/ls-files.c:636
-msgid "show staged contents' object name in the output"
-msgstr ""
+msgid "show files on the filesystem that need to be removed"
+msgstr "perlihatkan berkas pada sistem berkas yang perlu dihapus"
 
 #: builtin/ls-files.c:638
-msgid "show files on the filesystem that need to be removed"
-msgstr ""
+msgid "show 'other' directories' names only"
+msgstr "hanya perlihatkan nama direktori 'lainnya'"
 
 #: builtin/ls-files.c:640
-msgid "show 'other' directories' names only"
-msgstr ""
+msgid "show line endings of files"
+msgstr "perlihatkan akhiran baris berkas"
 
 #: builtin/ls-files.c:642
-msgid "show line endings of files"
-msgstr ""
-
-#: builtin/ls-files.c:644
 msgid "don't show empty directories"
-msgstr ""
+msgstr "jangan perlihatkan direktori kosong"
+
+#: builtin/ls-files.c:645
+msgid "show unmerged files in the output"
+msgstr "perlihatkan berkas tak tergabung di dalam keluaran"
 
 #: builtin/ls-files.c:647
-msgid "show unmerged files in the output"
-msgstr ""
+msgid "show resolve-undo information"
+msgstr "perlihatkan informasi resolve-undo"
 
 #: builtin/ls-files.c:649
-msgid "show resolve-undo information"
-msgstr ""
-
-#: builtin/ls-files.c:651
 msgid "skip files matching pattern"
-msgstr ""
+msgstr "lewati berkas yang cocok dengan pola"
 
-#: builtin/ls-files.c:654
-msgid "exclude patterns are read from <file>"
-msgstr ""
+#: builtin/ls-files.c:652
+msgid "read exclude patterns from <file>"
+msgstr "baca pola pengecualian dari <berkas>"
+
+#: builtin/ls-files.c:655
+msgid "read additional per-directory exclude patterns in <file>"
+msgstr "baca pola pengecualian tambahan per direktor dalam <berkas>"
 
 #: builtin/ls-files.c:657
-msgid "read additional per-directory exclude patterns in <file>"
-msgstr ""
-
-#: builtin/ls-files.c:659
 msgid "add the standard git exclusions"
-msgstr ""
+msgstr "tambahkan pengecualian git standar"
 
-#: builtin/ls-files.c:663
+#: builtin/ls-files.c:661
 msgid "make the output relative to the project top directory"
-msgstr ""
+msgstr "buat keluaran relatif terhadap direktori puncak proyek"
+
+#: builtin/ls-files.c:664
+msgid "recurse through submodules"
+msgstr "rekursi melalui submodul"
 
 #: builtin/ls-files.c:666
-msgid "recurse through submodules"
-msgstr ""
-
-#: builtin/ls-files.c:668
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr ""
+"jika <berkas> apapun tidak berada di indeks, perlakukan sebagai kesalahan"
 
-#: builtin/ls-files.c:669
+#: builtin/ls-files.c:667
 msgid "tree-ish"
-msgstr ""
+msgstr "mirip-pohon"
+
+#: builtin/ls-files.c:668
+msgid "pretend that paths removed since <tree-ish> are still present"
+msgstr "berpura-pura bahwa jalur yang dihapus sejak <mirip-pohon> masih ada"
 
 #: builtin/ls-files.c:670
-msgid "pretend that paths removed since <tree-ish> are still present"
-msgstr ""
+msgid "show debugging data"
+msgstr "perlihatkan data penirkutuan"
 
 #: builtin/ls-files.c:672
-msgid "show debugging data"
-msgstr ""
-
-#: builtin/ls-files.c:674
 msgid "suppress duplicate entries"
-msgstr ""
+msgstr "hapus entri duplikat"
 
 #: builtin/ls-remote.c:9
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<repository> [<refs>...]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repository> [<refs>...]]"
 msgstr ""
+"git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repositori> [<referensi>...]]"
 
 #: builtin/ls-remote.c:60
 msgid "do not print remote URL"
-msgstr ""
+msgstr "jangan cetak URL remote"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1399
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1103
 msgid "exec"
-msgstr ""
+msgstr "exec"
 
 #: builtin/ls-remote.c:62 builtin/ls-remote.c:64
 msgid "path of git-upload-pack on the remote host"
-msgstr ""
+msgstr "jalur git-upload-pack pada host remote"
 
 #: builtin/ls-remote.c:66
 msgid "limit to tags"
-msgstr ""
+msgstr "batasi ke tag"
 
 #: builtin/ls-remote.c:67
 msgid "limit to heads"
-msgstr ""
+msgstr "batasi ke kepala"
 
 #: builtin/ls-remote.c:68
 msgid "do not show peeled tags"
-msgstr ""
+msgstr "jangan perlihatkan tag terkupas"
 
 #: builtin/ls-remote.c:70
 msgid "take url.<base>.insteadOf into account"
-msgstr ""
+msgstr "perhitungkan url.<dasar>.insteadOf"
 
 #: builtin/ls-remote.c:73
 msgid "exit with exit code 2 if no matching refs are found"
 msgstr ""
+"keluar dengan kode keluar 2 jika tidak ada referensi yang cocok ditemukan"
 
 #: builtin/ls-remote.c:76
 msgid "show underlying ref in addition to the object pointed by it"
-msgstr ""
+msgstr "perlihatkan referensi pokok selain objek yang ditunjuk olehnya"
 
 #: builtin/ls-tree.c:30
 msgid "git ls-tree [<options>] <tree-ish> [<path>...]"
-msgstr ""
+msgstr "git ls-tree [<opsi>] <mirip-pohon> [<jalur>...]"
 
 #: builtin/ls-tree.c:128
 msgid "only show trees"
-msgstr ""
+msgstr "hanya perlihatkan pohon"
 
 #: builtin/ls-tree.c:130
 msgid "recurse into subtrees"
-msgstr ""
+msgstr "rekursi ke dalam subpohon"
 
 #: builtin/ls-tree.c:132
 msgid "show trees when recursing"
-msgstr ""
+msgstr "perlihatkan pohon ketika rekursi"
 
 #: builtin/ls-tree.c:135
 msgid "terminate entries with NUL byte"
-msgstr ""
+msgstr "akhiri entri dengan bita NUL"
 
 #: builtin/ls-tree.c:136
 msgid "include object size"
-msgstr ""
+msgstr "masukkan ukuran objek"
 
 #: builtin/ls-tree.c:138 builtin/ls-tree.c:140
 msgid "list only filenames"
-msgstr ""
+msgstr "hanya daftar nama berkas"
 
 #: builtin/ls-tree.c:143
 msgid "use full path names"
-msgstr ""
+msgstr "gunakan nama berkas lengkap"
 
 #: builtin/ls-tree.c:145
 msgid "list entire tree; not just current directory (implies --full-name)"
 msgstr ""
+"daftar pohon keseluruhan; bukan hanya direktori saat ini (menyiratkan --full-"
+"name)"
 
 #. TRANSLATORS: keep <> in "<" mail ">" info.
 #: builtin/mailinfo.c:14
@@ -16867,7 +17249,7 @@ msgstr ""
 msgid "use headers in message's body"
 msgstr ""
 
-#: builtin/mailsplit.c:241
+#: builtin/mailsplit.c:239
 #, c-format
 msgid "empty mbox: '%s'"
 msgstr ""
@@ -16981,143 +17363,143 @@ msgstr ""
 msgid "Merging %s with %s\n"
 msgstr ""
 
-#: builtin/merge.c:58
+#: builtin/merge.c:59
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<opsi>] [<komit>...]"
 
-#: builtin/merge.c:123
+#: builtin/merge.c:124
 msgid "switch `m' requires a value"
 msgstr "tombol `m' butuh sebuah nilai"
 
-#: builtin/merge.c:146
+#: builtin/merge.c:147
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "opsi `%s' butuh sebuah nilai"
 
-#: builtin/merge.c:199
+#: builtin/merge.c:200
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Tidak dapat menemukan strategi penggabungan '%s'.\n"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Available strategies are:"
 msgstr "Strategi yang tersedia:"
 
-#: builtin/merge.c:205
+#: builtin/merge.c:206
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Strategi kustom yang tersedia:"
 
-#: builtin/merge.c:256 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "jangan perlihatkan diffstat pada akhir penggabungan"
 
-#: builtin/merge.c:259 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "perlihatkan diffstat pada akhir penggabungan"
 
-#: builtin/merge.c:260 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(sinonim untuk --stat)"
 
-#: builtin/merge.c:262 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "tambah (paling banyak <n>) entri dari log pendek ke pesan komit penggabungan"
 
-#: builtin/merge.c:265 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "buat satu komit daripada melakukan penggabungan"
 
-#: builtin/merge.c:267 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "lakukan komit jika penggabungan sukses (asali)"
 
-#: builtin/merge.c:269 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "sunting pesan sebelum komit"
 
-#: builtin/merge.c:271
+#: builtin/merge.c:272
 msgid "allow fast-forward (default)"
 msgstr "perbolehkan maju cepat (asali)"
 
-#: builtin/merge.c:273 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "batalkan jika maju cepat tidak dimungkinkan"
 
-#: builtin/merge.c:277 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "periksa bahwa komit bernama punya tandatangan GPG yang valid"
 
-#: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:540 builtin/rebase.c:1413 builtin/revert.c:114
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "strategi"
 
-#: builtin/merge.c:279 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "strategi penggabungan yang digunakan"
 
-#: builtin/merge.c:280 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:172
 msgid "option=value"
 msgstr "opsi=nilai"
 
-#: builtin/merge.c:281 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "opsi untuk strategi penggabungan yang dipilih"
 
-#: builtin/merge.c:283
+#: builtin/merge.c:284
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "pesan komit penggabungan (untuk penggabungan bukan maju cepat)"
 
-#: builtin/merge.c:290
+#: builtin/merge.c:291
 msgid "abort the current in-progress merge"
 msgstr "batalkan penggabungan yang sedang berlangsung saat ini"
 
-#: builtin/merge.c:292
+#: builtin/merge.c:293
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort tapi biarkan indeks dan pohon kerja"
 
-#: builtin/merge.c:294
+#: builtin/merge.c:295
 msgid "continue the current in-progress merge"
 msgstr "lanjutkan penggabungan yang sedang berlangsung saat ini"
 
-#: builtin/merge.c:296 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "perbolehkan penggabungan riwayat yang tak terkait"
 
-#: builtin/merge.c:303
+#: builtin/merge.c:304
 msgid "bypass pre-merge-commit and commit-msg hooks"
-msgstr "lewati hook pre-merge-commit dan commit-msg"
+msgstr "lewati kail pre-merge-commit dan commit-msg"
 
-#: builtin/merge.c:320
+#: builtin/merge.c:321
 msgid "could not run stash."
 msgstr "tidak dapat menjalankan stase."
 
-#: builtin/merge.c:325
+#: builtin/merge.c:326
 msgid "stash failed"
 msgstr "stase gagal"
 
-#: builtin/merge.c:330
+#: builtin/merge.c:331
 #, c-format
 msgid "not a valid object: %s"
 msgstr "bukan objek valid: %s"
 
-#: builtin/merge.c:352 builtin/merge.c:369
+#: builtin/merge.c:353 builtin/merge.c:370
 msgid "read-tree failed"
 msgstr "read-tree gagal"
 
-#: builtin/merge.c:400
+#: builtin/merge.c:401
 msgid "Already up to date. (nothing to squash)"
 msgstr "Sudah diperbarui. (tidak ada yang bisa dilumat)"
 
-#: builtin/merge.c:414
+#: builtin/merge.c:415
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Lumat komit -- tak perbarui HEAD\n"
 
-#: builtin/merge.c:464
+#: builtin/merge.c:465
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Tidak ada pesan komit -- tak perbarui HEAD\n"
@@ -17132,33 +17514,33 @@ msgstr "'%s' tidak menunjuk pada sebuah komit"
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Untai branch.%s.mergeoptions jelek: %s"
 
-#: builtin/merge.c:729
+#: builtin/merge.c:730
 msgid "Not handling anything other than two heads merge."
 msgstr "Tak tangani apapun selain penggabungan dua kepala."
 
-#: builtin/merge.c:742
+#: builtin/merge.c:743
 #, c-format
-msgid "Unknown option for merge-recursive: -X%s"
-msgstr "Opsi merge-recursive tak dikenal: -X%s"
+msgid "unknown strategy option: -X%s"
+msgstr "opsi strategi tidak dikenal: -X%s"
 
-#: builtin/merge.c:761 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "tidak dapat menulis %s"
 
-#: builtin/merge.c:813
+#: builtin/merge.c:814
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "Tidak dapat membaca dari '%s'"
 
-#: builtin/merge.c:822
+#: builtin/merge.c:823
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Tak mengkomit penggabungan; gunakan 'git commit' untuk menyelesaikan "
 "penggabungan.\n"
 
-#: builtin/merge.c:828
+#: builtin/merge.c:829
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -17168,11 +17550,11 @@ msgstr ""
 "diperlukan, khususnya jika itu menggabungkan hulu terbarui ke cabang\n"
 "topik.\n"
 
-#: builtin/merge.c:833
+#: builtin/merge.c:834
 msgid "An empty message aborts the commit.\n"
 msgstr "Pesan kosong membatalkan komit.\n"
 
-#: builtin/merge.c:836
+#: builtin/merge.c:837
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -17181,72 +17563,72 @@ msgstr ""
 "Baris yang diawali dengan '%c' akan diabaikan, dan pesan kosong batalkan\n"
 "komit.\n"
 
-#: builtin/merge.c:889
+#: builtin/merge.c:892
 msgid "Empty commit message."
 msgstr "Pesan komit kosong"
 
-#: builtin/merge.c:904
+#: builtin/merge.c:907
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Luar biasa.\n"
 
-#: builtin/merge.c:965
+#: builtin/merge.c:968
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr "Penggabungan otomatis gagal; selesaikan konflik lalu komit hasilnya.\n"
 
-#: builtin/merge.c:1004
+#: builtin/merge.c:1007
 msgid "No current branch."
 msgstr "Tidak ada cabang saat ini."
 
-#: builtin/merge.c:1006
+#: builtin/merge.c:1009
 msgid "No remote for the current branch."
 msgstr "Tidak ada remote untuk cabang saat ini."
 
-#: builtin/merge.c:1008
+#: builtin/merge.c:1011
 msgid "No default upstream defined for the current branch."
 msgstr "Tidak ada hulu asali yang ditentukan untuk cabang saat ini."
 
-#: builtin/merge.c:1013
+#: builtin/merge.c:1016
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Tidak ada cabang pelacak remote untuk %s dari %s"
 
-#: builtin/merge.c:1070
+#: builtin/merge.c:1073
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Nilai jelek '%s' dalam lingkungan '%s'"
 
-#: builtin/merge.c:1173
+#: builtin/merge.c:1174
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "bukan sesuatu yang kami bisa gabungkan di %s: %s"
 
-#: builtin/merge.c:1207
+#: builtin/merge.c:1208
 msgid "not something we can merge"
 msgstr "bukan sesuatu yang kami bisa gabungkan"
 
-#: builtin/merge.c:1317
+#: builtin/merge.c:1321
 msgid "--abort expects no arguments"
 msgstr "--abort harap tanpa argumen"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1325
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Tidak ada penggabungan yang bisa dibatalkan (MERGE_HEAD hilang)."
 
-#: builtin/merge.c:1339
+#: builtin/merge.c:1343
 msgid "--quit expects no arguments"
 msgstr "--quit harap tanpa argumen"
 
-#: builtin/merge.c:1352
+#: builtin/merge.c:1356
 msgid "--continue expects no arguments"
 msgstr "--continue harap tanpa argumen"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1360
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Tidak ada penggabungan yang sedang berlangsung (MERGE_HEAD hilang)."
 
-#: builtin/merge.c:1372
+#: builtin/merge.c:1376
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17254,7 +17636,7 @@ msgstr ""
 "Anda belum mengakhiri penggabungan Anda (MERGE_HEAD ada).\n"
 "Mohon komit perubahan Anda sebelum Anda gabungkan."
 
-#: builtin/merge.c:1379
+#: builtin/merge.c:1383
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17262,89 +17644,85 @@ msgstr ""
 "Anda belum mengakhiri pemetikan ceri Anda (CHERRY_PICK_HEAD ada).\n"
 "Mohon komit perubahan Anda sebelum Anda gabungkan."
 
-#: builtin/merge.c:1382
+#: builtin/merge.c:1386
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Anda belum mengakhiri pemetikan ceri Anda (CHERRY_PICK_HEAD ada)."
 
-#: builtin/merge.c:1396
+#: builtin/merge.c:1400
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Anda tidak dapat menggabungkan --squash dengan --no-ff."
 
-#: builtin/merge.c:1398
+#: builtin/merge.c:1402
 msgid "You cannot combine --squash with --commit."
 msgstr "Anda tidak dapat menggabungkan --squash dengan --commit"
 
-#: builtin/merge.c:1414
+#: builtin/merge.c:1418
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
 "Tidak ada komit yang disebutkan dan merge.defaultToUpstream tidak disetel."
 
-#: builtin/merge.c:1431
+#: builtin/merge.c:1435
 msgid "Squash commit into empty head not supported yet"
 msgstr "Lumat komit ke kepala kosong belum didukung"
 
-#: builtin/merge.c:1433
+#: builtin/merge.c:1437
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Komit nir maju cepat tidak masuk akal ke kepala kosong"
 
-#: builtin/merge.c:1438
+#: builtin/merge.c:1442
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - bukan sesuatu yang kami bisa gabungkan"
 
-#: builtin/merge.c:1440
+#: builtin/merge.c:1444
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Hanya bisa menggabungkan tepantnya satu komit ke kepala kosong"
 
-#: builtin/merge.c:1521
+#: builtin/merge.c:1531
 msgid "refusing to merge unrelated histories"
 msgstr "menolak menggabungkan riwayat tak terkait"
 
-#: builtin/merge.c:1540
+#: builtin/merge.c:1550
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Memperbarui %s..%s\n"
 
-#: builtin/merge.c:1587
+#: builtin/merge.c:1598
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Mencoba penggabungan dalam indeks yang sangat sepele\n"
 
-#: builtin/merge.c:1594
+#: builtin/merge.c:1605
 #, c-format
 msgid "Nope.\n"
 msgstr "Tidak.\n"
 
-#: builtin/merge.c:1625
-msgid "Not possible to fast-forward, aborting."
-msgstr "Tidak mungkin untuk maju cepat, batalkan."
-
-#: builtin/merge.c:1653 builtin/merge.c:1719
+#: builtin/merge.c:1664 builtin/merge.c:1730
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Memutar ulang pohon ke asli...\n"
 
-#: builtin/merge.c:1657
+#: builtin/merge.c:1668
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Mencoba strategi penggabungan %s...\n"
 
-#: builtin/merge.c:1709
+#: builtin/merge.c:1720
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Tidak ada strategi yang menangani penggabungan.\n"
 
-#: builtin/merge.c:1711
+#: builtin/merge.c:1722
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Penggabungan dengan strategi %s gagal.\n"
 
-#: builtin/merge.c:1721
+#: builtin/merge.c:1732
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "Menggunakan strategi %s untuk menyiapkan penyelesaian dengan tangan.\n"
 
-#: builtin/merge.c:1735
+#: builtin/merge.c:1746
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -17380,15 +17758,15 @@ msgstr ""
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr ""
 
-#: builtin/mktag.c:97
+#: builtin/mktag.c:98
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr ""
 
-#: builtin/mktag.c:100
+#: builtin/mktag.c:101
 msgid "tag on stdin did not refer to a valid object"
 msgstr ""
 
-#: builtin/mktag.c:103 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:243
 msgid "unable to write tag file"
 msgstr ""
 
@@ -17409,42 +17787,51 @@ msgid "allow creation of more than one tree"
 msgstr ""
 
 #: builtin/multi-pack-index.c:10
-msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
+msgid ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
 msgstr ""
 
-#: builtin/multi-pack-index.c:13
+#: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
 msgstr ""
 
-#: builtin/multi-pack-index.c:16
+#: builtin/multi-pack-index.c:17
 msgid "git multi-pack-index [<options>] expire"
 msgstr ""
 
-#: builtin/multi-pack-index.c:19
+#: builtin/multi-pack-index.c:20
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
 msgstr ""
 
-#: builtin/multi-pack-index.c:54
+#: builtin/multi-pack-index.c:57
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
 
-#: builtin/multi-pack-index.c:69
+#: builtin/multi-pack-index.c:98
 msgid "preferred-pack"
 msgstr ""
 
-#: builtin/multi-pack-index.c:70
+#: builtin/multi-pack-index.c:99
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr ""
 
-#: builtin/multi-pack-index.c:128
+#: builtin/multi-pack-index.c:100
+msgid "write multi-pack bitmap"
+msgstr ""
+
+#: builtin/multi-pack-index.c:105
+msgid "write multi-pack index containing only given indexes"
+msgstr ""
+
+#: builtin/multi-pack-index.c:107
+msgid "refs snapshot for selecting bitmap commits"
+msgstr ""
+
+#: builtin/multi-pack-index.c:202
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
-msgstr ""
-
-#: builtin/multi-pack-index.c:179
-#, c-format
-msgid "unrecognized subcommand: %s"
 msgstr ""
 
 #: builtin/mv.c:18
@@ -17474,72 +17861,72 @@ msgstr "paksa pindah/ganti nama bahkan jika target ada"
 msgid "skip move/rename errors"
 msgstr "lewati kesalahan pindah/ganti nama"
 
-#: builtin/mv.c:170
+#: builtin/mv.c:172
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "tujuan '%s' bukan direktori"
 
-#: builtin/mv.c:181
+#: builtin/mv.c:184
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Memeriksa penamaan ulang '%s' ke '%s'\n"
 
-#: builtin/mv.c:185
+#: builtin/mv.c:190
 msgid "bad source"
 msgstr "sumber jelek"
 
-#: builtin/mv.c:188
+#: builtin/mv.c:193
 msgid "can not move directory into itself"
 msgstr "tidak dapat memindahkan direktori ke dirinya sendiri"
 
-#: builtin/mv.c:191
+#: builtin/mv.c:196
 msgid "cannot move directory over file"
 msgstr "tidak dapat memindahkan direktori ke berkas"
 
-#: builtin/mv.c:200
+#: builtin/mv.c:205
 msgid "source directory is empty"
 msgstr "direktori asal kosong"
 
-#: builtin/mv.c:225
+#: builtin/mv.c:231
 msgid "not under version control"
 msgstr "bukan dalam kontrol versi"
 
-#: builtin/mv.c:227
+#: builtin/mv.c:233
 msgid "conflicted"
 msgstr "terkonflik"
 
-#: builtin/mv.c:230
+#: builtin/mv.c:236
 msgid "destination exists"
 msgstr "tujuan ada"
 
-#: builtin/mv.c:238
+#: builtin/mv.c:244
 #, c-format
 msgid "overwriting '%s'"
 msgstr "menimpa '%s'"
 
-#: builtin/mv.c:241
+#: builtin/mv.c:247
 msgid "Cannot overwrite"
 msgstr "Tidak dapat menimpa"
 
-#: builtin/mv.c:244
+#: builtin/mv.c:250
 msgid "multiple sources for the same target"
 msgstr "banyak asal untuk target yang sama"
 
-#: builtin/mv.c:246
+#: builtin/mv.c:252
 msgid "destination directory does not exist"
 msgstr "direktori tujuan tidak ada"
 
-#: builtin/mv.c:253
+#: builtin/mv.c:280
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, source=%s, destination=%s"
 
-#: builtin/mv.c:274
+#: builtin/mv.c:308
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Mengganti nama %s ke %s\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:667
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "gagal mengganti nama '%s'"
@@ -17711,47 +18098,47 @@ msgstr ""
 msgid "failed to finish 'show' for object '%s'"
 msgstr ""
 
-#: builtin/notes.c:197
+#: builtin/notes.c:195
 msgid "please supply the note contents using either -m or -F option"
 msgstr ""
 
-#: builtin/notes.c:206
+#: builtin/notes.c:204
 msgid "unable to write note object"
 msgstr ""
 
-#: builtin/notes.c:208
+#: builtin/notes.c:206
 #, c-format
 msgid "the note contents have been left in %s"
 msgstr ""
 
-#: builtin/notes.c:242 builtin/tag.c:576
+#: builtin/notes.c:240 builtin/tag.c:577
 #, c-format
 msgid "could not open or read '%s'"
 msgstr ""
 
-#: builtin/notes.c:263 builtin/notes.c:313 builtin/notes.c:315
-#: builtin/notes.c:383 builtin/notes.c:438 builtin/notes.c:526
-#: builtin/notes.c:531 builtin/notes.c:610 builtin/notes.c:672
+#: builtin/notes.c:261 builtin/notes.c:311 builtin/notes.c:313
+#: builtin/notes.c:381 builtin/notes.c:436 builtin/notes.c:524
+#: builtin/notes.c:529 builtin/notes.c:608 builtin/notes.c:670
 #, c-format
 msgid "failed to resolve '%s' as a valid ref."
 msgstr ""
 
-#: builtin/notes.c:265
+#: builtin/notes.c:263
 #, c-format
 msgid "failed to read object '%s'."
 msgstr ""
 
-#: builtin/notes.c:268
+#: builtin/notes.c:266
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
 msgstr ""
 
-#: builtin/notes.c:309
+#: builtin/notes.c:307
 #, c-format
 msgid "malformed input line: '%s'."
 msgstr ""
 
-#: builtin/notes.c:324
+#: builtin/notes.c:322
 #, c-format
 msgid "failed to copy notes from '%s' to '%s'"
 msgstr ""
@@ -17759,186 +18146,186 @@ msgstr ""
 #. TRANSLATORS: the first %s will be replaced by a git
 #. notes command: 'add', 'merge', 'remove', etc.
 #.
-#: builtin/notes.c:356
+#: builtin/notes.c:354
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr ""
 
-#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
-#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
-#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
-#: builtin/prune-packed.c:25 builtin/tag.c:586
+#: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
+#: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
+#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
+#: builtin/prune-packed.c:25 builtin/tag.c:587
 msgid "too many arguments"
 msgstr ""
 
-#: builtin/notes.c:389 builtin/notes.c:678
+#: builtin/notes.c:387 builtin/notes.c:676
 #, c-format
 msgid "no note found for object %s."
 msgstr ""
 
-#: builtin/notes.c:410 builtin/notes.c:576
+#: builtin/notes.c:408 builtin/notes.c:574
 msgid "note contents as a string"
 msgstr ""
 
-#: builtin/notes.c:413 builtin/notes.c:579
+#: builtin/notes.c:411 builtin/notes.c:577
 msgid "note contents in a file"
 msgstr ""
 
-#: builtin/notes.c:416 builtin/notes.c:582
+#: builtin/notes.c:414 builtin/notes.c:580
 msgid "reuse and edit specified note object"
 msgstr ""
 
-#: builtin/notes.c:419 builtin/notes.c:585
+#: builtin/notes.c:417 builtin/notes.c:583
 msgid "reuse specified note object"
 msgstr ""
 
-#: builtin/notes.c:422 builtin/notes.c:588
+#: builtin/notes.c:420 builtin/notes.c:586
 msgid "allow storing empty note"
 msgstr ""
 
-#: builtin/notes.c:423 builtin/notes.c:496
+#: builtin/notes.c:421 builtin/notes.c:494
 msgid "replace existing notes"
 msgstr ""
 
-#: builtin/notes.c:448
+#: builtin/notes.c:446
 #, c-format
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
 
-#: builtin/notes.c:463 builtin/notes.c:544
+#: builtin/notes.c:461 builtin/notes.c:542
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
 msgstr ""
 
-#: builtin/notes.c:475 builtin/notes.c:637 builtin/notes.c:902
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr ""
 
-#: builtin/notes.c:497
+#: builtin/notes.c:495
 msgid "read objects from stdin"
 msgstr ""
 
-#: builtin/notes.c:499
+#: builtin/notes.c:497
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr ""
 
-#: builtin/notes.c:517
+#: builtin/notes.c:515
 msgid "too few arguments"
 msgstr ""
 
-#: builtin/notes.c:538
+#: builtin/notes.c:536
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
 
-#: builtin/notes.c:550
+#: builtin/notes.c:548
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
 msgstr ""
 
-#: builtin/notes.c:603
+#: builtin/notes.c:601
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
 "Please use 'git notes add -f -m/-F/-c/-C' instead.\n"
 msgstr ""
 
-#: builtin/notes.c:698
+#: builtin/notes.c:696
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
 msgstr ""
 
-#: builtin/notes.c:700
+#: builtin/notes.c:698
 msgid "failed to delete ref NOTES_MERGE_REF"
 msgstr ""
 
-#: builtin/notes.c:702
+#: builtin/notes.c:700
 msgid "failed to remove 'git notes merge' worktree"
 msgstr ""
 
-#: builtin/notes.c:722
+#: builtin/notes.c:720
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
 msgstr ""
 
-#: builtin/notes.c:724
+#: builtin/notes.c:722
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
 msgstr ""
 
-#: builtin/notes.c:726
+#: builtin/notes.c:724
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
 msgstr ""
 
-#: builtin/notes.c:739
+#: builtin/notes.c:737
 msgid "failed to resolve NOTES_MERGE_REF"
 msgstr ""
 
-#: builtin/notes.c:742
+#: builtin/notes.c:740
 msgid "failed to finalize notes merge"
 msgstr ""
 
-#: builtin/notes.c:768
+#: builtin/notes.c:766
 #, c-format
 msgid "unknown notes merge strategy %s"
 msgstr ""
 
-#: builtin/notes.c:784
+#: builtin/notes.c:782
 msgid "General options"
 msgstr ""
 
-#: builtin/notes.c:786
+#: builtin/notes.c:784
 msgid "Merge options"
 msgstr ""
 
-#: builtin/notes.c:788
+#: builtin/notes.c:786
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
 msgstr ""
 
-#: builtin/notes.c:790
+#: builtin/notes.c:788
 msgid "Committing unmerged notes"
 msgstr ""
 
-#: builtin/notes.c:792
+#: builtin/notes.c:790
 msgid "finalize notes merge by committing unmerged notes"
 msgstr ""
 
-#: builtin/notes.c:794
+#: builtin/notes.c:792
 msgid "Aborting notes merge resolution"
 msgstr ""
 
-#: builtin/notes.c:796
+#: builtin/notes.c:794
 msgid "abort notes merge"
 msgstr ""
 
-#: builtin/notes.c:807
+#: builtin/notes.c:805
 msgid "cannot mix --commit, --abort or -s/--strategy"
 msgstr ""
 
-#: builtin/notes.c:812
+#: builtin/notes.c:810
 msgid "must specify a notes ref to merge"
 msgstr ""
 
-#: builtin/notes.c:836
+#: builtin/notes.c:834
 #, c-format
 msgid "unknown -s/--strategy: %s"
 msgstr ""
 
-#: builtin/notes.c:873
+#: builtin/notes.c:871
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr ""
 
-#: builtin/notes.c:876
+#: builtin/notes.c:874
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr ""
 
-#: builtin/notes.c:878
+#: builtin/notes.c:876
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -17946,41 +18333,41 @@ msgid ""
 "abort'.\n"
 msgstr ""
 
-#: builtin/notes.c:897 builtin/tag.c:589
+#: builtin/notes.c:895 builtin/tag.c:590
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr ""
 
-#: builtin/notes.c:900
+#: builtin/notes.c:898
 #, c-format
 msgid "Object %s has no note\n"
 msgstr ""
 
-#: builtin/notes.c:912
+#: builtin/notes.c:910
 msgid "attempt to remove non-existent note is not an error"
 msgstr ""
 
-#: builtin/notes.c:915
+#: builtin/notes.c:913
 msgid "read object names from the standard input"
 msgstr ""
 
-#: builtin/notes.c:954 builtin/prune.c:132 builtin/worktree.c:146
+#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr ""
 
-#: builtin/notes.c:955
+#: builtin/notes.c:953
 msgid "report pruned notes"
 msgstr ""
 
-#: builtin/notes.c:998
+#: builtin/notes.c:996
 msgid "notes-ref"
 msgstr ""
 
-#: builtin/notes.c:999
+#: builtin/notes.c:997
 msgid "use notes from <notes-ref>"
 msgstr ""
 
-#: builtin/notes.c:1034 builtin/stash.c:1735
+#: builtin/notes.c:1032 builtin/stash.c:1752
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr ""
@@ -18027,357 +18414,362 @@ msgstr ""
 msgid "expected object at offset %<PRIuMAX> in pack %s"
 msgstr ""
 
-#: builtin/pack-objects.c:1155
+#: builtin/pack-objects.c:1160
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 
-#: builtin/pack-objects.c:1168
+#: builtin/pack-objects.c:1173
 msgid "Writing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:1229 builtin/update-index.c:90
+#: builtin/pack-objects.c:1235 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr ""
 
-#: builtin/pack-objects.c:1281
+#: builtin/pack-objects.c:1268
+msgid "failed to write bitmap index"
+msgstr ""
+
+#: builtin/pack-objects.c:1294
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr ""
 
-#: builtin/pack-objects.c:1523
+#: builtin/pack-objects.c:1536
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 
-#: builtin/pack-objects.c:1971
+#: builtin/pack-objects.c:1984
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:1980
+#: builtin/pack-objects.c:1993
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:2261
+#: builtin/pack-objects.c:2274
 msgid "Counting objects"
 msgstr ""
 
-#: builtin/pack-objects.c:2426
+#: builtin/pack-objects.c:2439
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr ""
 
-#: builtin/pack-objects.c:2496 builtin/pack-objects.c:2512
-#: builtin/pack-objects.c:2522
+#: builtin/pack-objects.c:2509 builtin/pack-objects.c:2525
+#: builtin/pack-objects.c:2535
 #, c-format
 msgid "object %s cannot be read"
 msgstr ""
 
-#: builtin/pack-objects.c:2499 builtin/pack-objects.c:2526
+#: builtin/pack-objects.c:2512 builtin/pack-objects.c:2539
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr ""
 
-#: builtin/pack-objects.c:2536
+#: builtin/pack-objects.c:2549
 msgid "suboptimal pack - out of memory"
 msgstr ""
 
-#: builtin/pack-objects.c:2851
+#: builtin/pack-objects.c:2864
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr ""
 
-#: builtin/pack-objects.c:2990
+#: builtin/pack-objects.c:3003
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3076
+#: builtin/pack-objects.c:3089
 msgid "Compressing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3082
+#: builtin/pack-objects.c:3095
 msgid "inconsistency with delta count"
 msgstr ""
 
-#: builtin/pack-objects.c:3161
+#: builtin/pack-objects.c:3174
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
 "hash> <uri>' (got '%s')"
 msgstr ""
 
-#: builtin/pack-objects.c:3164
+#: builtin/pack-objects.c:3177
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
 msgstr ""
 
-#: builtin/pack-objects.c:3199
+#: builtin/pack-objects.c:3212
 #, c-format
 msgid "could not get type of object %s in pack %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3321 builtin/pack-objects.c:3335
+#: builtin/pack-objects.c:3340 builtin/pack-objects.c:3351
+#: builtin/pack-objects.c:3365
 #, c-format
 msgid "could not find pack '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3378
+#: builtin/pack-objects.c:3408
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
 " %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3384
+#: builtin/pack-objects.c:3414
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
 " %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3482
+#: builtin/pack-objects.c:3507
 msgid "invalid value for --missing"
 msgstr ""
 
-#: builtin/pack-objects.c:3541 builtin/pack-objects.c:3650
+#: builtin/pack-objects.c:3532 builtin/pack-objects.c:3619
 msgid "cannot open pack index"
 msgstr ""
 
-#: builtin/pack-objects.c:3572
+#: builtin/pack-objects.c:3541
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr ""
 
-#: builtin/pack-objects.c:3658
+#: builtin/pack-objects.c:3627
 msgid "unable to force loose object"
 msgstr ""
 
-#: builtin/pack-objects.c:3788
+#: builtin/pack-objects.c:3757
 #, c-format
 msgid "not a rev '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3791 builtin/rev-parse.c:1061
+#: builtin/pack-objects.c:3760 builtin/rev-parse.c:1061
 #, c-format
 msgid "bad revision '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3819
+#: builtin/pack-objects.c:3788
 msgid "unable to add recent objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3872
+#: builtin/pack-objects.c:3841
 #, c-format
 msgid "unsupported index version %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3876
+#: builtin/pack-objects.c:3845
 #, c-format
 msgid "bad index version '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3915
+#: builtin/pack-objects.c:3884
 msgid "<version>[,<offset>]"
 msgstr ""
 
-#: builtin/pack-objects.c:3916
+#: builtin/pack-objects.c:3885
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 
-#: builtin/pack-objects.c:3919
+#: builtin/pack-objects.c:3888
 msgid "maximum size of each output pack file"
 msgstr ""
 
-#: builtin/pack-objects.c:3921
+#: builtin/pack-objects.c:3890
 msgid "ignore borrowed objects from alternate object store"
 msgstr ""
 
-#: builtin/pack-objects.c:3923
+#: builtin/pack-objects.c:3892
 msgid "ignore packed objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3925
+#: builtin/pack-objects.c:3894
 msgid "limit pack window by objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3927
+#: builtin/pack-objects.c:3896
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 
-#: builtin/pack-objects.c:3929
+#: builtin/pack-objects.c:3898
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 
-#: builtin/pack-objects.c:3931
+#: builtin/pack-objects.c:3900
 msgid "reuse existing deltas"
 msgstr ""
 
-#: builtin/pack-objects.c:3933
+#: builtin/pack-objects.c:3902
 msgid "reuse existing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3935
+#: builtin/pack-objects.c:3904
 msgid "use OFS_DELTA objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3937
+#: builtin/pack-objects.c:3906
 msgid "use threads when searching for best delta matches"
 msgstr ""
 
-#: builtin/pack-objects.c:3939
+#: builtin/pack-objects.c:3908
 msgid "do not create an empty pack output"
 msgstr ""
 
-#: builtin/pack-objects.c:3941
+#: builtin/pack-objects.c:3910
 msgid "read revision arguments from standard input"
 msgstr ""
 
-#: builtin/pack-objects.c:3943
+#: builtin/pack-objects.c:3912
 msgid "limit the objects to those that are not yet packed"
 msgstr ""
 
-#: builtin/pack-objects.c:3946
+#: builtin/pack-objects.c:3915
 msgid "include objects reachable from any reference"
 msgstr ""
 
-#: builtin/pack-objects.c:3949
+#: builtin/pack-objects.c:3918
 msgid "include objects referred by reflog entries"
 msgstr ""
 
-#: builtin/pack-objects.c:3952
+#: builtin/pack-objects.c:3921
 msgid "include objects referred to by the index"
 msgstr ""
 
-#: builtin/pack-objects.c:3955
+#: builtin/pack-objects.c:3924
 msgid "read packs from stdin"
 msgstr ""
 
-#: builtin/pack-objects.c:3957
+#: builtin/pack-objects.c:3926
 msgid "output pack to stdout"
 msgstr ""
 
-#: builtin/pack-objects.c:3959
+#: builtin/pack-objects.c:3928
 msgid "include tag objects that refer to objects to be packed"
 msgstr ""
 
-#: builtin/pack-objects.c:3961
+#: builtin/pack-objects.c:3930
 msgid "keep unreachable objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3963
+#: builtin/pack-objects.c:3932
 msgid "pack loose unreachable objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3965
+#: builtin/pack-objects.c:3934
 msgid "unpack unreachable objects newer than <time>"
 msgstr ""
 
-#: builtin/pack-objects.c:3968
+#: builtin/pack-objects.c:3937
 msgid "use the sparse reachability algorithm"
 msgstr ""
 
-#: builtin/pack-objects.c:3970
+#: builtin/pack-objects.c:3939
 msgid "create thin packs"
 msgstr ""
 
-#: builtin/pack-objects.c:3972
+#: builtin/pack-objects.c:3941
 msgid "create packs suitable for shallow fetches"
 msgstr ""
 
-#: builtin/pack-objects.c:3974
+#: builtin/pack-objects.c:3943
 msgid "ignore packs that have companion .keep file"
 msgstr ""
 
-#: builtin/pack-objects.c:3976
+#: builtin/pack-objects.c:3945
 msgid "ignore this pack"
 msgstr ""
 
-#: builtin/pack-objects.c:3978
+#: builtin/pack-objects.c:3947
 msgid "pack compression level"
 msgstr ""
 
-#: builtin/pack-objects.c:3980
+#: builtin/pack-objects.c:3949
 msgid "do not hide commits by grafts"
 msgstr ""
 
-#: builtin/pack-objects.c:3982
+#: builtin/pack-objects.c:3951
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3984
+#: builtin/pack-objects.c:3953
 msgid "write a bitmap index together with the pack index"
 msgstr ""
 
-#: builtin/pack-objects.c:3988
+#: builtin/pack-objects.c:3957
 msgid "write a bitmap index if possible"
 msgstr ""
 
-#: builtin/pack-objects.c:3992
+#: builtin/pack-objects.c:3961
 msgid "handling for missing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3995
+#: builtin/pack-objects.c:3964
 msgid "do not pack objects in promisor packfiles"
 msgstr ""
 
-#: builtin/pack-objects.c:3997
+#: builtin/pack-objects.c:3966
 msgid "respect islands during delta compression"
 msgstr ""
 
-#: builtin/pack-objects.c:3999
+#: builtin/pack-objects.c:3968
 msgid "protocol"
 msgstr ""
 
-#: builtin/pack-objects.c:4000
+#: builtin/pack-objects.c:3969
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
 
-#: builtin/pack-objects.c:4033
+#: builtin/pack-objects.c:4002
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr ""
 
-#: builtin/pack-objects.c:4038
+#: builtin/pack-objects.c:4007
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr ""
 
-#: builtin/pack-objects.c:4094
+#: builtin/pack-objects.c:4063
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 
-#: builtin/pack-objects.c:4096
+#: builtin/pack-objects.c:4065
 msgid "minimum pack size limit is 1 MiB"
 msgstr ""
 
-#: builtin/pack-objects.c:4101
+#: builtin/pack-objects.c:4070
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 
-#: builtin/pack-objects.c:4104
+#: builtin/pack-objects.c:4073
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr ""
 
-#: builtin/pack-objects.c:4110
+#: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr ""
 
-#: builtin/pack-objects.c:4112
+#: builtin/pack-objects.c:4081
 msgid "cannot use --filter with --stdin-packs"
 msgstr ""
 
-#: builtin/pack-objects.c:4116
+#: builtin/pack-objects.c:4085
 msgid "cannot use internal rev list with --stdin-packs"
 msgstr ""
 
-#: builtin/pack-objects.c:4175
+#: builtin/pack-objects.c:4144
 msgid "Enumerating objects"
 msgstr ""
 
-#: builtin/pack-objects.c:4212
+#: builtin/pack-objects.c:4181
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -18425,7 +18817,7 @@ msgstr ""
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr ""
 
-#: builtin/prune.c:152
+#: builtin/prune.c:151
 msgid "cannot prune in a precious-objects repo"
 msgstr ""
 
@@ -18450,11 +18842,11 @@ msgstr "Opsi yang berkaitan dengan penggabungan"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "masukkan perubahan dengan pendasaran ulang daripada penggabungan"
 
-#: builtin/pull.c:158 builtin/rebase.c:491 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "perbolehkan maju cepat"
 
-#: builtin/pull.c:167 parse-options.h:340
+#: builtin/pull.c:167 parse-options.h:339
 msgid "automatically stash/stash pop before and after"
 msgstr "stash/stash pop otomatis sebelum dan sesudah"
 
@@ -18509,7 +18901,7 @@ msgstr ""
 "satu cabang. Oleh karena ini bukan remote terkonfigurasi asali untuk\n"
 "cabang Anda saat ini, Anda harus sebutkan satu cabang pada baris perintah."
 
-#: builtin/pull.c:456 builtin/rebase.c:1248
+#: builtin/pull.c:456 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Anda tidak berada pada sebuah cabang."
 
@@ -18526,7 +18918,7 @@ msgid "See git-pull(1) for details."
 msgstr "Lihat git-pull(1) untuk selengkapnya."
 
 #: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
-#: builtin/rebase.c:1254
+#: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<remote>"
 
@@ -18534,7 +18926,7 @@ msgstr "<remote>"
 msgid "<branch>"
 msgstr "<cabang>"
 
-#: builtin/pull.c:471 builtin/rebase.c:1246
+#: builtin/pull.c:471 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Tidak ada informasi pelacakan untuk cabang saat ini."
 
@@ -18563,11 +18955,11 @@ msgstr "Tidak dapat mengakses komit %s"
 msgid "ignoring --verify-signatures for rebase"
 msgstr "mengabaikan --verify-signatures untuk pendasaran ulang"
 
-#: builtin/pull.c:930
+#: builtin/pull.c:936
 msgid ""
-"Pulling without specifying how to reconcile divergent branches is\n"
-"discouraged. You can squelch this message by running one of the following\n"
-"commands sometime before your next pull:\n"
+"You have divergent branches and need to specify how to reconcile them.\n"
+"You can do so by running one of the following commands sometime before\n"
+"your next pull:\n"
 "\n"
 "  git config pull.rebase false  # merge (the default strategy)\n"
 "  git config pull.rebase true   # rebase\n"
@@ -18579,9 +18971,10 @@ msgid ""
 "or --ff-only on the command line to override the configured default per\n"
 "invocation.\n"
 msgstr ""
-"Menarik tanpa menyebutkan cara merujukkan cabang yang berlainan tidak\n"
-"disarankan. Anda dapat mematikan pesan ini dengan menjalankan salah\n"
-"satu perintah berikut sebelum penarikan berikutnya:\n"
+"Anda punya cabang-cabang yang berlainan dan perlu menyebutkan cara\n"
+"merujukkannya.\n"
+"Anda dapat melakukannya dengan menjalankan salah satu perintah berikut\n"
+"suatu saat sebelum penarikan berikutnya:\n"
 "\n"
 "  git config pull.rebase false  # penggabungan (strategi asali)\n"
 "  git config pull.rebase true   # pendasaran ulang\n"
@@ -18592,21 +18985,21 @@ msgstr ""
 "--rebase, --no-rebase, atau --ff-only pada baris perintah untuk menimpa\n"
 "asali terkonfigurasi untuk setiap invokasi.\n"
 
-#: builtin/pull.c:990
+#: builtin/pull.c:1010
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Memperbarui cabang yang belum lahir dengan perubahan yang ditambahkan ke "
 "indeks."
 
-#: builtin/pull.c:994
+#: builtin/pull.c:1014
 msgid "pull with rebase"
 msgstr "tarik dengan pendasaran ulang"
 
-#: builtin/pull.c:995
+#: builtin/pull.c:1015
 msgid "please commit or stash them."
 msgstr "mohon komit atau stase itu."
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1040
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -18616,7 +19009,7 @@ msgstr ""
 "fetch memperbarui kepala cabang saat ini.\n"
 "memajukan-cepat pohon kerja Anda dari komit %s."
 
-#: builtin/pull.c:1026
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -18633,15 +19026,23 @@ msgstr ""
 "$ git reset --hard\n"
 "untuk memulihkan."
 
-#: builtin/pull.c:1041
+#: builtin/pull.c:1061
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Tidak dapat menggabungkan banyak cabang ke kepala kosong."
 
-#: builtin/pull.c:1045
+#: builtin/pull.c:1066
 msgid "Cannot rebase onto multiple branches."
 msgstr "Tidak dapat mendasarkan ulang pada banyak cabang."
 
-#: builtin/pull.c:1065
+#: builtin/pull.c:1068
+msgid "Cannot fast-forward to multiple branches."
+msgstr "Tidak dapat maju cepat ke banyak cabang."
+
+#: builtin/pull.c:1082
+msgid "Need to specify how to reconcile divergent branches."
+msgstr "Perlu sebutkan cara merujukkan cabang yang berlainan."
+
+#: builtin/pull.c:1096
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "tidak dapat mendasarkan ulang dengan modifikasi submodul yang terekam lokal."
@@ -18817,15 +19218,15 @@ msgstr "Mendorong ke %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "gagal dorong beberapa referensi ke '%s'"
 
-#: builtin/push.c:544
+#: builtin/push.c:544 builtin/submodule--helper.c:3258
 msgid "repository"
 msgstr "repositori"
 
-#: builtin/push.c:545 builtin/send-pack.c:189
+#: builtin/push.c:545 builtin/send-pack.c:193
 msgid "push all refs"
 msgstr "dorong semua referensi"
 
-#: builtin/push.c:546 builtin/send-pack.c:191
+#: builtin/push.c:546 builtin/send-pack.c:195
 msgid "mirror all refs"
 msgstr "cermin semua referensi"
 
@@ -18837,19 +19238,19 @@ msgstr "hapus referensi"
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "dorong tag (tidak dapat digunakan dengan --all atau --mirror)"
 
-#: builtin/push.c:552 builtin/send-pack.c:192
+#: builtin/push.c:552 builtin/send-pack.c:196
 msgid "force updates"
 msgstr "paksa pembaruan"
 
-#: builtin/push.c:553 builtin/send-pack.c:204
+#: builtin/push.c:553 builtin/send-pack.c:208
 msgid "<refname>:<expect>"
 msgstr "<nama referensi>:<harapan>"
 
-#: builtin/push.c:554 builtin/send-pack.c:205
+#: builtin/push.c:554 builtin/send-pack.c:209
 msgid "require old value of ref to be at this value"
 msgstr "memerlukan nilai lama referensi berada pada nilai saat ini"
 
-#: builtin/push.c:557 builtin/send-pack.c:208
+#: builtin/push.c:557 builtin/send-pack.c:212
 msgid "require remote updates to be integrated locally"
 msgstr "memerlukan pembaruan remote diintegrasikan ke lokal"
 
@@ -18857,12 +19258,12 @@ msgstr "memerlukan pembaruan remote diintegrasikan ke lokal"
 msgid "control recursive pushing of submodules"
 msgstr "kontrol dorong rekursif submodul"
 
-#: builtin/push.c:561 builtin/send-pack.c:199
+#: builtin/push.c:561 builtin/send-pack.c:203
 msgid "use thin pack"
 msgstr "gunakan paket tipis"
 
-#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:186
-#: builtin/send-pack.c:187
+#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:190
+#: builtin/send-pack.c:191
 msgid "receive pack program"
 msgstr "program terima paket"
 
@@ -18876,17 +19277,17 @@ msgstr "buang referensi terhapus lokal"
 
 #: builtin/push.c:569
 msgid "bypass pre-push hook"
-msgstr "lewati kait pra-dorong"
+msgstr "lewati kail pra-dorong"
 
 #: builtin/push.c:570
 msgid "push missing but relevant tags"
 msgstr "dorong tag yang hilang tapi relevan"
 
-#: builtin/push.c:572 builtin/send-pack.c:193
+#: builtin/push.c:572 builtin/send-pack.c:197
 msgid "GPG sign the push"
 msgstr "Tandatangan GPG dorong"
 
-#: builtin/push.c:574 builtin/send-pack.c:200
+#: builtin/push.c:574 builtin/send-pack.c:204
 msgid "request atomic transaction on remote side"
 msgstr "minta transaksi atomik pada sisi remote"
 
@@ -18997,81 +19398,86 @@ msgstr ""
 #: builtin/read-tree.c:41
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
-"[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
-"index-output=<file>] (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
+"[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
+"ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
+"git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
+"prefix=<prefiks>) [-u | -i]] [--no-sparse-checkout] [--index-"
+"output=<berkas>] (--empty | <mirip-pohon 1> [<mirip-pohon 2> <mirip-pohon "
+"3>])"
 
-#: builtin/read-tree.c:124
+#: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
-msgstr ""
+msgstr "tulis indeks yang dihasilkan ke <berkas>"
 
-#: builtin/read-tree.c:127
+#: builtin/read-tree.c:119
 msgid "only empty the index"
-msgstr ""
+msgstr "hanya kosongkan indeks"
 
-#: builtin/read-tree.c:129
+#: builtin/read-tree.c:121
 msgid "Merging"
-msgstr ""
+msgstr "Menggabungkan"
 
-#: builtin/read-tree.c:131
+#: builtin/read-tree.c:123
 msgid "perform a merge in addition to a read"
-msgstr ""
+msgstr "lakukan penggabungan selain pembacaan"
 
-#: builtin/read-tree.c:133
+#: builtin/read-tree.c:125
 msgid "3-way merge if no file level merging required"
 msgstr ""
+"penggabungan 3 arah jika tidak ada penggabungan level berkas yang dibutuhkan"
 
-#: builtin/read-tree.c:135
+#: builtin/read-tree.c:127
 msgid "3-way merge in presence of adds and removes"
-msgstr ""
+msgstr "penggabungan 3 arah dengan kehadiran penambahan dan penghapusan"
+
+#: builtin/read-tree.c:129
+msgid "same as -m, but discard unmerged entries"
+msgstr "sama seperti -m, tapi buang entri tak tergabung"
+
+#: builtin/read-tree.c:130
+msgid "<subdirectory>/"
+msgstr "<subdirektori>/"
+
+#: builtin/read-tree.c:131
+msgid "read the tree into the index under <subdirectory>/"
+msgstr "baca pohon ke dalam indeks pada <subdirektori>/"
+
+#: builtin/read-tree.c:134
+msgid "update working tree with merge result"
+msgstr "perbarui pohon kerja dengan hasil penggabungan"
+
+#: builtin/read-tree.c:136
+msgid "gitignore"
+msgstr "gitignore"
 
 #: builtin/read-tree.c:137
-msgid "same as -m, but discard unmerged entries"
-msgstr ""
+msgid "allow explicitly ignored files to be overwritten"
+msgstr "perbolehkan berkas yang diabaikan secara eksplisit untuk ditimpa"
 
-#: builtin/read-tree.c:138
-msgid "<subdirectory>/"
-msgstr ""
+#: builtin/read-tree.c:140
+msgid "don't check the working tree after merging"
+msgstr "jangan periksa pohon kerja setelah penggabungan"
 
-#: builtin/read-tree.c:139
-msgid "read the tree into the index under <subdirectory>/"
-msgstr ""
+#: builtin/read-tree.c:141
+msgid "don't update the index or the work tree"
+msgstr "jangan perbarui indeks atau pohon kerja"
 
-#: builtin/read-tree.c:142
-msgid "update working tree with merge result"
-msgstr ""
-
-#: builtin/read-tree.c:144
-msgid "gitignore"
-msgstr ""
+#: builtin/read-tree.c:143
+msgid "skip applying sparse checkout filter"
+msgstr "lewatkan penerapan saringan checkout tipis"
 
 #: builtin/read-tree.c:145
-msgid "allow explicitly ignored files to be overwritten"
-msgstr ""
-
-#: builtin/read-tree.c:148
-msgid "don't check the working tree after merging"
-msgstr ""
+msgid "debug unpack-trees"
+msgstr "nirkutukan unpack-trees"
 
 #: builtin/read-tree.c:149
-msgid "don't update the index or the work tree"
-msgstr ""
-
-#: builtin/read-tree.c:151
-msgid "skip applying sparse checkout filter"
-msgstr ""
-
-#: builtin/read-tree.c:153
-msgid "debug unpack-trees"
-msgstr ""
-
-#: builtin/read-tree.c:157
 msgid "suppress feedback messages"
-msgstr ""
+msgstr "matikan pesan umpan balik"
 
-#: builtin/read-tree.c:188
+#: builtin/read-tree.c:183
 msgid "You need to resolve your current index first"
-msgstr ""
+msgstr "Anda perlu menguraikan indeks Anda saat ini dulu"
 
 #: builtin/rebase.c:35
 msgid ""
@@ -19092,193 +19498,44 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:194 builtin/rebase.c:218 builtin/rebase.c:245
-#, c-format
-msgid "unusable todo list: '%s'"
-msgstr "daftar todo tidak dapat digunakan: '%s'"
-
-#: builtin/rebase.c:311
+#: builtin/rebase.c:230
 #, c-format
 msgid "could not create temporary %s"
 msgstr "tidak dapat membuat %s sementara"
 
-#: builtin/rebase.c:317
+#: builtin/rebase.c:236
 msgid "could not mark as interactive"
 msgstr "tidak dapat menandai sebagai interaktif"
 
-#: builtin/rebase.c:370
+#: builtin/rebase.c:289
 msgid "could not generate todo list"
 msgstr "tidak dapat membuat daftar todo"
 
-#: builtin/rebase.c:412
+#: builtin/rebase.c:331
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "basis komit harus diberikan dengan --upstream atau --onto"
 
-#: builtin/rebase.c:481
-msgid "git rebase--interactive [<options>]"
-msgstr "git rebase--interactive [<opsi>]"
-
-#: builtin/rebase.c:494 builtin/rebase.c:1389
-msgid "keep commits which start empty"
-msgstr "simpan komit yang dimulai kosong"
-
-#: builtin/rebase.c:498 builtin/revert.c:128
-msgid "allow commits with empty messages"
-msgstr "perbolehkan komit dengan pesan kosong"
-
-#: builtin/rebase.c:500
-msgid "rebase merge commits"
-msgstr "dasarkan ulang komit penggabungan"
-
-#: builtin/rebase.c:502
-msgid "keep original branch points of cousins"
-msgstr "simpan titik cabang sepupu asal "
-
-#: builtin/rebase.c:504
-msgid "move commits that begin with squash!/fixup!"
-msgstr "pindahkan komit yang diawali dengan squash!/fixup!"
-
-#: builtin/rebase.c:505
-msgid "sign commits"
-msgstr "tandatangani komit"
-
-#: builtin/rebase.c:507 builtin/rebase.c:1328
-msgid "display a diffstat of what changed upstream"
-msgstr "perlihatkan diffstat apa yang berubah di hulu"
-
-#: builtin/rebase.c:509
-msgid "continue rebase"
-msgstr "lanjutkan pendasaran ulang"
-
-#: builtin/rebase.c:511
-msgid "skip commit"
-msgstr "lewatkan komit"
-
-#: builtin/rebase.c:512
-msgid "edit the todo list"
-msgstr "sunting daftar todo"
-
-#: builtin/rebase.c:514
-msgid "show the current patch"
-msgstr "perlihatkan tambalan saat ini"
-
-#: builtin/rebase.c:517
-msgid "shorten commit ids in the todo list"
-msgstr "pendekkan id komit dalam daftar todo"
-
-#: builtin/rebase.c:519
-msgid "expand commit ids in the todo list"
-msgstr "jabarkan id komit dalam daftar todo"
-
-#: builtin/rebase.c:521
-msgid "check the todo list"
-msgstr "periksa daftar todo"
-
-#: builtin/rebase.c:523
-msgid "rearrange fixup/squash lines"
-msgstr "susun ulang baris fixup/squash"
-
-#: builtin/rebase.c:525
-msgid "insert exec commands in todo list"
-msgstr "masukkan perintah exec ke dalam daftar todo"
-
-#: builtin/rebase.c:526
-msgid "onto"
-msgstr "ke"
-
-#: builtin/rebase.c:529
-msgid "restrict-revision"
-msgstr "restrict-revision"
-
-#: builtin/rebase.c:529
-msgid "restrict revision"
-msgstr "batasi revisi"
-
-#: builtin/rebase.c:531
-msgid "squash-onto"
-msgstr "squash-onto"
-
-#: builtin/rebase.c:532
-msgid "squash onto"
-msgstr "lumat ke"
-
-#: builtin/rebase.c:534
-msgid "the upstream commit"
-msgstr "komit hulu"
-
-#: builtin/rebase.c:536
-msgid "head-name"
-msgstr "head-name"
-
-#: builtin/rebase.c:536
-msgid "head name"
-msgstr "nama kepala"
-
-#: builtin/rebase.c:541
-msgid "rebase strategy"
-msgstr "strategi pendasaran"
-
-#: builtin/rebase.c:542
-msgid "strategy-opts"
-msgstr "strategy-opts"
-
-#: builtin/rebase.c:543
-msgid "strategy options"
-msgstr "opsi strategi"
-
-#: builtin/rebase.c:544
-msgid "switch-to"
-msgstr "switch-to"
-
-#: builtin/rebase.c:545
-msgid "the branch or commit to checkout"
-msgstr "cabang atau komit untuk di-checkout"
-
-#: builtin/rebase.c:546
-msgid "onto-name"
-msgstr "onto-name"
-
-#: builtin/rebase.c:546
-msgid "onto name"
-msgstr "nama ke"
-
-#: builtin/rebase.c:547
-msgid "cmd"
-msgstr "cmd"
-
-#: builtin/rebase.c:547
-msgid "the command to run"
-msgstr "perintah untuk dijalankan"
-
-#: builtin/rebase.c:550 builtin/rebase.c:1422
-msgid "automatically re-schedule any `exec` that fails"
-msgstr "jadwal ulang otomatis `exec` apa saja yang gagal"
-
-#: builtin/rebase.c:566
-msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-msgstr "--[no-]rebase-cousins tidak ada efek tanpa --rebase-merges"
-
-#: builtin/rebase.c:582
+#: builtin/rebase.c:390
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s butuh tulang belakang penggabungan"
 
-#: builtin/rebase.c:625
+#: builtin/rebase.c:432
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "tidak dapat mendapatkan 'ke': '%s'"
 
-#: builtin/rebase.c:642
+#: builtin/rebase.c:449
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "orig-head tidak valid: '%s'"
 
-#: builtin/rebase.c:667
+#: builtin/rebase.c:474
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "abaikan allow_rerere_autoupdate yang tak valid: '%s'"
 
-#: builtin/rebase.c:813 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:597
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -19293,7 +19550,7 @@ msgstr ""
 "Untuk membatalkan dan kembali ke kondisi sebelum \"git rebase\",jalankan "
 "\"git rebase --abort\"."
 
-#: builtin/rebase.c:896
+#: builtin/rebase.c:680
 #, c-format
 msgid ""
 "\n"
@@ -19312,7 +19569,7 @@ msgstr ""
 "\n"
 "Hasilnya git tidak dapat mendasarkan ulang itu."
 
-#: builtin/rebase.c:1222
+#: builtin/rebase.c:925
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -19321,7 +19578,7 @@ msgstr ""
 "tipe kosong tak dikenali '%s'; nilai yang valid adalah \"drop\", \"keep\", "
 "dan \"ask\"."
 
-#: builtin/rebase.c:1240
+#: builtin/rebase.c:943
 #, c-format
 msgid ""
 "%s\n"
@@ -19338,7 +19595,7 @@ msgstr ""
 "    git rebase '<cabang>'.\n"
 "\n"
 
-#: builtin/rebase.c:1256
+#: builtin/rebase.c:959
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -19351,183 +19608,193 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<cabang> %s\n"
 "\n"
 
-#: builtin/rebase.c:1286
+#: builtin/rebase.c:989
 msgid "exec commands cannot contain newlines"
 msgstr "perintah exec tidak dapat berisi baris baru"
 
-#: builtin/rebase.c:1290
+#: builtin/rebase.c:993
 msgid "empty exec command"
 msgstr "perintah exec kosong"
 
-#: builtin/rebase.c:1319
+#: builtin/rebase.c:1023
 msgid "rebase onto given branch instead of upstream"
 msgstr "dasarkan ulang kepada cabang yang diberikan daripada hulu"
 
-#: builtin/rebase.c:1321
+#: builtin/rebase.c:1025
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "gunakan merge-base hulu dan cabang sebagai dasar saat ini"
 
-#: builtin/rebase.c:1323
+#: builtin/rebase.c:1027
 msgid "allow pre-rebase hook to run"
-msgstr "perbolehkan hook pre-rebase untuk dijalankan"
+msgstr "perbolehkan kail pre-rebase untuk dijalankan"
 
-#: builtin/rebase.c:1325
+#: builtin/rebase.c:1029
 msgid "be quiet. implies --no-stat"
 msgstr "diam. menyiratkan --no-stat"
 
-#: builtin/rebase.c:1331
+#: builtin/rebase.c:1032
+msgid "display a diffstat of what changed upstream"
+msgstr "perlihatkan diffstat apa yang berubah di hulu"
+
+#: builtin/rebase.c:1035
 msgid "do not show diffstat of what changed upstream"
 msgstr "jangan perlihatkan diffstat apa yang berubah di hulu"
 
-#: builtin/rebase.c:1334
+#: builtin/rebase.c:1038
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "tambahkan trailer Signed-off-by ke setiap komit"
 
-#: builtin/rebase.c:1337
+#: builtin/rebase.c:1041
 msgid "make committer date match author date"
 msgstr "jadikan tanggal pengkomit sama dengan tanggal pengarang"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1043
 msgid "ignore author date and use current date"
 msgstr "abaikan tanggal pengarang dan gunakan tanggal saat ini"
 
-#: builtin/rebase.c:1341
+#: builtin/rebase.c:1045
 msgid "synonym of --reset-author-date"
 msgstr "sinonim dari --reset-author-date"
 
-#: builtin/rebase.c:1343 builtin/rebase.c:1347
+#: builtin/rebase.c:1047 builtin/rebase.c:1051
 msgid "passed to 'git apply'"
 msgstr "lewatkan ke 'git apply'"
 
-#: builtin/rebase.c:1345
+#: builtin/rebase.c:1049
 msgid "ignore changes in whitespace"
 msgstr "abaikan perubahan spasi"
 
-#: builtin/rebase.c:1349 builtin/rebase.c:1352
+#: builtin/rebase.c:1053 builtin/rebase.c:1056
 msgid "cherry-pick all commits, even if unchanged"
 msgstr "petik ceri semua komit, bahkan jika tak berubah"
 
-#: builtin/rebase.c:1354
+#: builtin/rebase.c:1058
 msgid "continue"
 msgstr "lanjutkan"
 
-#: builtin/rebase.c:1357
+#: builtin/rebase.c:1061
 msgid "skip current patch and continue"
 msgstr "lewatkan tambalan saat ini dan lanjutkan"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1063
 msgid "abort and check out the original branch"
 msgstr "hentikan dan check out cabang asli"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1066
 msgid "abort but keep HEAD where it is"
 msgstr "hentikan tapi simpan HEAD dimana itu berada"
 
-#: builtin/rebase.c:1363
+#: builtin/rebase.c:1067
 msgid "edit the todo list during an interactive rebase"
 msgstr "sunting daftar todo selama pendasaran ulang interaktif"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1070
 msgid "show the patch file being applied or merged"
 msgstr "perlihatkan berkas tambalan yang sedang diterapkan atau digabungkan"
 
-#: builtin/rebase.c:1369
+#: builtin/rebase.c:1073
 msgid "use apply strategies to rebase"
 msgstr "gunakan strategi penerapan ke pendasaran ulang"
 
-#: builtin/rebase.c:1373
+#: builtin/rebase.c:1077
 msgid "use merging strategies to rebase"
 msgstr "gunakan strategi penggabungan ke pendasaran ulang"
 
-#: builtin/rebase.c:1377
+#: builtin/rebase.c:1081
 msgid "let the user edit the list of commits to rebase"
 msgstr "biarkan pengguna menyunting daftar komit untuk didasarkan ulang"
 
-#: builtin/rebase.c:1381
+#: builtin/rebase.c:1085
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(USANG) coba buat ulang penggabungan daripada abaikan itu"
 
-#: builtin/rebase.c:1386
+#: builtin/rebase.c:1090
 msgid "how to handle commits that become empty"
 msgstr "bagaimana cara menangani komit yang menjadi kosong"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1093
+msgid "keep commits which start empty"
+msgstr "simpan komit yang dimulai kosong"
+
+#: builtin/rebase.c:1097
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "pindahakan komit yang diawali dengan squash!/fixup! di bawah -i"
 
-#: builtin/rebase.c:1400
+#: builtin/rebase.c:1104
 msgid "add exec lines after each commit of the editable list"
 msgstr ""
 "tambahkan baris exec setelah setiap komit dari daftar yang bisa disunting"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1108
 msgid "allow rebasing commits with empty messages"
 msgstr "perbolehkan mendasarkan ulang komit dengan pesan kosong"
 
-#: builtin/rebase.c:1408
+#: builtin/rebase.c:1112
 msgid "try to rebase merges instead of skipping them"
 msgstr "coba mendasarkan ulang penggabungan daripada melewatkan itu"
 
-#: builtin/rebase.c:1411
+#: builtin/rebase.c:1115
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr "gunakan 'merge-base --fork-point' untuk menyaring hulu"
 
-#: builtin/rebase.c:1413
+#: builtin/rebase.c:1117
 msgid "use the given merge strategy"
 msgstr "gunakan strategi penggabungan yang diberikan"
 
-#: builtin/rebase.c:1415 builtin/revert.c:115
+#: builtin/rebase.c:1119 builtin/revert.c:115
 msgid "option"
 msgstr "opsi"
 
-#: builtin/rebase.c:1416
+#: builtin/rebase.c:1120
 msgid "pass the argument through to the merge strategy"
 msgstr "lewatkan argumen ke strategi penggabungan"
 
-#: builtin/rebase.c:1419
+#: builtin/rebase.c:1123
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "dasarkan ulang semua komit yang bisa dicapai hingga ke akar"
 
-#: builtin/rebase.c:1424
+#: builtin/rebase.c:1126
+msgid "automatically re-schedule any `exec` that fails"
+msgstr "jadwal ulang otomatis `exec` apa saja yang gagal"
+
+#: builtin/rebase.c:1128
 msgid "apply all changes, even those already present upstream"
 msgstr "terapkan semua perubahan, bahkan yang sudah ada di hulu"
 
-#: builtin/rebase.c:1442
+#: builtin/rebase.c:1149
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "Sepertinya 'git am' sedang berjalan. Tidak dapat mendasarkan ulang"
 
-#: builtin/rebase.c:1483
-msgid ""
-"git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
-msgstr ""
-"git rebase --preserve-merges usang. Gunakan --rebase-merges sebagai gantinya."
+#: builtin/rebase.c:1180
+msgid "--preserve-merges was replaced by --rebase-merges"
+msgstr "--preserve-merges digantikan oleh --rebase-merges"
 
-#: builtin/rebase.c:1488
+#: builtin/rebase.c:1193
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "tidak dapat menggabungkan '--keep-base' dengan '--onto'"
 
-#: builtin/rebase.c:1490
+#: builtin/rebase.c:1195
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "tidak dapat menggabungkan '--keep-base' dengan '--root'"
 
-#: builtin/rebase.c:1494
+#: builtin/rebase.c:1199
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "tidak dapat menggabungkan '--root' dengan '--fork-point'"
 
-#: builtin/rebase.c:1497
+#: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "Tidak ada pendasaran ulang yang sedang berjalan?"
 
-#: builtin/rebase.c:1501
+#: builtin/rebase.c:1206
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Aksi --edit-todo hanya dapat digunakan selama pendasaran ulang interaktif."
 
-#: builtin/rebase.c:1524 t/helper/test-fast-rebase.c:122
+#: builtin/rebase.c:1229 t/helper/test-fast-rebase.c:122
 msgid "Cannot read HEAD"
 msgstr "Tidak dapat membaca HEAD"
 
-#: builtin/rebase.c:1536
+#: builtin/rebase.c:1241
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -19535,16 +19802,16 @@ msgstr ""
 "Anda harus menyunting semua konflik penggabungan lalu\n"
 "tandai itu sebagai terselesaikan menggunakan git add"
 
-#: builtin/rebase.c:1555
+#: builtin/rebase.c:1260
 msgid "could not discard worktree changes"
 msgstr "tidak dapat menyingkirkan perubahan pohon kerja"
 
-#: builtin/rebase.c:1574
+#: builtin/rebase.c:1279
 #, c-format
 msgid "could not move back to %s"
 msgstr "tidak dapt memindahkan kembali ke %s"
 
-#: builtin/rebase.c:1620
+#: builtin/rebase.c:1325
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -19565,144 +19832,133 @@ msgstr ""
 "dan jalankan saya lagi. Saya berhenti seandainya Anda masih punya\n"
 "sesuatu yang berharga di sana.\n"
 
-#: builtin/rebase.c:1648
+#: builtin/rebase.c:1353
 msgid "switch `C' expects a numerical value"
 msgstr "tombol `C' harap nilai numerik"
 
-#: builtin/rebase.c:1690
+#: builtin/rebase.c:1395
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Mode tidak dikenal: %s"
 
-#: builtin/rebase.c:1729
+#: builtin/rebase.c:1434
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy butuh --merge atau --interactive"
 
-#: builtin/rebase.c:1759
+#: builtin/rebase.c:1463
 msgid "cannot combine apply options with merge options"
 msgstr "tidak dapat menggabungkan opsi penerapan dengan opsi penggabungan"
 
-#: builtin/rebase.c:1772
+#: builtin/rebase.c:1476
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Tulang belakang pendasaran ulang tidak dikenal: %s"
 
-#: builtin/rebase.c:1802
+#: builtin/rebase.c:1505
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec butuh --exec atau --interactive"
 
-#: builtin/rebase.c:1822
-msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-msgstr "tidak dapat menggabungkan '--preserve-merges' dengan '--rebase-merges'"
-
-#: builtin/rebase.c:1826
-msgid ""
-"error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-msgstr ""
-"error: tidak dapat menggabungkan '--preserve-merges' dengan '--reschedule-"
-"failed-exec'"
-
-#: builtin/rebase.c:1850
+#: builtin/rebase.c:1536
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "hulu tidak valid '%s'"
 
-#: builtin/rebase.c:1856
+#: builtin/rebase.c:1542
 msgid "Could not create new root commit"
 msgstr "tidak dapat membuat komit akar baru"
 
-#: builtin/rebase.c:1882
+#: builtin/rebase.c:1568
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': butuh tepatnya satu dasar penggabungan dengan cabang"
 
-#: builtin/rebase.c:1885
+#: builtin/rebase.c:1571
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': butuh tepatnya satu dasar penggabungan"
 
-#: builtin/rebase.c:1893
+#: builtin/rebase.c:1580
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "Tidak menunjuk pada komit yang valid '%s'"
 
-#: builtin/rebase.c:1921
+#: builtin/rebase.c:1607
 #, c-format
-msgid "fatal: no such branch/commit '%s'"
-msgstr "fatal: tidak ada cabang/komit seperti '%s'"
+msgid "no such branch/commit '%s'"
+msgstr "tidak ada cabang/komit seperti '%s'"
 
-#: builtin/rebase.c:1929 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2431
+#: builtin/rebase.c:1618 builtin/submodule--helper.c:39
+#: builtin/submodule--helper.c:2658
 #, c-format
 msgid "No such ref: %s"
 msgstr "Tidak ada referensi seperti: %s"
 
-#: builtin/rebase.c:1940
+#: builtin/rebase.c:1629
 msgid "Could not resolve HEAD to a revision"
 msgstr "Tidak dapat menguraikan HEAD ke sebuah revisi"
 
-#: builtin/rebase.c:1961
+#: builtin/rebase.c:1650
 msgid "Please commit or stash them."
 msgstr "Mohon komit atau stase itu."
 
-#: builtin/rebase.c:1997
+#: builtin/rebase.c:1686
 #, c-format
 msgid "could not switch to %s"
 msgstr "tidak dapat mengganti ke %s"
 
-#: builtin/rebase.c:2008
+#: builtin/rebase.c:1697
 msgid "HEAD is up to date."
 msgstr "HEAD terbaru."
 
-#: builtin/rebase.c:2010
+#: builtin/rebase.c:1699
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Cabang saat ini %s terbaru.\n"
 
-#: builtin/rebase.c:2018
+#: builtin/rebase.c:1707
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD terbaru, pendasaran ulang dipaksa."
 
-#: builtin/rebase.c:2020
+#: builtin/rebase.c:1709
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Cabang saat ini %s terbaru, pendasaran ulang dipaksa.\n"
 
-#: builtin/rebase.c:2028
+#: builtin/rebase.c:1717
 msgid "The pre-rebase hook refused to rebase."
-msgstr "Hook pre-rebase menolak mendasarkan ulang."
+msgstr "Kail pre-rebase menolak mendasarkan ulang."
 
-#: builtin/rebase.c:2035
+#: builtin/rebase.c:1724
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Perubahan unuk %s:\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:1727
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Perubahan dari %s ke %s:\n"
 
-#: builtin/rebase.c:2063
+#: builtin/rebase.c:1752
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Pertama, memutar ulang kepala untuk memainkan ulang karya Anda diatas "
 "itu...\n"
 
-#: builtin/rebase.c:2072
+#: builtin/rebase.c:1761
 msgid "Could not detach HEAD"
 msgstr "Tidak dapat melepas HEAD"
 
-#: builtin/rebase.c:2081
+#: builtin/rebase.c:1770
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Maju-cepat %s ke %s.\n"
 
-#: builtin/receive-pack.c:34
+#: builtin/receive-pack.c:35
 msgid "git receive-pack <git-dir>"
-msgstr ""
+msgstr "git receive-pack <direktori git>"
 
-#: builtin/receive-pack.c:1275
+#: builtin/receive-pack.c:1280
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -19718,8 +19974,20 @@ msgid ""
 "To squelch this message and still keep the default behaviour, set\n"
 "'receive.denyCurrentBranch' configuration variable to 'refuse'."
 msgstr ""
+"Secara asali, memperbarui cabang saat ini di dalam repositori non-bare\n"
+"tidak diperbolehkan, karena akan membuat indeks dan pohon kerja inkonsisten\n"
+"dengan yang Anda dorong, dan akan memerlukan 'git reset --hard' untuk\n"
+"mencocokkan pohon kerja dengan HEAD.\n"
+"\n"
+"Anda dapat menyetel variabel konfigurasi 'receive.denyCurrentBranch' ke\n"
+"'ignore' atau 'warn' di repositori remote untuk memperbolehkan dorong ke\n"
+"cabang saat itu; tetapi tidak disarankan kecuali Anda dapat memperbarui\n"
+"pohon kerjanya agar cocok dengan apa yang Anda dorong dengan cara lain.\n"
+"\n"
+"Untuk mematikan pesan ini dan tetap menjaga kebiasaan asali, setel\n"
+"variabel konfigurasi 'receive.denyCurrentBranch' ke 'refuse'."
 
-#: builtin/receive-pack.c:1295
+#: builtin/receive-pack.c:1300
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -19730,14 +19998,22 @@ msgid ""
 "\n"
 "To squelch this message, you can set it to 'refuse'."
 msgstr ""
+"Secara asali, menghapus cabang saat ini tidak diperbolehkan, karena\n"
+"'git clone' selanjutnya tidak berujung pada berkas apapun ter-checkout,\n"
+"dan mengakibatkan kebingungan.\n"
+"Anda dapat menyetel variabel konfigurasi 'receive.denyDeleteCurrent' ke\n"
+"'warn' atau 'ignore' di dalam repositori remote untuk memperbolehkan\n"
+"menghapus cabang saat ini, dengan atau tanpa pesan peringatan.\n"
+"\n"
+"Untuk mematikan pesan ini, Anda dapat menyetelnya ke 'refuse'."
 
-#: builtin/receive-pack.c:2478
+#: builtin/receive-pack.c:2480
 msgid "quiet"
-msgstr ""
+msgstr "diam"
 
-#: builtin/receive-pack.c:2492
+#: builtin/receive-pack.c:2495
 msgid "You must specify a directory."
-msgstr ""
+msgstr "Anda harus menyebutkan sebuah direktori."
 
 #: builtin/reflog.c:17
 msgid ""
@@ -19745,54 +20021,59 @@ msgid ""
 "rewrite] [--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all] "
 "<refs>..."
 msgstr ""
+"git reflog expire [--expire=<waktu>] [--expire-unreachable=<waktu>] [--"
+"rewrite] [--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all] "
+"<referensi>..."
 
 #: builtin/reflog.c:22
 msgid ""
 "git reflog delete [--rewrite] [--updateref] [--dry-run | -n] [--verbose] "
 "<refs>..."
 msgstr ""
+"git reflog delete [--rewrite] [--updateref] [--dry-run | -n] [--verbose] "
+"<referensi>..."
 
 #: builtin/reflog.c:25
 msgid "git reflog exists <ref>"
-msgstr ""
+msgstr "git reflog exists <referensi>"
 
 #: builtin/reflog.c:568 builtin/reflog.c:573
 #, c-format
 msgid "'%s' is not a valid timestamp"
-msgstr ""
+msgstr "'%s' bukan stempel waktu valid"
 
 #: builtin/reflog.c:609
 #, c-format
 msgid "Marking reachable objects..."
-msgstr ""
+msgstr "Menandai objek yang bisa dicapai..."
 
 #: builtin/reflog.c:647
 #, c-format
 msgid "%s points nowhere!"
-msgstr ""
+msgstr "%s tidak menunjuk ke apapun!"
 
-#: builtin/reflog.c:699
+#: builtin/reflog.c:700
 msgid "no reflog specified to delete"
-msgstr ""
+msgstr "tidak ada log referensi yang disebutkan untuk dihapus"
 
 #: builtin/reflog.c:708
 #, c-format
 msgid "not a reflog: %s"
-msgstr ""
+msgstr "bukan sebuah log referensi: %s"
 
 #: builtin/reflog.c:713
 #, c-format
 msgid "no reflog for '%s'"
-msgstr ""
+msgstr "tidak ada log referensi untuk '%s'"
 
 #: builtin/reflog.c:759
 #, c-format
 msgid "invalid ref format: %s"
-msgstr ""
+msgstr "format referensi tidak valid: %s"
 
 #: builtin/reflog.c:768
 msgid "git reflog [ show | expire | delete | exists ]"
-msgstr ""
+msgstr "git reflog [ show | expire | delete | exists ]"
 
 #: builtin/remote.c:17
 msgid "git remote [-v | --verbose]"
@@ -19926,7 +20207,7 @@ msgstr "menyebutkan cabang master tidak masuk akal dengan --mirror"
 msgid "specifying branches to track makes sense only with fetch mirrors"
 msgstr "menyebutkan cabang untuk dilacak hanya masuk akal dengan cermin ambil"
 
-#: builtin/remote.c:195 builtin/remote.c:700
+#: builtin/remote.c:195 builtin/remote.c:705
 #, c-format
 msgid "remote %s already exists."
 msgstr "remote %s sudah ada"
@@ -19936,25 +20217,30 @@ msgstr "remote %s sudah ada"
 msgid "Could not setup master '%s'"
 msgstr "Tidak dapat mengatur master '%s'"
 
-#: builtin/remote.c:355
+#: builtin/remote.c:322
+#, c-format
+msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
+msgstr ""
+
+#: builtin/remote.c:366
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr "Tidak dapat mendapatkan peta pengambilan untuk spek referensi %s"
 
-#: builtin/remote.c:454 builtin/remote.c:462
+#: builtin/remote.c:460 builtin/remote.c:468
 msgid "(matching)"
 msgstr "(sepadan)"
 
-#: builtin/remote.c:466
+#: builtin/remote.c:472
 msgid "(delete)"
 msgstr "(hapus)"
 
-#: builtin/remote.c:655
+#: builtin/remote.c:660
 #, c-format
 msgid "could not set '%s'"
 msgstr "tidak dapat menyetel '%s'"
 
-#: builtin/remote.c:660
+#: builtin/remote.c:665
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -19965,17 +20251,17 @@ msgstr ""
 "\t%s:%d\n"
 "sekarang menamai remote yang tiada '%s'"
 
-#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:943
+#: builtin/remote.c:696 builtin/remote.c:841 builtin/remote.c:948
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Tidak ada remote seperti: '%s'"
 
-#: builtin/remote.c:710
+#: builtin/remote.c:715
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "Tidak dapat menamai ulang bagian konfigurasi '%s' ke '%s'"
 
-#: builtin/remote.c:730
+#: builtin/remote.c:735
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -19986,17 +20272,17 @@ msgstr ""
 "\t%s\n"
 "\tMohon perbarui konfigurasi secara manual bila diperlukan."
 
-#: builtin/remote.c:770
+#: builtin/remote.c:775
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "menghapus '%s' gagal"
 
-#: builtin/remote.c:804
+#: builtin/remote.c:809
 #, c-format
 msgid "creating '%s' failed"
 msgstr "membuat '%s' gagal"
 
-#: builtin/remote.c:882
+#: builtin/remote.c:887
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -20010,120 +20296,120 @@ msgstr[1] ""
 "Catatan: Beberapa cabang diluar hierarki refs/remotes tidak dihapus;\n"
 "untuk menghapus itu, gunakan:"
 
-#: builtin/remote.c:896
+#: builtin/remote.c:901
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Tidak dapat menghapus bagian konfigurasi '%s'"
 
-#: builtin/remote.c:999
+#: builtin/remote.c:1009
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " baru (pengambilan berikutnya akan simpan di remotes/%s)"
 
-#: builtin/remote.c:1002
+#: builtin/remote.c:1012
 msgid " tracked"
 msgstr " dilacak"
 
-#: builtin/remote.c:1004
+#: builtin/remote.c:1014
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " basi (gunakan 'git remote prune' untuk hapus)"
 
-#: builtin/remote.c:1006
+#: builtin/remote.c:1016
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1047
+#: builtin/remote.c:1057
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr ""
 "branch.%s.merge tidak valid; tidak dapat mendasarkan ulang ke lebih dari "
 "satu cabang"
 
-#: builtin/remote.c:1056
+#: builtin/remote.c:1066
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "dasarkan ulang secara interaktif ke remote %s"
 
-#: builtin/remote.c:1058
+#: builtin/remote.c:1068
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "dasarkan ulang secara interaktif (dengan penggabungan) ke remote %s"
 
-#: builtin/remote.c:1061
+#: builtin/remote.c:1071
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "dasarkan ulang ke remote %s"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1075
 #, c-format
 msgid " merges with remote %s"
 msgstr " gabungkan dengan remote %s"
 
-#: builtin/remote.c:1068
+#: builtin/remote.c:1078
 #, c-format
 msgid "merges with remote %s"
 msgstr "gabungkan dengan remote %s"
 
-#: builtin/remote.c:1071
+#: builtin/remote.c:1081
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    dan dengan remote %s\n"
 
-#: builtin/remote.c:1114
+#: builtin/remote.c:1124
 msgid "create"
 msgstr "buat"
 
-#: builtin/remote.c:1117
+#: builtin/remote.c:1127
 msgid "delete"
 msgstr "hapus"
 
-#: builtin/remote.c:1121
+#: builtin/remote.c:1131
 msgid "up to date"
 msgstr "terbaru"
 
-#: builtin/remote.c:1124
+#: builtin/remote.c:1134
 msgid "fast-forwardable"
 msgstr "bisa dimaju cepat"
 
-#: builtin/remote.c:1127
+#: builtin/remote.c:1137
 msgid "local out of date"
 msgstr "lokal kuno"
 
-#: builtin/remote.c:1134
+#: builtin/remote.c:1144
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s memaksa untuk %-*s (%s)"
 
-#: builtin/remote.c:1137
+#: builtin/remote.c:1147
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s mendorong ke %-*s (%s)"
 
-#: builtin/remote.c:1141
+#: builtin/remote.c:1151
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s memaksa untuk %s"
 
-#: builtin/remote.c:1144
+#: builtin/remote.c:1154
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s mendorong ke %s"
 
-#: builtin/remote.c:1212
+#: builtin/remote.c:1222
 msgid "do not query remotes"
 msgstr "jangan tanyakan remote"
 
-#: builtin/remote.c:1239
+#: builtin/remote.c:1243
 #, c-format
 msgid "* remote %s"
 msgstr "* remote %s"
 
-#: builtin/remote.c:1240
+#: builtin/remote.c:1244
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL pengambilan: %s"
 
-#: builtin/remote.c:1241 builtin/remote.c:1257 builtin/remote.c:1396
+#: builtin/remote.c:1245 builtin/remote.c:1261 builtin/remote.c:1398
 msgid "(no URL)"
 msgstr "(tidak ada URL)"
 
@@ -20131,326 +20417,348 @@ msgstr "(tidak ada URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1255 builtin/remote.c:1257
+#: builtin/remote.c:1259 builtin/remote.c:1261
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL pendorongan: %s"
 
-#: builtin/remote.c:1259 builtin/remote.c:1261 builtin/remote.c:1263
+#: builtin/remote.c:1263 builtin/remote.c:1265 builtin/remote.c:1267
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Cabang HEAD: %s"
 
-#: builtin/remote.c:1259
+#: builtin/remote.c:1263
 msgid "(not queried)"
 msgstr "(tidak ditanyakan)"
 
-#: builtin/remote.c:1261
+#: builtin/remote.c:1265
 msgid "(unknown)"
 msgstr "(tidak diketahui)"
 
-#: builtin/remote.c:1265
+#: builtin/remote.c:1269
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr ""
 "  Cabang HEAD (HEAD remote ambigu, bisa jadi salah satu dari yang berikut):\n"
 
-#: builtin/remote.c:1277
+#: builtin/remote.c:1281
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Cabang remote:%s"
 msgstr[1] "  Cabang remote:%s"
 
-#: builtin/remote.c:1280 builtin/remote.c:1306
+#: builtin/remote.c:1284 builtin/remote.c:1310
 msgid " (status not queried)"
 msgstr " (status tidak ditanyakan)"
 
-#: builtin/remote.c:1289
+#: builtin/remote.c:1293
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Cabang lokal dikonfigurasi untuk 'git pull':"
 msgstr[1] "  Cabang lokal dikonfigurasi untuk 'git pull':"
 
-#: builtin/remote.c:1297
+#: builtin/remote.c:1301
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  Referensi lokal yang akan dicerminkan oleh 'git push'"
 
-#: builtin/remote.c:1303
+#: builtin/remote.c:1307
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Referensi lokal dikonfigurasi untuk 'git push'%s:"
 msgstr[1] "  Referensi lokal dikonfigurasi untuk 'git push'%s:"
 
-#: builtin/remote.c:1324
+#: builtin/remote.c:1328
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "setel refs/remotes/<nama>/HEAD tergantung remote"
 
-#: builtin/remote.c:1326
+#: builtin/remote.c:1330
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "hapus refs/remotes/<nama>/HEAD"
 
-#: builtin/remote.c:1341
+#: builtin/remote.c:1344
 msgid "Cannot determine remote HEAD"
 msgstr "Tidak dapat menentukan HEAD remote"
 
-#: builtin/remote.c:1343
+#: builtin/remote.c:1346
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr "Banyak cabang HEAD remote. Mohon pilih satu secara eksplisit dengan:"
 
-#: builtin/remote.c:1353
+#: builtin/remote.c:1356
 #, c-format
 msgid "Could not delete %s"
 msgstr "Tidak dapat menghapus %s"
 
-#: builtin/remote.c:1361
+#: builtin/remote.c:1364
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "Bukan referensi valid: %s"
 
-#: builtin/remote.c:1363
+#: builtin/remote.c:1366
 #, c-format
 msgid "Could not setup %s"
 msgstr "Tidak dapat mengatur %s"
 
-#: builtin/remote.c:1381
+#: builtin/remote.c:1384
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s akan menjadi teruntai!"
 
-#: builtin/remote.c:1382
+#: builtin/remote.c:1385
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s telah menjadi teruntai!"
 
-#: builtin/remote.c:1392
+#: builtin/remote.c:1394
 #, c-format
 msgid "Pruning %s"
 msgstr "Memangkas %s"
 
-#: builtin/remote.c:1393
+#: builtin/remote.c:1395
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1409
+#: builtin/remote.c:1411
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [akan pangkas] %s"
 
-#: builtin/remote.c:1412
+#: builtin/remote.c:1414
 #, c-format
 msgid " * [pruned] %s"
 msgstr " * [dipangkas] %s"
 
-#: builtin/remote.c:1457
+#: builtin/remote.c:1459
 msgid "prune remotes after fetching"
 msgstr "pangkas remote setelah pengambilan"
 
-#: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
+#: builtin/remote.c:1523 builtin/remote.c:1579 builtin/remote.c:1649
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Tidak ada remote seperti '%s'"
 
-#: builtin/remote.c:1539
+#: builtin/remote.c:1541
 msgid "add branch"
 msgstr "tambah cabang"
 
-#: builtin/remote.c:1546
+#: builtin/remote.c:1548
 msgid "no remote specified"
 msgstr "tidak ada remote yang disebutkan"
 
-#: builtin/remote.c:1563
+#: builtin/remote.c:1565
 msgid "query push URLs rather than fetch URLs"
 msgstr "tanyakan URL pendorongan daripada URL pengambilan"
 
-#: builtin/remote.c:1565
+#: builtin/remote.c:1567
 msgid "return all URLs"
 msgstr "kembalikan semua URL"
 
-#: builtin/remote.c:1595
+#: builtin/remote.c:1597
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "tidak ada URL yang dikonfigurasi untuk remote '%s'"
 
-#: builtin/remote.c:1621
+#: builtin/remote.c:1623
 msgid "manipulate push URLs"
 msgstr "manipulasi URL pendorongan"
 
-#: builtin/remote.c:1623
+#: builtin/remote.c:1625
 msgid "add URL"
 msgstr "tambah URL"
 
-#: builtin/remote.c:1625
+#: builtin/remote.c:1627
 msgid "delete URLs"
 msgstr "hapus URL"
 
-#: builtin/remote.c:1632
+#: builtin/remote.c:1634
 msgid "--add --delete doesn't make sense"
 msgstr "--add --delete tidak masuk akal"
 
-#: builtin/remote.c:1673
+#: builtin/remote.c:1675
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "pola URL lama tidak valid: %s"
 
-#: builtin/remote.c:1681
+#: builtin/remote.c:1683
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Tidak ada URL yang ditemukan seperti: %s"
 
-#: builtin/remote.c:1683
+#: builtin/remote.c:1685
 msgid "Will not delete all non-push URLs"
 msgstr "Tidak akan hapus semua URL non-dorong"
 
-#: builtin/repack.c:26
-msgid "git repack [<options>]"
-msgstr ""
+#: builtin/remote.c:1702
+msgid "be verbose; must be placed before a subcommand"
+msgstr "jadi lebih bertele-tele; harus ditempatkan sebelum subperintah"
 
-#: builtin/repack.c:31
+#: builtin/repack.c:28
+msgid "git repack [<options>]"
+msgstr "git repack [<opsi>]"
+
+#: builtin/repack.c:33
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writebitmaps configuration."
 msgstr ""
+"Pengepakan ulang tambahan tidak kompatibel dengan indeks bitmap. Gunakan\n"
+" --no-write-bitmap-index atau nonaktifkan konfigurasi pack.writebitmaps."
 
-#: builtin/repack.c:198
+#: builtin/repack.c:201
 msgid "could not start pack-objects to repack promisor objects"
-msgstr ""
+msgstr "tidak dapat memulai pack-objects untuk mengepak ulang objek pejanji"
 
-#: builtin/repack.c:270 builtin/repack.c:630
+#: builtin/repack.c:273 builtin/repack.c:816
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
-msgstr ""
+msgstr "repack: Mengharapkan baris ID objek hex penuh hanya dari pack-objects."
 
-#: builtin/repack.c:294
+#: builtin/repack.c:297
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
+"tidak dapat menyelesaikan pack-objects untuk mengepak ulang objek pejanji"
 
-#: builtin/repack.c:309
+#: builtin/repack.c:312
 #, c-format
 msgid "cannot open index for %s"
-msgstr ""
+msgstr "tidak dapat membuka indeks untuk %s"
 
-#: builtin/repack.c:368
+#: builtin/repack.c:371
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
-msgstr ""
+msgstr "pak %s terlalu besar untuk dipertimbangkan dalam deret geometri"
 
-#: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
+#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
 #, c-format
 msgid "pack %s too large to roll up"
-msgstr ""
-
-#: builtin/repack.c:460
-msgid "pack everything in a single pack"
-msgstr ""
-
-#: builtin/repack.c:462
-msgid "same as -a, and turn unreachable objects loose"
-msgstr ""
-
-#: builtin/repack.c:465
-msgid "remove redundant packs, and run git-prune-packed"
-msgstr ""
-
-#: builtin/repack.c:467
-msgid "pass --no-reuse-delta to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:469
-msgid "pass --no-reuse-object to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:471
-msgid "do not run git-update-server-info"
-msgstr ""
-
-#: builtin/repack.c:474
-msgid "pass --local to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:476
-msgid "write bitmap index"
-msgstr ""
-
-#: builtin/repack.c:478
-msgid "pass --delta-islands to git-pack-objects"
-msgstr ""
-
-#: builtin/repack.c:479
-msgid "approxidate"
-msgstr ""
-
-#: builtin/repack.c:480
-msgid "with -A, do not loosen objects older than this"
-msgstr ""
-
-#: builtin/repack.c:482
-msgid "with -a, repack unreachable objects"
-msgstr ""
-
-#: builtin/repack.c:484
-msgid "size of the window used for delta compression"
-msgstr ""
-
-#: builtin/repack.c:485 builtin/repack.c:491
-msgid "bytes"
-msgstr ""
-
-#: builtin/repack.c:486
-msgid "same as the above, but limit memory size instead of entries count"
-msgstr ""
-
-#: builtin/repack.c:488
-msgid "limits the maximum delta depth"
-msgstr ""
-
-#: builtin/repack.c:490
-msgid "limits the maximum number of threads"
-msgstr ""
-
-#: builtin/repack.c:492
-msgid "maximum size of each packfile"
-msgstr ""
-
-#: builtin/repack.c:494
-msgid "repack objects in packs marked with .keep"
-msgstr ""
+msgstr "pak %s terlalu besar untuk digulung"
 
 #: builtin/repack.c:496
-msgid "do not repack this pack"
-msgstr ""
+#, c-format
+msgid "could not open tempfile %s for writing"
+msgstr "tidak dapat membuka berkas sementara '%s' untuk ditulis"
 
-#: builtin/repack.c:498
-msgid "find a geometric progression with factor <N>"
-msgstr ""
+#: builtin/repack.c:514
+msgid "could not close refs snapshot tempfile"
+msgstr "tidak dapat menutup berkas sementara jepretan referensi"
 
-#: builtin/repack.c:508
-msgid "cannot delete packs in a precious-objects repo"
-msgstr ""
+#: builtin/repack.c:628
+msgid "pack everything in a single pack"
+msgstr "pak semuanya dalam satu pak"
 
-#: builtin/repack.c:512
-msgid "--keep-unreachable and -A are incompatible"
-msgstr ""
+#: builtin/repack.c:630
+msgid "same as -a, and turn unreachable objects loose"
+msgstr "sama seperti -a, dan jadikan objek yang tak dapat dicapai longgar"
 
-#: builtin/repack.c:527
-msgid "--geometric is incompatible with -A, -a"
-msgstr ""
+#: builtin/repack.c:633
+msgid "remove redundant packs, and run git-prune-packed"
+msgstr "hapus pak berlebihan, dan jalankan git-prune-packed"
+
+#: builtin/repack.c:635
+msgid "pass --no-reuse-delta to git-pack-objects"
+msgstr "lewatkan --no-reuse-delta ke git-pack-objects"
+
+#: builtin/repack.c:637
+msgid "pass --no-reuse-object to git-pack-objects"
+msgstr "lewatkan --no-reuse-object ke git-pack-objects"
 
 #: builtin/repack.c:639
-msgid "Nothing new to pack."
-msgstr ""
+msgid "do not run git-update-server-info"
+msgstr "jangan jalankan git-update-server-info"
 
-#: builtin/repack.c:669
+#: builtin/repack.c:642
+msgid "pass --local to git-pack-objects"
+msgstr "lewatkan --local ke git-pack-objects"
+
+#: builtin/repack.c:644
+msgid "write bitmap index"
+msgstr "tulis indeks bitmap"
+
+#: builtin/repack.c:646
+msgid "pass --delta-islands to git-pack-objects"
+msgstr "lewatkan --delta-islands ke git-pack-objects"
+
+#: builtin/repack.c:647
+msgid "approxidate"
+msgstr "tanggal aproksimasi"
+
+#: builtin/repack.c:648
+msgid "with -A, do not loosen objects older than this"
+msgstr "dengan -A, jangan longgarkan objek lebih lama dari ini"
+
+#: builtin/repack.c:650
+msgid "with -a, repack unreachable objects"
+msgstr "dengan -a, pak ulang objek yang tak dapat dicapai"
+
+#: builtin/repack.c:652
+msgid "size of the window used for delta compression"
+msgstr "ukuran jendela yang digunakan untuk kompresi delta"
+
+#: builtin/repack.c:653 builtin/repack.c:659
+msgid "bytes"
+msgstr "bita"
+
+#: builtin/repack.c:654
+msgid "same as the above, but limit memory size instead of entries count"
+msgstr ""
+"sama seperti yang diatas, tetapi batasi penggunaan memori daripada hitungan "
+"entri"
+
+#: builtin/repack.c:656
+msgid "limits the maximum delta depth"
+msgstr "batasi kedalaman delta maksimum"
+
+#: builtin/repack.c:658
+msgid "limits the maximum number of threads"
+msgstr "batasi jumlah utas maksimum"
+
+#: builtin/repack.c:660
+msgid "maximum size of each packfile"
+msgstr "ukuran maksimum setiap berkas pak"
+
+#: builtin/repack.c:662
+msgid "repack objects in packs marked with .keep"
+msgstr "pak ulang objek dalam pak yang ditandai dengan .keep"
+
+#: builtin/repack.c:664
+msgid "do not repack this pack"
+msgstr "jangan pak ulang pak ini"
+
+#: builtin/repack.c:666
+msgid "find a geometric progression with factor <N>"
+msgstr "temukan deret geometri dengan faktor <N>"
+
+#: builtin/repack.c:668
+msgid "write a multi-pack index of the resulting packs"
+msgstr "tulis indeks multipak dari pak yang dihasilkan"
+
+#: builtin/repack.c:678
+msgid "cannot delete packs in a precious-objects repo"
+msgstr "tidak dapat menghapus pak dalam repositori objek berharga"
+
+#: builtin/repack.c:682
+msgid "--keep-unreachable and -A are incompatible"
+msgstr "--keep-unreachable dan -A tidak kompatibel"
+
+#: builtin/repack.c:713
+msgid "--geometric is incompatible with -A, -a"
+msgstr "--geometric tidak kompatibel dengan -A, -a"
+
+#: builtin/repack.c:825
+msgid "Nothing new to pack."
+msgstr "Tidak ada yang baru untuk dipak."
+
+#: builtin/repack.c:855
 #, c-format
 msgid "missing required file: %s"
-msgstr ""
+msgstr "berkas yang diperlukan hilang: %s"
 
-#: builtin/repack.c:671
+#: builtin/repack.c:857
 #, c-format
 msgid "could not unlink: %s"
-msgstr ""
+msgstr "tidak dapat membatal taut: %s"
 
 #: builtin/replace.c:22
 msgid "git replace [-f] <object> <replacement>"
@@ -20748,92 +21056,92 @@ msgstr "gabungan"
 msgid "keep"
 msgstr "simpan"
 
-#: builtin/reset.c:83
+#: builtin/reset.c:89
 msgid "You do not have a valid HEAD."
 msgstr "Anda tidak punya HEAD yang valid."
 
-#: builtin/reset.c:85
+#: builtin/reset.c:91
 msgid "Failed to find tree of HEAD."
 msgstr "Gagal menemukan pohon HEAD."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:97
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Gagal menemukan pohon dari %s."
 
-#: builtin/reset.c:116
+#: builtin/reset.c:122
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD sekarang pada %s"
 
-#: builtin/reset.c:195
+#: builtin/reset.c:201
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Tidak dapat lakukan reset %s di tengah-tengah penggabungan."
 
-#: builtin/reset.c:295 builtin/stash.c:589 builtin/stash.c:663
-#: builtin/stash.c:687
+#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
+#: builtin/stash.c:703
 msgid "be quiet, only report errors"
 msgstr "diam, hanya laporkan kesalahan"
 
-#: builtin/reset.c:297
+#: builtin/reset.c:303
 msgid "reset HEAD and index"
 msgstr "setel ulang HEAD dan indeks"
 
-#: builtin/reset.c:298
+#: builtin/reset.c:304
 msgid "reset only HEAD"
 msgstr "hanya setel ulang HEAD"
 
-#: builtin/reset.c:300 builtin/reset.c:302
+#: builtin/reset.c:306 builtin/reset.c:308
 msgid "reset HEAD, index and working tree"
 msgstr "setel ulang HEAD, indeks dan pohon kerja"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:310
 msgid "reset HEAD but keep local changes"
 msgstr "setel ulang HEAD tapi simpan perubahan lokal"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:316
 msgid "record only the fact that removed paths will be added later"
 msgstr "hanya rekam fakta bahwa jalur yang terhapus akan ditambahkan nanti"
 
-#: builtin/reset.c:344
+#: builtin/reset.c:350
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Gagal menguraikan '%s' sebagai revisi yang valid."
 
-#: builtin/reset.c:352
+#: builtin/reset.c:358
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Gagal menguraikan '%s' sebagaikan pohon yang valid."
 
-#: builtin/reset.c:361
+#: builtin/reset.c:367
 msgid "--patch is incompatible with --{hard,mixed,soft}"
 msgstr "--patch tidak kompatibel dengan --{hard,mixed,soft}"
 
-#: builtin/reset.c:371
+#: builtin/reset.c:377
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed dengan jalur usang; sebagai gantinya gunakan 'git reset --<jalur>'."
 
-#: builtin/reset.c:373
+#: builtin/reset.c:379
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Tidak dapat lakukan reset %s dengan jalur."
 
-#: builtin/reset.c:388
+#: builtin/reset.c:394
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "Reset %s tidak diperbolehkan dalam repositori bare"
 
-#: builtin/reset.c:392
+#: builtin/reset.c:398
 msgid "-N can only be used with --mixed"
 msgstr "-N hanya dapat digunakan dengan --mixed"
 
-#: builtin/reset.c:413
+#: builtin/reset.c:419
 msgid "Unstaged changes after reset:"
 msgstr "Perubahan tak tergelar setelah setel ulang:"
 
-#: builtin/reset.c:416
+#: builtin/reset.c:422
 #, c-format
 msgid ""
 "\n"
@@ -20846,58 +21154,58 @@ msgstr ""
 "Anda dapat menggunakan '--quiet' untuk hindari hal ini. Setel konfigurasi\n"
 "reset.quiet ke true untuk membuat hal tersebut asali.\n"
 
-#: builtin/reset.c:434
+#: builtin/reset.c:440
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Tidak dapat menyetel ulang berkas indeks ke revisi '%s'."
 
-#: builtin/reset.c:439
+#: builtin/reset.c:445
 msgid "Could not write new index file."
 msgstr "Tidak dapat menulis berkas indeks baru."
 
 #: builtin/rev-list.c:541
 msgid "cannot combine --exclude-promisor-objects and --missing"
-msgstr ""
+msgstr "tidak dapat menggabungkan --exclude-promisor-objects dan --missing"
 
 #: builtin/rev-list.c:602
 msgid "object filtering requires --objects"
-msgstr ""
+msgstr "penyaringan objek memerlukan --objects"
 
 #: builtin/rev-list.c:674
 msgid "rev-list does not support display of notes"
-msgstr ""
+msgstr "rev-list tidak mendukung penampilan catatan"
 
 #: builtin/rev-list.c:679
 msgid "marked counting is incompatible with --objects"
-msgstr ""
+msgstr "penghitungan tertanda tidak kompatibel dengan --objects"
 
 #: builtin/rev-parse.c:409
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
-msgstr ""
+msgstr "git rev-parse --parseopt [<opsi>] -- [<argumen>...]"
 
 #: builtin/rev-parse.c:414
 msgid "keep the `--` passed as an arg"
-msgstr ""
+msgstr "tetap `--` dilewatkan sebagai argumen"
 
 #: builtin/rev-parse.c:416
 msgid "stop parsing after the first non-option argument"
-msgstr ""
+msgstr "hentikan penguraian setelah argumen non-opsi pertama"
 
 #: builtin/rev-parse.c:419
 msgid "output in stuck long form"
-msgstr ""
+msgstr "keluarkan dalam bentuk lengket panjang"
 
 #: builtin/rev-parse.c:438
 msgid "premature end of input"
-msgstr ""
+msgstr "akhir masukan prematur"
 
 #: builtin/rev-parse.c:442
 msgid "no usage string given before the `--' separator"
-msgstr ""
+msgstr "tidak ada untai penggunaan yang diberikan sebelum pemisah `--'"
 
 #: builtin/rev-parse.c:548
 msgid "Needed a single revision"
-msgstr ""
+msgstr "Butuh satu revisi"
 
 #: builtin/rev-parse.c:552
 msgid ""
@@ -20907,50 +21215,55 @@ msgid ""
 "\n"
 "Run \"git rev-parse --parseopt -h\" for more information on the first usage."
 msgstr ""
+"git rev-parse --parseopt [<opsi>] -- [<argumen>...]\n"
+"   atau: git rev-parse --sq-quote [<argumen>...]\n"
+"   atau: git rev-parse [<opsi>] [<argumen>...]\n"
+"Jalankan \"git rev-parse --parseopt -h\" untuk informasi lebih lanjut pada "
+"penggunaan pertama."
 
 #: builtin/rev-parse.c:712
 msgid "--resolve-git-dir requires an argument"
-msgstr ""
+msgstr "--resolve-git-dir butuh sebuah argumen"
 
 #: builtin/rev-parse.c:715
 #, c-format
 msgid "not a gitdir '%s'"
-msgstr ""
+msgstr "bukan sebuah gitdir '%s'"
 
 #: builtin/rev-parse.c:739
 msgid "--git-path requires an argument"
-msgstr ""
+msgstr "--git-path buth sebuah argumen"
 
 #: builtin/rev-parse.c:749
 msgid "-n requires an argument"
-msgstr ""
+msgstr "-n butuh sebuah argumen"
 
 #: builtin/rev-parse.c:763
 msgid "--path-format requires an argument"
-msgstr ""
+msgstr "--path-format butuh sebuah argumen"
 
 #: builtin/rev-parse.c:769
 #, c-format
 msgid "unknown argument to --path-format: %s"
-msgstr ""
+msgstr "argumen ke --path-format tidak dikenal: %s"
 
 #: builtin/rev-parse.c:776
 msgid "--default requires an argument"
-msgstr ""
+msgstr "--default butuh sebuah argumen"
 
 #: builtin/rev-parse.c:782
 msgid "--prefix requires an argument"
-msgstr ""
+msgstr "--prefix butuh sebuah argumen"
 
 #: builtin/rev-parse.c:851
 #, c-format
 msgid "unknown mode for --abbrev-ref: %s"
-msgstr ""
+msgstr "mode untuk --abbrev-ref tidak dikenal: %s"
 
 #: builtin/rev-parse.c:1023
 #, c-format
 msgid "unknown mode for --show-object-format: %s"
-msgstr ""
+msgstr "mode untuk --show-object-format tidak dikenal: %s"
 
 #: builtin/revert.c:24
 msgid "git revert [<options>] <commit-ish>..."
@@ -21026,15 +21339,19 @@ msgstr "tambahkan nama komit"
 msgid "preserve initially empty commits"
 msgstr "pertahankan komit kosong awal"
 
+#: builtin/revert.c:128
+msgid "allow commits with empty messages"
+msgstr "perbolehkan komit dengan pesan kosong"
+
 #: builtin/revert.c:129
 msgid "keep redundant, empty commits"
 msgstr "simpan komit kosong mubazir"
 
-#: builtin/revert.c:237
+#: builtin/revert.c:241
 msgid "revert failed"
 msgstr "pembalikan gagal"
 
-#: builtin/revert.c:250
+#: builtin/revert.c:254
 msgid "cherry-pick failed"
 msgstr "pemetikan ceri gagal"
 
@@ -21084,69 +21401,73 @@ msgid_plural "the following files have local modifications:"
 msgstr[0] "berkas berikut punya modifikasi lokal:"
 msgstr[1] "berkas berikut punya modifikasi lokal:"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "do not list removed files"
 msgstr "jangan daftar berkas terhapus"
 
-#: builtin/rm.c:245
+#: builtin/rm.c:246
 msgid "only remove from the index"
 msgstr "hanya hapus dari indeks"
 
-#: builtin/rm.c:246
+#: builtin/rm.c:247
 msgid "override the up-to-date check"
 msgstr "timpa pemeriksaan terbaru"
 
-#: builtin/rm.c:247
+#: builtin/rm.c:248
 msgid "allow recursive removal"
 msgstr "perbolehkan penghapusan rekursif"
 
-#: builtin/rm.c:249
+#: builtin/rm.c:250
 msgid "exit with a zero status even if nothing matched"
 msgstr "keluar dengan nol bahkan jika tidak ada yang cocok"
 
-#: builtin/rm.c:283
+#: builtin/rm.c:285
 msgid "No pathspec was given. Which files should I remove?"
 msgstr ""
 "Tidak ada spek jalur yang diberikan. Berkas mana yang harusnya saya hapus?"
 
-#: builtin/rm.c:310
+#: builtin/rm.c:315
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "mohon gelar perubahan Anda ke .gitmodules atau stase itu untuk melanjutkan"
 
-#: builtin/rm.c:331
+#: builtin/rm.c:337
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "tidak menghapus '%s' secara rekursif tanpa -r"
 
-#: builtin/rm.c:379
+#: builtin/rm.c:385
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: tidak dapat menghapus %s"
 
 #: builtin/send-pack.c:20
 msgid ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<host>:]<directory> "
-"[<ref>...]\n"
-"  --all and explicit <ref> specification are mutually exclusive."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>\n"
+"]              [--verbose] [--thin] [--atomic]\n"
+"              [<tuan rumah>:]<direktori> (--all | <referensi>...)"
 
-#: builtin/send-pack.c:188
+#: builtin/send-pack.c:192
 msgid "remote name"
-msgstr ""
+msgstr "nama remote"
 
-#: builtin/send-pack.c:201
+#: builtin/send-pack.c:205
 msgid "use stateless RPC protocol"
-msgstr ""
+msgstr "gunakan protokol RPC nirkeadaan"
 
-#: builtin/send-pack.c:202
+#: builtin/send-pack.c:206
 msgid "read refs from stdin"
-msgstr ""
+msgstr "baca referensi dari masukan standar"
 
-#: builtin/send-pack.c:203
+#: builtin/send-pack.c:207
 msgid "print status from remote helper"
-msgstr ""
+msgstr "cetak status dari pembantu remote"
 
 #: builtin/shortlog.c:16
 msgid "git shortlog [<options>] [<revision-range>] [[--] <path>...]"
@@ -21201,21 +21522,21 @@ msgstr "bidang"
 msgid "group by field"
 msgstr "kelompokkan oleh bidang"
 
-#: builtin/shortlog.c:391
+#: builtin/shortlog.c:394
 msgid "too many arguments given outside repository"
 msgstr "terlalu banyak argumen diberikan di luar repositori"
 
 #: builtin/show-branch.c:13
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<kapan>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<revisi> | <glob>)...]"
+"                [--current] [--color[=<kapan>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<revisi> | <glob>)...]"
 
 #: builtin/show-branch.c:17
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -21228,116 +21549,116 @@ msgid_plural "ignoring %s; cannot handle more than %d refs"
 msgstr[0] "mengabaikan %s; tidak dapat menangani lebih dari %d referensi"
 msgstr[1] "mengabaikan %s; tidak dapat menangani lebih dari %d referensi"
 
-#: builtin/show-branch.c:548
+#: builtin/show-branch.c:547
 #, c-format
 msgid "no matching refs with %s"
 msgstr "tidak ada referensi yang cocok dengan %s"
 
-#: builtin/show-branch.c:645
+#: builtin/show-branch.c:644
 msgid "show remote-tracking and local branches"
 msgstr "perlihatkan cabang pelacak remote dan lokal"
 
-#: builtin/show-branch.c:647
+#: builtin/show-branch.c:646
 msgid "show remote-tracking branches"
 msgstr "perlihatkan cabang pelacak remote"
 
-#: builtin/show-branch.c:649
+#: builtin/show-branch.c:648
 msgid "color '*!+-' corresponding to the branch"
 msgstr "warna '*!+-' bersesuaian pada cabang"
 
-#: builtin/show-branch.c:651
+#: builtin/show-branch.c:650
 msgid "show <n> more commits after the common ancestor"
 msgstr "perlihatkan <n> komit lagi setelah nenek moyang yang sama"
 
-#: builtin/show-branch.c:653
+#: builtin/show-branch.c:652
 msgid "synonym to more=-1"
 msgstr "sinonim untuk more=-1"
 
-#: builtin/show-branch.c:654
+#: builtin/show-branch.c:653
 msgid "suppress naming strings"
 msgstr "sembunyikan untai penamaan"
 
-#: builtin/show-branch.c:656
+#: builtin/show-branch.c:655
 msgid "include the current branch"
 msgstr "masukkan cabang saat ini"
 
-#: builtin/show-branch.c:658
+#: builtin/show-branch.c:657
 msgid "name commits with their object names"
 msgstr "namai komit dengan nama objeknya"
 
-#: builtin/show-branch.c:660
+#: builtin/show-branch.c:659
 msgid "show possible merge bases"
 msgstr "perlihatkan dasar penggabungan yang mungkin"
 
-#: builtin/show-branch.c:662
+#: builtin/show-branch.c:661
 msgid "show refs unreachable from any other ref"
 msgstr ""
 "perlihatkan referensi yang tidak dapat dicapai dari referensi yang lainnya"
 
-#: builtin/show-branch.c:664
+#: builtin/show-branch.c:663
 msgid "show commits in topological order"
 msgstr "perlihatkan komit dalam urutan topologis"
 
-#: builtin/show-branch.c:667
+#: builtin/show-branch.c:666
 msgid "show only commits not on the first branch"
 msgstr "hanya perlihatkan komit yang bukan pada cabang pertama"
 
-#: builtin/show-branch.c:669
+#: builtin/show-branch.c:668
 msgid "show merges reachable from only one tip"
 msgstr "perlihatkan penggabungan yang bisa dicapai hanya dari satu ujung"
 
-#: builtin/show-branch.c:671
+#: builtin/show-branch.c:670
 msgid "topologically sort, maintaining date order where possible"
 msgstr "urutkan secara topologis, pelihara urutan tanggal bila memungkinkan"
 
-#: builtin/show-branch.c:674
+#: builtin/show-branch.c:673
 msgid "<n>[,<base>]"
 msgstr "<n>[,<dasar>]"
 
-#: builtin/show-branch.c:675
+#: builtin/show-branch.c:674
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "perlihatkan <n> entri ref-log terkini dimulai dari dasar"
 
-#: builtin/show-branch.c:711
+#: builtin/show-branch.c:710
 msgid ""
 "--reflog is incompatible with --all, --remotes, --independent or --merge-base"
 msgstr ""
 "--reflog tidak kompatibel dengan --all, --remotes, --independent atau --"
 "merge-base"
 
-#: builtin/show-branch.c:735
+#: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "tidak ada cabang yang diberikan, dan HEAD tidak valid"
 
-#: builtin/show-branch.c:738
+#: builtin/show-branch.c:737
 msgid "--reflog option needs one branch name"
 msgstr "opsi --reflog butuh satu nama cabang"
 
-#: builtin/show-branch.c:741
+#: builtin/show-branch.c:740
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
 msgstr[0] "hanya %d entri yang bisa diperlihatkan pada satu waktu."
 msgstr[1] "hanya %d entri yang bisa diperlihatkan pada satu waktu."
 
-#: builtin/show-branch.c:745
+#: builtin/show-branch.c:744
 #, c-format
 msgid "no such ref %s"
 msgstr "tidak ada referensi seperti %s"
 
-#: builtin/show-branch.c:831
+#: builtin/show-branch.c:828
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "tidak dapat menangani lebih dari %d revisi."
 msgstr[1] "tidak dapat menangani lebih dari %d revisi."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:832
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "'%s' bukan sebuah referensi yang valid."
 
-#: builtin/show-branch.c:838
+#: builtin/show-branch.c:835
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "tidak dapat menemukan komit %s (%s)"
@@ -21408,70 +21729,82 @@ msgstr ""
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 
-#: builtin/sparse-checkout.c:227
+#: builtin/sparse-checkout.c:173
+#, c-format
+msgid ""
+"directory '%s' contains untracked files, but is not in the sparse-checkout "
+"cone"
+msgstr ""
+
+#: builtin/sparse-checkout.c:181
+#, c-format
+msgid "failed to remove directory '%s'"
+msgstr ""
+
+#: builtin/sparse-checkout.c:321
 msgid "failed to create directory for sparse-checkout file"
 msgstr ""
 
-#: builtin/sparse-checkout.c:268
+#: builtin/sparse-checkout.c:362
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 
-#: builtin/sparse-checkout.c:270
+#: builtin/sparse-checkout.c:364
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr ""
 
-#: builtin/sparse-checkout.c:290
+#: builtin/sparse-checkout.c:384
 msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 msgstr ""
 
-#: builtin/sparse-checkout.c:310
+#: builtin/sparse-checkout.c:404
 msgid "initialize the sparse-checkout in cone mode"
 msgstr ""
 
-#: builtin/sparse-checkout.c:312
+#: builtin/sparse-checkout.c:406
 msgid "toggle the use of a sparse index"
 msgstr ""
 
-#: builtin/sparse-checkout.c:340
+#: builtin/sparse-checkout.c:434
 msgid "failed to modify sparse-index config"
 msgstr ""
 
-#: builtin/sparse-checkout.c:361
+#: builtin/sparse-checkout.c:455
 #, c-format
 msgid "failed to open '%s'"
 msgstr ""
 
-#: builtin/sparse-checkout.c:413
+#: builtin/sparse-checkout.c:507
 #, c-format
 msgid "could not normalize path %s"
 msgstr ""
 
-#: builtin/sparse-checkout.c:425
+#: builtin/sparse-checkout.c:519
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr ""
 
-#: builtin/sparse-checkout.c:450
+#: builtin/sparse-checkout.c:544
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr ""
 
-#: builtin/sparse-checkout.c:504 builtin/sparse-checkout.c:528
+#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
 msgid "unable to load existing sparse-checkout patterns"
 msgstr ""
 
-#: builtin/sparse-checkout.c:573
+#: builtin/sparse-checkout.c:667
 msgid "read patterns from standard in"
 msgstr ""
 
-#: builtin/sparse-checkout.c:588
+#: builtin/sparse-checkout.c:682
 msgid "git sparse-checkout reapply"
 msgstr ""
 
-#: builtin/sparse-checkout.c:607
+#: builtin/sparse-checkout.c:701
 msgid "git sparse-checkout disable"
 msgstr ""
 
-#: builtin/sparse-checkout.c:638
+#: builtin/sparse-checkout.c:732
 msgid "error while refreshing working directory"
 msgstr ""
 
@@ -21507,7 +21840,7 @@ msgstr ""
 "          [--pathspec-from-file=<berkas> [--pathspec-file-nul]]\n"
 "          [--] [<spek jalur>...]]"
 
-#: builtin/stash.c:34 builtin/stash.c:87
+#: builtin/stash.c:34
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
@@ -21537,6 +21870,14 @@ msgstr ""
 "          [-u|--include-untracked] [-a|--all] [-m|--message <pesan>]\n"
 "          [--] [<spek jalur>...]"
 
+#: builtin/stash.c:87
+msgid ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<message>]"
+msgstr ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<pesan>]"
+
 #: builtin/stash.c:130
 #, c-format
 msgid "'%s' is not a stash-like commit"
@@ -21560,7 +21901,7 @@ msgstr "%s bukan referensi valid"
 msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear dengan argument tak diimplementasikan"
 
-#: builtin/stash.c:431
+#: builtin/stash.c:447
 #, c-format
 msgid ""
 "WARNING: Untracked file in way of tracked file!  Renaming\n"
@@ -21572,168 +21913,168 @@ msgstr ""
 "            %s -> %s\n"
 "         untuk buat ruang.\n"
 
-#: builtin/stash.c:492
+#: builtin/stash.c:508
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "tidak dapat menerapkan stase di tengah-tengah penggabungan"
 
-#: builtin/stash.c:503
+#: builtin/stash.c:519
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "tidak dapat membuat diff %s^!."
 
-#: builtin/stash.c:510
+#: builtin/stash.c:526
 msgid "conflicts in index. Try without --index."
 msgstr "konflik dalam indeks. Coba tanpa --index."
 
-#: builtin/stash.c:516
+#: builtin/stash.c:532
 msgid "could not save index tree"
 msgstr "tidak dapat menyimpan pohon indeks"
 
-#: builtin/stash.c:525
-msgid "could not restore untracked files from stash"
-msgstr "tidak dapat mengembalikan berkas tak terlacak dari stase"
-
-#: builtin/stash.c:539
+#: builtin/stash.c:552
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Menggabungkan %s dengan %s"
 
-#: builtin/stash.c:549
+#: builtin/stash.c:562
 msgid "Index was not unstashed."
 msgstr "Indeks tak dibatal-stasekan."
 
-#: builtin/stash.c:591 builtin/stash.c:689
+#: builtin/stash.c:575
+msgid "could not restore untracked files from stash"
+msgstr "tidak dapat mengembalikan berkas tak terlacak dari stase"
+
+#: builtin/stash.c:607 builtin/stash.c:705
 msgid "attempt to recreate the index"
 msgstr "coba membuat ulang indeks"
 
-#: builtin/stash.c:635
+#: builtin/stash.c:651
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "%s (%s) dijatuhkan"
 
-#: builtin/stash.c:638
+#: builtin/stash.c:654
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Tidak dapat menjatuhkan entri stase"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:667
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' bukan referensi stase"
 
-#: builtin/stash.c:701
+#: builtin/stash.c:717
 msgid "The stash entry is kept in case you need it again."
 msgstr "Entri stase disimpan jika Anda butuh itu lagi."
 
-#: builtin/stash.c:724
+#: builtin/stash.c:740
 msgid "No branch name specified"
 msgstr "Tidak ada nama cabang yang disebutkan"
 
-#: builtin/stash.c:808
+#: builtin/stash.c:824
 msgid "failed to parse tree"
 msgstr "gagal menguraikan pohon"
 
-#: builtin/stash.c:819
+#: builtin/stash.c:835
 msgid "failed to unpack trees"
 msgstr "gagal membongkar pohon"
 
-#: builtin/stash.c:839
+#: builtin/stash.c:855
 msgid "include untracked files in the stash"
 msgstr "masukkan berkas tak terlacak ke dalam stase"
 
-#: builtin/stash.c:842
+#: builtin/stash.c:858
 msgid "only show untracked files in the stash"
 msgstr "hanya perlihatkan berkas tak terlacak dalam stase"
 
-#: builtin/stash.c:929 builtin/stash.c:966
+#: builtin/stash.c:945 builtin/stash.c:982
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Tidak dapat memperbarui %s dengan %s"
 
-#: builtin/stash.c:947 builtin/stash.c:1602 builtin/stash.c:1667
+#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
 msgid "stash message"
 msgstr "pesan stase"
 
-#: builtin/stash.c:957
+#: builtin/stash.c:973
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" butuh satu argumen <komit>"
 
-#: builtin/stash.c:1171
+#: builtin/stash.c:1187
 msgid "No changes selected"
 msgstr "Tidak ada perubahan yang dipilih"
 
-#: builtin/stash.c:1271
+#: builtin/stash.c:1287
 msgid "You do not have the initial commit yet"
 msgstr "Anda belum punya komit awal"
 
-#: builtin/stash.c:1298
+#: builtin/stash.c:1314
 msgid "Cannot save the current index state"
 msgstr "Tidak dapat menyimpan keadaan indeks saat ini"
 
-#: builtin/stash.c:1307
+#: builtin/stash.c:1323
 msgid "Cannot save the untracked files"
 msgstr "Tidak dapat menyimpan berkas tak terlacak"
 
-#: builtin/stash.c:1318 builtin/stash.c:1327
+#: builtin/stash.c:1334 builtin/stash.c:1343
 msgid "Cannot save the current worktree state"
 msgstr "Tidak dapat menyimpang keadaan pohon kerja saat ini"
 
-#: builtin/stash.c:1355
+#: builtin/stash.c:1371
 msgid "Cannot record working tree state"
 msgstr "Tidak dapat merekam keadaan pohon kerja"
 
-#: builtin/stash.c:1404
+#: builtin/stash.c:1420
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Tidak dapat menggunakan --patch dan --include-untracked atau --all pada "
 "waktu yang bersamaan"
 
-#: builtin/stash.c:1422
+#: builtin/stash.c:1438
 msgid "Did you forget to 'git add'?"
 msgstr "Anda lupa untuk 'git add'?"
 
-#: builtin/stash.c:1437
+#: builtin/stash.c:1453
 msgid "No local changes to save"
 msgstr "Tidak ada perubahan lokal untuk disimpan"
 
-#: builtin/stash.c:1444
+#: builtin/stash.c:1460
 msgid "Cannot initialize stash"
 msgstr "Tidak dapat menginisialisasi stase"
 
-#: builtin/stash.c:1459
+#: builtin/stash.c:1475
 msgid "Cannot save the current status"
 msgstr "Tidak dapat menyimpan status saat ini"
 
-#: builtin/stash.c:1464
+#: builtin/stash.c:1480
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Direktori kerja dan keadaan indeks %s disimpan"
 
-#: builtin/stash.c:1554
+#: builtin/stash.c:1571
 msgid "Cannot remove worktree changes"
 msgstr "Tidak dapat menghapus perubahaan pohon kerja"
 
-#: builtin/stash.c:1593 builtin/stash.c:1658
+#: builtin/stash.c:1610 builtin/stash.c:1675
 msgid "keep index"
 msgstr "jaga indeks"
 
-#: builtin/stash.c:1595 builtin/stash.c:1660
+#: builtin/stash.c:1612 builtin/stash.c:1677
 msgid "stash in patch mode"
 msgstr "stase dalam mode tambalan"
 
-#: builtin/stash.c:1596 builtin/stash.c:1661
+#: builtin/stash.c:1613 builtin/stash.c:1678
 msgid "quiet mode"
 msgstr "mode hening"
 
-#: builtin/stash.c:1598 builtin/stash.c:1663
+#: builtin/stash.c:1615 builtin/stash.c:1680
 msgid "include untracked files in stash"
 msgstr "masukkan berkas tak terlacak ke dalam stase"
 
-#: builtin/stash.c:1600 builtin/stash.c:1665
+#: builtin/stash.c:1617 builtin/stash.c:1682
 msgid "include ignore files"
 msgstr "masukkan berkas ignore"
 
-#: builtin/stash.c:1700
+#: builtin/stash.c:1717
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -21757,7 +22098,7 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr ""
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2440
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Mengharapkan nama referensi penuh, dapat %s"
@@ -21771,28 +22112,35 @@ msgstr "submodule--helper print-default-remote tidak membutuhkan argumen"
 msgid "cannot strip one component off url '%s'"
 msgstr "tidak dapat mencopot satu komponen dari url '%s'"
 
-#: builtin/submodule--helper.c:411 builtin/submodule--helper.c:1887
-#: builtin/submodule--helper.c:2891
+#: builtin/submodule--helper.c:211
+#, c-format
+msgid ""
+"could not look up configuration '%s'. Assuming this repository is its own "
+"authoritative upstream."
+msgstr ""
+"tidak dapat mencari konfigurasi '%s'. Asumsi bahwa repositori ini adalah "
+"hulu otoritatif tersendiri."
+
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
 msgid "alternative anchor for relative paths"
 msgstr "jangkar alternatif untuk jalur relatif"
 
-#: builtin/submodule--helper.c:416
+#: builtin/submodule--helper.c:410
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<jalur>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:474 builtin/submodule--helper.c:631
-#: builtin/submodule--helper.c:654
+#: builtin/submodule--helper.c:468 builtin/submodule--helper.c:605
+#: builtin/submodule--helper.c:628
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
-msgstr ""
-"Tidak ada url yang ditemukan untuk jalur submodul '%s' dalam .gitmodules"
+msgstr "Tidak ada url yang ditemukan untuk jalur submodul '%s' di .gitmodules"
 
-#: builtin/submodule--helper.c:526
+#: builtin/submodule--helper.c:520
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Memasuki '%s'\n"
 
-#: builtin/submodule--helper.c:529
+#: builtin/submodule--helper.c:523
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -21801,7 +22149,7 @@ msgstr ""
 "run_command mengembalikan status bukan nol untuk %s\n"
 "."
 
-#: builtin/submodule--helper.c:551
+#: builtin/submodule--helper.c:545
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -21812,77 +22160,68 @@ msgstr ""
 "bersarang %s\n"
 "."
 
-#: builtin/submodule--helper.c:567
+#: builtin/submodule--helper.c:561
 msgid "suppress output of entering each submodule command"
 msgstr "sembunyikan keluaran memasuki setiap perintah submodul"
 
-#: builtin/submodule--helper.c:569 builtin/submodule--helper.c:890
-#: builtin/submodule--helper.c:1489
+#: builtin/submodule--helper.c:563 builtin/submodule--helper.c:864
+#: builtin/submodule--helper.c:1453
 msgid "recurse into nested submodules"
 msgstr "rekursi ke dalam submodul bersarang"
 
-#: builtin/submodule--helper.c:574
+#: builtin/submodule--helper.c:568
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr ""
 "git submodule--helper foreach [--quiet] [--recursive] [--] [<perintah>]"
 
-#: builtin/submodule--helper.c:601
-#, c-format
-msgid ""
-"could not look up configuration '%s'. Assuming this repository is its own "
-"authoritative upstream."
-msgstr ""
-"tidak dapat mencari konfigurasi '%s'. Asumsi bahwa repositori ini adalah "
-"hulu otoritatif tersendiri."
-
-#: builtin/submodule--helper.c:668
+#: builtin/submodule--helper.c:642
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr "Gagal mendaftarkan url untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:672
+#: builtin/submodule--helper.c:646
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Submodul '%s' (%s) didaftarkan untuk jalur '%s'\n"
 
-#: builtin/submodule--helper.c:682
+#: builtin/submodule--helper.c:656
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "peringatan: perintah mode pembaruan disarankan untuk submodul '%s'\n"
 
-#: builtin/submodule--helper.c:689
+#: builtin/submodule--helper.c:663
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr "Gagal mendaftarkan mode pembaruan untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:711
+#: builtin/submodule--helper.c:685
 msgid "suppress output for initializing a submodule"
 msgstr "sembunyikan keluaran menginisialisasi submodul"
 
-#: builtin/submodule--helper.c:716
+#: builtin/submodule--helper.c:690
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<opsi>] [<jalur>]"
 
-#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
+#: builtin/submodule--helper.c:763 builtin/submodule--helper.c:898
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "tidak ada pemetaan submodul ditemukan di .gitmodules untuk jalur '%s'"
 
-#: builtin/submodule--helper.c:837
+#: builtin/submodule--helper.c:811
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "tidak dapat menguraikan referensi HEAD di dalam submodul '%s'"
 
-#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1459
+#: builtin/submodule--helper.c:838 builtin/submodule--helper.c:1423
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "gagal merekursi ke dalam submodul '%s'"
 
-#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1625
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
 msgid "suppress submodule status output"
 msgstr "sembunyikan keluaran status submodul"
 
-#: builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:863
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -21890,96 +22229,96 @@ msgstr ""
 "gunakan komit yang disimpan di dalam indeks daripada yang disimpan di dalam "
 "HEAD"
 
-#: builtin/submodule--helper.c:895
+#: builtin/submodule--helper.c:869
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quiet] [--cached] [--recursive] [<jalur>...]"
 
-#: builtin/submodule--helper.c:919
+#: builtin/submodule--helper.c:893
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <jalur>"
 
-#: builtin/submodule--helper.c:991
+#: builtin/submodule--helper.c:965
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
 msgstr "* %s %s(blob)->%s(submodul)"
 
-#: builtin/submodule--helper.c:994
+#: builtin/submodule--helper.c:968
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
 msgstr "* %s %s(submodul)->%s(blob)"
 
-#: builtin/submodule--helper.c:1007
+#: builtin/submodule--helper.c:981
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: builtin/submodule--helper.c:1057
+#: builtin/submodule--helper.c:1031
 #, c-format
 msgid "couldn't hash object from '%s'"
 msgstr "tidak dapat hash objek dari '%s'"
 
-#: builtin/submodule--helper.c:1061
+#: builtin/submodule--helper.c:1035
 #, c-format
 msgid "unexpected mode %o\n"
 msgstr "mode tidak diharapkan %o\n"
 
-#: builtin/submodule--helper.c:1302
+#: builtin/submodule--helper.c:1276
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr "gunakan komit yang disimpan di dalam indeks daripada HEAD submodul"
 
-#: builtin/submodule--helper.c:1304
+#: builtin/submodule--helper.c:1278
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr "bandingkan komit di dalam indeks dengan yang di dalam HEAD submodul"
 
-#: builtin/submodule--helper.c:1306
+#: builtin/submodule--helper.c:1280
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr "lewatkan submodul dengan nilai 'ignore_config' disetel ke 'all'"
 
-#: builtin/submodule--helper.c:1308
+#: builtin/submodule--helper.c:1282
 msgid "limit the summary size"
 msgstr "batasi ukuran ringkasan"
 
-#: builtin/submodule--helper.c:1313
+#: builtin/submodule--helper.c:1287
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 msgstr "git submodule--helper summary [<opsi>] [<commit>] -- [<jalur>]"
 
-#: builtin/submodule--helper.c:1337
+#: builtin/submodule--helper.c:1311
 msgid "could not fetch a revision for HEAD"
 msgstr "tidak dapat mengambil revisi untuk HEAD"
 
-#: builtin/submodule--helper.c:1342
+#: builtin/submodule--helper.c:1316
 msgid "--cached and --files are mutually exclusive"
 msgstr "--cached dan --files saling eksklusif"
 
-#: builtin/submodule--helper.c:1409
+#: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Mensinkronisasi url submodul untuk '%s'\n"
 
-#: builtin/submodule--helper.c:1415
+#: builtin/submodule--helper.c:1379
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "gagal mendaftarkan url untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1429
+#: builtin/submodule--helper.c:1393
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "gagal mendapatkan remote asali untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:1440
+#: builtin/submodule--helper.c:1404
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "gagal memperbarui remote untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:1487
+#: builtin/submodule--helper.c:1451
 msgid "suppress output of synchronizing submodule url"
 msgstr "sembunyikan keluaran mensinkronisasi url submodul"
 
-#: builtin/submodule--helper.c:1494
+#: builtin/submodule--helper.c:1458
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<jalur>]"
 
-#: builtin/submodule--helper.c:1548
+#: builtin/submodule--helper.c:1512
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -21988,7 +22327,7 @@ msgstr ""
 "Pohon kerja submodul '%s' berisi direktori .git (gunakan 'rm -rf' bila Anda "
 "benar-benar ingin menghapus itu termasuk semua riwayatnya)"
 
-#: builtin/submodule--helper.c:1560
+#: builtin/submodule--helper.c:1524
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -21997,46 +22336,46 @@ msgstr ""
 "Pohon kerja submodul '%s' berisi modifikasi lokal; gunakan '-f' untuk "
 "menyingkirkan itu"
 
-#: builtin/submodule--helper.c:1568
+#: builtin/submodule--helper.c:1532
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Direktori '%s' dibersihkan\n"
 
-#: builtin/submodule--helper.c:1570
+#: builtin/submodule--helper.c:1534
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Tidak dapat menghapus pohon kerja submodul '%s'\n"
 
-#: builtin/submodule--helper.c:1581
+#: builtin/submodule--helper.c:1545
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "tidak dapat membuat direktori submodul kosong %s"
 
-#: builtin/submodule--helper.c:1597
+#: builtin/submodule--helper.c:1561
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submodul '%s' (%s) tak terdaftar untuk jalur '%s'\n"
 
-#: builtin/submodule--helper.c:1626
+#: builtin/submodule--helper.c:1590
 msgid "remove submodule working trees even if they contain local changes"
 msgstr "hapus pohon kerja submodul bahkan jika itu berisi perubahan lokal"
 
-#: builtin/submodule--helper.c:1627
+#: builtin/submodule--helper.c:1591
 msgid "unregister all submodules"
 msgstr "batal daftar semua submodul"
 
-#: builtin/submodule--helper.c:1632
+#: builtin/submodule--helper.c:1596
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<jalur>...]]"
 
-#: builtin/submodule--helper.c:1646
+#: builtin/submodule--helper.c:1610
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr ""
 "Gunakan '--all' jika Anda benar-benar ingin deinisialisasi semua submodul"
 
-#: builtin/submodule--helper.c:1690
+#: builtin/submodule--helper.c:1655
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -22048,68 +22387,68 @@ msgstr ""
 " itu, setel submodule.alternateErrorStrategy ke 'info' atau yang sama,\n"
 "kloning degan '--reference-if-able' daripada '--reference'."
 
-#: builtin/submodule--helper.c:1729 builtin/submodule--helper.c:1732
+#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "submodul '%s' tidak dapat menambahkan pengganti: %s"
 
-#: builtin/submodule--helper.c:1768
+#: builtin/submodule--helper.c:1739
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Nilai '%s' untuk submodule.alternateErrorStrategy tidak dikenal"
 
-#: builtin/submodule--helper.c:1775
+#: builtin/submodule--helper.c:1746
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Nilai '%s' untuk submodule.alternateLocation tidak dikenal"
 
-#: builtin/submodule--helper.c:1800
+#: builtin/submodule--helper.c:1771
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "menolak membuat/menggunakan '%s' di dalam direktori git submodul yang lain"
 
-#: builtin/submodule--helper.c:1841
+#: builtin/submodule--helper.c:1812
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "gagal mengkloning '%s' ke dalam jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1846
+#: builtin/submodule--helper.c:1817
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "direktori tidak kosong: '%s'"
 
-#: builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1829
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "tidak dapat mendapatkan direktori submodul untuk '%s'"
 
-#: builtin/submodule--helper.c:1890 builtin/submodule--helper.c:2894
+#: builtin/submodule--helper.c:1861
 msgid "where the new submodule will be cloned to"
 msgstr "di mana submodul baru akan dikloning"
 
-#: builtin/submodule--helper.c:1893 builtin/submodule--helper.c:2897
+#: builtin/submodule--helper.c:1864
 msgid "name of the new submodule"
 msgstr "nama submodul baru"
 
-#: builtin/submodule--helper.c:1896 builtin/submodule--helper.c:2900
+#: builtin/submodule--helper.c:1867
 msgid "url where to clone the submodule from"
 msgstr "url di mana submodul dikloning"
 
-#: builtin/submodule--helper.c:1904 builtin/submodule--helper.c:2907
+#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
 msgid "depth for shallow clones"
 msgstr "kedalaman untuk kloning dangkal"
 
-#: builtin/submodule--helper.c:1907 builtin/submodule--helper.c:2365
-#: builtin/submodule--helper.c:2909
+#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
+#: builtin/submodule--helper.c:3257
 msgid "force cloning progress"
 msgstr "paksa perkembangan kloning"
 
-#: builtin/submodule--helper.c:1909 builtin/submodule--helper.c:2367
+#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
 msgid "disallow cloning into non-empty directory"
 msgstr "tak perbolehkan kloning ke dalam direktori bukan kosong"
 
-#: builtin/submodule--helper.c:1916
+#: builtin/submodule--helper.c:1887
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -22119,82 +22458,180 @@ msgstr ""
 "<repositori>] [--name <nama>] [--depth <kedalaman>] [--single-branch] --url "
 "<url> --path <jalur>"
 
-#: builtin/submodule--helper.c:1953
+#: builtin/submodule--helper.c:1924
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Mode pembaruan '%s' tidak valid untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1957
+#: builtin/submodule--helper.c:1928
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr "Mode pembaruan '%s' tidak valid untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:2058
+#: builtin/submodule--helper.c:2043
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Jalur submodul '%s' tidak diinisialisasi"
 
-#: builtin/submodule--helper.c:2062
+#: builtin/submodule--helper.c:2047
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Mungkin Anda ingin menggunakan 'update --init'?"
 
-#: builtin/submodule--helper.c:2092
+#: builtin/submodule--helper.c:2077
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Melewati submodul tak tergabung %s"
 
-#: builtin/submodule--helper.c:2121
+#: builtin/submodule--helper.c:2106
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Melewati submodul '%s'"
 
-#: builtin/submodule--helper.c:2271
+#: builtin/submodule--helper.c:2256
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Gagal mengkloning '%s'. Percobaan ulang dijadwalkan"
 
-#: builtin/submodule--helper.c:2282
+#: builtin/submodule--helper.c:2267
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Gagal mengkloning '%s' untuk kedua kalinya, batalkan"
 
-#: builtin/submodule--helper.c:2344 builtin/submodule--helper.c:2590
+#: builtin/submodule--helper.c:2372
+#, c-format
+msgid "Unable to checkout '%s' in submodule path '%s'"
+msgstr "Tidak dapat men-checkout '%s' pada jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:2376
+#, c-format
+msgid "Unable to rebase '%s' in submodule path '%s'"
+msgstr "Gagal mendasarkan ulang '%s' pada jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:2380
+#, c-format
+msgid "Unable to merge '%s' in submodule path '%s'"
+msgstr "Tidak dapat menggabungkan '%s' pada jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:2384
+#, c-format
+msgid "Execution of '%s %s' failed in submodule path '%s'"
+msgstr "Eksekusi '%s %s' gagal di jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:2408
+#, c-format
+msgid "Submodule path '%s': checked out '%s'\n"
+msgstr "Jalur submodul '%s': ter-checkout '%s'\n"
+
+#: builtin/submodule--helper.c:2412
+#, c-format
+msgid "Submodule path '%s': rebased into '%s'\n"
+msgstr "Jalur submodul '%s: terdasarkan ulang ke '%s''\n"
+
+#: builtin/submodule--helper.c:2416
+#, c-format
+msgid "Submodule path '%s': merged in '%s'\n"
+msgstr "Jalur submodul '%s': tergabung dalam '%s'\n"
+
+#: builtin/submodule--helper.c:2420
+#, c-format
+msgid "Submodule path '%s': '%s %s'\n"
+msgstr "Jalur submodul '%s': '%s %s'\n"
+
+#: builtin/submodule--helper.c:2444
+#, c-format
+msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
+msgstr ""
+"Tidak dapat mengambil di dalam jalur submodul '%s'; mencoba mengambil "
+"langsung %s:"
+
+#: builtin/submodule--helper.c:2453
+#, c-format
+msgid ""
+"Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
+"of that commit failed."
+msgstr ""
+"Terambil di dalam jalur submodul '%s', tetapi itu tidak berisi %s. "
+"Pengambilan langsung komit tersebut gagal."
+
+#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2812
 msgid "path into the working tree"
 msgstr "jalur ke dalam pohon kerja"
 
-#: builtin/submodule--helper.c:2347
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "jalur ke dalam pohon kerja, melintasi perbatasan submodul bersarang"
 
-#: builtin/submodule--helper.c:2351
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
 msgid "rebase, merge, checkout or none"
 msgstr "dasarkan ulang, gabungkan, checkout atau tidak sama sekali"
 
-#: builtin/submodule--helper.c:2357
+#: builtin/submodule--helper.c:2517
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr "buat klon dangkal terpotong hingga sejumlah revisi yang disebutkan"
 
-#: builtin/submodule--helper.c:2360
+#: builtin/submodule--helper.c:2520
 msgid "parallel jobs"
 msgstr "pekerjaan paralel"
 
-#: builtin/submodule--helper.c:2362
+#: builtin/submodule--helper.c:2522
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "apakah klon awal seharusnya mengikuti rekomendasi dangkal"
 
-#: builtin/submodule--helper.c:2363
+#: builtin/submodule--helper.c:2523
 msgid "don't print cloning progress"
 msgstr "jangan cetak perkembangan pengkloningan"
 
-#: builtin/submodule--helper.c:2374
+#: builtin/submodule--helper.c:2534
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=<jalur>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:2387
+#: builtin/submodule--helper.c:2547
 msgid "bad value for update parameter"
 msgstr "nilai jelek untuk parameter pembaruan"
 
-#: builtin/submodule--helper.c:2435
+#: builtin/submodule--helper.c:2565
+msgid "suppress output for update by rebase or merge"
+msgstr ""
+"sembunyikan keluaran untuk pembaruan oleh pendasaran ulang atau penggabungan"
+
+#: builtin/submodule--helper.c:2566
+msgid "force checkout updates"
+msgstr "paksa pembaruan checkout"
+
+#: builtin/submodule--helper.c:2568
+msgid "don't fetch new objects from the remote site"
+msgstr "jangan ambil objek baru dari situs remote"
+
+#: builtin/submodule--helper.c:2570
+msgid "overrides update mode in case the repository is a fresh clone"
+msgstr "timpa mode pembaruan jika repositori adalah kloning segar"
+
+#: builtin/submodule--helper.c:2571
+msgid "depth for shallow fetch"
+msgstr "kedalaman untuk pengambilan dangkal"
+
+#: builtin/submodule--helper.c:2581
+msgid "sha1"
+msgstr "sha1"
+
+#: builtin/submodule--helper.c:2582
+msgid "SHA1 expected by superproject"
+msgstr "SHA1 diharapkan oleh proyek super"
+
+#: builtin/submodule--helper.c:2584
+msgid "subsha1"
+msgstr "subsha1"
+
+#: builtin/submodule--helper.c:2585
+msgid "SHA1 of submodule's HEAD"
+msgstr "SHA1 dari HEAD submodul"
+
+#: builtin/submodule--helper.c:2591
+msgid "git submodule--helper run-update-procedure [<options>] <path>"
+msgstr "git submodule--helper run-update-procedure [<opsi>] <jalur>"
+
+#: builtin/submodule--helper.c:2662
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -22203,181 +22640,226 @@ msgstr ""
 "Cabang submodul (%s) dikonfigurasikan untuk mewarisi cabang dari proyek "
 "super, tapi proyek super tidak pada cabang apapun"
 
-#: builtin/submodule--helper.c:2558
+#: builtin/submodule--helper.c:2780
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "tidak dapat mendapat pegangan repositori untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2813
 msgid "recurse into submodules"
 msgstr "rekursi ke dalam submodul"
 
-#: builtin/submodule--helper.c:2597
+#: builtin/submodule--helper.c:2819
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<opsi>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:2653
+#: builtin/submodule--helper.c:2875
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "periksa apakah itu aman untuk menulis ke berkas .gitmodules"
 
-#: builtin/submodule--helper.c:2656
+#: builtin/submodule--helper.c:2878
 msgid "unset the config in the .gitmodules file"
 msgstr "batal setel konfigurasi dalam berkas .gitmodules"
 
-#: builtin/submodule--helper.c:2661
+#: builtin/submodule--helper.c:2883
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <nama> [<nilai>]"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <nama>"
 
-#: builtin/submodule--helper.c:2663
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2682 git-submodule.sh:150
-#, sh-format
+#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
+#: builtin/submodule--helper.c:3276
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "mohom pastikan berkas .gitmodules di dalam pohon kerja"
 
-#: builtin/submodule--helper.c:2698
+#: builtin/submodule--helper.c:2920
 msgid "suppress output for setting url of a submodule"
 msgstr "sembunyikan keluaran penyetelan url submodule"
 
-#: builtin/submodule--helper.c:2702
+#: builtin/submodule--helper.c:2924
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <jalur> <url baru>"
 
-#: builtin/submodule--helper.c:2735
+#: builtin/submodule--helper.c:2957
 msgid "set the default tracking branch to master"
 msgstr "setel cabang pelacak asali ke master"
 
-#: builtin/submodule--helper.c:2737
+#: builtin/submodule--helper.c:2959
 msgid "set the default tracking branch"
 msgstr "setel cabang pelacak asali"
 
-#: builtin/submodule--helper.c:2741
+#: builtin/submodule--helper.c:2963
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) <jalur>"
 
-#: builtin/submodule--helper.c:2742
+#: builtin/submodule--helper.c:2964
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <cabang> <jalur>"
 
-#: builtin/submodule--helper.c:2749
+#: builtin/submodule--helper.c:2971
 msgid "--branch or --default required"
 msgstr "--branch atau --default dibutuhkan"
 
-#: builtin/submodule--helper.c:2752
+#: builtin/submodule--helper.c:2974
 msgid "--branch and --default are mutually exclusive"
 msgstr "--branch dan --default saling eksklusif"
 
-#: builtin/submodule--helper.c:2815
+#: builtin/submodule--helper.c:3037
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Menambahkan repo yang sudah ada pada '%s' ke indeks\n"
 
-#: builtin/submodule--helper.c:2818
+#: builtin/submodule--helper.c:3040
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "'%s' sudah ada dan bukan repo git valid"
 
-#: builtin/submodule--helper.c:2828
+#: builtin/submodule--helper.c:3053
 #, c-format
-msgid "A git directory for '%s' is found locally with remote(s):"
-msgstr "Sebuah direktori git untuk '%s' ditemukan lokal dengan remote:"
+msgid "A git directory for '%s' is found locally with remote(s):\n"
+msgstr "Sebuah direktori git untuk '%s' ditemukan lokal dengan remote:\n"
 
-#: builtin/submodule--helper.c:2833
+#: builtin/submodule--helper.c:3060
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
 "  %s\n"
 "use the '--force' option. If the local git directory is not the correct "
 "repo\n"
-"or if you are unsure what this means, choose another name with the '--name' "
-"option.\n"
+"or you are unsure what this means choose another name with the '--name' "
+"option."
 msgstr ""
-"Jika Anda ingin menggunakan ulang direktori git lokal ini daripada "
-"mengkloning lagi dari\n"
+"Jika Anda ingin menggunakan ulang direktori git lokal ini daripada mengkloning lagi dari\n"
 "  %s\n"
-"gynakan opsi '--force'. Jika direktori git lokal bukan repo yang benar\n"
-"atau Anda tidak yakin apa maksudnya, pilih nama yang lain dengan opsi "
-"'--name'.\n"
+"gunakan opsi '--force'. Jika direktori git lokal bukan repo yang benar\n"
+"atau Anda tidak yakin apa maksudnya, pilih nama yang lain dengan opsi '--"
+"name'."
 
-#: builtin/submodule--helper.c:2842
+#: builtin/submodule--helper.c:3072
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Mengaktifkan ulang direktori git lokal untuk submodul '%s'\n"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:3109
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "Tidak dapat men-checkout submodul '%s'"
 
-#: builtin/submodule--helper.c:2888
-msgid "branch of repository to checkout on cloning"
-msgstr "cabang repositori untuk di-checkout saat kloning"
+#: builtin/submodule--helper.c:3148
+#, c-format
+msgid "Failed to add submodule '%s'"
+msgstr "Tidak dapat menambahkan submodul '%s'"
 
-#: builtin/submodule--helper.c:2910
+#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
+#: builtin/submodule--helper.c:3165
+#, c-format
+msgid "Failed to register submodule '%s'"
+msgstr "Gagal mendaftarkan jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:3221
+#, c-format
+msgid "'%s' already exists in the index"
+msgstr "'%s' sudah ada di dalam indeks"
+
+#: builtin/submodule--helper.c:3224
+#, c-format
+msgid "'%s' already exists in the index and is not a submodule"
+msgstr "'%s' sudah ada di dalam indeks dan bukan submodul"
+
+#: builtin/submodule--helper.c:3253
+msgid "branch of repository to add as submodule"
+msgstr "cabang repositori untuk ditambahkan sebagai submodul"
+
+#: builtin/submodule--helper.c:3254
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "perbolehkan menambah jalur submodul yang diabaikan"
 
-#: builtin/submodule--helper.c:2917
-msgid ""
-"git submodule--helper add-clone [<options>...] --url <url> --path <path> --"
-"name <name>"
-msgstr ""
-"git submodule--helper add-clone [<opsi>...] --url <url> --path <path> "
-"--name <nama>"
+#: builtin/submodule--helper.c:3256
+msgid "print only error messages"
+msgstr "hanya cetak pesan kesalahan"
 
-#: builtin/submodule--helper.c:2985 git.c:449 git.c:724
+#: builtin/submodule--helper.c:3260
+msgid "borrow the objects from reference repositories"
+msgstr "pinjam objek dari repositori referensi"
+
+#: builtin/submodule--helper.c:3262
+msgid ""
+"sets the submodule’s name to the given string instead of defaulting to its "
+"path"
+msgstr ""
+"setel nama submodul ke untai yang diberikan daripada diasalkan ke jalurnya"
+
+#: builtin/submodule--helper.c:3269
+msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
+msgstr "git submodule--helper add [<opsi>] [--] <repositori> [<jalur>]"
+
+#: builtin/submodule--helper.c:3297
+msgid "Relative path can only be used from the toplevel of the working tree"
+msgstr "Jalur relatif hanya dapat digunakan dari level atas dari pohon kerja"
+
+#: builtin/submodule--helper.c:3305
+#, c-format
+msgid "repo URL: '%s' must be absolute or begin with ./|../"
+msgstr "URL repo: '%s' harus absolut atau diawali dengan ./|../"
+
+#: builtin/submodule--helper.c:3340
+#, c-format
+msgid "'%s' is not a valid submodule name"
+msgstr "'%s' bukan nama submodul yang valid"
+
+#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s tidak mendukung --super-prefix"
 
-#: builtin/submodule--helper.c:2991
+#: builtin/submodule--helper.c:3410
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' bukan subperintah submodule--helper valid"
 
 #: builtin/symbolic-ref.c:8
 msgid "git symbolic-ref [<options>] <name> [<ref>]"
-msgstr ""
+msgstr "git symbolic-ref [<opsi>] <nama> [<referensi>]"
 
 #: builtin/symbolic-ref.c:9
 msgid "git symbolic-ref -d [-q] <name>"
-msgstr ""
+msgstr "git symbolic-ref -d [-q] <nama>"
 
 #: builtin/symbolic-ref.c:42
 msgid "suppress error message for non-symbolic (detached) refs"
-msgstr ""
+msgstr "matikan pesan kesalahan untuk referensi non-simbolik (terlepas)"
 
 #: builtin/symbolic-ref.c:43
 msgid "delete symbolic ref"
-msgstr ""
+msgstr "hapus referensi simbolik"
 
 #: builtin/symbolic-ref.c:44
 msgid "shorten ref output"
-msgstr ""
+msgstr "pendekkan keluaran referensi"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason"
-msgstr ""
+msgstr "alasan"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason of the update"
-msgstr ""
+msgstr "alasan pembaruan"
 
 #: builtin/tag.c:25
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
-"\t\t<tagname> [<head>]"
+"        <tagname> [<head>]"
 msgstr ""
 "git tag [-a | -s | -u <id kunci>] [-f] [-m <pesan | -F <berkas>]\n"
-"\t\t<nama tag> [<kepala>]"
+"        <nama tag> [<kepala>]"
 
 #: builtin/tag.c:27
 msgid "git tag -d <tagname>..."
@@ -22387,12 +22869,13 @@ msgstr "git tag -d <nama tag>..."
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
-"\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"        [--format=<format>] [--merged <commit>] [--no-merged <commit>] "
 "[<pattern>...]"
 msgstr ""
 "git tag -l [-n[<angka>]] [--contains <komit>] [--no-contains <komit>] [--"
 "points-at <objek>]\n"
-"\t\t[--format=<format>] [--merged <komit>] [--no-merged <komit>] [<pola>...]"
+"        [--format=<format>] [--merged <komit>] [--no-merged <komit>] "
+"[<pola>...]"
 
 #: builtin/tag.c:30
 msgid "git tag -v [--format=<format>] <tagname>..."
@@ -22458,130 +22941,130 @@ msgstr ""
 msgid "bad object type."
 msgstr "tipe objek jelek."
 
-#: builtin/tag.c:328
+#: builtin/tag.c:326
 msgid "no tag message?"
 msgstr "tidak ada pesan tag?"
 
-#: builtin/tag.c:335
+#: builtin/tag.c:333
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Pesan tag dibiarkan di %s\n"
 
-#: builtin/tag.c:446
+#: builtin/tag.c:444
 msgid "list tag names"
 msgstr "daftarkan nama tag"
 
-#: builtin/tag.c:448
+#: builtin/tag.c:446
 msgid "print <n> lines of each tag message"
 msgstr "cetak <n> baris dari setiap pesan tag"
 
-#: builtin/tag.c:450
+#: builtin/tag.c:448
 msgid "delete tags"
 msgstr "hapus tag"
 
-#: builtin/tag.c:451
+#: builtin/tag.c:449
 msgid "verify tags"
 msgstr "verifikasi tag"
 
-#: builtin/tag.c:453
+#: builtin/tag.c:451
 msgid "Tag creation options"
 msgstr "Opsi pembuatan tag"
 
-#: builtin/tag.c:455
+#: builtin/tag.c:453
 msgid "annotated tag, needs a message"
 msgstr "tag bercatat, butuh sebuah pesan"
 
-#: builtin/tag.c:457
+#: builtin/tag.c:455
 msgid "tag message"
 msgstr "pesan tag"
 
-#: builtin/tag.c:459
+#: builtin/tag.c:457
 msgid "force edit of tag message"
 msgstr "paksa sunting pesan tag"
 
-#: builtin/tag.c:460
+#: builtin/tag.c:458
 msgid "annotated and GPG-signed tag"
 msgstr "tag bercatat dan bertandatangan GPG"
 
-#: builtin/tag.c:463
+#: builtin/tag.c:461
 msgid "use another key to sign the tag"
 msgstr "gunakan kunci yang lain untuk menandatangani tag"
 
-#: builtin/tag.c:464
+#: builtin/tag.c:462
 msgid "replace the tag if exists"
 msgstr "ganti tag jika ada"
 
-#: builtin/tag.c:465 builtin/update-ref.c:505
+#: builtin/tag.c:463 builtin/update-ref.c:511
 msgid "create a reflog"
 msgstr "buat log referensi"
 
-#: builtin/tag.c:467
+#: builtin/tag.c:465
 msgid "Tag listing options"
 msgstr "Opsi daftar tag"
 
-#: builtin/tag.c:468
+#: builtin/tag.c:466
 msgid "show tag list in columns"
 msgstr "perlihatkan daftar tag dalam kolom"
 
-#: builtin/tag.c:469 builtin/tag.c:471
+#: builtin/tag.c:467 builtin/tag.c:469
 msgid "print only tags that contain the commit"
 msgstr "hanya cetak tag yang berisi komit"
 
-#: builtin/tag.c:470 builtin/tag.c:472
+#: builtin/tag.c:468 builtin/tag.c:470
 msgid "print only tags that don't contain the commit"
 msgstr "hanya cetak tag yang tidak berisi komit"
 
-#: builtin/tag.c:473
+#: builtin/tag.c:471
 msgid "print only tags that are merged"
 msgstr "hanya cetak tag yang tergabung"
 
-#: builtin/tag.c:474
+#: builtin/tag.c:472
 msgid "print only tags that are not merged"
 msgstr "hanya cetak tag yang tak tergabung"
 
-#: builtin/tag.c:478
+#: builtin/tag.c:476
 msgid "print only tags of the object"
 msgstr "hanya cetak tag dari objek"
 
-#: builtin/tag.c:526
+#: builtin/tag.c:525
 msgid "--column and -n are incompatible"
 msgstr "--column dan -n tidak kompatibel"
 
-#: builtin/tag.c:548
+#: builtin/tag.c:546
 msgid "-n option is only allowed in list mode"
 msgstr "opsi -n hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:550
+#: builtin/tag.c:548
 msgid "--contains option is only allowed in list mode"
 msgstr "opsi --contains hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:552
+#: builtin/tag.c:550
 msgid "--no-contains option is only allowed in list mode"
 msgstr "opsi --no-contains hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:554
+#: builtin/tag.c:552
 msgid "--points-at option is only allowed in list mode"
 msgstr "opsi --points-at hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:556
+#: builtin/tag.c:554
 msgid "--merged and --no-merged options are only allowed in list mode"
 msgstr "opsi --merged dan --no-merged hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:567
+#: builtin/tag.c:568
 msgid "only one -F or -m option is allowed."
 msgstr "hanya satu opsi -F atau -m yang diperbolehkan."
 
-#: builtin/tag.c:592
+#: builtin/tag.c:593
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "'%s' bukan nama tag yang valid."
 
-#: builtin/tag.c:597
+#: builtin/tag.c:598
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "tag '%s' sudah ada"
 
-#: builtin/tag.c:628
+#: builtin/tag.c:629
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Tag '%s' diperbarui (yaitu %s)\n"
@@ -22593,273 +23076,282 @@ msgstr ""
 #: builtin/update-index.c:84
 #, c-format
 msgid "failed to create directory %s"
-msgstr ""
+msgstr "gagal membuat direktori %s"
 
-#: builtin/update-index.c:100
-#, c-format
-msgid "failed to create file %s"
-msgstr ""
-
-#: builtin/update-index.c:108
+#: builtin/update-index.c:106
 #, c-format
 msgid "failed to delete file %s"
-msgstr ""
+msgstr "gagal menghapus berkas %s"
 
-#: builtin/update-index.c:115 builtin/update-index.c:221
+#: builtin/update-index.c:113 builtin/update-index.c:219
 #, c-format
 msgid "failed to delete directory %s"
-msgstr ""
+msgstr "gagal menghapus direktori %s"
 
-#: builtin/update-index.c:140
+#: builtin/update-index.c:138
 #, c-format
 msgid "Testing mtime in '%s' "
-msgstr ""
+msgstr "Menguji mtime di '%s' "
 
-#: builtin/update-index.c:154
+#: builtin/update-index.c:152
 msgid "directory stat info does not change after adding a new file"
-msgstr ""
+msgstr "info stat direktori tidak berubah setelah menambahkan berkas baru"
 
-#: builtin/update-index.c:167
+#: builtin/update-index.c:165
 msgid "directory stat info does not change after adding a new directory"
-msgstr ""
+msgstr "info stat direktori tidak berubah setelah menambahkan direktori baru"
 
-#: builtin/update-index.c:180
+#: builtin/update-index.c:178
 msgid "directory stat info changes after updating a file"
-msgstr ""
+msgstr "info stat direktori berubah setelah memperbarui berkas"
 
-#: builtin/update-index.c:191
+#: builtin/update-index.c:189
 msgid "directory stat info changes after adding a file inside subdirectory"
 msgstr ""
+"info stat direktori berubah setelah menambahkan berkas di dalam subdirektori"
 
-#: builtin/update-index.c:202
+#: builtin/update-index.c:200
 msgid "directory stat info does not change after deleting a file"
-msgstr ""
+msgstr "info stat direktori tidak berubah setelah menghapus berkas"
 
-#: builtin/update-index.c:215
+#: builtin/update-index.c:213
 msgid "directory stat info does not change after deleting a directory"
-msgstr ""
+msgstr "info stat direktori tidak berubah setelah menghapus direktori"
 
-#: builtin/update-index.c:222
+#: builtin/update-index.c:220
 msgid " OK"
-msgstr ""
+msgstr " OK"
 
-#: builtin/update-index.c:591
+#: builtin/update-index.c:589
 msgid "git update-index [<options>] [--] [<file>...]"
-msgstr ""
+msgstr "git update-index [<opsi>] [--] [<berkas>...]"
 
-#: builtin/update-index.c:976
+#: builtin/update-index.c:974
 msgid "continue refresh even when index needs update"
-msgstr ""
+msgstr "lanjutkan penyegaran bahkan ketika indeks perlu diperbarui"
 
-#: builtin/update-index.c:979
+#: builtin/update-index.c:977
 msgid "refresh: ignore submodules"
-msgstr ""
+msgstr "refresh: abaikan submodul"
+
+#: builtin/update-index.c:980
+msgid "do not ignore new files"
+msgstr "jangan abaikan berkas baru"
 
 #: builtin/update-index.c:982
-msgid "do not ignore new files"
-msgstr ""
+msgid "let files replace directories and vice-versa"
+msgstr "biarkan berkas menggantikan direktori dan sebaliknya"
 
 #: builtin/update-index.c:984
-msgid "let files replace directories and vice-versa"
-msgstr ""
+msgid "notice files missing from worktree"
+msgstr "catat berkas hilang dari pohon kerja"
 
 #: builtin/update-index.c:986
-msgid "notice files missing from worktree"
-msgstr ""
-
-#: builtin/update-index.c:988
 msgid "refresh even if index contains unmerged entries"
-msgstr ""
+msgstr "segarkan bahkan jika indeks berisi entri tak tergabung"
 
-#: builtin/update-index.c:991
+#: builtin/update-index.c:989
 msgid "refresh stat information"
-msgstr ""
+msgstr "segarkan informasi stat"
 
-#: builtin/update-index.c:995
+#: builtin/update-index.c:993
 msgid "like --refresh, but ignore assume-unchanged setting"
-msgstr ""
+msgstr "seperti --refresh, tapi abaikan setelan assume-unchanged"
 
-#: builtin/update-index.c:999
+#: builtin/update-index.c:997
 msgid "<mode>,<object>,<path>"
-msgstr ""
+msgstr "<mode>,<objek>,<jalur>"
 
-#: builtin/update-index.c:1000
+#: builtin/update-index.c:998
 msgid "add the specified entry to the index"
-msgstr ""
+msgstr "tambahkan entri yang disebutkan ke indeks"
 
-#: builtin/update-index.c:1010
+#: builtin/update-index.c:1008
 msgid "mark files as \"not changing\""
-msgstr ""
+msgstr "tandai berkas sebagai \"not changing\""
 
-#: builtin/update-index.c:1013
+#: builtin/update-index.c:1011
 msgid "clear assumed-unchanged bit"
-msgstr ""
+msgstr "bersihkan bita assumed-unchanged"
 
-#: builtin/update-index.c:1016
+#: builtin/update-index.c:1014
 msgid "mark files as \"index-only\""
-msgstr ""
+msgstr "tandai berkas sebagai \"index-only\""
 
-#: builtin/update-index.c:1019
+#: builtin/update-index.c:1017
 msgid "clear skip-worktree bit"
-msgstr ""
+msgstr "bersihkan bita skip-worktree"
+
+#: builtin/update-index.c:1020
+msgid "do not touch index-only entries"
+msgstr "jangan sentuh entri index-only"
 
 #: builtin/update-index.c:1022
-msgid "do not touch index-only entries"
-msgstr ""
+msgid "add to index only; do not add content to object database"
+msgstr "hanya tambahkan ke indeks; jangan tambahkan konten ke basis data objek"
 
 #: builtin/update-index.c:1024
-msgid "add to index only; do not add content to object database"
-msgstr ""
+msgid "remove named paths even if present in worktree"
+msgstr "hapus jalur bernama bahkan jika ada dalam pohon kerja"
 
 #: builtin/update-index.c:1026
-msgid "remove named paths even if present in worktree"
-msgstr ""
+msgid "with --stdin: input lines are terminated by null bytes"
+msgstr "dengan --stdin: baris masukan diakhiri dengan bita null"
 
 #: builtin/update-index.c:1028
-msgid "with --stdin: input lines are terminated by null bytes"
-msgstr ""
-
-#: builtin/update-index.c:1030
 msgid "read list of paths to be updated from standard input"
-msgstr ""
+msgstr "baca daftar jalur yang akan diperbarui dari masukan standar"
 
-#: builtin/update-index.c:1034
+#: builtin/update-index.c:1032
 msgid "add entries from standard input to the index"
-msgstr ""
+msgstr "tambahkan entri dari masukan standar ke indeks"
 
-#: builtin/update-index.c:1038
+#: builtin/update-index.c:1036
 msgid "repopulate stages #2 and #3 for the listed paths"
-msgstr ""
+msgstr "populasi ulang tahapan #2 dan #3 untuk jalur yang terdaftar"
 
-#: builtin/update-index.c:1042
+#: builtin/update-index.c:1040
 msgid "only update entries that differ from HEAD"
-msgstr ""
+msgstr "hanya perbarui entri yang berbeda dari HEAD"
 
-#: builtin/update-index.c:1046
+#: builtin/update-index.c:1044
 msgid "ignore files missing from worktree"
-msgstr ""
+msgstr "abaikan berkas yang hilang dari pohon kerja"
+
+#: builtin/update-index.c:1047
+msgid "report actions to standard output"
+msgstr "laporkan aksi ke keluaran standar"
 
 #: builtin/update-index.c:1049
-msgid "report actions to standard output"
-msgstr ""
-
-#: builtin/update-index.c:1051
 msgid "(for porcelains) forget saved unresolved conflicts"
-msgstr ""
+msgstr "(untuk porselen) lupakan konflik tak terselesaikan yang disimpan"
+
+#: builtin/update-index.c:1053
+msgid "write index in this format"
+msgstr "tulis indeks dalam format ini"
 
 #: builtin/update-index.c:1055
-msgid "write index in this format"
-msgstr ""
+msgid "enable or disable split index"
+msgstr "aktifkan atau nonaktifkan indeks terpisah"
 
 #: builtin/update-index.c:1057
-msgid "enable or disable split index"
-msgstr ""
+msgid "enable/disable untracked cache"
+msgstr "aktifkan/nonaktifkan tembolok tak terlacak"
 
 #: builtin/update-index.c:1059
-msgid "enable/disable untracked cache"
-msgstr ""
+msgid "test if the filesystem supports untracked cache"
+msgstr "uji jika sistem berkas mendukung tembolok tak terlacak"
 
 #: builtin/update-index.c:1061
-msgid "test if the filesystem supports untracked cache"
-msgstr ""
+msgid "enable untracked cache without testing the filesystem"
+msgstr "aktifkan tembolok tak terlacak tanpa menguji sistem berkas"
 
 #: builtin/update-index.c:1063
-msgid "enable untracked cache without testing the filesystem"
-msgstr ""
+msgid "write out the index even if is not flagged as changed"
+msgstr "tulis indeks bahkan jika tidak dianggap berubah"
 
 #: builtin/update-index.c:1065
-msgid "write out the index even if is not flagged as changed"
-msgstr ""
+msgid "enable or disable file system monitor"
+msgstr "aktifkan atau nonaktifkan monitor sistem berkas"
 
 #: builtin/update-index.c:1067
-msgid "enable or disable file system monitor"
-msgstr ""
-
-#: builtin/update-index.c:1069
 msgid "mark files as fsmonitor valid"
-msgstr ""
+msgstr "tandai berkas sebagai fsmonitor valid"
 
-#: builtin/update-index.c:1072
+#: builtin/update-index.c:1070
 msgid "clear fsmonitor valid bit"
-msgstr ""
+msgstr "bersihkan bita fsmonitor valid"
 
-#: builtin/update-index.c:1175
+#: builtin/update-index.c:1173
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
 msgstr ""
+"core.splitIndex disetel ke false; hapus atau ubah, jika Anda benar-benar "
+"ingin mengaktifkan indeks terpisah"
 
-#: builtin/update-index.c:1184
+#: builtin/update-index.c:1182
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
 msgstr ""
+"core.splitIndex disetel ke true; hapus atau ubah, jika Anda benar-benar  "
+"ingin menonaktifkan indeks terpisah"
 
-#: builtin/update-index.c:1196
+#: builtin/update-index.c:1194
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
 msgstr ""
+"core.untrackedCache disetel ke true; hapus atau ubah, jika Anda benar-benar "
+"ingin menonaktifkan tembolok tak terlacak"
 
-#: builtin/update-index.c:1200
+#: builtin/update-index.c:1198
 msgid "Untracked cache disabled"
-msgstr ""
+msgstr "Tembolok tak terlacak dinonaktifkan"
 
-#: builtin/update-index.c:1208
+#: builtin/update-index.c:1206
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
 msgstr ""
+"core.untrackedCache disetel ke false; hapus atau ubah, jika Anda benar-benar "
+"ingin mengaktifkan tembolok tak terlacak"
 
-#: builtin/update-index.c:1212
+#: builtin/update-index.c:1210
 #, c-format
 msgid "Untracked cache enabled for '%s'"
-msgstr ""
+msgstr "Tembolok tak terlacak diaktifkan untuk '%s'"
 
-#: builtin/update-index.c:1220
+#: builtin/update-index.c:1218
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
+"core.fsmonitor tak disetel; setel jika Anda benar-benar ingin mengaktifkan "
+"fsmonitor"
 
-#: builtin/update-index.c:1224
+#: builtin/update-index.c:1222
 msgid "fsmonitor enabled"
-msgstr ""
+msgstr "fsmonitor diaktifkan"
 
-#: builtin/update-index.c:1227
+#: builtin/update-index.c:1225
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
+"core.fsmonitor disetel; hapus jika Anda benar-benar ingin menonaktifkan "
+"fsmonitor"
 
-#: builtin/update-index.c:1231
+#: builtin/update-index.c:1229
 msgid "fsmonitor disabled"
-msgstr ""
+msgstr "fsmonitor dinonaktifkan"
 
 #: builtin/update-ref.c:10
 msgid "git update-ref [<options>] -d <refname> [<old-val>]"
-msgstr ""
+msgstr "git update-ref [<opsi>] -d <nama referensi> [<nilai lama>]"
 
 #: builtin/update-ref.c:11
 msgid "git update-ref [<options>]    <refname> <new-val> [<old-val>]"
 msgstr ""
+"git update-ref [<opsi>]    <nama referensi> <nilai baru> [<nilai lama>]"
 
 #: builtin/update-ref.c:12
 msgid "git update-ref [<options>] --stdin [-z]"
-msgstr ""
+msgstr "git update-ref [<opsi>] --stdin [-z]"
 
-#: builtin/update-ref.c:500
+#: builtin/update-ref.c:506
 msgid "delete the reference"
-msgstr ""
+msgstr "hapus referensi"
 
-#: builtin/update-ref.c:502
+#: builtin/update-ref.c:508
 msgid "update <refname> not the one it points to"
-msgstr ""
+msgstr "perbarui <nama referensi> bukan yang ditunjuknya"
 
-#: builtin/update-ref.c:503
+#: builtin/update-ref.c:509
 msgid "stdin has NUL-terminated arguments"
-msgstr ""
+msgstr "stdin punya argumen yang diakhiri dengan NUL"
 
-#: builtin/update-ref.c:504
+#: builtin/update-ref.c:510
 msgid "read updates from stdin"
-msgstr ""
+msgstr "baca pembaruan dari masukan standar"
 
 #: builtin/update-server-info.c:7
 msgid "git update-server-info [--force]"
@@ -22871,343 +23363,338 @@ msgstr ""
 
 #: builtin/upload-pack.c:11
 msgid "git upload-pack [<options>] <dir>"
-msgstr ""
+msgstr "git upload-pack [<opsi>] <direktori>"
 
-#: builtin/upload-pack.c:23 t/helper/test-serve-v2.c:17
+#: builtin/upload-pack.c:24 t/helper/test-serve-v2.c:17
 msgid "quit after a single request/response exchange"
-msgstr ""
+msgstr "keluar setelah pertukaran permintaan/jawaban tunggal"
 
-#: builtin/upload-pack.c:25
-msgid "exit immediately after initial ref advertisement"
-msgstr ""
-
-#: builtin/upload-pack.c:27
-msgid "do not try <directory>/.git/ if <directory> is no Git directory"
-msgstr ""
+#: builtin/upload-pack.c:26
+msgid "serve up the info/refs for git-http-backend"
+msgstr "layani info/referensi untuk git-http-backend"
 
 #: builtin/upload-pack.c:29
+msgid "do not try <directory>/.git/ if <directory> is no Git directory"
+msgstr "jangan coba <direktori>.git/ jika <direktori> bukan direktori Git"
+
+#: builtin/upload-pack.c:31
 msgid "interrupt transfer after <n> seconds of inactivity"
-msgstr ""
+msgstr "interupsi transfer setelah <n> detik niraktivitas"
 
 #: builtin/verify-commit.c:19
 msgid "git verify-commit [-v | --verbose] <commit>..."
-msgstr ""
+msgstr "git verify-commit [-v | --verbose] <komit>..."
 
 #: builtin/verify-commit.c:68
 msgid "print commit contents"
-msgstr ""
+msgstr "cetak isi komit"
 
 #: builtin/verify-commit.c:69 builtin/verify-tag.c:37
 msgid "print raw gpg status output"
-msgstr ""
+msgstr "cetak keluaran status gpg mentah"
 
 #: builtin/verify-pack.c:59
 msgid "git verify-pack [-v | --verbose] [-s | --stat-only] <pack>..."
-msgstr ""
+msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] <pak>..."
 
 #: builtin/verify-pack.c:70
 msgid "verbose"
-msgstr ""
+msgstr "bertele-tele"
 
 #: builtin/verify-pack.c:72
 msgid "show statistics only"
-msgstr ""
+msgstr "hanya perlihatkan statistik"
 
 #: builtin/verify-tag.c:18
 msgid "git verify-tag [-v | --verbose] [--format=<format>] <tag>..."
-msgstr ""
+msgstr "git verify-tag [-v | --verbose] [--format=<format>] <tag>..."
 
 #: builtin/verify-tag.c:36
 msgid "print tag contents"
-msgstr ""
+msgstr "cetak isi tag"
 
-#: builtin/worktree.c:18
+#: builtin/worktree.c:19
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
 msgstr ""
 
-#: builtin/worktree.c:19
+#: builtin/worktree.c:20
 msgid "git worktree list [<options>]"
 msgstr ""
 
-#: builtin/worktree.c:20
+#: builtin/worktree.c:21
 msgid "git worktree lock [<options>] <path>"
 msgstr ""
 
-#: builtin/worktree.c:21
+#: builtin/worktree.c:22
 msgid "git worktree move <worktree> <new-path>"
 msgstr ""
 
-#: builtin/worktree.c:22
+#: builtin/worktree.c:23
 msgid "git worktree prune [<options>]"
 msgstr ""
 
-#: builtin/worktree.c:23
+#: builtin/worktree.c:24
 msgid "git worktree remove [<options>] <worktree>"
 msgstr ""
 
-#: builtin/worktree.c:24
+#: builtin/worktree.c:25
 msgid "git worktree unlock <path>"
 msgstr ""
 
-#: builtin/worktree.c:61 builtin/worktree.c:944
-#, c-format
-msgid "failed to delete '%s'"
-msgstr ""
-
-#: builtin/worktree.c:74
+#: builtin/worktree.c:75
 #, c-format
 msgid "Removing %s/%s: %s"
 msgstr ""
 
-#: builtin/worktree.c:147
+#: builtin/worktree.c:148
 msgid "report pruned working trees"
 msgstr ""
 
-#: builtin/worktree.c:149
+#: builtin/worktree.c:150
 msgid "expire working trees older than <time>"
 msgstr ""
 
-#: builtin/worktree.c:219
+#: builtin/worktree.c:220
 #, c-format
 msgid "'%s' already exists"
 msgstr ""
 
-#: builtin/worktree.c:228
+#: builtin/worktree.c:229
 #, c-format
 msgid "unusable worktree destination '%s'"
 msgstr ""
 
-#: builtin/worktree.c:233
+#: builtin/worktree.c:234
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
 "use '%s -f -f' to override, or 'unlock' and 'prune' or 'remove' to clear"
 msgstr ""
 
-#: builtin/worktree.c:235
+#: builtin/worktree.c:236
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
 "use '%s -f' to override, or 'prune' or 'remove' to clear"
 msgstr ""
 
-#: builtin/worktree.c:286
+#: builtin/worktree.c:287
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr ""
 
-#: builtin/worktree.c:308
+#: builtin/worktree.c:309
 msgid "initializing"
 msgstr ""
 
-#: builtin/worktree.c:420 builtin/worktree.c:426
+#: builtin/worktree.c:421 builtin/worktree.c:427
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr ""
 
-#: builtin/worktree.c:422
+#: builtin/worktree.c:423
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr ""
 
-#: builtin/worktree.c:431
+#: builtin/worktree.c:432
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr ""
 
-#: builtin/worktree.c:437
+#: builtin/worktree.c:438
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr ""
 
-#: builtin/worktree.c:482
+#: builtin/worktree.c:483
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:486
 msgid "create a new branch"
 msgstr ""
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:488
 msgid "create or reset a branch"
 msgstr ""
 
-#: builtin/worktree.c:489
+#: builtin/worktree.c:490
 msgid "populate the new working tree"
 msgstr ""
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:491
 msgid "keep the new working tree locked"
 msgstr ""
 
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/worktree.c:493 builtin/worktree.c:730
 msgid "reason for locking"
 msgstr ""
 
-#: builtin/worktree.c:495
+#: builtin/worktree.c:496
 msgid "set up tracking mode (see git-branch(1))"
 msgstr ""
 
-#: builtin/worktree.c:498
+#: builtin/worktree.c:499
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 
-#: builtin/worktree.c:506
+#: builtin/worktree.c:507
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr ""
 
-#: builtin/worktree.c:508
+#: builtin/worktree.c:509
 msgid "--reason requires --lock"
 msgstr ""
 
-#: builtin/worktree.c:512
+#: builtin/worktree.c:513
 msgid "added with --lock"
 msgstr ""
 
-#: builtin/worktree.c:574
+#: builtin/worktree.c:575
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr ""
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:692
 msgid "show extended annotations and reasons, if available"
 msgstr ""
 
-#: builtin/worktree.c:693
+#: builtin/worktree.c:694
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 
-#: builtin/worktree.c:702
+#: builtin/worktree.c:703
 msgid "--verbose and --porcelain are mutually exclusive"
 msgstr ""
 
-#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
-#: builtin/worktree.c:972
+#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
+#: builtin/worktree.c:973
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr ""
 
-#: builtin/worktree.c:743 builtin/worktree.c:776
+#: builtin/worktree.c:744 builtin/worktree.c:777
 msgid "The main working tree cannot be locked or unlocked"
 msgstr ""
 
-#: builtin/worktree.c:748
+#: builtin/worktree.c:749
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr ""
 
-#: builtin/worktree.c:750
+#: builtin/worktree.c:751
 #, c-format
 msgid "'%s' is already locked"
 msgstr ""
 
-#: builtin/worktree.c:778
+#: builtin/worktree.c:779
 #, c-format
 msgid "'%s' is not locked"
 msgstr ""
 
-#: builtin/worktree.c:819
+#: builtin/worktree.c:820
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 
-#: builtin/worktree.c:827
+#: builtin/worktree.c:828
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 
-#: builtin/worktree.c:850 builtin/worktree.c:974
+#: builtin/worktree.c:851 builtin/worktree.c:975
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr ""
 
-#: builtin/worktree.c:855
+#: builtin/worktree.c:856
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr ""
 
-#: builtin/worktree.c:868
+#: builtin/worktree.c:869
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:870
+#: builtin/worktree.c:871
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:873
+#: builtin/worktree.c:874
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr ""
 
-#: builtin/worktree.c:878
+#: builtin/worktree.c:879
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr ""
 
-#: builtin/worktree.c:924
+#: builtin/worktree.c:925
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr ""
 
-#: builtin/worktree.c:928
+#: builtin/worktree.c:929
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 
-#: builtin/worktree.c:933
+#: builtin/worktree.c:934
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr ""
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:957
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 
-#: builtin/worktree.c:979
+#: builtin/worktree.c:980
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:981
+#: builtin/worktree.c:982
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:985
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr ""
 
-#: builtin/worktree.c:1008
+#: builtin/worktree.c:1009
 #, c-format
 msgid "repair: %s: %s"
 msgstr ""
 
-#: builtin/worktree.c:1011
+#: builtin/worktree.c:1012
 #, c-format
 msgid "error: %s: %s"
 msgstr ""
 
 #: builtin/write-tree.c:15
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
-msgstr ""
+msgstr "git write-tree [--missing-ok] [--prefix=<prefiks>/]"
 
 #: builtin/write-tree.c:28
 msgid "<prefix>/"
-msgstr ""
+msgstr "<prefiks>/"
 
 #: builtin/write-tree.c:29
 msgid "write tree object for a subdirectory <prefix>"
-msgstr ""
+msgstr "tulis objek pohon untuk subdirektori <prefiks>"
 
 #: builtin/write-tree.c:31
 msgid "only useful for debugging"
-msgstr ""
+msgstr "hanya berguna untuk penirkutuan"
 
 #: git.c:28
 msgid ""
@@ -23219,6 +23706,14 @@ msgid ""
 "           [--super-prefix=<path>] [--config-env=<name>=<envvar>]\n"
 "           <command> [<args>]"
 msgstr ""
+"git [--version] [--help] [-C <jalur>] [-c <nama>=<nilai>]\n"
+"           [--exec-path[=<jalur>]] [--html-path] [--man-path] [--info-path]\n"
+"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--"
+"bare]\n"
+"           [--git-dir=<jalur>] [--work-tree=<jalur>] [--namespace=<nama>]\n"
+"           [--super-prefix=<jalur>] [--config-env=<nama>=<variabel "
+"lingkungan>]\n"
+"           <perintah> [<argumen>]"
 
 #: git.c:36
 msgid ""
@@ -23227,51 +23722,55 @@ msgid ""
 "to read about a specific subcommand or concept.\n"
 "See 'git help git' for an overview of the system."
 msgstr ""
+"'git help -a' dan 'git help -g' daftar subperintah tersedia dan beberapa\n"
+"panduan konsep. Lihat 'git help <perintah>' atau 'git help <konsep>'\n"
+"untuk baca tentang perintah atau konsep spesifik.\n"
+"Lihat 'git help git' untuk gambaran tentang sistem."
 
 #: git.c:188
 #, c-format
 msgid "no directory given for --git-dir\n"
-msgstr ""
+msgstr "tidak ada direktori yang diberikan untuk --git-dir\n"
 
 #: git.c:202
 #, c-format
 msgid "no namespace given for --namespace\n"
-msgstr ""
+msgstr "tidak ada ruang nama yang diberikan untuk --namespace\n"
 
 #: git.c:216
 #, c-format
 msgid "no directory given for --work-tree\n"
-msgstr ""
+msgstr "tidak ada direktori yang diberikan untuk --work-tree\n"
 
 #: git.c:230
 #, c-format
 msgid "no prefix given for --super-prefix\n"
-msgstr ""
+msgstr "tidak ada prefiks yang diberikan untuk --super-prefix\n"
 
 #: git.c:252
 #, c-format
 msgid "-c expects a configuration string\n"
-msgstr ""
+msgstr "-c mengharapkan sebuah untai konfigurasi\n"
 
 #: git.c:260
 #, c-format
 msgid "no config key given for --config-env\n"
-msgstr ""
+msgstr "tidak ada kunci konfigurasi yang diberikan untuk --config-env\n"
 
 #: git.c:300
 #, c-format
 msgid "no directory given for -C\n"
-msgstr ""
+msgstr "tidak ada direktori yang diberikan untuk -C\n"
 
 #: git.c:326
 #, c-format
 msgid "unknown option: %s\n"
-msgstr ""
+msgstr "opsi tidak dikenal: %s\n"
 
 #: git.c:375
 #, c-format
 msgid "while expanding alias '%s': '%s'"
-msgstr ""
+msgstr "ketika memperluas alias '%s': '%s'"
 
 #: git.c:384
 #, c-format
@@ -23279,55 +23778,59 @@ msgid ""
 "alias '%s' changes environment variables.\n"
 "You can use '!git' in the alias to do this"
 msgstr ""
+"alias '%s' merubah variabel lingkungan.\n"
+"Anda dapat menggunakan '!git' dalam alias untuk melakukannya."
 
 #: git.c:391
 #, c-format
 msgid "empty alias for %s"
-msgstr ""
+msgstr "alias kosong untuk %s"
 
 #: git.c:394
 #, c-format
 msgid "recursive alias: %s"
-msgstr ""
+msgstr "alias rekursif: %s"
 
 #: git.c:476
 msgid "write failure on standard output"
-msgstr ""
+msgstr "kegagalan menulis pada keluaran standar"
 
 #: git.c:478
 msgid "unknown write failure on standard output"
-msgstr ""
+msgstr "kegagal menulis tidak diketahui pada keluaran standar"
 
 #: git.c:480
 msgid "close failed on standard output"
-msgstr ""
+msgstr "penutupan gagal pada keluaran standar"
 
-#: git.c:833
+#: git.c:832
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
-msgstr ""
+msgstr "putaran alias terdeteksi: perluasan '%s' tidak berhenti:%s"
 
-#: git.c:883
+#: git.c:882
 #, c-format
 msgid "cannot handle %s as a builtin"
-msgstr ""
+msgstr "tidak dapat menangani %s sebagai bawaan"
 
-#: git.c:896
+#: git.c:895
 #, c-format
 msgid ""
 "usage: %s\n"
 "\n"
 msgstr ""
+"penggunaan: %s\n"
+"\n"
 
-#: git.c:916
+#: git.c:915
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
-msgstr ""
+msgstr "perluasan alias '%s' gagal; '%s' bukan sebuah perintah git\n"
 
-#: git.c:928
+#: git.c:927
 #, c-format
 msgid "failed to run command '%s': %s\n"
-msgstr ""
+msgstr "gagal menjalankan perintah '%s': %s\n"
 
 #: http-fetch.c:118
 #, c-format
@@ -23371,147 +23874,109 @@ msgstr ""
 msgid "exit immediately after advertising capabilities"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:262
-#, c-format
-msgid "socket/pipe already in use: '%s'"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:264
-#, c-format
-msgid "could not start server on: '%s'"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
-msgid "could not spawn daemon in the background"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:356
-msgid "waitpid failed"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:376
-msgid "daemon not online yet"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:406
-msgid "daemon failed to start"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:410
-msgid "waitpid is confused"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:541
-msgid "daemon has not shutdown yet"
-msgstr ""
-
-#: t/helper/test-simple-ipc.c:682
+#: t/helper/test-simple-ipc.c:581
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:683
+#: t/helper/test-simple-ipc.c:582
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:684
+#: t/helper/test-simple-ipc.c:583
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:685
+#: t/helper/test-simple-ipc.c:584
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:686
+#: t/helper/test-simple-ipc.c:585
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:687
+#: t/helper/test-simple-ipc.c:586
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:688
+#: t/helper/test-simple-ipc.c:587
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:696
+#: t/helper/test-simple-ipc.c:595
 msgid "name or pathname of unix domain socket"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:698
+#: t/helper/test-simple-ipc.c:597
 msgid "named-pipe name"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:700
+#: t/helper/test-simple-ipc.c:599
 msgid "number of threads in server thread pool"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:701
+#: t/helper/test-simple-ipc.c:600
 msgid "seconds to wait for daemon to start or stop"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:703
+#: t/helper/test-simple-ipc.c:602
 msgid "number of bytes"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:704
+#: t/helper/test-simple-ipc.c:603
 msgid "number of requests per thread"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "byte"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "ballast character"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "token"
 msgstr ""
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "command token to send to the server"
 msgstr ""
 
-#: http.c:399
+#: http.c:350
 #, c-format
 msgid "negative value for http.postbuffer; defaulting to %d"
 msgstr ""
 
-#: http.c:420
+#: http.c:371
 msgid "Delegation control is not supported with cURL < 7.22.0"
 msgstr ""
 
-#: http.c:429
-msgid "Public key pinning not supported with cURL < 7.44.0"
+#: http.c:380
+msgid "Public key pinning not supported with cURL < 7.39.0"
 msgstr ""
 
-#: http.c:910
+#: http.c:812
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
 msgstr ""
 
-#: http.c:989
-msgid "Protocol restrictions not supported with cURL < 7.19.4"
-msgstr ""
-
-#: http.c:1132
+#: http.c:1016
 #, c-format
 msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
 msgstr ""
 
-#: http.c:1139
+#: http.c:1023
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
 msgstr ""
 
-#: http.c:1143
+#: http.c:1027
 #, c-format
 msgid "Could not set SSL backend to '%s': already set"
 msgstr ""
 
-#: http.c:2034
+#: http.c:1876
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -23524,45 +23989,50 @@ msgstr ""
 msgid "invalid quoting in push-option value: '%s'"
 msgstr ""
 
-#: remote-curl.c:307
+#: remote-curl.c:304
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr ""
 
-#: remote-curl.c:408
+#: remote-curl.c:405
 msgid "invalid server response; expected service, got flush packet"
 msgstr ""
 
-#: remote-curl.c:439
+#: remote-curl.c:436
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr ""
 
-#: remote-curl.c:499
+#: remote-curl.c:496
 #, c-format
 msgid "repository '%s' not found"
 msgstr ""
 
-#: remote-curl.c:503
+#: remote-curl.c:500
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr ""
 
-#: remote-curl.c:507
+#: remote-curl.c:504
+#, c-format
+msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
+msgstr ""
+
+#: remote-curl.c:508
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr ""
 
-#: remote-curl.c:513
+#: remote-curl.c:514
 #, c-format
 msgid "redirecting to %s"
 msgstr ""
 
-#: remote-curl.c:644
+#: remote-curl.c:645
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr ""
 
-#: remote-curl.c:656
+#: remote-curl.c:657
 msgid "remote server sent unexpected response end packet"
 msgstr ""
 
@@ -23570,83 +24040,83 @@ msgstr ""
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
 
-#: remote-curl.c:756
+#: remote-curl.c:755
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr ""
 
-#: remote-curl.c:758
+#: remote-curl.c:757
 msgid "remote-curl: unexpected response end packet"
 msgstr ""
 
-#: remote-curl.c:834
+#: remote-curl.c:833
 #, c-format
 msgid "RPC failed; %s"
 msgstr ""
 
-#: remote-curl.c:874
+#: remote-curl.c:873
 msgid "cannot handle pushes this big"
 msgstr ""
 
-#: remote-curl.c:989
+#: remote-curl.c:986
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr ""
 
-#: remote-curl.c:993
+#: remote-curl.c:990
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr ""
 
-#: remote-curl.c:1043
+#: remote-curl.c:1040
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr ""
 
-#: remote-curl.c:1045
+#: remote-curl.c:1042
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr ""
 
-#: remote-curl.c:1134
+#: remote-curl.c:1131
 msgid "dumb http transport does not support shallow capabilities"
 msgstr ""
 
-#: remote-curl.c:1149
+#: remote-curl.c:1146
 msgid "fetch failed."
 msgstr ""
 
-#: remote-curl.c:1195
+#: remote-curl.c:1192
 msgid "cannot fetch by sha1 over smart http"
 msgstr ""
 
-#: remote-curl.c:1239 remote-curl.c:1245
+#: remote-curl.c:1236 remote-curl.c:1242
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr ""
 
-#: remote-curl.c:1257 remote-curl.c:1375
+#: remote-curl.c:1254 remote-curl.c:1372
 #, c-format
 msgid "http transport does not support %s"
 msgstr ""
 
-#: remote-curl.c:1293
+#: remote-curl.c:1290
 msgid "git-http-push failed"
 msgstr ""
 
-#: remote-curl.c:1481
+#: remote-curl.c:1478
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr ""
 
-#: remote-curl.c:1513
+#: remote-curl.c:1510
 msgid "remote-curl: error reading command stream from git"
 msgstr ""
 
-#: remote-curl.c:1520
+#: remote-curl.c:1517
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr ""
 
-#: remote-curl.c:1561
+#: remote-curl.c:1558
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr ""
@@ -23667,44 +24137,44 @@ msgstr ""
 msgid "object filtering"
 msgstr ""
 
-#: parse-options.h:184
+#: parse-options.h:183
 msgid "expiry-date"
 msgstr ""
 
-#: parse-options.h:198
+#: parse-options.h:197
 msgid "no-op (backward compatibility)"
 msgstr ""
 
-#: parse-options.h:310
+#: parse-options.h:309
 msgid "be more verbose"
 msgstr ""
 
-#: parse-options.h:312
+#: parse-options.h:311
 msgid "be more quiet"
 msgstr ""
 
-#: parse-options.h:318
+#: parse-options.h:317
 msgid "use <n> digits to display object names"
 msgstr ""
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "how to strip spaces and #comments from message"
 msgstr ""
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid "read pathspec from file"
 msgstr ""
 
-#: parse-options.h:339
+#: parse-options.h:338
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "key"
 msgstr ""
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "field name to sort on"
 msgstr ""
 
@@ -24388,37 +24858,6 @@ msgstr ""
 msgid "An overview of recommended workflows with Git"
 msgstr ""
 
-#: git-bisect.sh:68
-msgid "bisect run failed: no command provided."
-msgstr ""
-
-#: git-bisect.sh:73
-#, sh-format
-msgid "running $command"
-msgstr ""
-
-#: git-bisect.sh:80
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"exit code $res from '$command' is < 0 or >= 128"
-msgstr ""
-
-#: git-bisect.sh:105
-msgid "bisect run cannot continue any more"
-msgstr ""
-
-#: git-bisect.sh:111
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"'bisect-state $state' exited with error code $res"
-msgstr ""
-
-#: git-bisect.sh:118
-msgid "bisect run success"
-msgstr ""
-
 #: git-merge-octopus.sh:46
 msgid ""
 "Error: Your local changes to the following files would be overwritten by "
@@ -24457,383 +24896,26 @@ msgstr ""
 msgid "Simple merge did not work, trying automatic merge."
 msgstr ""
 
-#: git-submodule.sh:179
-msgid "Relative path can only be used from the toplevel of the working tree"
-msgstr ""
-
-#: git-submodule.sh:189
-#, sh-format
-msgid "repo URL: '$repo' must be absolute or begin with ./|../"
-msgstr ""
-
-#: git-submodule.sh:208
-#, sh-format
-msgid "'$sm_path' already exists in the index"
-msgstr ""
-
-#: git-submodule.sh:211
-#, sh-format
-msgid "'$sm_path' already exists in the index and is not a submodule"
-msgstr ""
-
-#: git-submodule.sh:218
-#, sh-format
-msgid "'$sm_path' does not have a commit checked out"
-msgstr ""
-
-#: git-submodule.sh:248
-#, sh-format
-msgid "Failed to add submodule '$sm_path'"
-msgstr ""
-
-#: git-submodule.sh:257
-#, sh-format
-msgid "Failed to register submodule '$sm_path'"
-msgstr ""
-
-#: git-submodule.sh:532
+#: git-submodule.sh:401
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr ""
 
-#: git-submodule.sh:542
+#: git-submodule.sh:411
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr ""
 
-#: git-submodule.sh:547
+#: git-submodule.sh:416
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
 "'$sm_path'"
 msgstr ""
 
-#: git-submodule.sh:565
-#, sh-format
-msgid ""
-"Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
-"$sha1:"
-msgstr ""
-
-#: git-submodule.sh:571
-#, sh-format
-msgid ""
-"Fetched in submodule path '$displaypath', but it did not contain $sha1. "
-"Direct fetching of that commit failed."
-msgstr ""
-
-#: git-submodule.sh:578
-#, sh-format
-msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
-msgstr ""
-
-#: git-submodule.sh:579
-#, sh-format
-msgid "Submodule path '$displaypath': checked out '$sha1'"
-msgstr ""
-
-#: git-submodule.sh:583
-#, sh-format
-msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
-msgstr ""
-
-#: git-submodule.sh:584
-#, sh-format
-msgid "Submodule path '$displaypath': rebased into '$sha1'"
-msgstr ""
-
-#: git-submodule.sh:589
-#, sh-format
-msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
-msgstr ""
-
-#: git-submodule.sh:590
-#, sh-format
-msgid "Submodule path '$displaypath': merged in '$sha1'"
-msgstr ""
-
-#: git-submodule.sh:595
-#, sh-format
-msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
-msgstr ""
-
-#: git-submodule.sh:596
-#, sh-format
-msgid "Submodule path '$displaypath': '$command $sha1'"
-msgstr ""
-
-#: git-submodule.sh:627
+#: git-submodule.sh:464
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:109
-msgid "Applied autostash."
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:112
-#, sh-format
-msgid "Cannot store $stash_sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:113
-msgid ""
-"Applying autostash resulted in conflicts.\n"
-"Your changes are safe in the stash.\n"
-"You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:191
-#, sh-format
-msgid "Rebasing ($new_count/$total)"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:197
-msgid ""
-"\n"
-"Commands:\n"
-"p, pick <commit> = use commit\n"
-"r, reword <commit> = use commit, but edit the commit message\n"
-"e, edit <commit> = use commit, but stop for amending\n"
-"s, squash <commit> = use commit, but meld into previous commit\n"
-"f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
-"x, exec <commit> = run command (the rest of the line) using shell\n"
-"d, drop <commit> = remove commit\n"
-"l, label <label> = label current HEAD with a name\n"
-"t, reset <label> = reset HEAD to a label\n"
-"m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       create a merge commit using the original merge commit's\n"
-".       message (or the oneline, if no original merge commit was\n"
-".       specified). Use -c <commit> to reword the commit message.\n"
-"\n"
-"These lines can be re-ordered; they are executed from top to bottom.\n"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:260
-#, sh-format
-msgid ""
-"You can amend the commit now, with\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Once you are satisfied with your changes, run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:285
-#, sh-format
-msgid "$sha1: not a commit that can be picked"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:324
-#, sh-format
-msgid "Invalid commit name: $sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:354
-msgid "Cannot write current commit's replacement sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:405
-#, sh-format
-msgid "Fast-forward to $sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:407
-#, sh-format
-msgid "Cannot fast-forward to $sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:416
-#, sh-format
-msgid "Cannot move HEAD to $first_parent"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:421
-#, sh-format
-msgid "Refusing to squash a merge: $sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:439
-#, sh-format
-msgid "Error redoing merge $sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:448
-#, sh-format
-msgid "Could not pick $sha1"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:457
-#, sh-format
-msgid "This is the commit message #${n}:"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:462
-#, sh-format
-msgid "The commit message #${n} will be skipped:"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:473
-#, sh-format
-msgid "This is a combination of $count commit."
-msgid_plural "This is a combination of $count commits."
-msgstr[0] ""
-msgstr[1] ""
-
-#: git-rebase--preserve-merges.sh:482
-#, sh-format
-msgid "Cannot write $fixup_msg"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:485
-msgid "This is a combination of 2 commits."
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:526 git-rebase--preserve-merges.sh:569
-#: git-rebase--preserve-merges.sh:572
-#, sh-format
-msgid "Could not apply $sha1... $rest"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:601
-#, sh-format
-msgid ""
-"Could not amend commit after successfully picking $sha1... $rest\n"
-"This is most likely due to an empty commit message, or the pre-commit hook\n"
-"failed. If the pre-commit hook failed, you may need to resolve the issue "
-"before\n"
-"you are able to reword the commit."
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:616
-#, sh-format
-msgid "Stopped at $sha1_abbrev... $rest"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:631
-#, sh-format
-msgid "Cannot '$squash_style' without a previous commit"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:673
-#, sh-format
-msgid "Executing: $rest"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:681
-#, sh-format
-msgid "Execution failed: $rest"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:683
-msgid "and made changes to the index and/or the working tree"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:685
-msgid ""
-"You can fix the problem, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-
-#. TRANSLATORS: after these lines is a command to be issued by the user
-#: git-rebase--preserve-merges.sh:698
-#, sh-format
-msgid ""
-"Execution succeeded: $rest\n"
-"but left changes to the index and/or the working tree\n"
-"Commit or stash your changes, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:709
-#, sh-format
-msgid "Unknown command: $command $sha1 $rest"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:710
-msgid "Please fix this using 'git rebase --edit-todo'."
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:745
-#, sh-format
-msgid "Successfully rebased and updated $head_name."
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:802
-msgid "Could not remove CHERRY_PICK_HEAD"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:807
-#, sh-format
-msgid ""
-"You have staged changes in your working tree.\n"
-"If these changes are meant to be\n"
-"squashed into the previous commit, run:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"If they are meant to go into a new commit, run:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"In both cases, once you're done, continue with:\n"
-"\n"
-"  git rebase --continue\n"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:824
-msgid "Error trying to find the author identity to amend commit"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:829
-msgid ""
-"You have uncommitted changes in your working tree. Please commit them\n"
-"first and then run 'git rebase --continue' again."
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:834 git-rebase--preserve-merges.sh:838
-msgid "Could not commit staged changes."
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:869 git-rebase--preserve-merges.sh:955
-msgid "Could not execute editor"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:890
-#, sh-format
-msgid "Could not checkout $switch_to"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:897
-msgid "No HEAD?"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:898
-#, sh-format
-msgid "Could not create temporary $state_dir"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:901
-msgid "Could not mark as interactive"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:933
-#, sh-format
-msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-msgstr[0] ""
-msgstr[1] ""
-
-#: git-rebase--preserve-merges.sh:945
-msgid "Note that empty commits are commented out"
-msgstr ""
-
-#: git-rebase--preserve-merges.sh:987 git-rebase--preserve-merges.sh:992
-msgid "Could not init rewritten commits"
 msgstr ""
 
 #: git-sh-setup.sh:89 git-sh-setup.sh:94
@@ -24852,44 +24934,28 @@ msgid "fatal: $program_name cannot be used without a working tree."
 msgstr ""
 
 #: git-sh-setup.sh:221
-msgid "Cannot rebase: You have unstaged changes."
-msgstr ""
-
-#: git-sh-setup.sh:224
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 
-#: git-sh-setup.sh:227
-msgid "Cannot pull with rebase: You have unstaged changes."
-msgstr ""
-
-#: git-sh-setup.sh:230
+#: git-sh-setup.sh:224
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr ""
 
-#: git-sh-setup.sh:243
-msgid "Cannot rebase: Your index contains uncommitted changes."
-msgstr ""
-
-#: git-sh-setup.sh:246
-msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-msgstr ""
-
-#: git-sh-setup.sh:249
+#: git-sh-setup.sh:235
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 
-#: git-sh-setup.sh:253
+#: git-sh-setup.sh:237
 msgid "Additionally, your index contains uncommitted changes."
 msgstr ""
 
-#: git-sh-setup.sh:373
+#: git-sh-setup.sh:357
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr ""
 
-#: git-sh-setup.sh:378
+#: git-sh-setup.sh:362
 msgid "Unable to determine absolute path of git directory"
 msgstr ""
 
@@ -25155,35 +25221,35 @@ msgstr ""
 
 #: git-send-email.perl:129
 msgid "local zone differs from GMT by a non-minute interval\n"
-msgstr ""
+msgstr "zona lokal berbeda dari GMT oleh selang non-menit\n"
 
 #: git-send-email.perl:136 git-send-email.perl:142
 msgid "local time offset greater than or equal to 24 hours\n"
-msgstr ""
+msgstr "offset waktu lokal lebih dari atau sama dengan 24 jam\n"
 
 #: git-send-email.perl:214
 #, perl-format
 msgid "fatal: command '%s' died with exit code %d"
-msgstr ""
+msgstr "fatal: perintah '%s' mati dengan kode keluar %d"
 
 #: git-send-email.perl:227
 msgid "the editor exited uncleanly, aborting everything"
-msgstr ""
+msgstr "penyunting keluar dengan kotor, membatalkan semua"
 
 #: git-send-email.perl:316
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
-msgstr ""
+msgstr "'%s' berisi versi menengah dari email yang Anda buat.\n"
 
 #: git-send-email.perl:321
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
-msgstr ""
+msgstr "'%s.final' berisi email yang dibuat.\n"
 
 #: git-send-email.perl:450
 msgid "--dump-aliases incompatible with other options\n"
-msgstr ""
+msgstr "--dump-aliases tidak kompatibel dengan opsi yang lain\n"
 
 #: git-send-email.perl:525
 msgid ""
@@ -25191,46 +25257,52 @@ msgid ""
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
 "Set sendemail.forbidSendmailVariables to false to disable this check.\n"
 msgstr ""
+"fatal: opsi konfigurasi untuk 'sendmail' ditemukan\n"
+"git-send-email dikonfigurasikan dengan opsi sendemail.* - catat 'e'.\n"
+"Setel sendemail.forbidSendmailVariables ke false untuk menonaktifkan "
+"pemeriksaan ini.\n"
 
 #: git-send-email.perl:530 git-send-email.perl:746
 msgid "Cannot run git format-patch from outside a repository\n"
-msgstr ""
+msgstr "tidak dapat menjalankan git format-patch diluar repositori\n"
 
 #: git-send-email.perl:533
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
 msgstr ""
+"`batch-size` dan `relogin` harus disebutkan bersamaan (lewat baris perintah "
+"atau opsi konfigurasi)\n"
 
 #: git-send-email.perl:546
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
-msgstr ""
+msgstr "Bidang --suppress-cc tidak dikenal: '%s'\n"
 
 #: git-send-email.perl:577
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
-msgstr ""
+msgstr "Setelan --confirm tidak dikenal: '%s'\n"
 
 #: git-send-email.perl:617
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
-msgstr ""
+msgstr "peringatan: alias sendmail dengan kutipan tidak didukung: %s\n"
 
 #: git-send-email.perl:619
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
-msgstr ""
+msgstr "peringatan: `:include:` tidak didukung: %s\n"
 
 #: git-send-email.perl:621
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
-msgstr ""
+msgstr "peringatan: pengalihan `/file` atau `|pipe` tidak didukung: %s\n"
 
 #: git-send-email.perl:626
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
-msgstr ""
+msgstr "peringatan: baris sendmail tidak dikenal: %s\n"
 
 #: git-send-email.perl:711
 #, perl-format
@@ -25241,11 +25313,16 @@ msgid ""
 "    * Saying \"./%s\" if you mean a file; or\n"
 "    * Giving --format-patch option if you mean a range.\n"
 msgstr ""
+"Berkas '%s' ada tetapi bisa jadi itu rentang komit\n"
+"untuk membuat tambalan. Mohon disambiguasi dengan...\n"
+"\n"
+"    * Sebutkan \"./%s\" jika maksud Anda sebuah berkas; atau\n"
+"    * Berikan opsi --format-patch jika maksud Anda sebuah rentang.\n"
 
 #: git-send-email.perl:732
 #, perl-format
 msgid "Failed to opendir %s: %s"
-msgstr ""
+msgstr "Gagal membuka direktori %s: %s"
 
 #: git-send-email.perl:767
 msgid ""
@@ -25253,16 +25330,19 @@ msgid ""
 "No patch files specified!\n"
 "\n"
 msgstr ""
+"\n"
+"Tidak ada berkas tambalan yang disebutkan!\n"
+"\n"
 
 #: git-send-email.perl:780
 #, perl-format
 msgid "No subject line in %s?"
-msgstr ""
+msgstr "Tidak ada baris subjek di %s?"
 
 #: git-send-email.perl:791
 #, perl-format
 msgid "Failed to open for writing %s: %s"
-msgstr ""
+msgstr "Gagal membuka untuk menulis %s: %s"
 
 #: git-send-email.perl:802
 msgid ""
@@ -25272,36 +25352,42 @@ msgid ""
 "\n"
 "Clear the body content if you don't wish to send a summary.\n"
 msgstr ""
+"Baris yang diawali dengan \"GIT:\" akan dihapus.\n"
+"Pertimbangkan memasukkan diffstat keseluruhan atau daftar isi\n"
+"untuk tambalan yang Anda tulis.\n"
+"\n"
+"Bersihkan konten badan jika Anda tidak ingin mengirimkan rangkuman.\n"
 
 #: git-send-email.perl:826
 #, perl-format
 msgid "Failed to open %s: %s"
-msgstr ""
+msgstr "Gagal membuka %s: %s"
 
 #: git-send-email.perl:843
 #, perl-format
 msgid "Failed to open %s.final: %s"
-msgstr ""
+msgstr "Gagal membuka %s.final: %s"
 
 #: git-send-email.perl:886
 msgid "Summary email is empty, skipping it\n"
-msgstr ""
+msgstr "Surel rangkuman kosong, lewati\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
 #: git-send-email.perl:935
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
-msgstr ""
+msgstr "Anda yakin ingin menggunakan <%s> [y/N]? "
 
 #: git-send-email.perl:990
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
 msgstr ""
+"Berkas berikut 8bit, tetapi tidak menyebutkan Content-Transfer-Encoding.\n"
 
 #: git-send-email.perl:995
 msgid "Which 8bit encoding should I declare [UTF-8]? "
-msgstr ""
+msgstr "Pengkodean 8bit apa yang harus saya sebut [UTF-8]? "
 
 #: git-send-email.perl:1003
 #, perl-format
@@ -25311,24 +25397,30 @@ msgid ""
 "has the template subject '*** SUBJECT HERE ***'. Pass --force if you really "
 "want to send.\n"
 msgstr ""
+"Menolak mengirim karena tambalan\n"
+"\t%s\n"
+"punya subjek templat '*** SUBJECT HERE ***'. Lewatkan --force jika Anda "
+"benar-benar ingin mengirim.\n"
 
 #: git-send-email.perl:1022
 msgid "To whom should the emails be sent (if anyone)?"
-msgstr ""
+msgstr "Kepada siapa surel harus dikirim (jika ada)?"
 
 #: git-send-email.perl:1040
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
-msgstr ""
+msgstr "fatal: alias '%s' diperluas ke dirinya sendiri\n"
 
 #: git-send-email.perl:1052
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
+"Message-ID yang akan digunakan sebagai In-Reply-To untuk surel pertama (jika "
+"ada)?"
 
 #: git-send-email.perl:1114 git-send-email.perl:1122
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
-msgstr ""
+msgstr "kesalahan: tidak dapat mengekstrak alamat yang valid dari: %s\n"
 
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
@@ -25336,11 +25428,12 @@ msgstr ""
 #: git-send-email.perl:1126
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr ""
+"Apa yang Anda lakukan dengan alamat ini? ([q] keluar|[d] jatuh|[e] sunting): "
 
 #: git-send-email.perl:1446
 #, perl-format
 msgid "CA path \"%s\" does not exist"
-msgstr ""
+msgstr "Jalur CA \"%s\" tidak ada"
 
 #: git-send-email.perl:1529
 msgid ""
@@ -25355,145 +25448,303 @@ msgid ""
 "    run 'git config --global sendemail.confirm auto'.\n"
 "\n"
 msgstr ""
+"    Daftar Cc diatas telah diperluas oleh alamat tambahan\n"
+"    yang ditemukan dalam pesan komit tambalan. Secara asali\n"
+"    send-email membisiki sebelum mengirim ketika ini terjadi.\n"
+"    Perilaku ini dikontrol oleh setelan konfigurasi sendemail.confirm.\n"
+"\n"
+"    Untuk informasi lebih lanjut, jalankan 'git send-email --help'.\n"
+"    Untuk menjaga perilaku saat ini, tetapi mematikan pesan ini,\n"
+"    jalankan 'git config --global sendemail.confirm auto'.\n"
 
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
 #: git-send-email.perl:1544
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
-msgstr ""
+msgstr "Kirim surel ini? ([y]a|[n] tidak|[e] sunting|[q] keluar|semu[a]): "
 
 #: git-send-email.perl:1547
 msgid "Send this email reply required"
-msgstr ""
+msgstr "Balasan kirim surel ini diperlukan"
 
 #: git-send-email.perl:1581
 msgid "The required SMTP server is not properly defined."
-msgstr ""
+msgstr "Peladen SMTP yang diperlukan tidak dijelaskan dengan baik."
 
 #: git-send-email.perl:1628
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
-msgstr ""
+msgstr "Peladen tidak mendukung STARTTLS! %s"
 
 #: git-send-email.perl:1633 git-send-email.perl:1637
 #, perl-format
 msgid "STARTTLS failed! %s"
-msgstr ""
+msgstr "STARTTLS gagal! %s"
 
 #: git-send-email.perl:1646
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
+"Tidak dapat menginisialisasi SMTP dengan benar. Periksa konfigurasi dan "
+"gunakan --smtp-debug."
 
 #: git-send-email.perl:1664
 #, perl-format
 msgid "Failed to send %s\n"
-msgstr ""
+msgstr "Gagal mengirim %s\n"
 
 #: git-send-email.perl:1667
 #, perl-format
 msgid "Dry-Sent %s\n"
-msgstr ""
+msgstr "Terkirim-kering %s\n"
 
 #: git-send-email.perl:1667
 #, perl-format
 msgid "Sent %s\n"
-msgstr ""
+msgstr "Terkirim %s\n"
 
 #: git-send-email.perl:1669
 msgid "Dry-OK. Log says:\n"
-msgstr ""
+msgstr "OK-kering. Log berkata:\n"
 
 #: git-send-email.perl:1669
 msgid "OK. Log says:\n"
-msgstr ""
+msgstr "OK. Log berkata:\n"
 
 #: git-send-email.perl:1688
 msgid "Result: "
-msgstr ""
+msgstr "Hasil: "
 
 #: git-send-email.perl:1691
 msgid "Result: OK\n"
-msgstr ""
+msgstr "Hasil: OK\n"
 
-#: git-send-email.perl:1709
+#: git-send-email.perl:1708
 #, perl-format
 msgid "can't open file %s"
-msgstr ""
+msgstr "tidak dapat membuka berkas %s"
 
 #: git-send-email.perl:1756 git-send-email.perl:1776
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
-msgstr ""
+msgstr "(mbox) Menambahkan cc: %s dari baris '%s'\n"
 
 #: git-send-email.perl:1762
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
-msgstr ""
+msgstr "(mbox) Menambahkan to: %s dari baris '%s'\n"
 
 #: git-send-email.perl:1819
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
-msgstr ""
+msgstr "(non-mbox) Menambahkan cc: %s dari baris '%s'\n"
 
 #: git-send-email.perl:1854
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
-msgstr ""
+msgstr "(body) Menambahkan cc: %s dari baris '%s'\n"
 
-#: git-send-email.perl:1965
+#: git-send-email.perl:1973
 #, perl-format
 msgid "(%s) Could not execute '%s'"
-msgstr ""
+msgstr "(%s) Tidak dapat menjalankan '%s'"
 
-#: git-send-email.perl:1972
+#: git-send-email.perl:1980
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
-msgstr ""
+msgstr "(%s) Menambahkan %s: %s dari: '%s'\n"
 
-#: git-send-email.perl:1976
+#: git-send-email.perl:1984
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
-msgstr ""
-
-#: git-send-email.perl:2006
-msgid "cannot send message as 7bit"
-msgstr ""
+msgstr "(%s) gagal menutup pipa ke '%s'"
 
 #: git-send-email.perl:2014
-msgid "invalid transfer encoding"
-msgstr ""
+msgid "cannot send message as 7bit"
+msgstr "tidak dapat mengirim pesan sebagai 7bit"
 
-#: git-send-email.perl:2051
+#: git-send-email.perl:2022
+msgid "invalid transfer encoding"
+msgstr "pengkodean transfer tidak valid"
+
+#: git-send-email.perl:2059
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
 "%s\n"
 "warning: no patches were sent\n"
 msgstr ""
+"fatal: %s: ditolak oleh kail sendemail-validate\n"
+"%s\n"
+"peringatan: tidak ada tambalan yang dikirimkan\n"
 
-#: git-send-email.perl:2061 git-send-email.perl:2114 git-send-email.perl:2124
+#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
 #, perl-format
 msgid "unable to open %s: %s\n"
-msgstr ""
+msgstr "tidak dapat membuka %s: %s\n"
 
-#: git-send-email.perl:2064
+#: git-send-email.perl:2072
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
 "warning: no patches were sent\n"
 msgstr ""
+"fatal: %s:%d lebih panjang dari 998 karakter\n"
+"peringatan: tidak ada tambalan yang dikirimkan\n"
 
-#: git-send-email.perl:2082
+#: git-send-email.perl:2090
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
-msgstr ""
+msgstr "Melewati %s dengan akhiran cadangan '%s'.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2086
+#: git-send-email.perl:2094
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
-msgstr ""
+msgstr "Anda benar-benar ingin mengirim %s? [y|N]: "
+
+#~ msgid "unusable todo list: '%s'"
+#~ msgstr "daftar todo tidak dapat digunakan: '%s'"
+
+#~ msgid "git rebase--interactive [<options>]"
+#~ msgstr "git rebase--interactive [<opsi>]"
+
+#~ msgid "rebase merge commits"
+#~ msgstr "dasarkan ulang komit penggabungan"
+
+#~ msgid "keep original branch points of cousins"
+#~ msgstr "simpan titik cabang sepupu asal "
+
+#~ msgid "move commits that begin with squash!/fixup!"
+#~ msgstr "pindahkan komit yang diawali dengan squash!/fixup!"
+
+#~ msgid "sign commits"
+#~ msgstr "tandatangani komit"
+
+#~ msgid "continue rebase"
+#~ msgstr "lanjutkan pendasaran ulang"
+
+#~ msgid "skip commit"
+#~ msgstr "lewatkan komit"
+
+#~ msgid "edit the todo list"
+#~ msgstr "sunting daftar todo"
+
+#~ msgid "show the current patch"
+#~ msgstr "perlihatkan tambalan saat ini"
+
+#~ msgid "shorten commit ids in the todo list"
+#~ msgstr "pendekkan id komit dalam daftar todo"
+
+#~ msgid "expand commit ids in the todo list"
+#~ msgstr "jabarkan id komit dalam daftar todo"
+
+#~ msgid "check the todo list"
+#~ msgstr "periksa daftar todo"
+
+#~ msgid "rearrange fixup/squash lines"
+#~ msgstr "susun ulang baris fixup/squash"
+
+#~ msgid "insert exec commands in todo list"
+#~ msgstr "masukkan perintah exec ke dalam daftar todo"
+
+#~ msgid "onto"
+#~ msgstr "ke"
+
+#~ msgid "restrict-revision"
+#~ msgstr "restrict-revision"
+
+#~ msgid "restrict revision"
+#~ msgstr "batasi revisi"
+
+#~ msgid "squash-onto"
+#~ msgstr "squash-onto"
+
+#~ msgid "squash onto"
+#~ msgstr "lumat ke"
+
+#~ msgid "the upstream commit"
+#~ msgstr "komit hulu"
+
+#~ msgid "head-name"
+#~ msgstr "head-name"
+
+#~ msgid "head name"
+#~ msgstr "nama kepala"
+
+#~ msgid "rebase strategy"
+#~ msgstr "strategi pendasaran"
+
+#~ msgid "strategy-opts"
+#~ msgstr "strategy-opts"
+
+#~ msgid "strategy options"
+#~ msgstr "opsi strategi"
+
+#~ msgid "switch-to"
+#~ msgstr "switch-to"
+
+#~ msgid "the branch or commit to checkout"
+#~ msgstr "cabang atau komit untuk di-checkout"
+
+#~ msgid "onto-name"
+#~ msgstr "onto-name"
+
+#~ msgid "onto name"
+#~ msgstr "nama ke"
+
+#~ msgid "cmd"
+#~ msgstr "cmd"
+
+#~ msgid "the command to run"
+#~ msgstr "perintah untuk dijalankan"
+
+#~ msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
+#~ msgstr "--[no-]rebase-cousins tidak ada efek tanpa --rebase-merges"
+
+#~ msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
+#~ msgstr ""
+#~ "tidak dapat menggabungkan '--preserve-merges' dengan '--rebase-merges'"
+
+#~ msgid ""
+#~ "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
+#~ msgstr ""
+#~ "error: tidak dapat menggabungkan '--preserve-merges' dengan '--reschedule-"
+#~ "failed-exec'"
+
+#~ msgid "exclude patterns are read from <file>"
+#~ msgstr "pola pengecualian dibaca dari <berkas>"
+
+#~ msgid ""
+#~ "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
+#~ msgstr ""
+#~ "git bisect--helper --bisect-next-check <istilah bagus> <istilah jelek> "
+#~ "[<istilah>]"
+
+#~ msgid "--bisect-next-check requires 2 or 3 arguments"
+#~ msgstr "--bisect-next-check butuh 2 atau 3 argumen"
+
+#~ msgid "cannot store pack file"
+#~ msgstr "tidak dapat menyimpan berkas paket"
+
+#~ msgid "cannot store index file"
+#~ msgstr "tidak dapat menyimpan berkas indeks"
+
+#~ msgid ""
+#~ "git submodule--helper add-clone [<options>...] --url <url> --path <path> "
+#~ "--name <name>"
+#~ msgstr ""
+#~ "git submodule--helper add-clone [<opsi>...] --url <url> --path <path> --"
+#~ "name <nama>"
+
+#~ msgid "Could not open '%s' for writing."
+#~ msgstr "Tidak dapat membuka '%s' untuk ditulis."
+
+#~ msgid "cannot open packfile '%s'"
+#~ msgstr "tidak dapat membuka berkas paket '%s'"
+
+#~ msgid "Unknown option for merge-recursive: -X%s"
+#~ msgstr "Opsi merge-recursive tak dikenal: -X%s"
 
 #~ msgid "git merge --abort"
 #~ msgstr "git merge --abort"


### PR DESCRIPTION
Update following components:
  * add-interactive.c
  * add-patch.c
  * diff.c
  * gc.c
  * builtin/bisect--helper.c
  * builtin/commit.c
  * builtin/fetch.c
  * builtin/merge.c
  * builtin/rebase.c
  * builtin/pull.c
  * builtin/push.c
  * builtin/submodule--helper.c

Translate following new components:
  * apply.c
  * bundle.c
  * git.c
  * git-send-email.perl
  * rerere.c
  * builtin/am.c
  * builtin/apply.c
  * builtin/archive.c
  * builtin/bundle.c
  * builtin/cat-file.c
  * builtin/commit-tree.c
  * builtin/count-objects.c
  * builtin/difftool.c
  * builtin/fast-export.c
  * builtin/fast-import.c
  * builtin/fetch-pack.c
  * builtin/fsck.c
  * builtin/gc.c
  * builtin/hash-object.c
  * builtin/ls-files.c
  * builtin/ls-remote.c
  * builtin/ls-tree.c
  * builtin/read-tree.c
  * builtin/receive-pack.c
  * builtin/reflog.c
  * builtin/repack.c
  * builtin/rev-list.c
  * builtin/rev-parse.c
  * builtin/send-pack.c
  * builtin/symbolic-ref.c
  * builtin/update-index.c
  * builtin/update-ref.c
  * builtin/upload-pack.c
  * builtin/verify-pack.c
  * builtin/verify-commit.c
  * builtin/verify-tag.c
  * builtin/write-tree.c

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>
