### PR TITLE
Update Swedish translation

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git 2.34.0\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-10 08:55+0800\n"
-"PO-Revision-Date: 2022-01-08 21:11+0100\n"
+"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"PO-Revision-Date: 2022-01-11 16:34+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -16,15 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Gtranslator 3.30.1\n"
+"X-Generator: Gtranslator 3.38.0\n"
 
 #: add-interactive.c:380
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Vadå (%s)?"
 
-#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
-#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3509
+#: sequencer.c:3974 sequencer.c:4136 builtin/rebase.c:1233
 #: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "kunde inte läsa indexet"
@@ -53,7 +53,7 @@ msgstr "Uppdatera"
 msgid "could not stage '%s'"
 msgstr "kunde inte köa \"%s\""
 
-#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3713
 msgid "could not write index"
 msgstr "kunde inte skriva indexet"
 
@@ -69,8 +69,8 @@ msgstr[1] "uppdaterade %d sökvägar\n"
 msgid "note: %s is untracked now.\n"
 msgstr "observera: %s spåras inte längre.\n"
 
-#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
-#: builtin/reset.c:151
+#: add-interactive.c:733 apply.c:4151 builtin/checkout.c:306
+#: builtin/reset.c:167
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry misslyckades för sökvägen \"%s\""
@@ -111,21 +111,21 @@ msgstr[1] "lade till %d sökvägar\n"
 msgid "ignoring unmerged: %s"
 msgstr "ignorerar ej sammanslagen: %s"
 
-#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1371
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Endast binära filer ändrade.\n"
 
-#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1373
 #, c-format
 msgid "No changes.\n"
 msgstr "Inga ändringar.\n"
 
-#: add-interactive.c:947 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1381
 msgid "Patch update"
 msgstr "Uppdatera patch"
 
-#: add-interactive.c:986 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1794
 msgid "Review diff"
 msgstr "Granska diff"
 
@@ -193,11 +193,11 @@ msgstr "markera en numrerad post"
 msgid "(empty) select nothing"
 msgstr "(tomt) markera ingenting"
 
-#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:839 git-add--interactive.perl:1898
 msgid "*** Commands ***"
 msgstr "*** Kommandon ***"
 
-#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:840 git-add--interactive.perl:1895
 msgid "What now"
 msgstr "Vad nu"
 
@@ -209,13 +209,13 @@ msgstr "köad"
 msgid "unstaged"
 msgstr "ej köad"
 
-#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
-#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
-#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
-#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
-#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
-#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
+#: add-interactive.c:1148 apply.c:5020 apply.c:5023 builtin/am.c:2367
+#: builtin/am.c:2370 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:153 builtin/merge.c:287 builtin/pull.c:194
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1861 builtin/submodule--helper.c:2504
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2579 builtin/submodule--helper.c:2812
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "sökväg"
@@ -224,27 +224,27 @@ msgstr "sökväg"
 msgid "could not refresh index"
 msgstr "kunde inte uppdatera indexet"
 
-#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:804 git-add--interactive.perl:1805
 #, c-format
 msgid "Bye.\n"
 msgstr "Hej då.\n"
 
-#: add-patch.c:34 git-add--interactive.perl:1431
+#: add-patch.c:34 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
 msgstr "Köa ändrat läge [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:35 git-add--interactive.perl:1432
+#: add-patch.c:35 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
 msgstr "Köa borttagning [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:36 git-add--interactive.perl:1433
+#: add-patch.c:36 git-add--interactive.perl:1435
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
 msgstr "Köa tillägg [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:37 git-add--interactive.perl:1434
+#: add-patch.c:37 git-add--interactive.perl:1436
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Köa stycket [y,n,q,a,d%s,?]? "
@@ -271,22 +271,22 @@ msgstr ""
 "a - köa stycket och alla följande i filen\n"
 "d - köa inte stycket eller något av de följande i filen\n"
 
-#: add-patch.c:56 git-add--interactive.perl:1437
+#: add-patch.c:56 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
 msgstr "Stash:a ändrat läge [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:57 git-add--interactive.perl:1438
+#: add-patch.c:57 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
 msgstr "Stash:a borttagning [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:58 git-add--interactive.perl:1439
+#: add-patch.c:58 git-add--interactive.perl:1441
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
 msgstr "Stash:a tillägg [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:59 git-add--interactive.perl:1440
+#: add-patch.c:59 git-add--interactive.perl:1442
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
 msgstr "Stash:a stycket [y,n,q,a,d%s,?]? "
@@ -313,22 +313,22 @@ msgstr ""
 "a - \"stash\":a stycket och alla följande i filen\n"
 "d - \"stash\":a inte stycket eller något av de följande i filen\n"
 
-#: add-patch.c:80 git-add--interactive.perl:1443
+#: add-patch.c:80 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
 msgstr "Ta bort ändrat läge från kön [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:81 git-add--interactive.perl:1444
+#: add-patch.c:81 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
 msgstr "Ta bort borttagning från kön [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:82 git-add--interactive.perl:1445
+#: add-patch.c:82 git-add--interactive.perl:1447
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
 msgstr "Ta bort tillägg från kön [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:83 git-add--interactive.perl:1446
+#: add-patch.c:83 git-add--interactive.perl:1448
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Ta bort stycket från kön [y,n,q,a,d%s,?]? "
@@ -355,22 +355,22 @@ msgstr ""
 "a - ta bort stycket och alla följande i filen från kön\n"
 "d - ta inte bort stycket eller något av de följande i filen från kön\n"
 
-#: add-patch.c:103 git-add--interactive.perl:1449
+#: add-patch.c:103 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
 msgstr "Applicera ändrat läge på indexet [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:104 git-add--interactive.perl:1450
+#: add-patch.c:104 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
 msgstr "Applicera borttagning på indexet [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:105 git-add--interactive.perl:1451
+#: add-patch.c:105 git-add--interactive.perl:1453
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
 msgstr "Applicera tillägg på indexet [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:106 git-add--interactive.perl:1452
+#: add-patch.c:106 git-add--interactive.perl:1454
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
 msgstr "Applicera stycket på indexet [y,n,q,a,d%s,?]? "
@@ -397,26 +397,26 @@ msgstr ""
 "a - applicera stycket och alla följande i filen\n"
 "d - applicera inte stycket eller något av de följande i filen\n"
 
-#: add-patch.c:126 git-add--interactive.perl:1455
-#: git-add--interactive.perl:1473
+#: add-patch.c:126 git-add--interactive.perl:1457
+#: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta ändrat läge från arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:127 git-add--interactive.perl:1456
-#: git-add--interactive.perl:1474
+#: add-patch.c:127 git-add--interactive.perl:1458
+#: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta borttagning från arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:128 git-add--interactive.perl:1457
-#: git-add--interactive.perl:1475
+#: add-patch.c:128 git-add--interactive.perl:1459
+#: git-add--interactive.perl:1477
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta tillägg från arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:129 git-add--interactive.perl:1458
-#: git-add--interactive.perl:1476
+#: add-patch.c:129 git-add--interactive.perl:1460
+#: git-add--interactive.perl:1478
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta stycket från arbetskatalogen [y,n,q,a,d%s,?]? "
@@ -443,22 +443,22 @@ msgstr ""
 "a - förkasta stycket och alla följande i filen\n"
 "d - förkasta inte stycket eller något av de följande i filen\n"
 
-#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1461
+#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta ändrat läge från indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1462
+#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta borttagning från indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1463
+#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1465
 #, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta tillägg från indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1464
+#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1466
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Kasta stycket från indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
@@ -477,22 +477,22 @@ msgstr ""
 "a - förkasta stycket och alla följande i filen\n"
 "d - förkasta inte stycket eller något av de följande i filen\n"
 
-#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1467
+#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera ändrat läge på indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1468
+#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera borttagning på indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1469
+#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1471
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera tillägg på indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
+#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1472
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera stycket på indexet och arbetskatalogen [y,n,q,a,d%s,?]? "
@@ -630,7 +630,7 @@ msgstr "\"git apply --cached\" misslyckades"
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1247 git-add--interactive.perl:1242
+#: add-patch.c:1247 git-add--interactive.perl:1244
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
@@ -641,11 +641,11 @@ msgstr ""
 msgid "The selected hunks do not apply to the index!"
 msgstr "Markerade stycken kan inte appliceras på indexet!"
 
-#: add-patch.c:1291 git-add--interactive.perl:1346
+#: add-patch.c:1291 git-add--interactive.perl:1348
 msgid "Apply them to the worktree anyway? "
 msgstr "Applicera dem på arbetskatalogen trots det? "
 
-#: add-patch.c:1298 git-add--interactive.perl:1349
+#: add-patch.c:1298 git-add--interactive.perl:1351
 msgid "Nothing was applied.\n"
 msgstr "Ingenting applicerades.\n"
 
@@ -683,11 +683,11 @@ msgstr "Inget följande stycke"
 msgid "No other hunks to goto"
 msgstr "Inga andra stycken att gå till"
 
-#: add-patch.c:1549 git-add--interactive.perl:1606
+#: add-patch.c:1549 git-add--interactive.perl:1608
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "gå till vilket stycke (<ret> för att se fler)? "
 
-#: add-patch.c:1550 git-add--interactive.perl:1608
+#: add-patch.c:1550 git-add--interactive.perl:1610
 msgid "go to which hunk? "
 msgstr "gå till vilket stycke? "
 
@@ -707,7 +707,7 @@ msgstr[1] "Beklagar, det finns bara %d stycken."
 msgid "No other hunks to search"
 msgstr "Inga andra stycken att söka efter"
 
-#: add-patch.c:1581 git-add--interactive.perl:1661
+#: add-patch.c:1581 git-add--interactive.perl:1663
 msgid "search for regex? "
 msgstr "sök efter reguljärt uttryck? "
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Exiting because of an unresolved conflict."
 msgstr "Avslutar på grund av olöst konflikgt."
 
-#: advice.c:209 builtin/merge.c:1379
+#: advice.c:209 builtin/merge.c:1382
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Du har inte avslutat sammanslagningen (MERGE_HEAD finns)."
 
@@ -896,21 +896,33 @@ msgstr "okänt alternativ för whitespace: \"%s\""
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr "okänt alternativ för ignore-whitespace: \"%s\""
 
-#: apply.c:136
-msgid "--reject and --3way cannot be used together."
-msgstr "--reject och --3way kan inte användas samtidigt."
+#: apply.c:136 archive.c:584 range-diff.c:559 revision.c:2303 revision.c:2307
+#: revision.c:2316 revision.c:2321 revision.c:2527 revision.c:2870
+#: revision.c:2874 revision.c:2880 revision.c:2883 revision.c:2885
+#: builtin/add.c:510 builtin/add.c:512 builtin/add.c:529 builtin/add.c:541
+#: builtin/branch.c:727 builtin/checkout.c:467 builtin/checkout.c:470
+#: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
+#: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
+#: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
+#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
+#: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
+#: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
+#: builtin/rebase.c:1193 builtin/rebase.c:1195 builtin/rebase.c:1199
+#: builtin/repack.c:684 builtin/repack.c:715 builtin/reset.c:426
+#: builtin/reset.c:462 builtin/rev-list.c:541 builtin/show-branch.c:710
+#: builtin/stash.c:1707 builtin/stash.c:1710 builtin/submodule--helper.c:1316
+#: builtin/submodule--helper.c:2975 builtin/tag.c:526 builtin/tag.c:572
+#: builtin/worktree.c:702
+#, c-format
+msgid "options '%s' and '%s' cannot be used together"
+msgstr "flaggorna \"%s\" och \"%s\" kan inte användas samtidigt"
 
-#: apply.c:139
-msgid "--3way outside a repository"
-msgstr "--3way utanför arkiv"
-
-#: apply.c:150
-msgid "--index outside a repository"
-msgstr "--index utanför arkiv"
-
-#: apply.c:153
-msgid "--cached outside a repository"
-msgstr "--cached utanför arkiv"
+#: apply.c:139 apply.c:150 apply.c:153
+#, c-format
+msgid "'%s' outside a repository"
+msgstr "\"%s\" utanför arkiv"
 
 #: apply.c:800
 #, c-format
@@ -1123,8 +1135,8 @@ msgstr "patch misslyckades: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "kan inte checka ut %s"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
-#: setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:104 pack-revindex.c:214
+#: setup.c:309
 #, c-format
 msgid "failed to read %s"
 msgstr "misslyckades läsa %s"
@@ -1134,381 +1146,379 @@ msgstr "misslyckades läsa %s"
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "läser från \"%s\" som är på andra sidan av en symbolisk länk"
 
-#: apply.c:3442 apply.c:3709
+#: apply.c:3442 apply.c:3711
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "sökvägen %s har ändrat namn/tagits bort"
 
-#: apply.c:3549 apply.c:3724
+#: apply.c:3549 apply.c:3726
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: finns inte i indexet"
 
-#: apply.c:3558 apply.c:3732 apply.c:3976
+#: apply.c:3558 apply.c:3734 apply.c:3978
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: motsvarar inte indexet"
 
-#: apply.c:3593
+#: apply.c:3595
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr "arkivet saknar objekt som behövs för att utföra 3-vägssammanslagning."
 
-#: apply.c:3596
+#: apply.c:3598
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Utför trevägssammanslagning...\n"
 
-#: apply.c:3612 apply.c:3616
+#: apply.c:3614 apply.c:3618
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "kunde inte läsa aktuellt innehåll i \"%s\""
 
-#: apply.c:3628
+#: apply.c:3630
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Misslyckades utföra trevägssammanslagning...\n"
 
-#: apply.c:3642
+#: apply.c:3644
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Applicerade patchen på \"%s\" med konflikter.\n"
 
-#: apply.c:3647
+#: apply.c:3649
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Tillämpade patchen på  \"%s\" rent.\n"
 
-#: apply.c:3664
+#: apply.c:3666
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Faller tillbaka på direkt tillämpning...\n"
 
-#: apply.c:3676
+#: apply.c:3678
 msgid "removal patch leaves file contents"
 msgstr "patch för borttagning lämnar kvar filinnehåll"
 
-#: apply.c:3749
+#: apply.c:3751
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: fel typ"
 
-#: apply.c:3751
+#: apply.c:3753
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s har typen %o, förväntade %o"
 
-#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
-#: read-cache.c:1368
+#: apply.c:3918 apply.c:3920 read-cache.c:889 read-cache.c:918
+#: read-cache.c:1381
 #, c-format
 msgid "invalid path '%s'"
 msgstr "ogiltig sökväg \"%s\""
 
-#: apply.c:3974
+#: apply.c:3976
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: finns redan i indexet"
 
-#: apply.c:3978
+#: apply.c:3980
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: finns redan i arbetskatalogen"
 
-#: apply.c:3998
+#: apply.c:4000
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "nytt läge (%o) för %s motsvarar inte gammalt läge (%o)"
 
-#: apply.c:4003
+#: apply.c:4005
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "nytt läge (%o) för %s motsvarar inte gammalt läge (%o) för %s"
 
-#: apply.c:4023
+#: apply.c:4025
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "den berörda filen \"%s\" är på andra sidan av en symbolisk länk"
 
-#: apply.c:4027
+#: apply.c:4029
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: patchen kan inte tillämpas"
 
-#: apply.c:4042
+#: apply.c:4044
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Kontrollerar patchen %s..."
 
-#: apply.c:4134
+#: apply.c:4136
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "sha1-informationen saknas eller är oanvändbar för undermodulen %s"
 
-#: apply.c:4141
+#: apply.c:4143
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "nytt läge för %s, som inte finns i nuvarande HEAD"
 
-#: apply.c:4144
+#: apply.c:4146
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "sha1-informationen saknas eller är oanvändbar (%s)."
 
-#: apply.c:4153
+#: apply.c:4155
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "kunde inte lägga till %s till temporärt index"
 
-#: apply.c:4163
+#: apply.c:4165
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "kunde inte skriva temporärt index till %s"
 
-#: apply.c:4301
+#: apply.c:4303
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "kan inte ta bort %s från indexet"
 
-#: apply.c:4335
+#: apply.c:4337
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "trasig patch för undermodulen %s"
 
-#: apply.c:4341
+#: apply.c:4343
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "kan inte ta status på nyligen skapade filen \"%s\""
 
-#: apply.c:4349
+#: apply.c:4351
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "kan inte skapa säkerhetsminne för nyligen skapade filen %s"
 
-#: apply.c:4355 apply.c:4500
+#: apply.c:4357 apply.c:4502
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "kan inte lägga till cachepost för %s"
 
-#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
-#: builtin/gc.c:2276
+#: apply.c:4400 builtin/bisect--helper.c:540 builtin/gc.c:2258
+#: builtin/gc.c:2293
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "misslyckades skriva till \"%s\""
 
-#: apply.c:4402
+#: apply.c:4404
 #, c-format
 msgid "closing file '%s'"
 msgstr "stänger filen \"%s\""
 
-#: apply.c:4472
+#: apply.c:4474
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "kan inte skriva filen \"%s\" läge %o"
 
-#: apply.c:4570
+#: apply.c:4572
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Tillämpade patchen %s rent."
 
-#: apply.c:4578
+#: apply.c:4580
 msgid "internal error"
 msgstr "internt fel"
 
-#: apply.c:4581
+#: apply.c:4583
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Tillämpade patchen %%s med %d refuserad..."
 msgstr[1] "Tillämpade patchen %%s med %d refuserade..."
 
-#: apply.c:4592
+#: apply.c:4594
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "trunkerar .rej-filnamnet till %.*s.rej"
 
-#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
+#: apply.c:4602
 #, c-format
 msgid "cannot open %s"
 msgstr "kan inte öppna %s"
 
-#: apply.c:4614
+#: apply.c:4616
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Stycke %d tillämpades rent."
 
-#: apply.c:4618
+#: apply.c:4620
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Refuserar stycke %d."
 
-#: apply.c:4747
+#: apply.c:4749
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Ignorerar patch \"%s\"."
 
-#: apply.c:4755
-msgid "unrecognized input"
-msgstr "indata känns inte igen"
+#: apply.c:4758
+msgid "No valid patches in input (allow with \"--allow-empty\")"
+msgstr "Inga giltiga patchar i indata (tillåt med \"--allow-empty\")"
 
-#: apply.c:4775
+#: apply.c:4779
 msgid "unable to read index file"
 msgstr "kan inte läsa indexfilen"
 
-#: apply.c:4932
+#: apply.c:4936
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "kan inte öppna patchen \"%s\": %s"
 
-#: apply.c:4959
+#: apply.c:4963
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "undertryckte %d fel i blanksteg"
 msgstr[1] "undertryckte %d fel i blanksteg"
 
-#: apply.c:4965 apply.c:4980
+#: apply.c:4969 apply.c:4984
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d rad lägger till fel i blanksteg."
 msgstr[1] "%d rader lägger till fel i blanksteg."
 
-#: apply.c:4973
+#: apply.c:4977
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d rad applicerade efter att ha rättat fel i blanksteg."
 msgstr[1] "%d rader applicerade efter att ha rättat fel i blanksteg."
 
-#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
+#: apply.c:4993 builtin/add.c:704 builtin/mv.c:338 builtin/rm.c:430
 msgid "Unable to write new index file"
 msgstr "Kunde inte skriva ny indexfil"
 
-#: apply.c:5017
+#: apply.c:5021
 msgid "don't apply changes matching the given path"
 msgstr "tillämpa inte ändringar som motsvarar given sökväg"
 
-#: apply.c:5020
+#: apply.c:5024
 msgid "apply changes matching the given path"
 msgstr "tillämpa ändringar som motsvarar given sökväg"
 
-#: apply.c:5022 builtin/am.c:2320
+#: apply.c:5026 builtin/am.c:2376
 msgid "num"
 msgstr "antal"
 
-#: apply.c:5023
+#: apply.c:5027
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "ta bort <antal> inledande snedstreck från traditionella diff-sökvägar"
 
-#: apply.c:5026
+#: apply.c:5030
 msgid "ignore additions made by the patch"
 msgstr "ignorera tillägg gjorda av patchen"
 
-#: apply.c:5028
+#: apply.c:5032
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr "istället för att tillämpa patchen, skriv ut diffstat för indata"
 
-#: apply.c:5032
+#: apply.c:5036
 msgid "show number of added and deleted lines in decimal notation"
 msgstr "visa antal tillagda och borttagna rader decimalt"
 
-#: apply.c:5034
+#: apply.c:5038
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "istället för att tillämpa patchen, skriv ut en summering av indata"
 
-#: apply.c:5036
+#: apply.c:5040
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "istället för att tillämpa patchen, se om patchen kan tillämpas"
 
-#: apply.c:5038
+#: apply.c:5042
 msgid "make sure the patch is applicable to the current index"
 msgstr "se till att patchen kan tillämpas på aktuellt index"
 
-#: apply.c:5040
+#: apply.c:5044
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "markera nya filer med \"git add --intent-to-add\""
 
-#: apply.c:5042
+#: apply.c:5046
 msgid "apply a patch without touching the working tree"
 msgstr "tillämpa en patch utan att röra arbetskatalogen"
 
-#: apply.c:5044
+#: apply.c:5048
 msgid "accept a patch that touches outside the working area"
 msgstr "godta en patch som rör filer utanför arbetskatalogen"
 
-#: apply.c:5047
+#: apply.c:5051
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "tillämpa också patchen (använd med --stat/--summary/--check)"
 
-#: apply.c:5049
+#: apply.c:5053
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "försök en trevägssammanslagning, fall tillbaka på normal patch om det "
 "misslyckas"
 
-#: apply.c:5051
+#: apply.c:5055
 msgid "build a temporary index based on embedded index information"
 msgstr "bygg ett temporärt index baserat på inbyggd indexinformation"
 
-#: apply.c:5054 builtin/checkout-index.c:196
+#: apply.c:5058 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "sökvägar avdelas med NUL-tecken"
 
-#: apply.c:5056
+#: apply.c:5060
 msgid "ensure at least <n> lines of context match"
 msgstr "se till att åtminstone <n> rader sammanhang är lika"
 
-#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
+#: apply.c:5061 builtin/am.c:2352 builtin/am.c:2355
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
 #: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
 #: builtin/rebase.c:1051
 msgid "action"
 msgstr "åtgärd"
 
-#: apply.c:5058
+#: apply.c:5062
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "detektera nya eller ändrade rader som har fel i blanktecken"
 
-#: apply.c:5061 apply.c:5064
+#: apply.c:5065 apply.c:5068
 msgid "ignore changes in whitespace when finding context"
 msgstr "ignorera ändringar i blanktecken för sammanhang"
 
-#: apply.c:5067
+#: apply.c:5071
 msgid "apply the patch in reverse"
 msgstr "tillämpa patchen baklänges"
 
-#: apply.c:5069
+#: apply.c:5073
 msgid "don't expect at least one line of context"
 msgstr "förvänta inte minst en rad sammanhang"
 
-#: apply.c:5071
+#: apply.c:5075
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "lämna refuserade stycken i motsvarande *.rej-filer"
 
-#: apply.c:5073
+#: apply.c:5077
 msgid "allow overlapping hunks"
 msgstr "tillåt överlappande stycken"
 
-#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
-#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
-msgid "be verbose"
-msgstr "var pratsam"
-
-#: apply.c:5076
+#: apply.c:5080
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "tolerera felaktigt detekterade saknade nyradstecken vid filslut"
 
-#: apply.c:5079
+#: apply.c:5083
 msgid "do not trust the line counts in the hunk headers"
 msgstr "lite inte på antalet linjer i styckehuvuden"
 
-#: apply.c:5081 builtin/am.c:2308
+#: apply.c:5085 builtin/am.c:2364
 msgid "root"
 msgstr "rot"
 
-#: apply.c:5082
+#: apply.c:5086
 msgid "prepend <root> to all filenames"
 msgstr "lägg till <rot> i alla filnamn"
+
+#: apply.c:5089
+msgid "don't return error for empty patches"
+msgstr "ge inte någon felkod för tomma patchar"
 
 #: archive-tar.c:125 archive-zip.c:345
 #, c-format
@@ -1520,16 +1530,16 @@ msgstr "kan inte strömma blob:en %s"
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "filens läge stöds ej: 0%o (SHA1: %s)"
 
-#: archive-tar.c:450
+#: archive-tar.c:447
 #, c-format
 msgid "unable to start '%s' filter"
 msgstr "kunde inte starta filtret \"%s\""
 
-#: archive-tar.c:453
+#: archive-tar.c:450
 msgid "unable to redirect descriptor"
 msgstr "kan inte omdirigera handtag"
 
-#: archive-tar.c:460
+#: archive-tar.c:457
 #, c-format
 msgid "'%s' filter reported error"
 msgstr "filtret \"%s\" rapporterade fel"
@@ -1573,19 +1583,13 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <arkiv> [--exec <kmd>] --list"
 
-#: archive.c:188
+#: archive.c:188 archive.c:341 builtin/gc.c:497 builtin/notes.c:238
+#: builtin/tag.c:578
 #, c-format
-msgid "cannot read %s"
-msgstr "kan inte läsa %s"
-
-#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
-#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
-#: builtin/merge.c:1145
-#, c-format
-msgid "could not read '%s'"
+msgid "cannot read '%s'"
 msgstr "kunde inte läsa \"%s\""
 
-#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
+#: archive.c:426 builtin/add.c:215 builtin/add.c:671 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "sökvägsangivelsen \"%s\" motsvarade inte några filer"
@@ -1627,7 +1631,7 @@ msgstr "fmt"
 msgid "archive format"
 msgstr "arkivformat"
 
-#: archive.c:552 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1790
 msgid "prefix"
 msgstr "prefix"
 
@@ -1637,9 +1641,9 @@ msgstr "lägg till prefix till varje sökväg i arkivet"
 
 #: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
 #: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
-#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
-#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
-#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/fast-export.c:1181 builtin/fast-export.c:1183
+#: builtin/fast-export.c:1187 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:654 builtin/ls-files.c:657 builtin/notes.c:410
 #: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "fil"
@@ -1669,7 +1673,7 @@ msgid "list supported archive formats"
 msgstr "visa understödda arkivformat"
 
 #: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
+#: builtin/submodule--helper.c:1870 builtin/submodule--helper.c:2513
 msgid "repo"
 msgstr "arkiv"
 
@@ -1677,7 +1681,7 @@ msgstr "arkiv"
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "hämta arkivet från fjärrarkivet <arkiv>"
 
-#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:708
 #: builtin/notes.c:496
 msgid "command"
 msgstr "kommando"
@@ -1690,17 +1694,19 @@ msgstr "sökväg till kommandot git-upload-archive på fjärren"
 msgid "Unexpected option --remote"
 msgstr "Oväntad flagga --remote"
 
-#: archive.c:580
-msgid "Option --exec can only be used together with --remote"
-msgstr "Flaggan --exec kan endast användas tillsammans med --remote"
+#: archive.c:580 fetch-pack.c:300 revision.c:2887 builtin/add.c:544
+#: builtin/add.c:576 builtin/checkout.c:1763 builtin/commit.c:370
+#: builtin/fast-export.c:1230 builtin/index-pack.c:1848 builtin/log.c:2115
+#: builtin/reset.c:435 builtin/reset.c:493 builtin/rm.c:281
+#: builtin/stash.c:1719 builtin/worktree.c:508 http-fetch.c:144
+#: http-fetch.c:153
+#, c-format
+msgid "the option '%s' requires '%s'"
+msgstr "flaggan \"%s\" kräver \"%s\""
 
 #: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Oväntad flagga --output"
-
-#: archive.c:584
-msgid "Options --add-file and --remote cannot be used together"
-msgstr "Flaggorna --add-file och --remote kan inte användas samtidigt"
 
 #: archive.c:606
 #, c-format
@@ -1810,7 +1816,7 @@ msgstr "en %s-revision behövs"
 msgid "could not create file '%s'"
 msgstr "kunde inte skapa filen \"%s\""
 
-#: bisect.c:985 builtin/merge.c:154
+#: bisect.c:985 builtin/merge.c:155
 #, c-format
 msgid "could not read file '%s'"
 msgstr "kunde inte läsa filen \"%s\""
@@ -1864,10 +1870,10 @@ msgstr ""
 "--reverse och --first-parent tillsammans kräver att du anger senaste "
 "incheckningen"
 
-#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
-#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
-#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
-#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: blame.c:2820 bundle.c:224 midx.c:1042 ref-filter.c:2370 remote.c:2158
+#: sequencer.c:2352 sequencer.c:4899 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:429 builtin/log.c:1036 builtin/log.c:1644 builtin/log.c:2071
+#: builtin/log.c:2362 builtin/merge.c:431 builtin/pack-objects.c:3373
 #: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
 #: builtin/shortlog.c:255
 msgid "revision walk setup failed"
@@ -1890,105 +1896,99 @@ msgstr "sökvägen %s i %s finns inte"
 msgid "cannot read blob %s for path %s"
 msgstr "kan inte läsa objektet %s för sökvägen %s"
 
-#: branch.c:53
+#: branch.c:77
+msgid ""
+"cannot inherit upstream tracking configuration of multiple refs when "
+"rebasing is requested"
+msgstr ""
+"kan inte ärva uppströmsspårningsinformation från flera referenser när "
+"ombasering är vald"
+
+#: branch.c:88
 #, c-format
+msgid "not setting branch '%s' as its own upstream"
+msgstr "ställer inte in grenen %s som sin egen uppströmsgren"
+
+#: branch.c:144
+#, c-format
+msgid "branch '%s' set up to track '%s' by rebasing."
+msgstr "grenen \"%s\" inställd på att spåra \"%s\" genom ombasering."
+
+#: branch.c:145
+#, c-format
+msgid "branch '%s' set up to track '%s'."
+msgstr "grenen \"%s\" inställd på att spåra \"%s\"."
+
+#: branch.c:148
+#, c-format
+msgid "branch '%s' set up to track:"
+msgstr "grenen \"%s\" inställd på att spåra:"
+
+#: branch.c:160
+msgid "unable to write upstream branch configuration"
+msgstr "kan inte skriva inställningar för uppströmsgren"
+
+#: branch.c:162
 msgid ""
 "\n"
 "After fixing the error cause you may try to fix up\n"
-"the remote tracking information by invoking\n"
-"\"git branch --set-upstream-to=%s%s%s\"."
+"the remote tracking information by invoking:"
 msgstr ""
 "\n"
 "När du har rättat felorsaken kan du försöka rätta\n"
-"fjärrspårningsinformationen genom att utföra\n"
-"\"git branch --set-upstream-to=%s%s%s\"."
+"fjärrspårningsinformationen genom att utföra:"
 
-#: branch.c:67
+#: branch.c:203
 #, c-format
-msgid "Not setting branch %s as its own upstream."
-msgstr "Ställer inte in grenen %s som sin egen uppströmsgren."
+msgid "asked to inherit tracking from '%s', but no remote is set"
+msgstr "bad om att ärva spårning från \"%s\", men ingen fjärr är vald"
 
-#: branch.c:93
+#: branch.c:209
 #, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s' by rebasing."
+msgid "asked to inherit tracking from '%s', but no merge configuration is set"
 msgstr ""
-"Grenen %s ställdes in att spåra fjärrgrenen \"%s\" från \"%s\" genom "
-"ombasering."
+"bad om att ärva spårning från \"%s\", men ingen sammanslagningsinställning "
+"är vald"
 
-#: branch.c:94
+#: branch.c:252
 #, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s'."
-msgstr "Grenen %s ställdes in att spåra fjärrgrenen \"%s\" från \"%s\"."
+msgid "not tracking: ambiguous information for ref %s"
+msgstr "spårar inte: tvetydig information för referensen %s"
 
-#: branch.c:98
+#: branch.c:287
 #, c-format
-msgid "Branch '%s' set up to track local branch '%s' by rebasing."
+msgid "'%s' is not a valid branch name"
+msgstr "\"%s\" är inte ett giltigt grennamn"
+
+#: branch.c:307
+#, c-format
+msgid "a branch named '%s' already exists"
+msgstr "det finns redan en gren som heter \"%s\""
+
+#: branch.c:313
+#, c-format
+msgid "cannot force update the branch '%s'checked out at '%s'"
 msgstr ""
-"Grenen \"%s\" ställdes in att spåra den lokala grenen \"%s\"  genom "
-"ombasering."
+"kan inte tvinga uppdatering av grenen \"%s\" som är utcheckad på \"%s\""
 
-#: branch.c:99
+#: branch.c:313
 #, c-format
-msgid "Branch '%s' set up to track local branch '%s'."
-msgstr "Grenen \"%s\" ställdes in att spåra den lokala grenen \"%s\"."
-
-#: branch.c:104
-#, c-format
-msgid "Branch '%s' set up to track remote ref '%s' by rebasing."
+msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr ""
-"Grenen \"%s\" ställdes in att spåra fjärreferensen \"%s\" genom ombasering."
+"kan inte tvinga uppdatering av grenen \"%s\" som är utcheckad på \"%s\""
 
-#: branch.c:105
+#: branch.c:336
 #, c-format
-msgid "Branch '%s' set up to track remote ref '%s'."
-msgstr "Grenen \"%s\" ställdes in att spåra fjärreferensen \"%s\"."
-
-#: branch.c:109
-#, c-format
-msgid "Branch '%s' set up to track local ref '%s' by rebasing."
+msgid "cannot set up tracking information; starting point '%s' is not a branch"
 msgstr ""
-"Grenen \"%s\" ställdes in att spåra den lokala referensen \"%s\" genom "
-"ombasering."
+"kan inte ställa in spårningsinformation; startpunkten \"%s\" är inte en gren"
 
-#: branch.c:110
-#, c-format
-msgid "Branch '%s' set up to track local ref '%s'."
-msgstr "Grenen \"%s\" ställdes in att spåra den lokala referensen \"%s\"."
-
-#: branch.c:119
-msgid "Unable to write upstream branch configuration"
-msgstr "Kan inte skriva inställningar för uppströmsgren"
-
-#: branch.c:156
-#, c-format
-msgid "Not tracking: ambiguous information for ref %s"
-msgstr "Spårar inte: tvetydig information för referensen %s"
-
-#: branch.c:189
-#, c-format
-msgid "'%s' is not a valid branch name."
-msgstr "\"%s\" är inte ett giltigt grennamn."
-
-#: branch.c:208
-#, c-format
-msgid "A branch named '%s' already exists."
-msgstr "Det finns redan en gren som heter \"%s\"."
-
-#: branch.c:213
-msgid "Cannot force update the current branch."
-msgstr "Kan inte tvinga uppdatering av aktuell gren."
-
-#: branch.c:233
-#, c-format
-msgid "Cannot setup tracking information; starting point '%s' is not a branch."
-msgstr "Kan inte ställa in spårning; startpunkten \"%s\" är inte en gren."
-
-#: branch.c:235
+#: branch.c:338
 #, c-format
 msgid "the requested upstream branch '%s' does not exist"
 msgstr "den efterfrågade uppströmsgrenen \"%s\" finns inte"
 
-#: branch.c:237
+#: branch.c:340
 msgid ""
 "\n"
 "If you are planning on basing your work on an upstream\n"
@@ -2008,27 +2008,28 @@ msgstr ""
 "spåra dess fjärrmotsvarighet kan du använda \"git push -u\"\n"
 "för att ställa in uppströmskonfigurationen när du sänder in."
 
-#: branch.c:281
+#: branch.c:384 builtin/replace.c:321 builtin/replace.c:377
+#: builtin/replace.c:423 builtin/replace.c:453
 #, c-format
-msgid "Not a valid object name: '%s'."
-msgstr "Objektnamnet är inte giltigt: \"%s\"."
+msgid "not a valid object name: '%s'"
+msgstr "objektnamnet är inte giltigt: \"%s\""
 
-#: branch.c:301
+#: branch.c:404
 #, c-format
-msgid "Ambiguous object name: '%s'."
-msgstr "Objektnamnet är tvetydigt: \"%s\"."
+msgid "ambiguous object name: '%s'"
+msgstr "objektnamnet är tvetydigt: \"%s\""
 
-#: branch.c:306
+#: branch.c:409
 #, c-format
-msgid "Not a valid branch point: '%s'."
-msgstr "Avgreningspunkten är inte giltig: \"%s\"."
+msgid "not a valid branch point: '%s'"
+msgstr "avgreningspunkten är inte giltig: \"%s\""
 
-#: branch.c:366
+#: branch.c:469
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr "\"%s\" är redan utcheckad på \"%s\""
 
-#: branch.c:389
+#: branch.c:494
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD i arbetskatalogen %s har inte uppdaterats"
@@ -2053,7 +2054,7 @@ msgstr "'%s' ser inte ut som en v2- eller v3-bunt-fil"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "okänt huvud: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2620 sequencer.c:3406
 #: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
@@ -2112,7 +2113,7 @@ msgstr "version %d för bunt stöds ej"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "kan inte skriva bunt med version %d med algoritmen %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1953 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "okänt argument: %s"
@@ -2149,7 +2150,7 @@ msgstr "dubblerat stycke-ID %<PRIx32> upptäckt"
 msgid "final chunk has non-zero id %<PRIx32>"
 msgstr "avslutande stycke har id %<PRIx32> som inte är noll"
 
-#: color.c:329
+#: color.c:354
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "felaktigt färgvärde: %.*s"
@@ -2199,190 +2200,190 @@ msgstr "ogiltig incheckingsgrafkedja: rad \"%s\" är inte ett hash-värde"
 msgid "unable to find all commit-graph files"
 msgstr "kan inte hitta alla incheckingsgraffiler"
 
-#: commit-graph.c:746 commit-graph.c:783
+#: commit-graph.c:749 commit-graph.c:786
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "ogiltig incheckningsposition. incheckningsgrafen är troligtvis trasig"
 
-#: commit-graph.c:767
+#: commit-graph.c:770
 #, c-format
 msgid "could not find commit %s"
 msgstr "kunde inte hitta incheckningen %s"
 
-#: commit-graph.c:800
+#: commit-graph.c:803
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "incheckningsgraf kräver spillgenerationsdata, men har ingen"
 
-#: commit-graph.c:1105 builtin/am.c:1342
+#: commit-graph.c:1108 builtin/am.c:1369
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "kunde inte tolka incheckningen %s"
 
-#: commit-graph.c:1367 builtin/pack-objects.c:3070
+#: commit-graph.c:1370 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "kunde inte hämta typ för objektet %s"
 
-#: commit-graph.c:1398
+#: commit-graph.c:1401
 msgid "Loading known commits in commit graph"
 msgstr "Läser in kända incheckningar i incheckningsgraf"
 
-#: commit-graph.c:1415
+#: commit-graph.c:1418
 msgid "Expanding reachable commits in commit graph"
 msgstr "Expanderar nåbara incheckningar i incheckningsgraf"
 
-#: commit-graph.c:1435
+#: commit-graph.c:1438
 msgid "Clearing commit marks in commit graph"
 msgstr "Rensar incheckningsmärken i incheckningsgraf"
 
-#: commit-graph.c:1454
+#: commit-graph.c:1457
 msgid "Computing commit graph topological levels"
 msgstr "Beräknar topografiska nivåer för incheckningsgraf"
 
-#: commit-graph.c:1507
+#: commit-graph.c:1510
 msgid "Computing commit graph generation numbers"
 msgstr "Beräknar generationsvärden för incheckningsgraf"
 
-#: commit-graph.c:1588
+#: commit-graph.c:1591
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Beräknar Bloom-filter för sökvägar ändrade av incheckningen"
 
-#: commit-graph.c:1665
+#: commit-graph.c:1668
 msgid "Collecting referenced commits"
 msgstr "Samlar refererade incheckningar"
 
-#: commit-graph.c:1690
+#: commit-graph.c:1693
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Söker incheckningar för incheckingsgraf i %d paket"
 msgstr[1] "Söker incheckningar för incheckingsgraf i %d paket"
 
-#: commit-graph.c:1703
+#: commit-graph.c:1706
 #, c-format
 msgid "error adding pack %s"
 msgstr "fel vid tillägg av paketet %s"
 
-#: commit-graph.c:1707
+#: commit-graph.c:1710
 #, c-format
 msgid "error opening index for %s"
 msgstr "fel vid öppning av indexet för %s"
 
-#: commit-graph.c:1744
+#: commit-graph.c:1747
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Söker incheckningar för incheckingsgraf i packade objekt"
 
-#: commit-graph.c:1762
+#: commit-graph.c:1765
 msgid "Finding extra edges in commit graph"
 msgstr "Söker ytterligare kanter i incheckingsgraf"
 
-#: commit-graph.c:1811
+#: commit-graph.c:1814
 msgid "failed to write correct number of base graph ids"
 msgstr "kunde inte skriva korrekt antal bas-graf-id:n"
 
-#: commit-graph.c:1842 midx.c:1146
+#: commit-graph.c:1845 midx.c:1149
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "kunde inte skapa inledande kataloger för %s"
 
-#: commit-graph.c:1855
+#: commit-graph.c:1858
 msgid "unable to create temporary graph layer"
 msgstr "kan inte skapa temporärt graflager"
 
-#: commit-graph.c:1860
+#: commit-graph.c:1863
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "kan inte justera delade behörigheter för \"%s\""
 
-#: commit-graph.c:1917
+#: commit-graph.c:1920
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Skriver ut incheckningsgraf i %d pass"
 msgstr[1] "Skriver ut incheckningsgraf i %d pass"
 
-#: commit-graph.c:1953
+#: commit-graph.c:1956
 msgid "unable to open commit-graph chain file"
 msgstr "Kunde inte öppna incheckningsgrafkedjefilen"
 
-#: commit-graph.c:1969
+#: commit-graph.c:1972
 msgid "failed to rename base commit-graph file"
 msgstr "kunde inte byta namn på bas-incheckingsgraffilen"
 
-#: commit-graph.c:1989
+#: commit-graph.c:1992
 msgid "failed to rename temporary commit-graph file"
 msgstr "kunde inte byta namn på temporär incheckningsgraffil"
 
-#: commit-graph.c:2122
+#: commit-graph.c:2125
 msgid "Scanning merged commits"
 msgstr "Söker sammanslagna incheckningar"
 
-#: commit-graph.c:2166
+#: commit-graph.c:2169
 msgid "Merging commit-graph"
 msgstr "Slår ihop incheckningsgraf"
 
-#: commit-graph.c:2274
+#: commit-graph.c:2277
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "försöker skriva en incheckningsgraf, men \"core.commitGraph\" är inaktiverad"
 
-#: commit-graph.c:2381
+#: commit-graph.c:2384
 msgid "too many commits to write graph"
 msgstr "för många incheckningar för att skriva graf"
 
-#: commit-graph.c:2479
+#: commit-graph.c:2482
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "filen med incheckningsgraf har felaktig kontrollsumma och är troligtvis "
 "trasig"
 
-#: commit-graph.c:2489
+#: commit-graph.c:2492
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "incheckningsgrafen har felaktig OID-ordning: %s så %s"
 
-#: commit-graph.c:2499 commit-graph.c:2514
+#: commit-graph.c:2502 commit-graph.c:2517
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "incheckningsgrafen har felaktig utbredningsvärde: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2506
+#: commit-graph.c:2509
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "kunde inte tolka incheckning %s från incheckningsgraf"
 
-#: commit-graph.c:2524
+#: commit-graph.c:2527
 msgid "Verifying commits in commit graph"
 msgstr "Bekräftar incheckningar i incheckningsgrafen"
 
-#: commit-graph.c:2539
+#: commit-graph.c:2542
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "misslyckades tolka incheckning %s från objektdatabasen för incheckningsgraf"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2549
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr "rot-trädets OID för incheckningen %s i incheckningsgrafen är %s != %s"
 
-#: commit-graph.c:2556
+#: commit-graph.c:2559
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "incheckningsgrafens föräldralista för incheckningen %s är för lång"
 
-#: commit-graph.c:2565
+#: commit-graph.c:2568
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "incheckningsgrafens förälder för %s är %s != %s"
 
-#: commit-graph.c:2579
+#: commit-graph.c:2582
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 "incheckningsgrafens föräldralista för incheckningen %s avslutas för tidigt"
 
-#: commit-graph.c:2584
+#: commit-graph.c:2587
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2390,7 +2391,7 @@ msgstr ""
 "incheckningsgrafen har generationsnummer noll för incheckningen %s, men icke-"
 "noll på annan plats"
 
-#: commit-graph.c:2588
+#: commit-graph.c:2591
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2398,22 +2399,22 @@ msgstr ""
 "incheckningsgrafen har generationsnummer skilt från noll för incheckningen "
 "%s, men noll på annan plats"
 
-#: commit-graph.c:2605
+#: commit-graph.c:2608
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 "incheckningsgrafens generation för incheckningen %s är %<PRIuMAX> < "
 "%<PRIuMAX>"
 
-#: commit-graph.c:2611
+#: commit-graph.c:2614
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "incheckningsdatumet för incheckningen %s i incheckningsgrafen är %<PRIuMAX> !"
 "= %<PRIuMAX>"
 
-#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
-#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3109 builtin/am.c:399 builtin/am.c:444
+#: builtin/am.c:449 builtin/am.c:1448 builtin/am.c:2123 builtin/replace.c:456
 #, c-format
 msgid "could not parse %s"
 msgstr "kunde inte tolka %s"
@@ -2443,29 +2444,29 @@ msgstr ""
 "Slå av detta meddelande genom att skriva\n"
 "\"git config advice.graftFileDeprecated false\""
 
-#: commit.c:1239
+#: commit.c:1241
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Incheckningen %s har en obetrodd GPG-signatur som påstås vara gjord av %s."
 
-#: commit.c:1243
+#: commit.c:1245
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr ""
 "Incheckningen %s har en felaktig GPG-signatur som påstås vara gjord av %s."
 
-#: commit.c:1246
+#: commit.c:1248
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Incheckning %s har inte någon GPG-signatur."
 
-#: commit.c:1249
+#: commit.c:1251
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Incheckningen %s har en korrekt GPG-signatur av %s\n"
 
-#: commit.c:1503
+#: commit.c:1505
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2532,7 +2533,7 @@ msgstr "nyckeln innehåller inte ett stycke: %s"
 msgid "key does not contain variable name: %s"
 msgstr "nyckeln innehåller inte variabelnamn: %s"
 
-#: config.c:470 sequencer.c:2804
+#: config.c:470 sequencer.c:2806
 #, c-format
 msgid "invalid key: %s"
 msgstr "felaktig nyckel: %s"
@@ -2690,145 +2691,145 @@ msgstr "core.commentChar kan bara vara ett tecken"
 msgid "invalid mode for object creation: %s"
 msgstr "felaktigt läge för skapande av objekt: %s"
 
-#: config.c:1581
+#: config.c:1584
 #, c-format
 msgid "malformed value for %s"
 msgstr "felformat värde för %s"
 
-#: config.c:1607
+#: config.c:1610
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "felformat värde för %s: %s"
 
-#: config.c:1608
+#: config.c:1611
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "måste vara en av nothing, matching, simple, upstream eller current"
 
-#: config.c:1669 builtin/pack-objects.c:4053
+#: config.c:1672 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "felaktig paketkomprimeringsgrad %d"
 
-#: config.c:1792
+#: config.c:1795
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "kunde inte läsa konfigurerings-blobobjektet \"%s\""
 
-#: config.c:1795
+#: config.c:1798
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "referensen \"%s\" pekar inte på en blob"
 
-#: config.c:1813
+#: config.c:1816
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "kan inte slå upp konfigurerings-bloben \"%s\""
 
-#: config.c:1858
+#: config.c:1861
 #, c-format
 msgid "failed to parse %s"
 msgstr "kunde inte tolka %s"
 
-#: config.c:1914
+#: config.c:1917
 msgid "unable to parse command-line config"
 msgstr "kan inte tolka kommandoradskonfiguration"
 
-#: config.c:2282
+#: config.c:2285
 msgid "unknown error occurred while reading the configuration files"
 msgstr "okänt fel uppstod vid läsning av konfigurationsfilerna"
 
-#: config.c:2456
+#: config.c:2459
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "Felaktigt %s: \"%s\""
 
-#: config.c:2501
+#: config.c:2504
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "värdet \"%d\" för splitIndex.maxPercentChange borde vara mellan 0 och 100"
 
-#: config.c:2547
+#: config.c:2550
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "kunde inte tolka värdet \"%s\" från kommandoradskonfiguration"
 
-#: config.c:2549
+#: config.c:2552
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "felaktig konfigurationsvariabel \"%s\" i filen \"%s\" på rad %d"
 
-#: config.c:2633
+#: config.c:2637
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "felaktigt sektionsnamn \"%s\""
 
-#: config.c:2665
+#: config.c:2669
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s har flera värden"
 
-#: config.c:2694
+#: config.c:2698
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "kan inte skriva nya konfigurationsfilen \"%s\""
 
-#: config.c:2946 config.c:3273
+#: config.c:2950 config.c:3277
 #, c-format
 msgid "could not lock config file %s"
 msgstr "kunde inte låsa konfigurationsfilen %s"
 
-#: config.c:2957
+#: config.c:2961
 #, c-format
 msgid "opening %s"
 msgstr "öppnar %s"
 
-#: config.c:2994 builtin/config.c:361
+#: config.c:2998 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "ogiltigt mönster: %s"
 
-#: config.c:3019
+#: config.c:3023
 #, c-format
 msgid "invalid config file %s"
 msgstr "ogiltig konfigurationsfil: \"%s\""
 
-#: config.c:3032 config.c:3286
+#: config.c:3036 config.c:3290
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat misslyckades på %s"
 
-#: config.c:3043
+#: config.c:3047
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "kunde inte utföra mmap på \"%s\"%s"
 
-#: config.c:3053 config.c:3291
+#: config.c:3057 config.c:3295
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod misslyckades på %s"
 
-#: config.c:3138 config.c:3388
+#: config.c:3142 config.c:3392
 #, c-format
 msgid "could not write config file %s"
 msgstr "kunde inte skriva konfigurationsfilen %s"
 
-#: config.c:3172
+#: config.c:3176
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "kunde inte ställa in \"%s\" till \"%s\""
 
-#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
+#: config.c:3178 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "kunde inte ta bort inställning för \"%s\""
 
-#: config.c:3264
+#: config.c:3268
 #, c-format
 msgid "invalid section name: %s"
 msgstr "felaktigt namn på stycke: %s"
 
-#: config.c:3431
+#: config.c:3435
 #, c-format
 msgid "missing value for '%s'"
 msgstr "värde saknas för \"%s\""
@@ -3007,7 +3008,7 @@ msgstr "kunde inte grena (fork)"
 
 # Vague original, not networking-related, but rather related to the actual
 # objects in the database.
-#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:57
 msgid "Checking connectivity"
 msgstr "Kontrollerar konnektivitet"
 
@@ -3308,17 +3309,17 @@ msgstr ""
 "Inte ett git-arkiv. Använd --no-index för att jämföra två sökvägar utanför "
 "en arbetskatalog."
 
-#: diff.c:157
+#: diff.c:158
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr "  Misslyckades tolka dirstat-avskärningsprocentandel \"%s\"\n"
 
-#: diff.c:162
+#: diff.c:163
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Okänd dirstat-parameter \"%s\"\n"
 
-#: diff.c:298
+#: diff.c:299
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3326,7 +3327,7 @@ msgstr ""
 "färginställningen för flyttade block måste vara en av \"no\", \"default\", "
 "\"blocks\", \"zebra\", \"dimmed-zebra\", \"plain\""
 
-#: diff.c:326
+#: diff.c:327
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3336,7 +3337,7 @@ msgstr ""
 "\", \"ignore-space-at-eol\", \"ignore-all-space\", \"allow-indentation-change"
 "\""
 
-#: diff.c:334
+#: diff.c:335
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3344,12 +3345,12 @@ msgstr ""
 "color-moved-ws: allow-indentation-change kan inte kombineras med andra "
 "blankstegslägen"
 
-#: diff.c:411
+#: diff.c:412
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Okänt värde för konfigurationsvariabeln \"diff.submodule\": \"%s\""
 
-#: diff.c:471
+#: diff.c:472
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3358,50 +3359,53 @@ msgstr ""
 "Hittade fel i konfigurationsvariabeln \"diff.dirstat\":\n"
 "%s"
 
-#: diff.c:4290
+#: diff.c:4237
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "extern diff dog, stannar vid %s"
 
-#: diff.c:4642
-msgid "--name-only, --name-status, --check and -s are mutually exclusive"
-msgstr "--name-only, --name-status, --check och -s är ömsesidigt uteslutande"
-
-#: diff.c:4645
-msgid "-G, -S and --find-object are mutually exclusive"
-msgstr "-G, -S och --find-object är ömsesidigt uteslutande"
-
-#: diff.c:4648
-msgid ""
-"-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
+#: diff.c:4589
+#, c-format
+msgid "options '%s', '%s', '%s', and '%s' cannot be used together"
 msgstr ""
-"-G och --pickaxe-regex är ömsesidigt uteslutande, använd --pickaxe-regex med "
-"-S"
+"flaggorna \"%s\", \"%s\", \"%s\" och \"%s\" kan inte användas samtidigt"
 
-#: diff.c:4651
-msgid ""
-"--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
-"with -G and -S"
+#: diff.c:4593 builtin/difftool.c:736 builtin/log.c:1982 builtin/worktree.c:506
+#, c-format
+msgid "options '%s', '%s', and '%s' cannot be used together"
+msgstr "flaggorna \"%s\", \"%s\" och \"%s\" kan inte användas samtidigt"
+
+#: diff.c:4597
+#, c-format
+msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
 msgstr ""
-"--pickaxe-all och --find-object är ömsesidigt uteslutande, använd --pickaxe-"
-"all med -G och -S"
+"flaggorna \"%s\" och \"%s\" kan inte användas samtidigt, använd \"%s\" med "
+"\"%s\""
 
-#: diff.c:4730
+#: diff.c:4601
+#, c-format
+msgid ""
+"options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
+msgstr ""
+"flaggorna \"%s\" och  \"%s\" kan inte användas samtidigt, använd \"%s\" med "
+"\"%s\" och \"%s\""
+
+#: diff.c:4681
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow kräver exakt en sökvägsangivelse"
 
-#: diff.c:4778
+#: diff.c:4729
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "ogiltigt värde för --stat: %s"
 
-#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: diff.c:4734 diff.c:4739 diff.c:4744 diff.c:4749 diff.c:5277
 #: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s förväntar ett numeriskt värde"
 
-#: diff.c:4815
+#: diff.c:4766
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3410,42 +3414,42 @@ msgstr ""
 "Misslyckades tolka argument till flaggan --dirstat/-X;\n"
 "%s"
 
-#: diff.c:4900
+#: diff.c:4851
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "okänd ändringsklass \"%c\" i --diff-filter=%s"
 
-#: diff.c:4924
+#: diff.c:4875
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "okänt värde efter ws-error-highlight=%.*s"
 
-#: diff.c:4938
+#: diff.c:4889
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "kunde inte slå upp \"%s\""
 
-#: diff.c:4988 diff.c:4994
+#: diff.c:4939 diff.c:4945
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s förväntar formen <n>/<m>"
 
-#: diff.c:5006
+#: diff.c:4957
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s förväntar ett tecken, fick \"%s\""
 
-#: diff.c:5027
+#: diff.c:4978
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "felaktigt argument till --color-moved: %s"
 
-#: diff.c:5046
+#: diff.c:4997
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "ogiltigt läge %s\" i --color-moved-ws"
 
-#: diff.c:5086
+#: diff.c:5037
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3453,154 +3457,154 @@ msgstr ""
 "flaggan diff-algorithm godtar\"myers\", \"minimal\", \"patience\" och "
 "\"histogram\""
 
-#: diff.c:5122 diff.c:5142
+#: diff.c:5073 diff.c:5093
 #, c-format
 msgid "invalid argument to %s"
 msgstr "ogiltigt argument för %s"
 
-#: diff.c:5246
+#: diff.c:5197
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "ogiltigt reguljärt uttryck angavs för -I: \"%s\""
 
-#: diff.c:5295
+#: diff.c:5246
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "misslyckades tolka argument till flaggan --submodule: \"%s\""
 
-#: diff.c:5351
+#: diff.c:5302
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "felaktigt argument --word-diff: %s"
 
-#: diff.c:5387
+#: diff.c:5338
 msgid "Diff output format options"
 msgstr "Formatflaggor för diff-utdata"
 
-#: diff.c:5389 diff.c:5395
+#: diff.c:5340 diff.c:5346
 msgid "generate patch"
 msgstr "skapar patch"
 
-#: diff.c:5392 builtin/log.c:179
+#: diff.c:5343 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "undertryck diff-utdata"
 
-#: diff.c:5397 diff.c:5511 diff.c:5518
+#: diff.c:5348 diff.c:5462 diff.c:5469
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5398 diff.c:5401
+#: diff.c:5349 diff.c:5352
 msgid "generate diffs with <n> lines context"
 msgstr "skapa diffar med <n> rader sammanhang"
 
-#: diff.c:5403
+#: diff.c:5354
 msgid "generate the diff in raw format"
 msgstr "generera diff i råformat"
 
-#: diff.c:5406
+#: diff.c:5357
 msgid "synonym for '-p --raw'"
 msgstr "synonym till \"-p --raw\""
 
-#: diff.c:5410
+#: diff.c:5361
 msgid "synonym for '-p --stat'"
 msgstr "synonym till \"-p --stat\""
 
-#: diff.c:5414
+#: diff.c:5365
 msgid "machine friendly --stat"
 msgstr "maskinläsbar --stat"
 
-#: diff.c:5417
+#: diff.c:5368
 msgid "output only the last line of --stat"
 msgstr "skriv bara ut den sista raden för --stat"
 
-#: diff.c:5419 diff.c:5427
+#: diff.c:5370 diff.c:5378
 msgid "<param1,param2>..."
 msgstr "<param1,param2>..."
 
-#: diff.c:5420
+#: diff.c:5371
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "skriv ut distributionen av relativa mängder ändringar för varje underkatalog"
 
-#: diff.c:5424
+#: diff.c:5375
 msgid "synonym for --dirstat=cumulative"
 msgstr "synonym för --dirstat=cumulative"
 
-#: diff.c:5428
+#: diff.c:5379
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "synonym för --dirstat=filer,param1,param2..."
 
-#: diff.c:5432
+#: diff.c:5383
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr "varna om ändringar introducerar konfliktmarkörer eller blankstegsfel"
 
-#: diff.c:5435
+#: diff.c:5386
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr "kortfattad summering såsom skapade, namnbyten och ändrade lägen"
 
-#: diff.c:5438
+#: diff.c:5389
 msgid "show only names of changed files"
 msgstr "visa endast namnen på ändrade filer"
 
-#: diff.c:5441
+#: diff.c:5392
 msgid "show only names and status of changed files"
 msgstr "visa endast namn och status för ändrade filer"
 
-#: diff.c:5443
+#: diff.c:5394
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<bredd>[,<namn-bredd>[,<antal>]]"
 
-#: diff.c:5444
+#: diff.c:5395
 msgid "generate diffstat"
 msgstr "skapa diffstat"
 
-#: diff.c:5446 diff.c:5449 diff.c:5452
+#: diff.c:5397 diff.c:5400 diff.c:5403
 msgid "<width>"
 msgstr "<bredd>"
 
-#: diff.c:5447
+#: diff.c:5398
 msgid "generate diffstat with a given width"
 msgstr "generera en diffstat med given bredd"
 
-#: diff.c:5450
+#: diff.c:5401
 msgid "generate diffstat with a given name width"
 msgstr "generera en diffstat med given namnbredd"
 
-#: diff.c:5453
+#: diff.c:5404
 msgid "generate diffstat with a given graph width"
 msgstr "generera en diffstat med given grafbredd"
 
-#: diff.c:5455
+#: diff.c:5406
 msgid "<count>"
 msgstr "<antal>"
 
-#: diff.c:5456
+#: diff.c:5407
 msgid "generate diffstat with limited lines"
 msgstr "generera diffstat med begränsade rader"
 
-#: diff.c:5459
+#: diff.c:5410
 msgid "generate compact summary in diffstat"
 msgstr "skapa kompakt översikt i diffstat"
 
-#: diff.c:5462
+#: diff.c:5413
 msgid "output a binary diff that can be applied"
 msgstr "skapa en binärdiff som kan appliceras"
 
-#: diff.c:5465
+#: diff.c:5416
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
 "visa fullständiga objektnamn i \"index\"-rader för läget både före och efter"
 
-#: diff.c:5467
+#: diff.c:5418
 msgid "show colored diff"
 msgstr "visa färgad diff"
 
-#: diff.c:5468
+#: diff.c:5419
 msgid "<kind>"
 msgstr "<typ>"
 
-#: diff.c:5469
+#: diff.c:5420
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3608,7 +3612,7 @@ msgstr ""
 "ljusmarkera blankstegsfel i \"context\" (sammanhang), \"old\" (gamla) eller "
 "\"new\" (nya) rader i diffen"
 
-#: diff.c:5472
+#: diff.c:5423
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3616,87 +3620,87 @@ msgstr ""
 "skriv inte om sökvägsnamn och använd NUL-tecken som fältseparerare i --raw "
 "eller --numstat"
 
-#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
+#: diff.c:5426 diff.c:5429 diff.c:5432 diff.c:5541
 msgid "<prefix>"
 msgstr "<prefix>"
 
-#: diff.c:5476
+#: diff.c:5427
 msgid "show the given source prefix instead of \"a/\""
 msgstr "visa givet källprefix istället för \"a/\""
 
-#: diff.c:5479
+#: diff.c:5430
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "visa givet målprefix istället för \"b/\""
 
-#: diff.c:5482
+#: diff.c:5433
 msgid "prepend an additional prefix to every line of output"
 msgstr "lägg till ytterligare prefix på alla rader i utdata"
 
-#: diff.c:5485
+#: diff.c:5436
 msgid "do not show any source or destination prefix"
 msgstr "visa inte käll- eller målprefix"
 
-#: diff.c:5488
+#: diff.c:5439
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr "visa sammnhang mellan diff-stycken upp till angivet antal rader"
 
-#: diff.c:5492 diff.c:5497 diff.c:5502
+#: diff.c:5443 diff.c:5448 diff.c:5453
 msgid "<char>"
 msgstr "<tecken>"
 
-#: diff.c:5493
+#: diff.c:5444
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "ange tecken för att ange ny rad istället för \"+\""
 
-#: diff.c:5498
+#: diff.c:5449
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "ange tecken för att ange gammal rad istället för \"-\""
 
-#: diff.c:5503
+#: diff.c:5454
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "ange tecken för att ange sammanhang istället för \" \""
 
-#: diff.c:5506
+#: diff.c:5457
 msgid "Diff rename options"
 msgstr "Diff-namnbytesflaggor"
 
-#: diff.c:5507
+#: diff.c:5458
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5508
+#: diff.c:5459
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr "dela upp kompletta omskrivningar till ta bort och skapa-par"
 
-#: diff.c:5512
+#: diff.c:5463
 msgid "detect renames"
 msgstr "detektera namnändringar"
 
-#: diff.c:5516
+#: diff.c:5467
 msgid "omit the preimage for deletes"
 msgstr "ta bort för-version för borttagningar"
 
-#: diff.c:5519
+#: diff.c:5470
 msgid "detect copies"
 msgstr "detektera kopior"
 
-#: diff.c:5523
+#: diff.c:5474
 msgid "use unmodified files as source to find copies"
 msgstr "använd oförändrade som källa för att hitta kopior"
 
-#: diff.c:5525
+#: diff.c:5476
 msgid "disable rename detection"
 msgstr "inaktivera detektering av namnbyten"
 
-#: diff.c:5528
+#: diff.c:5479
 msgid "use empty blobs as rename source"
 msgstr "använd tomma blob:ar som namnändringskälla"
 
-#: diff.c:5530
+#: diff.c:5481
 msgid "continue listing the history of a file beyond renames"
 msgstr "fortsätt lista historiken för en fil bortom namnändringar"
 
-#: diff.c:5533
+#: diff.c:5484
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3704,163 +3708,163 @@ msgstr ""
 "förhindra namnbyte/kopie-detektering om antalet namnbyten/kopior överskriver "
 "given gräns"
 
-#: diff.c:5535
+#: diff.c:5486
 msgid "Diff algorithm options"
 msgstr "Alternativ för diff-algoritm"
 
-#: diff.c:5537
+#: diff.c:5488
 msgid "produce the smallest possible diff"
 msgstr "skapa minsta möjliga diff"
 
-#: diff.c:5540
+#: diff.c:5491
 msgid "ignore whitespace when comparing lines"
 msgstr "ignorera blanktecken vid radjämförelse"
 
-#: diff.c:5543
+#: diff.c:5494
 msgid "ignore changes in amount of whitespace"
 msgstr "ignorera ändringar i antal blanktecken vid radjämförelse"
 
-#: diff.c:5546
+#: diff.c:5497
 msgid "ignore changes in whitespace at EOL"
 msgstr "ignorera blanktecken vid radslut"
 
-#: diff.c:5549
+#: diff.c:5500
 msgid "ignore carrier-return at the end of line"
 msgstr "ignorera CR-tecken vid radslut"
 
-#: diff.c:5552
+#: diff.c:5503
 msgid "ignore changes whose lines are all blank"
 msgstr "ignorera ändringar i rader som är helt blanka"
 
-#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
+#: diff.c:5505 diff.c:5527 diff.c:5530 diff.c:5575
 msgid "<regex>"
 msgstr "<reguttr>"
 
-#: diff.c:5555
+#: diff.c:5506
 msgid "ignore changes whose all lines match <regex>"
 msgstr "ignorera ändringar där samtliga rader motsvarar <reguttr>"
 
-#: diff.c:5558
+#: diff.c:5509
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr "heuristik för att flytta diff-gränser för lättare läsning"
 
-#: diff.c:5561
+#: diff.c:5512
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "skapa diffar med algoritmen \"patience diff\""
 
-#: diff.c:5565
+#: diff.c:5516
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "skapa diffar med algoritmen \"histogram diff\""
 
-#: diff.c:5567
+#: diff.c:5518
 msgid "<algorithm>"
 msgstr "<algoritm>"
 
-#: diff.c:5568
+#: diff.c:5519
 msgid "choose a diff algorithm"
 msgstr "välj en diff-algoritm"
 
-#: diff.c:5570
+#: diff.c:5521
 msgid "<text>"
 msgstr "<text>"
 
-#: diff.c:5571
+#: diff.c:5522
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "skapa diffar med algoritmen \"anchored diff\""
 
-#: diff.c:5573 diff.c:5582 diff.c:5585
+#: diff.c:5524 diff.c:5533 diff.c:5536
 msgid "<mode>"
 msgstr "<läge>"
 
-#: diff.c:5574
+#: diff.c:5525
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr "visa orddiff, där <läge> avgränsar ändrade ord"
 
-#: diff.c:5577
+#: diff.c:5528
 msgid "use <regex> to decide what a word is"
 msgstr "använd <reguttr> för att bestämma vad som är ett ord"
 
-#: diff.c:5580
+#: diff.c:5531
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "motsvarar --word-diff=color --word-diff-regex=<reguttr>"
 
-#: diff.c:5583
+#: diff.c:5534
 msgid "moved lines of code are colored differently"
 msgstr "flyttade kodrader färgas på annat sätt"
 
-#: diff.c:5586
+#: diff.c:5537
 msgid "how white spaces are ignored in --color-moved"
 msgstr "hur blanktecken ignoreras i --color-moved"
 
-#: diff.c:5589
+#: diff.c:5540
 msgid "Other diff options"
 msgstr "Andra diff-flaggor"
 
-#: diff.c:5591
+#: diff.c:5542
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "vid start från underkatalog, uteslut ändringar utanför och visa relativa "
 "sökvägar"
 
-#: diff.c:5595
+#: diff.c:5546
 msgid "treat all files as text"
 msgstr "hantera alla filer som text"
 
-#: diff.c:5597
+#: diff.c:5548
 msgid "swap two inputs, reverse the diff"
 msgstr "växla två indatafiler, vänd diffen"
 
-#: diff.c:5599
+#: diff.c:5550
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr "avsluta med 1 vid ändringar, annars 0"
 
-#: diff.c:5601
+#: diff.c:5552
 msgid "disable all output of the program"
 msgstr "slå av alla utdata från programmet"
 
-#: diff.c:5603
+#: diff.c:5554
 msgid "allow an external diff helper to be executed"
 msgstr "tillåt köra en extern diff-hjälpare"
 
-#: diff.c:5605
+#: diff.c:5556
 msgid "run external text conversion filters when comparing binary files"
 msgstr "kör externt textkonverteringsfiler när binärfiler jämförs"
 
-#: diff.c:5607
+#: diff.c:5558
 msgid "<when>"
 msgstr "<när>"
 
-#: diff.c:5608
+#: diff.c:5559
 msgid "ignore changes to submodules in the diff generation"
 msgstr "ignorera ändringar i undermoduler när diffen skapas"
 
-#: diff.c:5611
+#: diff.c:5562
 msgid "<format>"
 msgstr "<format>"
 
-#: diff.c:5612
+#: diff.c:5563
 msgid "specify how differences in submodules are shown"
 msgstr "ange hur ändringar i undermoduler visas"
 
-#: diff.c:5616
+#: diff.c:5567
 msgid "hide 'git add -N' entries from the index"
 msgstr "dölj \"git add -N\"-poster från indexet"
 
-#: diff.c:5619
+#: diff.c:5570
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "tolka \"git add -N\"-poster som äkta i indexet"
 
-#: diff.c:5621
+#: diff.c:5572
 msgid "<string>"
 msgstr "<sträng>"
 
-#: diff.c:5622
+#: diff.c:5573
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr "se efter ändringar som ändrar antalet förekomster av angiven sträng"
 
-#: diff.c:5625
+#: diff.c:5576
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3868,66 +3872,66 @@ msgstr ""
 "se efter ändringar som ändrar antalet förekomster av angivet reguljärt "
 "uttryck"
 
-#: diff.c:5628
+#: diff.c:5579
 msgid "show all changes in the changeset with -S or -G"
 msgstr "visa alla ändringar i ändringsuppsättningen med -S eller -G"
 
-#: diff.c:5631
+#: diff.c:5582
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr "tolka <sträng> i -S som utökade POSIX-reguljära uttryck"
 
-#: diff.c:5634
+#: diff.c:5585
 msgid "control the order in which files appear in the output"
 msgstr "styr ordningen i vilken filer visas i utdata"
 
-#: diff.c:5635 diff.c:5638
+#: diff.c:5586 diff.c:5589
 msgid "<path>"
 msgstr "<sökväg>"
 
-#: diff.c:5636
+#: diff.c:5587
 msgid "show the change in the specified path first"
 msgstr "visa ändringen i angiven sökväg först"
 
-#: diff.c:5639
+#: diff.c:5590
 msgid "skip the output to the specified path"
 msgstr "hoppa över utdata fram till angiven sökväg"
 
-#: diff.c:5641
+#: diff.c:5592
 msgid "<object-id>"
 msgstr "<objekt-id>"
 
-#: diff.c:5642
+#: diff.c:5593
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
 msgstr "se efter ändringar som ändrar antalet förekomster av angivet objekt"
 
-#: diff.c:5644
+#: diff.c:5595
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5645
+#: diff.c:5596
 msgid "select files by diff type"
 msgstr "välj filter efter diff-typ"
 
-#: diff.c:5647
+#: diff.c:5598
 msgid "<file>"
 msgstr "<fil>"
 
-#: diff.c:5648
+#: diff.c:5599
 msgid "Output to a specific file"
 msgstr "Skriv utdata till en specifik fil"
 
-#: diff.c:6306
+#: diff.c:6257
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr ""
 "uttömmande namnbytesdetektering hoppades över på grund av för många filer."
 
-#: diff.c:6309
+#: diff.c:6260
 msgid "only found copies from modified paths due to too many files."
 msgstr "hittade bara kopior från ändrade sökvägar på grund av för många filer."
 
-#: diff.c:6312
+#: diff.c:6263
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3970,29 +3974,29 @@ msgstr ""
 "din \"sparse-checkout\"-fil kan ha problem: mönstret \"%s\" förekommer flera "
 "gånger"
 
-#: dir.c:830
+#: dir.c:828
 msgid "disabling cone pattern matching"
 msgstr "inaktiverar konmönstermatchning"
 
-#: dir.c:1214
+#: dir.c:1212
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "kan inte använda %s som exkluderingsfil"
 
-#: dir.c:2464
+#: dir.c:2418
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "kunde inte öppna katalogen \"%s\""
 
-#: dir.c:2766
+#: dir.c:2720
 msgid "failed to get kernel name and information"
 msgstr "misslyckades hämta kärnans namn och information"
 
-#: dir.c:2890
+#: dir.c:2844
 msgid "untracked cache is disabled on this system or location"
 msgstr "ospårad cache är inaktiverad på systemet eller platsen"
 
-#: dir.c:3158
+#: dir.c:3112
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -4000,36 +4004,36 @@ msgstr ""
 "Kunde inte gissa katalognamn.\n"
 "Ange en katalog på kommandoraden"
 
-#: dir.c:3837
+#: dir.c:3800
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "indexfilen trasig i arkivet %s"
 
-#: dir.c:3884 dir.c:3889
+#: dir.c:3847 dir.c:3852
 #, c-format
 msgid "could not create directories for %s"
 msgstr "kunde inte skapa kataloger för %s"
 
-#: dir.c:3918
+#: dir.c:3881
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "kunde inte migrera git-katalog från \"%s\" till \"%s\""
 
-#: editor.c:77
+#: editor.c:74
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "tips: Väntar på att textredigeringsprogrammet ska stänga filen...%c"
 
-#: entry.c:177
+#: entry.c:179
 msgid "Filtering content"
 msgstr "Filtrerar innehåll"
 
-#: entry.c:498
+#: entry.c:500
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "kunde inte ta status på filen \"%s\""
 
-#: environment.c:143
+#: environment.c:145
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "felaktig git-namnrymdssökväg \"%s\""
@@ -4039,273 +4043,269 @@ msgstr "felaktig git-namnrymdssökväg \"%s\""
 msgid "too many args to run %s"
 msgstr "för många flaggor för att köra %s"
 
-#: fetch-pack.c:193
+#: fetch-pack.c:194
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: förväntade grund lista"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:197
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: förväntade ett flush-paket efter grund lista"
 
-#: fetch-pack.c:207
+#: fetch-pack.c:208
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: förväntade ACK/NAK, fick flush-paket"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:228
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: förväntade ACK/NAK, fick \"%s\""
 
-#: fetch-pack.c:238
+#: fetch-pack.c:239
 msgid "unable to write to remote"
 msgstr "kunde inte skriva till fjärren"
 
-#: fetch-pack.c:299
-msgid "--stateless-rpc requires multi_ack_detailed"
-msgstr "--stateless-rpc kräver \"multi_ack_detailed\""
-
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:395 fetch-pack.c:1439
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ogiltig \"shallow\"-rad: %s"
 
-#: fetch-pack.c:400 fetch-pack.c:1440
+#: fetch-pack.c:401 fetch-pack.c:1445
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ogiltig \"unshallow\"-rad: %s"
 
-#: fetch-pack.c:402 fetch-pack.c:1442
+#: fetch-pack.c:403 fetch-pack.c:1447
 #, c-format
 msgid "object not found: %s"
 msgstr "objektet hittades inte: %s"
 
-#: fetch-pack.c:405 fetch-pack.c:1445
+#: fetch-pack.c:406 fetch-pack.c:1450
 #, c-format
 msgid "error in object: %s"
 msgstr "fel i objekt: %s"
 
-#: fetch-pack.c:407 fetch-pack.c:1447
+#: fetch-pack.c:408 fetch-pack.c:1452
 #, c-format
 msgid "no shallow found: %s"
 msgstr "ingen \"shallow\" hittades: %s"
 
-#: fetch-pack.c:410 fetch-pack.c:1451
+#: fetch-pack.c:411 fetch-pack.c:1456
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "förväntade shallow/unshallow, fick %s"
 
-#: fetch-pack.c:450
+#: fetch-pack.c:451
 #, c-format
 msgid "got %s %d %s"
 msgstr "fick %s %d %s"
 
-#: fetch-pack.c:467
+#: fetch-pack.c:468
 #, c-format
 msgid "invalid commit %s"
 msgstr "ogiltig incheckning %s"
 
-#: fetch-pack.c:498
+#: fetch-pack.c:499
 msgid "giving up"
 msgstr "ger upp"
 
-#: fetch-pack.c:511 progress.c:339
+#: fetch-pack.c:512 progress.c:339
 msgid "done"
 msgstr "klart"
 
-#: fetch-pack.c:523
+#: fetch-pack.c:524
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "fick %s (%d) %s"
 
-#: fetch-pack.c:559
+#: fetch-pack.c:560
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Markerar %s som komplett"
 
-#: fetch-pack.c:774
+#: fetch-pack.c:775
 #, c-format
 msgid "already have %s (%s)"
 msgstr "har redan %s (%s)"
 
-#: fetch-pack.c:860
+#: fetch-pack.c:861
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-patch: kunde inte grena av sidbandsmultiplexare"
 
-#: fetch-pack.c:868
+#: fetch-pack.c:869
 msgid "protocol error: bad pack header"
 msgstr "protokollfel: felaktigt packhuvud"
 
-#: fetch-pack.c:962
+#: fetch-pack.c:965
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-patch: kunde inte grena av %s"
 
-#: fetch-pack.c:968
+#: fetch-pack.c:971
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-patch: ogiltig utdata från index-pack"
 
-#: fetch-pack.c:985
+#: fetch-pack.c:988
 #, c-format
 msgid "%s failed"
 msgstr "%s misslyckades"
 
-#: fetch-pack.c:987
+#: fetch-pack.c:990
 msgid "error in sideband demultiplexer"
 msgstr "fel i sidbands-avmultiplexare"
 
-#: fetch-pack.c:1030
+#: fetch-pack.c:1035
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Serverversionen är %.*s"
 
-#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
-#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
-#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
-#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
+#: fetch-pack.c:1043 fetch-pack.c:1049 fetch-pack.c:1052 fetch-pack.c:1058
+#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
+#: fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086 fetch-pack.c:1090
+#: fetch-pack.c:1096 fetch-pack.c:1102 fetch-pack.c:1107 fetch-pack.c:1112
 #, c-format
 msgid "Server supports %s"
 msgstr "Servern stöder %s"
 
-#: fetch-pack.c:1040
+#: fetch-pack.c:1045
 msgid "Server does not support shallow clients"
 msgstr "Servern stöder inte klienter med grunda arkiv"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-since"
 msgstr "Servern stöder inte --shallow-since"
 
-#: fetch-pack.c:1105
+#: fetch-pack.c:1110
 msgid "Server does not support --shallow-exclude"
 msgstr "Servern stöder inte --shallow-exclude"
 
-#: fetch-pack.c:1109
+#: fetch-pack.c:1114
 msgid "Server does not support --deepen"
 msgstr "Servern stöder inte --deepen"
 
-#: fetch-pack.c:1111
+#: fetch-pack.c:1116
 msgid "Server does not support this repository's object format"
 msgstr "Servern stöder inte det här arkivets objektformat"
 
-#: fetch-pack.c:1124
+#: fetch-pack.c:1129
 msgid "no common commits"
 msgstr "inga gemensamma incheckningar"
 
-#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
+#: fetch-pack.c:1138 fetch-pack.c:1485 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr "källarkivet är grunt, tillåter inte kloning."
 
-#: fetch-pack.c:1139 fetch-pack.c:1671
+#: fetch-pack.c:1144 fetch-pack.c:1681
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: hämtning misslyckades."
 
-#: fetch-pack.c:1253
+#: fetch-pack.c:1258
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "omaka algoritmer: klient %s; server %s"
 
-#: fetch-pack.c:1257
+#: fetch-pack.c:1262
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "servern stöder inte algoritmen \"%s\""
 
-#: fetch-pack.c:1290
+#: fetch-pack.c:1295
 msgid "Server does not support shallow requests"
 msgstr "Servern stöder inte grunda förfrågningar"
 
-#: fetch-pack.c:1297
+#: fetch-pack.c:1302
 msgid "Server supports filter"
 msgstr "Servern stöder filter"
 
-#: fetch-pack.c:1340 fetch-pack.c:2053
+#: fetch-pack.c:1345 fetch-pack.c:2063
 msgid "unable to write request to remote"
 msgstr "kunde inte skriva anrop till fjärren"
 
-#: fetch-pack.c:1358
+#: fetch-pack.c:1363
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "fel vid läsning av styckehuvudet \"%s\""
 
-#: fetch-pack.c:1364
+#: fetch-pack.c:1369
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "förväntade \"%s\", tog emot \"%s\""
 
-#: fetch-pack.c:1398
+#: fetch-pack.c:1403
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "oväntad bekräftelserad: \"%s\""
 
-#: fetch-pack.c:1403
+#: fetch-pack.c:1408
 #, c-format
 msgid "error processing acks: %d"
 msgstr "fel vid hantering av bekräftelser: %d"
 
-#: fetch-pack.c:1413
+#: fetch-pack.c:1418
 msgid "expected packfile to be sent after 'ready'"
 msgstr "väntade att paketfil skulle sändas efter \"ready\""
 
-#: fetch-pack.c:1415
+#: fetch-pack.c:1420
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 "väntade inte att några ytterligare sektioner skulle sändas efter \"ready\""
 
-#: fetch-pack.c:1456
+#: fetch-pack.c:1461
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "fel vid hantering av grund (\"shallow\") info: %d"
 
-#: fetch-pack.c:1505
+#: fetch-pack.c:1510
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "förväntade wanted-ref, fick %s"
 
-#: fetch-pack.c:1510
+#: fetch-pack.c:1515
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "oväntad wanted-ref: \"%s\""
 
-#: fetch-pack.c:1515
+#: fetch-pack.c:1520
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "fel vid hantering av önskade referenser: %d"
 
-#: fetch-pack.c:1545
+#: fetch-pack.c:1550
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: förväntade svarsavslutningspaket"
 
-#: fetch-pack.c:1949
+#: fetch-pack.c:1959
 msgid "no matching remote head"
 msgstr "inget motsvarande fjärrhuvud"
 
-#: fetch-pack.c:1972 builtin/clone.c:581
+#: fetch-pack.c:1982 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "fjärren sände inte alla nödvändiga objekt"
 
-#: fetch-pack.c:2075
+#: fetch-pack.c:2085
 msgid "unexpected 'ready' from remote"
 msgstr "oväntat \"ready\" från fjärr"
 
-#: fetch-pack.c:2098
+#: fetch-pack.c:2108
 #, c-format
 msgid "no such remote ref %s"
 msgstr "ingen sådan fjärreferens: %s"
 
-#: fetch-pack.c:2101
+#: fetch-pack.c:2111
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Servern tillåter inte förfrågan om ej tillkännagivet objekt %s"
 
-#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
-#: gpg-interface.c:918
+#: gpg-interface.c:329 gpg-interface.c:457 gpg-interface.c:974
+#: gpg-interface.c:990
 msgid "could not create temporary file"
 msgstr "kunde inte skapa temporära fil"
 
-#: gpg-interface.c:332 gpg-interface.c:454
+#: gpg-interface.c:332 gpg-interface.c:460
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "misslyckades skriva fristående signatur till \"%s\""
 
-#: gpg-interface.c:445
+#: gpg-interface.c:451
 msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
@@ -4313,7 +4313,7 @@ msgstr ""
 "gpg.ssh.allowedSignersFile måste ställas in och finnas för att bekräfta ssh-"
 "signaturer"
 
-#: gpg-interface.c:469
+#: gpg-interface.c:480
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
@@ -4321,56 +4321,56 @@ msgstr ""
 "\"ssh-keygen -Y find-principals/verify\" behövs för att bekräfta ssh-"
 "signaturer (tillgängligt i openssh version 8.2p1+)"
 
-#: gpg-interface.c:523
+#: gpg-interface.c:536
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
 msgstr "återkallningsfilen för ssh-signering inställd men saknas: %s"
 
-#: gpg-interface.c:576
+#: gpg-interface.c:624
 #, c-format
 msgid "bad/incompatible signature '%s'"
 msgstr "felaktig/inkompatibel signatur \"%s\""
 
-#: gpg-interface.c:735 gpg-interface.c:740
+#: gpg-interface.c:801 gpg-interface.c:806
 #, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
 msgstr "misslyckades hämta ssh-fingeravtrycket för nyckeln \"%s\""
 
-#: gpg-interface.c:762
+#: gpg-interface.c:829
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
 msgstr ""
 "måste konfigurera antingen user.signingkey eller gpg.ssh.defaultKeyCommand"
 
-#: gpg-interface.c:780
+#: gpg-interface.c:851
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
 msgstr "gpg.ssh.defaultKeyCommand lyckades men gav inga nycklar: %s %s"
 
-#: gpg-interface.c:786
+#: gpg-interface.c:857
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
 msgstr "gpg.ssh.defaultKeyCommand misslyckades: %s %s"
 
-#: gpg-interface.c:874
+#: gpg-interface.c:945
 msgid "gpg failed to sign the data"
 msgstr "gpg misslyckades signera data"
 
-#: gpg-interface.c:895
+#: gpg-interface.c:967
 msgid "user.signingkey needs to be set for ssh signing"
 msgstr "user.signingkey måste anges för ssh-signering"
 
-#: gpg-interface.c:906
+#: gpg-interface.c:978
 #, c-format
 msgid "failed writing ssh signing key to '%s'"
 msgstr "misslyckades skriva ssh-signeringsnyckel till \"%s\""
 
-#: gpg-interface.c:924
+#: gpg-interface.c:996
 #, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
 msgstr "misslyckades skriva ssh-signeringsnyckelbuffert till \"%s\""
 
-#: gpg-interface.c:942
+#: gpg-interface.c:1014
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
@@ -4378,7 +4378,7 @@ msgstr ""
 "\"ssh-keygen -Y sign\" behövs för ssh-signering (tillgängligt i openssh "
 "version 8.2p1+)"
 
-#: gpg-interface.c:954
+#: gpg-interface.c:1026
 #, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
 msgstr "misslyckades läsa ssh-signeringsdatabuffert från \"%s\""
@@ -4388,7 +4388,7 @@ msgstr "misslyckades läsa ssh-signeringsdatabuffert från \"%s\""
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "ignorerade felaktig färg \"%.*s\" i log.graphColors"
 
-#: grep.c:533
+#: grep.c:531
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4396,18 +4396,18 @@ msgstr ""
 "angivet mönster innehåller NULL-byte (via -f <fil>). Detta stöds endast med -"
 "P under PCRE v2"
 
-#: grep.c:1928
+#: grep.c:1942
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "\"%s\" kunde inte läsa %s"
 
-#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
+#: grep.c:1959 setup.c:177 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "misslyckades ta status på \"%s\""
 
-#: grep.c:1956
+#: grep.c:1970
 #, c-format
 msgid "'%s': short read"
 msgstr "\"%s\": kort läsning"
@@ -4528,8 +4528,8 @@ msgstr "Fortsätter under förutsättningen att du menade \"%s\"."
 
 #: help.c:646
 #, c-format
-msgid "Run '%s' instead? (y/N)"
-msgstr "Köra \"%s\" istället? (j/N)"
+msgid "Run '%s' instead [y/N]? "
+msgstr "Köra \"%s\" istället (j/N)?"
 
 #: help.c:654
 #, c-format
@@ -4753,7 +4753,7 @@ msgstr "förväntade \"flush\" efter ls-refs-argument"
 msgid "quoted CRLF detected"
 msgstr "citerad CRLF upptäcktes"
 
-#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:184 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "felaktig funktion \"%s\" för \"%s\""
@@ -4986,7 +4986,7 @@ msgstr "undermodul"
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "KONFLIKT (%s): Sammanslagningskonflikt i %s"
 
-#: merge-ort.c:3856
+#: merge-ort.c:3869
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4995,7 +4995,7 @@ msgstr ""
 "KONFLIKT (ändra/radera): %s raderad i %s och ändrad i %s. Versionen %s av %s "
 "lämnad i trädet."
 
-#: merge-ort.c:4152
+#: merge-ort.c:4165
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -5007,7 +5007,7 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4521
+#: merge-ort.c:4534
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "samling av sammanslagningsinfo misslyckades för träden %s, %s, %s"
@@ -5022,7 +5022,7 @@ msgstr ""
 "sammanslagning:\n"
 "  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:405
 msgid "Already up to date."
 msgstr "Redan à jour."
 
@@ -5304,7 +5304,7 @@ msgstr "sammanslagningen returnerade ingen incheckning"
 msgid "Could not parse object '%s'"
 msgstr "Kunde inte tolka objektet \"%s\""
 
-#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: merge-recursive.c:3834 builtin/merge.c:720 builtin/merge.c:906
 #: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "Kunde inte skriva indexet."
@@ -5313,8 +5313,8 @@ msgstr "Kunde inte skriva indexet."
 msgid "failed to read the cache"
 msgstr "misslyckades läsa cachen"
 
-#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
-#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: merge.c:102 rerere.c:704 builtin/am.c:1988 builtin/am.c:2022
+#: builtin/checkout.c:598 builtin/checkout.c:853 builtin/clone.c:706
 #: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "kunde inte skriva ny indexfil"
@@ -5323,212 +5323,212 @@ msgstr "kunde inte skriva ny indexfil"
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "multi-pack-indexets OID-utbredning har fel storlek"
 
-#: midx.c:109
+#: midx.c:111
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-indexfilen %s är för liten"
 
-#: midx.c:125
+#: midx.c:127
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "multi-pack-indexsignaturen 0x%08x stämmer inte med signaturen 0x%08x"
 
-#: midx.c:130
+#: midx.c:132
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-indexversionen %d stöds inte"
 
-#: midx.c:135
+#: midx.c:137
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "multi-pack-index-hashversionen %u stämmer inte med versionen %u"
 
-#: midx.c:152
+#: midx.c:154
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index saknar krävd paketnamn-stycke"
 
-#: midx.c:154
+#: midx.c:156
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index saknar krävt OID-utbredningsstycke"
 
-#: midx.c:156
+#: midx.c:158
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index saknar krävt OID-uppslagnignsstycke"
 
-#: midx.c:158
+#: midx.c:160
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index saknar krävt objekt-offsetstycke"
 
-#: midx.c:174
+#: midx.c:176
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "multi-pack-index-paketnamn i fel ordning: \"%s\" före \"%s\""
 
-#: midx.c:221
+#: midx.c:224
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "bad pack-int-id: %u (%u paket totalt)"
 
-#: midx.c:271
+#: midx.c:274
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr "multi-pack-index skriver 64-bitars offset, men off_t är för liten"
 
-#: midx.c:502
+#: midx.c:505
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "misslyckades läsa paketfilen \"%s\""
 
-#: midx.c:508
+#: midx.c:511
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "misslyckades öppna paketindexet \"%s\""
 
-#: midx.c:576
+#: midx.c:579
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "misslyckades hitta objekt %d i paketfilen"
 
-#: midx.c:892
+#: midx.c:895
 msgid "cannot store reverse index file"
 msgstr "kan inte spara reverse-index-fil"
 
-#: midx.c:990
+#: midx.c:993
 #, c-format
 msgid "could not parse line: %s"
 msgstr "kunde inte tolka rad: %s"
 
-#: midx.c:992
+#: midx.c:995
 #, c-format
 msgid "malformed line: %s"
 msgstr "felaktig rad: %s"
 
-#: midx.c:1159
+#: midx.c:1162
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr "ignorerar befintlig multi-pack-index; felaktig kontrollsumma"
 
-#: midx.c:1184
+#: midx.c:1187
 msgid "could not load pack"
 msgstr "kunde inte läsa paket{"
 
-#: midx.c:1190
+#: midx.c:1193
 #, c-format
 msgid "could not open index for %s"
 msgstr "kunde inte öppna indexet för %s"
 
-#: midx.c:1201
+#: midx.c:1204
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Lägger till paketfiler till multi-pack-index"
 
-#: midx.c:1244
+#: midx.c:1247
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "okänt föredraget paket: %s"
 
-#: midx.c:1289
+#: midx.c:1292
 #, c-format
 msgid "cannot select preferred pack %s with no objects"
 msgstr "kan inte välja föredraget paket %s som inte har några objekt"
 
-#: midx.c:1321
+#: midx.c:1324
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "såg inte paketfilen %s som skulle kastas"
 
-#: midx.c:1367
+#: midx.c:1370
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "föredraget paket \"%s\" har löpt ut"
 
-#: midx.c:1380
+#: midx.c:1383
 msgid "no pack files to index."
 msgstr "inga paketfiler att indexera."
 
-#: midx.c:1417
+#: midx.c:1420
 msgid "could not write multi-pack bitmap"
 msgstr "kunde inte skriva fler-paketsbitkarta"
 
-#: midx.c:1427
+#: midx.c:1430
 msgid "could not write multi-pack-index"
 msgstr "kunde inte skriva flerpakets-index"
 
-#: midx.c:1486 builtin/clean.c:37
+#: midx.c:1489 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "misslyckades ta bort %s"
 
-#: midx.c:1517
+#: midx.c:1522
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "misslyckades städa multi-pack-index på %s"
 
-#: midx.c:1577
+#: midx.c:1585
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "multi-pack-indexfilen finns, men kunde inte tolkas"
 
-#: midx.c:1585
+#: midx.c:1593
 msgid "incorrect checksum"
 msgstr "felaktig kontrollsumma"
 
-#: midx.c:1588
+#: midx.c:1596
 msgid "Looking for referenced packfiles"
 msgstr "Ser efter refererade packfiler"
 
-#: midx.c:1603
+#: midx.c:1611
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 "oid-utbredning i fel ordning: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1608
+#: midx.c:1616
 msgid "the midx contains no oid"
 msgstr "midx saknar oid"
 
-#: midx.c:1617
+#: midx.c:1625
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Bekräftar OID-ordning i multi-pack-index"
 
-#: midx.c:1626
+#: midx.c:1634
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "oid-uppslagning i fel ordning: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1646
+#: midx.c:1654
 msgid "Sorting objects by packfile"
 msgstr "Sorterar objekt efter packfil"
 
-#: midx.c:1653
+#: midx.c:1661
 msgid "Verifying object offsets"
 msgstr "Bekräftar offset för objekt"
 
-#: midx.c:1669
+#: midx.c:1677
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "misslyckades läsa paketpost för oid[%d] = %s"
 
-#: midx.c:1675
+#: midx.c:1683
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "misslyckades läsa paketindex för paketfil %s"
 
-#: midx.c:1684
+#: midx.c:1692
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "felaktigt objekt-offset för oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1709
+#: midx.c:1719
 msgid "Counting referenced objects"
 msgstr "Räknar refererade objekt"
 
-#: midx.c:1719
+#: midx.c:1729
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Ser efter och tar bort orefererade packfiler"
 
-#: midx.c:1911
+#: midx.c:1921
 msgid "could not start pack-objects"
 msgstr "kunde inte starta pack-objects"
 
-#: midx.c:1931
+#: midx.c:1941
 msgid "could not finish pack-objects"
 msgstr "kunde inte avsluta pack-objects"
 
@@ -5587,258 +5587,258 @@ msgstr "Vägrar skriva över anteckningar i %s (utanför refs/notes/)"
 msgid "Bad %s value: '%s'"
 msgstr "Felaktigt värde på %s: \"%s\""
 
-#: object-file.c:459
+#: object-file.c:456
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr "objektkatalogen %s finns inte; se .git/objects/info/alternates"
 
-#: object-file.c:517
+#: object-file.c:514
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "kunde inte normalisera supplerande objektsökväg: %s"
 
-#: object-file.c:591
+#: object-file.c:588
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: ignorerar supplerande objektlager, för djup nästling"
 
-#: object-file.c:598
+#: object-file.c:595
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "kan inte normalisera objektkatalogen: %s"
 
-#: object-file.c:641
+#: object-file.c:638
 msgid "unable to fdopen alternates lockfile"
 msgstr "kan inte utföra \"fdopen\" på suppleantlåsfil"
 
-#: object-file.c:659
+#: object-file.c:656
 msgid "unable to read alternates file"
 msgstr "kan inte läsa \"alternates\"-filen"
 
-#: object-file.c:666
+#: object-file.c:663
 msgid "unable to move new alternates file into place"
 msgstr "kan inte flytta ny \"alternates\"-fil på plats"
 
-#: object-file.c:701
+#: object-file.c:741
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "sökvägen \"%s\" finns inte"
 
-#: object-file.c:722
+#: object-file.c:762
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr "referensarkivet \"%s\" som en länkad utcheckning stöds inte ännu."
 
-#: object-file.c:728
+#: object-file.c:768
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "referensarkivet \"%s\" är inte ett lokalt arkiv."
 
-#: object-file.c:734
+#: object-file.c:774
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "referensarkivet \"%s\" är grunt"
 
-#: object-file.c:742
+#: object-file.c:782
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "referensarkivet \"%s\" är ympat"
 
-#: object-file.c:773
+#: object-file.c:813
 #, c-format
 msgid "could not find object directory matching %s"
 msgstr "kunde inte hitta objektkatalog för %s"
 
-#: object-file.c:823
+#: object-file.c:863
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "felaktig rad vid tolkning av supplerande referenser: %s"
 
-#: object-file.c:973
+#: object-file.c:1013
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "försök att utföra \"mmap\" på %<PRIuMAX> över gränsen %<PRIuMAX>"
 
-#: object-file.c:1008
+#: object-file.c:1048
 #, c-format
 msgid "mmap failed%s"
 msgstr "mmap misslyckades%s"
 
-#: object-file.c:1174
+#: object-file.c:1214
 #, c-format
 msgid "object file %s is empty"
 msgstr "objektfilen %s är tom"
 
-#: object-file.c:1293 object-file.c:2499
+#: object-file.c:1333 object-file.c:2542
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "trasigt löst objekt \"%s\""
 
-#: object-file.c:1295 object-file.c:2503
+#: object-file.c:1335 object-file.c:2546
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "skräp i slutet av löst objekt \"%s\""
 
-#: object-file.c:1417
+#: object-file.c:1457
 #, c-format
 msgid "unable to parse %s header"
 msgstr "kan inte tolka %s-huvud"
 
-#: object-file.c:1419
+#: object-file.c:1459
 msgid "invalid object type"
 msgstr "felaktig objekttyp"
 
-#: object-file.c:1430
+#: object-file.c:1470
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "kan inte packa upp %s-huvudet"
 
-#: object-file.c:1434
+#: object-file.c:1474
 #, c-format
 msgid "header for %s too long, exceeds %d bytes"
 msgstr "huvudet för %s är för långt, mer än %d byte"
 
-#: object-file.c:1664
+#: object-file.c:1704
 #, c-format
 msgid "failed to read object %s"
 msgstr "misslyckades läsa objektet %s"
 
-#: object-file.c:1668
+#: object-file.c:1708
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "ersättningen %s hittades inte för %s"
 
-#: object-file.c:1672
+#: object-file.c:1712
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "löst objekt %s (lagrat i %s) är trasigt"
 
-#: object-file.c:1676
+#: object-file.c:1716
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "packat objekt %s (lagrat i %s) är trasigt"
 
-#: object-file.c:1781
+#: object-file.c:1821
 #, c-format
 msgid "unable to write file %s"
 msgstr "kunde inte skriva filen %s"
 
-#: object-file.c:1788
+#: object-file.c:1828
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "kan inte sätta behörigheten till \"%s\""
 
-#: object-file.c:1795
+#: object-file.c:1835
 msgid "file write error"
 msgstr "fel vid skrivning av fil"
 
-#: object-file.c:1815
+#: object-file.c:1858
 msgid "error when closing loose object file"
 msgstr "fel vid stängning av fil för löst objekt"
 
-#: object-file.c:1882
+#: object-file.c:1925
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "otillräcklig behörighet för att lägga till objekt till arkivdatabasen %s"
 
-#: object-file.c:1884
+#: object-file.c:1927
 msgid "unable to create temporary file"
 msgstr "kan inte skapa temporär fil"
 
-#: object-file.c:1908
+#: object-file.c:1951
 msgid "unable to write loose object file"
 msgstr "kunde inte skriva fil för löst objekt"
 
-#: object-file.c:1914
+#: object-file.c:1957
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "kan inte utföra \"deflate\" på nytt objekt %s (%d)"
 
-#: object-file.c:1918
+#: object-file.c:1961
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "\"deflateend\" på objektet %s misslyckades (%d)"
 
-#: object-file.c:1922
+#: object-file.c:1965
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "förvirrad av instabil objektkälldata för %s"
 
-#: object-file.c:1933 builtin/pack-objects.c:1243
+#: object-file.c:1976 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "\"utime()\" misslyckades på %s"
 
-#: object-file.c:2011
+#: object-file.c:2054
 #, c-format
 msgid "cannot read object for %s"
 msgstr "kan inte läsa objekt för %s"
 
-#: object-file.c:2062
+#: object-file.c:2105
 msgid "corrupt commit"
 msgstr "trasik incheckning"
 
-#: object-file.c:2070
+#: object-file.c:2113
 msgid "corrupt tag"
 msgstr "trasig tagg"
 
-#: object-file.c:2170
+#: object-file.c:2213
 #, c-format
 msgid "read error while indexing %s"
 msgstr "läsfel vid indexering av %s"
 
-#: object-file.c:2173
+#: object-file.c:2216
 #, c-format
 msgid "short read while indexing %s"
 msgstr "för lite lästes vid indexering av %s"
 
-#: object-file.c:2246 object-file.c:2256
+#: object-file.c:2289 object-file.c:2299
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: misslyckades lägga in i databasen"
 
-#: object-file.c:2262
+#: object-file.c:2305
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: filtypen stöds ej"
 
-#: object-file.c:2286 builtin/fetch.c:1445
+#: object-file.c:2329 builtin/fetch.c:1448
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s är inte ett giltigt objekt"
 
-#: object-file.c:2288
+#: object-file.c:2331
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s är inte ett giltigt \"%s\"-objekt"
 
-#: object-file.c:2315
+#: object-file.c:2358
 #, c-format
 msgid "unable to open %s"
 msgstr "kan inte öppna %s"
 
-#: object-file.c:2510
+#: object-file.c:2553
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "hash stämmer inte för %s (förväntade %s)"
 
-#: object-file.c:2533
+#: object-file.c:2576
 #, c-format
 msgid "unable to mmap %s"
 msgstr "kan inte utföra \"mmap\" för %s"
 
-#: object-file.c:2539
+#: object-file.c:2582
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "kan inte packa upp huvud för %s"
 
-#: object-file.c:2544
+#: object-file.c:2587
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "kan inte tolka huvud för %s"
 
-#: object-file.c:2555
+#: object-file.c:2598
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "kan inte tolka innehåll i %s"
@@ -5965,25 +5965,25 @@ msgstr "kunde inte tolka objektet: %s"
 msgid "hash mismatch %s"
 msgstr "hashvärde stämmer inte överens %s"
 
-#: pack-bitmap.c:348
+#: pack-bitmap.c:353
 msgid "multi-pack bitmap is missing required reverse index"
 msgstr "flerpaketsbitkarta saknar nödvändigt omvänt index"
 
-#: pack-bitmap.c:424
+#: pack-bitmap.c:429
 msgid "load_reverse_index: could not open pack"
 msgstr "load_reverse_index: kunde inte öppna paket"
 
-#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
+#: pack-bitmap.c:1069 pack-bitmap.c:1075 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "kan inte hämta storlek på %s"
 
-#: pack-bitmap.c:1916
+#: pack-bitmap.c:1935
 #, c-format
 msgid "could not find %s in pack %s at offset %<PRIuMAX>"
 msgstr "kunde inte hitta %s i paketet %s på offset %<PRIuMAX>"
 
-#: pack-bitmap.c:1952 builtin/rev-list.c:92
+#: pack-bitmap.c:1971 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "kan inte hämta diskanvändning för %s"
@@ -6032,45 +6032,50 @@ msgstr "kunde inte göra %s läsbar"
 msgid "could not write '%s' promisor file"
 msgstr "kunde inte skriva kontraktsfilen \"%s\""
 
-#: packfile.c:626
+#: packfile.c:627
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "offset före slutet av packfilen (trasig .idx?)"
 
-#: packfile.c:656
+#: packfile.c:657
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "paketfilen %s kunde inte kopplas%s"
 
-#: packfile.c:1923
+#: packfile.c:1924
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "offset före slutet av packindex för %s (trasigt index?)"
 
-#: packfile.c:1927
+#: packfile.c:1928
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr "offset borton slutet av packindex för %s (trunkerat index?)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
+#: parse-options-cb.c:21 parse-options-cb.c:25 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "flaggan \"%s\" antar ett numeriskt värde"
 
-#: parse-options-cb.c:41
+#: parse-options-cb.c:42
 #, c-format
 msgid "malformed expiration date '%s'"
 msgstr "trasigt utlöpsdatum: \"%s\""
 
-#: parse-options-cb.c:54
+#: parse-options-cb.c:55
 #, c-format
 msgid "option `%s' expects \"always\", \"auto\", or \"never\""
 msgstr ""
 "flaggan \"%s\" antar \"always\" (alltid), \"auto\" eller \"never\" (aldrig)"
 
-#: parse-options-cb.c:132 parse-options-cb.c:149
+#: parse-options-cb.c:133 parse-options-cb.c:150
 #, c-format
 msgid "malformed object name '%s'"
 msgstr "felformat objektnamn \"%s\""
+
+#: parse-options-cb.c:307
+#, c-format
+msgid "option `%s' expects \"%s\" or \"%s\""
+msgstr "flaggan \"%s\" kräver \"%s\" eller \"%s\""
 
 #: parse-options.c:58
 #, c-format
@@ -6107,36 +6112,36 @@ msgstr "%s förväntar ett icke-negativt heltalsvärde, med valfritt k/m/g-suffi
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "tvetydig flagga: %s (kan vara --%s%s eller --%s%s)"
 
-#: parse-options.c:427 parse-options.c:435
+#: parse-options.c:428 parse-options.c:436
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "menade du \"--%s\" (med två bindestreck)?"
 
-#: parse-options.c:677 parse-options.c:1053
+#: parse-options.c:678 parse-options.c:1054
 #, c-format
 msgid "alias of --%s"
 msgstr "alias för --%s"
 
-#: parse-options.c:891
+#: parse-options.c:892
 #, c-format
 msgid "unknown option `%s'"
 msgstr "okänd flagga \"%s\""
 
-#: parse-options.c:893
+#: parse-options.c:894
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "okänd flagga \"%c\""
 
-#: parse-options.c:895
+#: parse-options.c:896
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "okänd icke-ascii-flagga i strängen: \"%s\""
 
-#: parse-options.c:919
+#: parse-options.c:920
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:933
+#: parse-options.c:934
 #, c-format
 msgid "usage: %s"
 msgstr "användning: %s"
@@ -6144,7 +6149,7 @@ msgstr "användning: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:948
+#: parse-options.c:949
 #, c-format
 msgid "   or: %s"
 msgstr "     eller: %s"
@@ -6168,17 +6173,17 @@ msgstr "     eller: %s"
 #. translated) N_() usage string, which contained embedded
 #. newlines before we split it up.
 #.
-#: parse-options.c:969
+#: parse-options.c:970
 #, c-format
 msgid "%*s%s"
 msgstr "%*s%s"
 
-#: parse-options.c:992
+#: parse-options.c:993
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:1039
+#: parse-options.c:1040
 msgid "-NUM"
 msgstr "-TAL"
 
@@ -6307,17 +6312,17 @@ msgstr "läsfel"
 msgid "the remote end hung up unexpectedly"
 msgstr "fjärren lade på oväntat"
 
-#: pkt-line.c:390 pkt-line.c:392
+#: pkt-line.c:417 pkt-line.c:419
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "protokollfel: felaktig radlängdstecken: %.4s"
 
-#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
+#: pkt-line.c:434 pkt-line.c:436 pkt-line.c:442 pkt-line.c:444
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "protokollfel: felaktig radlängd: %d"
 
-#: pkt-line.c:434 sideband.c:165
+#: pkt-line.c:472 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "fjärrfel: %s"
@@ -6369,7 +6374,7 @@ msgstr "kunde inte starta \"log\""
 msgid "could not read `log` output"
 msgstr "kunde inte läsa utdata från \"log\""
 
-#: range-diff.c:97 sequencer.c:5605
+#: range-diff.c:97 sequencer.c:5602
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "kunde inte tolka incheckningen \"%s\""
@@ -6392,60 +6397,56 @@ msgstr "kunde inte tolka git-huvudet \"%.*s\""
 msgid "failed to generate diff"
 msgstr "misslyckades skapa diff"
 
-#: range-diff.c:559
-msgid "--left-only and --right-only are mutually exclusive"
-msgstr "--left-only och --right-only är ömsesidigt uteslutande"
-
 #: range-diff.c:562 range-diff.c:564
 #, c-format
 msgid "could not parse log for '%s'"
 msgstr "kunde inte tolka loggen för \"%s\""
 
-#: read-cache.c:710
+#: read-cache.c:723
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr "lägger inte till filalias \"%s\" (\"%s\" finns redan i indexet)"
 
-#: read-cache.c:726
+#: read-cache.c:739
 msgid "cannot create an empty blob in the object database"
 msgstr "kan inte skapa tom blob i objektdatabasen"
 
-#: read-cache.c:748
+#: read-cache.c:761
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: kan bara lägga till vanliga filer, symboliska länkar och git-kataloger"
 
-#: read-cache.c:753 builtin/submodule--helper.c:3241
+#: read-cache.c:766 builtin/submodule--helper.c:3242
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "\"%s\" har inte någon utcheckad incheckning"
 
-#: read-cache.c:805
+#: read-cache.c:818
 #, c-format
 msgid "unable to index file '%s'"
 msgstr "kan inte indexera filen \"%s\""
 
-#: read-cache.c:824
+#: read-cache.c:837
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr "kan inte lägga till \"%s\" till indexet"
 
-#: read-cache.c:835
+#: read-cache.c:848
 #, c-format
 msgid "unable to stat '%s'"
 msgstr "kan inte ta status på \"%s\""
 
-#: read-cache.c:1373
+#: read-cache.c:1386
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "\"%s\" finns både som en fil och en katalog"
 
-#: read-cache.c:1588
+#: read-cache.c:1601
 msgid "Refresh index"
 msgstr "Uppdatera indexet"
 
-#: read-cache.c:1720
+#: read-cache.c:1733
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6454,7 +6455,7 @@ msgstr ""
 "index.version satt, men värdet är ogiltigt.\n"
 "Använder version %i"
 
-#: read-cache.c:1730
+#: read-cache.c:1743
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6463,143 +6464,143 @@ msgstr ""
 "GIT_INDEX_VERSION satt, men värdet är ogiltigt.\n"
 "Använder version %i"
 
-#: read-cache.c:1786
+#: read-cache.c:1799
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "felaktig signatur 0x%08x"
 
-#: read-cache.c:1789
+#: read-cache.c:1802
 #, c-format
 msgid "bad index version %d"
 msgstr "felaktig indexversion %d"
 
-#: read-cache.c:1798
+#: read-cache.c:1811
 msgid "bad index file sha1 signature"
 msgstr "felaktig sha1-signatur för indexfil"
 
-#: read-cache.c:1832
+#: read-cache.c:1845
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "index använder filtillägget %.4s, vilket vi inte förstår"
 
-#: read-cache.c:1834
+#: read-cache.c:1847
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "ignorerar filtillägget %.4s"
 
-#: read-cache.c:1871
+#: read-cache.c:1884
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "okänt format 0x%08x på indexpost"
 
-#: read-cache.c:1887
+#: read-cache.c:1900
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "felformat namnfält i indexet, nära sökvägen \"%s\""
 
-#: read-cache.c:1944
+#: read-cache.c:1957
 msgid "unordered stage entries in index"
 msgstr "osorterade köposter i index"
 
-#: read-cache.c:1947
+#: read-cache.c:1960
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "flera köposter för den sammanslagna filen \"%s\""
 
-#: read-cache.c:1950
+#: read-cache.c:1963
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "osorterade köposter för \"%s\""
 
-#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: read-cache.c:2078 read-cache.c:2384 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:600 builtin/check-ignore.c:183
+#: builtin/checkout.c:527 builtin/checkout.c:719 builtin/clean.c:1013
 #: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
-#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
-#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
+#: builtin/mv.c:148 builtin/reset.c:499 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3202
 msgid "index file corrupt"
 msgstr "indexfilen trasig"
 
-#: read-cache.c:2209
+#: read-cache.c:2222
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "kunde inte skapa tråd för load_cache_entries: %s"
 
-#: read-cache.c:2222
+#: read-cache.c:2235
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "kunde inte ansluta till tråden för load_cache_entries: %s"
 
-#: read-cache.c:2255
+#: read-cache.c:2268
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: öppning av indexfilen misslyckades"
 
-#: read-cache.c:2259
+#: read-cache.c:2272
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: kan inte ta startus på det öppna indexet"
 
-#: read-cache.c:2263
+#: read-cache.c:2276
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: indexfilen mindre än förväntat"
 
-#: read-cache.c:2267
+#: read-cache.c:2280
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: kan inte koppla indexfilen%s"
 
-#: read-cache.c:2310
+#: read-cache.c:2323
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "kunde inte skapa load_index_extensions-tråden: %s"
 
-#: read-cache.c:2337
+#: read-cache.c:2350
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "kunde inte utföra join på load_index_extensions-tråden: %s"
 
-#: read-cache.c:2375
+#: read-cache.c:2396
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "kunde inte uppdatera delat index \"%s\""
 
-#: read-cache.c:2434
+#: read-cache.c:2455
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "trasigt index, förväntade %s i %s, fick %s"
 
-#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
+#: read-cache.c:3086 strbuf.c:1191 wrapper.c:641 builtin/merge.c:1150
 #, c-format
 msgid "could not close '%s'"
 msgstr "kunde inte stänga \"%s\""
 
-#: read-cache.c:3108
+#: read-cache.c:3129
 msgid "failed to convert to a sparse-index"
 msgstr "misslyckades omvandla till glest index"
 
-#: read-cache.c:3179
+#: read-cache.c:3200
 #, c-format
 msgid "could not stat '%s'"
 msgstr "kunde inte ta status på \"%s\""
 
-#: read-cache.c:3192
+#: read-cache.c:3213
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "kunde inte öppna git-katalog: %s"
 
-#: read-cache.c:3204
+#: read-cache.c:3225
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "misslyckades ta bort länken: %s"
 
-#: read-cache.c:3233
+#: read-cache.c:3254
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "kan inte rätta behörighetsbitar på \"%s\""
 
-#: read-cache.c:3390
+#: read-cache.c:3411
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: kan inte återgå till kö 0"
@@ -6723,8 +6724,8 @@ msgstr ""
 "Ombaseringen kommer dock att avbrytas om du tar bort allting.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
-#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3883
+#: sequencer.c:3909 sequencer.c:5708 builtin/fsck.c:328 builtin/gc.c:1791
 #: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
@@ -6769,7 +6770,7 @@ msgstr ""
 msgid "%s: 'preserve' superseded by 'merges'"
 msgstr "%s: \"preserve\" har ersatts av \"merges\""
 
-#: ref-filter.c:42 wt-status.c:2036
+#: ref-filter.c:42 wt-status.c:2048
 msgid "gone"
 msgstr "försvunnen"
 
@@ -6808,7 +6809,8 @@ msgstr "Heltalsvärde förväntades refname:lstrip=%s"
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Heltalsvärde förväntades refname:rstrip=%s"
 
-#: ref-filter.c:265
+#: ref-filter.c:265 ref-filter.c:344 ref-filter.c:377 ref-filter.c:431
+#: ref-filter.c:443 ref-filter.c:462 ref-filter.c:534 ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "okänt %%(%s)-argument: %s"
@@ -6817,11 +6819,6 @@ msgstr "okänt %%(%s)-argument: %s"
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) tar inte argument"
-
-#: ref-filter.c:344
-#, c-format
-msgid "unrecognized %%(objectsize) argument: %s"
-msgstr "okänt %%(objectsize)-argument: %s"
 
 #: ref-filter.c:352
 #, c-format
@@ -6832,11 +6829,6 @@ msgstr "%%(deltabase) tar inte argument"
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) tar inte argument"
-
-#: ref-filter.c:377
-#, c-format
-msgid "unrecognized %%(subject) argument: %s"
-msgstr "okänt %%(subject)-argument: %s"
 
 #: ref-filter.c:396
 #, c-format
@@ -6853,25 +6845,10 @@ msgstr "okänt %%(trailers)-argument: %s"
 msgid "positive value expected contents:lines=%s"
 msgstr "positivt värde förväntat contents:lines=%s"
 
-#: ref-filter.c:431
-#, c-format
-msgid "unrecognized %%(contents) argument: %s"
-msgstr "okänt %%(contents)-argument: %s"
-
-#: ref-filter.c:443
-#, c-format
-msgid "unrecognized %%(raw) argument: %s"
-msgstr "okänt %%(raw)-argument: %s"
-
 #: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "positivt värde förväntat \"%s\" i %%(%s)"
-
-#: ref-filter.c:462
-#, c-format
-msgid "unrecognized argument '%s' in %%(%s)"
-msgstr "okänt argument \"%s\" i %%(%s)"
 
 #: ref-filter.c:476
 #, c-format
@@ -6893,20 +6870,10 @@ msgstr "okänd position:%s"
 msgid "unrecognized width:%s"
 msgstr "okänd bredd:%s"
 
-#: ref-filter.c:534
-#, c-format
-msgid "unrecognized %%(align) argument: %s"
-msgstr "okänt %%(align)-argument: %s"
-
 #: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "positiv bredd förväntad med atomen %%(align)"
-
-#: ref-filter.c:560
-#, c-format
-msgid "unrecognized %%(if) argument: %s"
-msgstr "okänt %%(if)-argument: %s"
 
 #: ref-filter.c:568
 #, c-format
@@ -6930,15 +6897,10 @@ msgid ""
 msgstr ""
 "inte ett git-arkiv, men fältet \"%.*s\" kräver tillgång till objektdata"
 
-#: ref-filter.c:844
+#: ref-filter.c:844 ref-filter.c:910 ref-filter.c:946 ref-filter.c:948
 #, c-format
-msgid "format: %%(if) atom used without a %%(then) atom"
-msgstr "format: atomen %%(if) använd utan en %%(then)-atom"
-
-#: ref-filter.c:910
-#, c-format
-msgid "format: %%(then) atom used without an %%(if) atom"
-msgstr "format: atomen %%(then) använd utan en %%(if)-atom"
+msgid "format: %%(%s) atom used without a %%(%s) atom"
+msgstr "format: atomen %%(%s) använd utan en %%(%s)-atom"
 
 #: ref-filter.c:912
 #, c-format
@@ -6949,16 +6911,6 @@ msgstr "format: atomen %%(then) använd mer än en gång"
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: atomen %%(then) använd efter %%(else)"
-
-#: ref-filter.c:946
-#, c-format
-msgid "format: %%(else) atom used without an %%(if) atom"
-msgstr "format: atomen %%(else) använd utan en %%(if)-atom"
-
-#: ref-filter.c:948
-#, c-format
-msgid "format: %%(else) atom used without a %%(then) atom"
-msgstr "format: atomen %%(else) använd utan en %%(then)-atom"
 
 #: ref-filter.c:950
 #, c-format
@@ -7034,22 +6986,22 @@ msgstr "felformat objekt vid \"%s\""
 msgid "ignoring ref with broken name %s"
 msgstr "ignorerar referens med trasigt namn %s"
 
-#: ref-filter.c:2250 refs.c:673
+#: ref-filter.c:2250 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "ignorerar trasig referens %s"
 
-#: ref-filter.c:2623
+#: ref-filter.c:2629
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "format: atomen %%(end) saknas"
 
-#: ref-filter.c:2726
+#: ref-filter.c:2740
 #, c-format
 msgid "malformed object name %s"
 msgstr "felformat objektnamn %s"
 
-#: ref-filter.c:2731
+#: ref-filter.c:2745
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "flaggan \"%s\" måste peka på en incheckning"
@@ -7094,71 +7046,71 @@ msgstr "kunde inte hämta \"%s\""
 msgid "invalid branch name: %s = %s"
 msgstr "felaktigt namn på gren: %s = %s"
 
-#: refs.c:671
+#: refs.c:674
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "ignorerar dinglande symbolisk referens %s"
 
-#: refs.c:920
+#: refs.c:925
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "loggen för referensen %s har lucka efter %s"
 
-#: refs.c:927
+#: refs.c:932
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "loggen för referensen %s slutade oväntat på %s"
 
-#: refs.c:992
+#: refs.c:997
 #, c-format
 msgid "log for %s is empty"
 msgstr "loggen för %s är tom"
 
-#: refs.c:1084
+#: refs.c:1090
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "vägrar uppdatera referens med trasigt namn \"%s\""
 
-#: refs.c:1155
+#: refs.c:1168
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref misslyckades för referensen \"%s\": %s"
 
-#: refs.c:2062
+#: refs.c:2069
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "flera uppdateringar för referensen \"%s\" tillåts inte"
 
-#: refs.c:2142
+#: refs.c:2152
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "referensuppdateringar förbjudna i karantänmiljö"
 
-#: refs.c:2153
+#: refs.c:2163
 msgid "ref updates aborted by hook"
 msgstr "referensuppdateringar avbrutna av krok"
 
-#: refs.c:2253 refs.c:2283
+#: refs.c:2271 refs.c:2301
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "\"%s\" finns; kan inte skapa \"%s\""
 
-#: refs.c:2259 refs.c:2294
+#: refs.c:2277 refs.c:2312
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "kan inte hantera \"%s\" och \"%s\" samtidigt"
 
-#: refs/files-backend.c:1271
+#: refs/files-backend.c:1268
 #, c-format
 msgid "could not remove reference %s"
 msgstr "kunde inte ta bort referensen %s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/files-backend.c:1282 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "kunde inte ta bort referensen %s: %s"
 
-#: refs/files-backend.c:1288 refs/packed-backend.c:1562
+#: refs/files-backend.c:1285 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "kunde inte ta bort referenser: %s"
@@ -7168,50 +7120,50 @@ msgstr "kunde inte ta bort referenser: %s"
 msgid "invalid refspec '%s'"
 msgstr "felaktig referensspecifikation: \"%s\""
 
-#: remote.c:351
+#: remote.c:402
 #, c-format
 msgid "config remote shorthand cannot begin with '/': %s"
 msgstr "konfigurerad kortform för fjärr kan inte börja med \"/\": %s"
 
-#: remote.c:399
+#: remote.c:450
 msgid "more than one receivepack given, using the first"
 msgstr "mer än en receivepack angavs, använder den första"
 
-#: remote.c:407
+#: remote.c:458
 msgid "more than one uploadpack given, using the first"
 msgstr "mer än en uploadpack angavs, använder den första"
 
-#: remote.c:590
+#: remote.c:699
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Kan inte hämta både %s och %s till %s"
 
-#: remote.c:594
+#: remote.c:703
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s spårar vanligtvis %s, inte %s"
 
-#: remote.c:598
+#: remote.c:707
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s spårar både %s och %s"
 
-#: remote.c:666
+#: remote.c:775
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "nyckeln \"%s\" i mönstret innehåller ingen \"*\""
 
-#: remote.c:676
+#: remote.c:785
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "värdet \"%s\" i mönstret innehåller ingen \"*\""
 
-#: remote.c:1083
+#: remote.c:1192
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "käll-referensspecifikationen %s motsvarar ingen"
 
-#: remote.c:1088
+#: remote.c:1197
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr "käll-referensspecifikationen %s motsvarar mer än en"
@@ -7220,7 +7172,7 @@ msgstr "käll-referensspecifikationen %s motsvarar mer än en"
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1103
+#: remote.c:1212
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -7243,7 +7195,7 @@ msgstr ""
 "\n"
 "Inget av dem fungerade, så vi gav upp. Ange fullständig referens."
 
-#: remote.c:1123
+#: remote.c:1232
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -7254,7 +7206,7 @@ msgstr ""
 "Var det meningen att skapa en ny gren genom att sända\n"
 "till \"%s:refs/heads/%s\"?"
 
-#: remote.c:1128
+#: remote.c:1237
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -7265,7 +7217,7 @@ msgstr ""
 "Var det meningen att skapa en ny tagg genom att sända\n"
 "till \"%s:refs/tags/%s\"?"
 
-#: remote.c:1133
+#: remote.c:1242
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -7276,7 +7228,7 @@ msgstr ""
 "Var det meningen att tagga ett nytt träd genom att sända\n"
 "till \"%s:refs/tags/%s\"?"
 
-#: remote.c:1138
+#: remote.c:1247
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -7287,114 +7239,114 @@ msgstr ""
 "Var det meningen att tagga en ny blob genom att sända\n"
 "till \"%s:refs/tags/%s\"?"
 
-#: remote.c:1174
+#: remote.c:1283
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "%s kan inte slås upp till en gren"
 
-#: remote.c:1185
+#: remote.c:1294
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "kan inte ta bort \"%s\": fjärreferensen finns inte"
 
-#: remote.c:1197
+#: remote.c:1306
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr "fjärr-referensspecifikationen \"%s\" motsvarar mer än en"
 
-#: remote.c:1204
+#: remote.c:1313
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr "fjärr-referensen \"%s\" hämtar från mer än en källa"
 
-#: remote.c:1724 remote.c:1825
+#: remote.c:1834 remote.c:1941
 msgid "HEAD does not point to a branch"
 msgstr "HEAD pekar inte på en gren"
 
-#: remote.c:1733
+#: remote.c:1843
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "okänd gren: \"%s\""
 
-#: remote.c:1736
+#: remote.c:1846
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "ingen standarduppström angiven för grenen \"%s\""
 
-#: remote.c:1742
+#: remote.c:1852
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "uppströmsgrenen \"%s\" är inte lagrad som en fjärrspårande gren"
 
-#: remote.c:1757
+#: remote.c:1867
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr "push-målet \"%s\" på fjärren \"%s\" har ingen lokalt spårande gren"
 
-#: remote.c:1769
+#: remote.c:1882
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "grenen \"%s\" har ingen fjärr för \"push\""
 
-#: remote.c:1779
+#: remote.c:1892
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "\"push\"-referensspecifikation för \"%s\" innehåller inte \"%s\""
 
-#: remote.c:1792
+#: remote.c:1905
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "\"push\" har inget mål (push.default är \"ingenting\")"
 
-#: remote.c:1814
+#: remote.c:1927
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "\"enkel push\" motsvarar flera olika mål"
 
-#: remote.c:1943
+#: remote.c:2060
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "Kunde inte hitta fjärr-referensen %s"
 
-#: remote.c:1956
+#: remote.c:2073
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ignorerar märklig referens \"%s\" lokalt"
 
-#: remote.c:2119
+#: remote.c:2236
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Din gren är baserad på \"%s\", men den har försvunnit uppströms.\n"
 
-#: remote.c:2123
+#: remote.c:2240
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (använd \"git branch --unset-upstream\" för att rätta)\n"
 
-#: remote.c:2126
+#: remote.c:2243
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Din gren är à jour med \"%s\".\n"
 
-#: remote.c:2130
+#: remote.c:2247
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Din gren och \"%s\" pekar på olika incheckningar.\n"
 
-#: remote.c:2133
+#: remote.c:2250
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (använd \"%s\" för detaljer)\n"
 
-#: remote.c:2137
+#: remote.c:2254
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Din gren ligger före \"%s\" med %d incheckning.\n"
 msgstr[1] "Din gren ligger före \"%s\" med %d incheckningar.\n"
 
-#: remote.c:2143
+#: remote.c:2260
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (använd \"git push\" för att publicera dina lokala incheckningar)\n"
 
-#: remote.c:2146
+#: remote.c:2263
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -7404,11 +7356,11 @@ msgstr[0] ""
 msgstr[1] ""
 "Din gren ligger efter \"%s\" med %d incheckningar, och kan snabbspolas.\n"
 
-#: remote.c:2154
+#: remote.c:2271
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (använd \"git pull\" för att uppdatera din lokala gren)\n"
 
-#: remote.c:2157
+#: remote.c:2274
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -7423,11 +7375,11 @@ msgstr[1] ""
 "Din gren och \"%s\" har divergerat,\n"
 "och har %d respektive %d olika incheckningar.\n"
 
-#: remote.c:2167
+#: remote.c:2284
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr "  (använd \"git pull\" för att slå ihop fjärrgrenen med din egen)\n"
 
-#: remote.c:2359
+#: remote.c:2476
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "kan inte tolka förväntat objektnamn \"%s\""
@@ -7460,7 +7412,7 @@ msgstr "kunde inte skriva rerere-post"
 msgid "there were errors while writing '%s' (%s)"
 msgstr "fel vid skrivning av \"%s\" (%s)"
 
-#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
+#: rerere.c:482 builtin/gc.c:2263 builtin/gc.c:2298
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "misslyckades spola \"%s\""
@@ -7505,8 +7457,8 @@ msgstr "kan inte ta bort lös länk \"%s\""
 msgid "Recorded preimage for '%s'"
 msgstr "Sparade förhandsbild för \"%s\""
 
-#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
-#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2017
+#: builtin/submodule--helper.c:1777 builtin/submodule--helper.c:1820
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "kunde inte skapa katalogen \"%s\""
@@ -7544,37 +7496,29 @@ msgstr "kan inte uppdatera katalogen rr-cache"
 msgid "could not determine HEAD revision"
 msgstr "kunde inte bestämma HEAD-revision"
 
-#: reset.c:70 reset.c:76 sequencer.c:3705
+#: reset.c:70 reset.c:76 sequencer.c:3700
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "kunde inte hitta trädet för %s."
 
-#: revision.c:2259
-msgid "--unsorted-input is incompatible with --no-walk"
-msgstr "--unsorted-input är inkompatibelt med --no-walk"
-
-#: revision.c:2346
+#: revision.c:2347
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<paketfil> stöds inte längre"
 
-#: revision.c:2655 revision.c:2659
-msgid "--no-walk is incompatible with --unsorted-input"
-msgstr "--no-walk är inkompatibelt med --unsorted-input"
-
-#: revision.c:2690
+#: revision.c:2686
 msgid "your current branch appears to be broken"
 msgstr "din nuvarande gren verkar vara trasig"
 
-#: revision.c:2693
+#: revision.c:2689
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "din nuvarande gren \"%s\" innehåller ännu inte några incheckningar"
 
-#: revision.c:2895
+#: revision.c:2891
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L stöder ännu inte andra diff-format än -p och -s"
 
-#: run-command.c:1278
+#: run-command.c:1262
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "kan inte skapa asynkron tråd: %s"
@@ -7639,8 +7583,8 @@ msgstr "felaktigt incheckningsmeddelandestädningsläge \"%s\""
 msgid "could not delete '%s'"
 msgstr "kunde inte ta bort \"%s\""
 
-#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
-#: builtin/rm.c:408
+#: sequencer.c:345 sequencer.c:4751 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:409
 #, c-format
 msgid "could not remove '%s'"
 msgstr "kunde inte ta bort \"%s\""
@@ -7702,13 +7646,13 @@ msgstr ""
 "För att avbryta och återgå till där du var före \"git revert\",\n"
 "kör \"git revert --abort\"."
 
-#: sequencer.c:448 sequencer.c:3290
+#: sequencer.c:448 sequencer.c:3292
 #, c-format
 msgid "could not lock '%s'"
 msgstr "kunde inte låsa \"%s\""
 
-#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
-#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
+#: sequencer.c:450 sequencer.c:3091 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3561 sequencer.c:5618 strbuf.c:1188 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "kunde inte skriva till \"%s\""
@@ -7718,11 +7662,17 @@ msgstr "kunde inte skriva till \"%s\""
 msgid "could not write eol to '%s'"
 msgstr "kunde inte skriva radslut till \"%s\""
 
-#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
-#: sequencer.c:3574
+#: sequencer.c:460 sequencer.c:3096 sequencer.c:3298 sequencer.c:3312
+#: sequencer.c:3569
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "misslyckades färdigställa \"%s\""
+
+#: sequencer.c:473 sequencer.c:1934 sequencer.c:3116 sequencer.c:3551
+#: sequencer.c:3679 builtin/am.c:289 builtin/commit.c:834 builtin/merge.c:1148
+#, c-format
+msgid "could not read '%s'"
+msgstr "kunde inte läsa \"%s\""
 
 #: sequencer.c:499
 #, c-format
@@ -7738,7 +7688,7 @@ msgstr "checka in dina ändringar eller använd \"stash\" för att fortsätta."
 msgid "%s: fast-forward"
 msgstr "%s: snabbspola"
 
-#: sequencer.c:574 builtin/tag.c:610
+#: sequencer.c:574 builtin/tag.c:614
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Felaktigt städningsläge %s"
@@ -7769,8 +7719,8 @@ msgstr "ingen nyckel i  \"%.*s\""
 msgid "unable to dequote value of '%s'"
 msgstr "kan inte ta bort citering av värdet \"%s\""
 
-#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
-#: builtin/am.c:822 builtin/rebase.c:694
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:756
+#: builtin/am.c:848 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "kunde inte öppna \"%s\" för läsning"
@@ -7833,11 +7783,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1229
+#: sequencer.c:1225
 msgid "'prepare-commit-msg' hook failed"
 msgstr "kroken \"prepare-commit-msg\" misslyckades"
 
-#: sequencer.c:1235
+#: sequencer.c:1231
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7864,7 +7814,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1248
+#: sequencer.c:1244
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7889,350 +7839,350 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1290
+#: sequencer.c:1288
 msgid "couldn't look up newly created commit"
 msgstr "kunde inte slå upp en precis skapad incheckning"
 
-#: sequencer.c:1292
+#: sequencer.c:1290
 msgid "could not parse newly created commit"
 msgstr "kunde inte tolka en precis skapad incheckning"
 
-#: sequencer.c:1338
+#: sequencer.c:1339
 msgid "unable to resolve HEAD after creating commit"
 msgstr "kunde inte bestämma HEAD efter att ha skapat incheckning"
 
-#: sequencer.c:1340
+#: sequencer.c:1342
 msgid "detached HEAD"
 msgstr "frånkopplad HEAD"
 
-#: sequencer.c:1344
+#: sequencer.c:1346
 msgid " (root-commit)"
 msgstr " (rotincheckning)"
 
-#: sequencer.c:1365
+#: sequencer.c:1367
 msgid "could not parse HEAD"
 msgstr "kunde inte tolka HEAD"
 
-#: sequencer.c:1367
+#: sequencer.c:1369
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s är inte en incheckning!"
 
-#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
+#: sequencer.c:1373 sequencer.c:1451 builtin/commit.c:1708
 msgid "could not parse HEAD commit"
 msgstr "kunde inte tolka HEAD:s incheckning"
 
-#: sequencer.c:1427 sequencer.c:2312
+#: sequencer.c:1429 sequencer.c:2314
 msgid "unable to parse commit author"
 msgstr "kunde inte tolka incheckningens författare"
 
-#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
+#: sequencer.c:1440 builtin/am.c:1643 builtin/merge.c:710
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree misslyckades skriva ett träd"
 
-#: sequencer.c:1471 sequencer.c:1591
+#: sequencer.c:1473 sequencer.c:1593
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "kunde inte läsa incheckningsmeddelande från \"%s\""
 
-#: sequencer.c:1502 sequencer.c:1534
+#: sequencer.c:1504 sequencer.c:1536
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "ogiltig författar-identitet \"%s\""
 
-#: sequencer.c:1508
+#: sequencer.c:1510
 msgid "corrupt author: missing date information"
 msgstr "trasig författare: saknar datuminformation"
 
-#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
-#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1549 builtin/am.c:1670 builtin/commit.c:1822 builtin/merge.c:915
+#: builtin/merge.c:940 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "kunde inte skriva incheckningsobjekt"
 
-#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1576 sequencer.c:4523 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "kunde inte uppdatera %s"
 
-#: sequencer.c:1623
+#: sequencer.c:1625
 #, c-format
 msgid "could not parse commit %s"
 msgstr "kunde inte tolka incheckningen %s"
 
-#: sequencer.c:1628
+#: sequencer.c:1630
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "kunde inte tolka föräldraincheckningen %s"
 
-#: sequencer.c:1711 sequencer.c:1992
+#: sequencer.c:1713 sequencer.c:1994
 #, c-format
 msgid "unknown command: %d"
 msgstr "okänt kommando: %d"
 
-#: sequencer.c:1753
+#: sequencer.c:1755
 msgid "This is the 1st commit message:"
 msgstr "Det här är 1:a incheckningsmeddelandet:"
 
-#: sequencer.c:1754
+#: sequencer.c:1756
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Det här är incheckningsmeddelande %d:"
 
-#: sequencer.c:1755
+#: sequencer.c:1757
 msgid "The 1st commit message will be skipped:"
 msgstr "1:a incheckningsmeddelandet kommer hoppas över:"
 
-#: sequencer.c:1756
+#: sequencer.c:1758
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Incheckningsmeddelande %d kommer hoppas över:"
 
-#: sequencer.c:1757
+#: sequencer.c:1759
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Det här är en kombination av %d incheckningar."
 
-#: sequencer.c:1904 sequencer.c:1961
+#: sequencer.c:1906 sequencer.c:1963
 #, c-format
 msgid "cannot write '%s'"
 msgstr "kan inte skriva \"%s\""
 
-#: sequencer.c:1951
+#: sequencer.c:1953
 msgid "need a HEAD to fixup"
 msgstr "behöver en HEAD-incheckning att rätta"
 
-#: sequencer.c:1953 sequencer.c:3601
+#: sequencer.c:1955 sequencer.c:3596
 msgid "could not read HEAD"
 msgstr "kunde inte läsa HEAD"
 
-#: sequencer.c:1955
+#: sequencer.c:1957
 msgid "could not read HEAD's commit message"
 msgstr "kunde inte läsa HEAD:s incheckningsmeddelande"
 
-#: sequencer.c:1979
+#: sequencer.c:1981
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "kunde inte läsa incheckningsmeddelande för %s"
 
-#: sequencer.c:2089
+#: sequencer.c:2091
 msgid "your index file is unmerged."
 msgstr "din indexfil har inte slagits ihop."
 
-#: sequencer.c:2096
+#: sequencer.c:2098
 msgid "cannot fixup root commit"
 msgstr "kan inte göra \"fixup\" på rotincheckning"
 
-#: sequencer.c:2115
+#: sequencer.c:2117
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "incheckning %s är en sammanslagning, men flaggan -m angavs inte."
 
-#: sequencer.c:2123 sequencer.c:2131
+#: sequencer.c:2125 sequencer.c:2133
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "incheckning %s har inte förälder %d"
 
-#: sequencer.c:2137
+#: sequencer.c:2139
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "kan inte hämta incheckningsmeddelande för %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2156
+#: sequencer.c:2158
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: kan inte tolka föräldraincheckningen %s"
 
-#: sequencer.c:2222
+#: sequencer.c:2224
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "kunde inte byta namn på \"%s\" till \"%s\""
 
-#: sequencer.c:2282
+#: sequencer.c:2284
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "kunde inte ångra %s... %s"
 
-#: sequencer.c:2283
+#: sequencer.c:2285
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "kunde inte tillämpa %s... %s"
 
-#: sequencer.c:2304
+#: sequencer.c:2306
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "utelämnar %s %s -- patchinnehållet finns redan uppströms\n"
 
-#: sequencer.c:2362
+#: sequencer.c:2364
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: misslyckades läsa indexet"
 
-#: sequencer.c:2370
+#: sequencer.c:2372
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: misslyckades uppdatera indexet"
 
-#: sequencer.c:2450
+#: sequencer.c:2452
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s tar inte argument: \"%s\""
 
-#: sequencer.c:2459
+#: sequencer.c:2461
 #, c-format
 msgid "missing arguments for %s"
 msgstr "argument saknas för %s"
 
-#: sequencer.c:2502
+#: sequencer.c:2504
 #, c-format
 msgid "could not parse '%s'"
 msgstr "kunde inte tolka \"%s\""
 
-#: sequencer.c:2563
+#: sequencer.c:2565
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "ogiltig rad %d: %.*s"
 
-#: sequencer.c:2574
+#: sequencer.c:2576
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "kan inte utföra \"%s\" utan en föregående incheckning"
 
-#: sequencer.c:2622 builtin/rebase.c:184
+#: sequencer.c:2624 builtin/rebase.c:184
 #, c-format
 msgid "could not read '%s'."
 msgstr "kunde inte läsa \"%s\"."
 
-#: sequencer.c:2660
+#: sequencer.c:2662
 msgid "cancelling a cherry picking in progress"
 msgstr "avbryter pågående \"cherry-pick\""
 
-#: sequencer.c:2669
+#: sequencer.c:2671
 msgid "cancelling a revert in progress"
 msgstr "avbryter pågående \"revert\""
 
-#: sequencer.c:2709
+#: sequencer.c:2711
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "rätta det med \"git rebase --edit-todo\"."
 
-#: sequencer.c:2711
+#: sequencer.c:2713
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "oanvändbart manus: \"%s\""
 
-#: sequencer.c:2716
+#: sequencer.c:2718
 msgid "no commits parsed."
 msgstr "inga incheckningar lästes."
 
-#: sequencer.c:2727
+#: sequencer.c:2729
 msgid "cannot cherry-pick during a revert."
 msgstr "kan inte utföra \"cherry-pick\" under en \"revert\"."
 
-#: sequencer.c:2729
+#: sequencer.c:2731
 msgid "cannot revert during a cherry-pick."
 msgstr "kan inte utföra \"revert\" under en \"cherry-pick\"."
 
-#: sequencer.c:2807
+#: sequencer.c:2809
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "felaktigt värde för %s: %s"
 
-#: sequencer.c:2916
+#: sequencer.c:2918
 msgid "unusable squash-onto"
 msgstr "oanvändbar squash-onto"
 
-#: sequencer.c:2936
+#: sequencer.c:2938
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "trasigt manus: \"%s\""
 
-#: sequencer.c:3031 sequencer.c:4905
+#: sequencer.c:3033 sequencer.c:4902
 msgid "empty commit set passed"
 msgstr "den angivna uppsättningen incheckningar är tom"
 
-#: sequencer.c:3048
+#: sequencer.c:3050
 msgid "revert is already in progress"
 msgstr "en \"revert\" pågår redan"
 
-#: sequencer.c:3050
+#: sequencer.c:3052
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "testa \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3053
+#: sequencer.c:3055
 msgid "cherry-pick is already in progress"
 msgstr "en \"cherry-pick\" pågår redan"
 
-#: sequencer.c:3055
+#: sequencer.c:3057
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "testa \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3069
+#: sequencer.c:3071
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "kunde inte skapa \"sequencer\"-katalogen \"%s\""
 
-#: sequencer.c:3084
+#: sequencer.c:3086
 msgid "could not lock HEAD"
 msgstr "kunde inte låsa HEAD"
 
-#: sequencer.c:3144 sequencer.c:4615
+#: sequencer.c:3146 sequencer.c:4612
 msgid "no cherry-pick or revert in progress"
 msgstr "ingen \"cherry-pick\" eller \"revert\" pågår"
 
-#: sequencer.c:3146 sequencer.c:3157
+#: sequencer.c:3148 sequencer.c:3159
 msgid "cannot resolve HEAD"
 msgstr "kan inte bestämma HEAD"
 
-#: sequencer.c:3148 sequencer.c:3192
+#: sequencer.c:3150 sequencer.c:3194
 msgid "cannot abort from a branch yet to be born"
 msgstr "kan inte avbryta från en gren som ännu inte är född"
 
-#: sequencer.c:3178 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kan inte öppna \"%s\""
 
-#: sequencer.c:3180
+#: sequencer.c:3182
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "kan inte läsa \"%s\": %s"
 
-#: sequencer.c:3181
+#: sequencer.c:3183
 msgid "unexpected end of file"
 msgstr "oväntat filslut"
 
-#: sequencer.c:3187
+#: sequencer.c:3189
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "sparad HEAD-fil från före \"cherry-pick\", \"%s\", är trasig"
 
-#: sequencer.c:3198
+#: sequencer.c:3200
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Du verkar ha flyttat HEAD.\n"
 "Spolar inte tillbaka, kontrollera HEAD!"
 
-#: sequencer.c:3239
+#: sequencer.c:3241
 msgid "no revert in progress"
 msgstr "ingen \"revers\" pågår"
 
-#: sequencer.c:3248
+#: sequencer.c:3250
 msgid "no cherry-pick in progress"
 msgstr "ingen \"cherry-pick\" pågår"
 
-#: sequencer.c:3258
+#: sequencer.c:3260
 msgid "failed to skip the commit"
 msgstr "kunde inte hoppa över incheckningen"
 
-#: sequencer.c:3265
+#: sequencer.c:3267
 msgid "there is nothing to skip"
 msgstr "ingenting att hoppa över"
 
-#: sequencer.c:3268
+#: sequencer.c:3270
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8241,16 +8191,16 @@ msgstr ""
 "har du redan checkat in?\n"
 "testa \"git %s --continue\""
 
-#: sequencer.c:3430 sequencer.c:4506
+#: sequencer.c:3432 sequencer.c:4503
 msgid "cannot read HEAD"
 msgstr "kan inte läsa HEAD"
 
-#: sequencer.c:3447
+#: sequencer.c:3449
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "kan inte kopiera in \"%s\" till \"%s\""
 
-#: sequencer.c:3455
+#: sequencer.c:3457
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8269,27 +8219,27 @@ msgstr ""
 "\n"
 "\tgit rebase --continue\n"
 
-#: sequencer.c:3465
+#: sequencer.c:3467
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Kunde inte tillämpa %s... %.*s"
 
-#: sequencer.c:3472
+#: sequencer.c:3474
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Kunde inte slå ihop %.*s"
 
-#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
+#: sequencer.c:3488 sequencer.c:3492 builtin/difftool.c:633
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "kunde inte kopiera in \"%s\" till \"%s\""
 
-#: sequencer.c:3502
+#: sequencer.c:3503
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Kör: %s\n"
 
-#: sequencer.c:3517
+#: sequencer.c:3514
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8304,11 +8254,11 @@ msgstr ""
 "\tgit rebase --continue\n"
 "\n"
 
-#: sequencer.c:3523
+#: sequencer.c:3520
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "och gjorde ändringar till indexet och/eller arbetskatalogen\n"
 
-#: sequencer.c:3529
+#: sequencer.c:3526
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8325,90 +8275,90 @@ msgstr ""
 "\tgit rebase --continue\n"
 "\n"
 
-#: sequencer.c:3591
+#: sequencer.c:3586
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "ogiltigt etikettnamn: \"%.*s\""
 
-#: sequencer.c:3664
+#: sequencer.c:3659
 msgid "writing fake root commit"
 msgstr "skriver fejkad rotincheckning"
 
-#: sequencer.c:3669
+#: sequencer.c:3664
 msgid "writing squash-onto"
 msgstr "skriver squash-onto"
 
-#: sequencer.c:3748
+#: sequencer.c:3743
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "kunde inte upplösa \"%s\""
 
-#: sequencer.c:3780
+#: sequencer.c:3775
 msgid "cannot merge without a current revision"
 msgstr "kan inte slå ihop utan en aktuell incheckning"
 
-#: sequencer.c:3802
+#: sequencer.c:3797
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "kan inte tolka \"%.*s\""
 
-#: sequencer.c:3811
+#: sequencer.c:3806
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "inget att slå samman: \"%.*s\""
 
-#: sequencer.c:3823
+#: sequencer.c:3818
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "\"octopus\"-sammanslagning kan inte köras ovanpå en [ny rot]"
 
-#: sequencer.c:3878
+#: sequencer.c:3873
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "kunde inte läsa incheckningsmeddelande för \"%s\""
 
-#: sequencer.c:4024
+#: sequencer.c:4019
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "kunde inte ens försöka slå ihop \"%.*s\""
 
-#: sequencer.c:4040
+#: sequencer.c:4035
 msgid "merge: Unable to write new index file"
 msgstr "sammanslagning: Kunde inte skriva ny indexfil"
 
-#: sequencer.c:4121
+#: sequencer.c:4116
 msgid "Cannot autostash"
 msgstr "Kan inte utföra \"autostash\""
 
-#: sequencer.c:4124
+#: sequencer.c:4119
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Oväntat svar från stash: \"%s\""
 
-#: sequencer.c:4130
+#: sequencer.c:4125
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Kunde inte skapa katalog för \"%s\""
 
-#: sequencer.c:4133
+#: sequencer.c:4128
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Skapade autostash: %s\n"
 
-#: sequencer.c:4137
+#: sequencer.c:4132
 msgid "could not reset --hard"
 msgstr "kunde inte utföra \"reset --hard\""
 
-#: sequencer.c:4162
+#: sequencer.c:4157
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Tillämpade autostash.\n"
 
-#: sequencer.c:4174
+#: sequencer.c:4169
 #, c-format
 msgid "cannot store %s"
 msgstr "kan inte spara %s"
 
-#: sequencer.c:4177
+#: sequencer.c:4172
 #, c-format
 msgid ""
 "%s\n"
@@ -8419,29 +8369,29 @@ msgstr ""
 "Dina ändringar är säkra i stashen.\n"
 "Du kan när som helst använda \"git stash pop\" eller \"git stash drop\".\n"
 
-#: sequencer.c:4182
+#: sequencer.c:4177
 msgid "Applying autostash resulted in conflicts."
 msgstr "Tillämpning av autostash gav konflikter."
 
-#: sequencer.c:4183
+#: sequencer.c:4178
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Autostash finns; skapar ny stash-post."
 
-#: sequencer.c:4255
+#: sequencer.c:4252
 msgid "could not detach HEAD"
 msgstr "kunde inte koppla från HEAD"
 
-#: sequencer.c:4270
+#: sequencer.c:4267
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Stoppade på HEAD\n"
 
-#: sequencer.c:4272
+#: sequencer.c:4269
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Stoppade på %s\n"
 
-#: sequencer.c:4304
+#: sequencer.c:4301
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8462,58 +8412,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4350
+#: sequencer.c:4347
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Ombaserar (%d/%d)%s"
 
-#: sequencer.c:4396
+#: sequencer.c:4393
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Stoppade på %s... %.*s\n"
 
-#: sequencer.c:4466
+#: sequencer.c:4463
 #, c-format
 msgid "unknown command %d"
 msgstr "okänt kommando %d"
 
-#: sequencer.c:4514
+#: sequencer.c:4511
 msgid "could not read orig-head"
 msgstr "kunde inte läsa orig-head"
 
-#: sequencer.c:4519
+#: sequencer.c:4516
 msgid "could not read 'onto'"
 msgstr "kunde inte läsa \"onto\""
 
-#: sequencer.c:4533
+#: sequencer.c:4530
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "kunde inte uppdatera HEAD till %s"
 
-#: sequencer.c:4593
+#: sequencer.c:4590
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Lyckades ombasera och uppdatera %s.\n"
 
-#: sequencer.c:4645
+#: sequencer.c:4642
 msgid "cannot rebase: You have unstaged changes."
 msgstr "kan inte ombasera: Du har oköade ändringar."
 
-#: sequencer.c:4654
+#: sequencer.c:4651
 msgid "cannot amend non-existing commit"
 msgstr "kan inte lägga till incheckning som inte finns"
 
-#: sequencer.c:4656
+#: sequencer.c:4653
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "ogiltig fil: \"%s\""
 
-#: sequencer.c:4658
+#: sequencer.c:4655
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "ogiltigt innehåll: \"%s\""
 
-#: sequencer.c:4661
+#: sequencer.c:4658
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8523,68 +8473,68 @@ msgstr ""
 "Du har ändringar i arbetskatalogen som inte checkats in. Checka in dem\n"
 "först och kör sedan \"git rebase --continue\" igen."
 
-#: sequencer.c:4697 sequencer.c:4736
+#: sequencer.c:4694 sequencer.c:4733
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "kunde inte skriva fil: \"%s\""
 
-#: sequencer.c:4752
+#: sequencer.c:4749
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "kunde inte ta bort CHERRY_PICK_HEAD"
 
-#: sequencer.c:4762
+#: sequencer.c:4759
 msgid "could not commit staged changes."
 msgstr "kunde inte checka in köade ändringar."
 
-#: sequencer.c:4882
+#: sequencer.c:4879
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: kan inte göra \"cherry-pick\" på typen \"%s\""
 
-#: sequencer.c:4886
+#: sequencer.c:4883
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: felaktig revision"
 
-#: sequencer.c:4921
+#: sequencer.c:4918
 msgid "can't revert as initial commit"
 msgstr "kan inte ångra som första incheckning"
 
-#: sequencer.c:5192 sequencer.c:5421
+#: sequencer.c:5189 sequencer.c:5418
 #, c-format
 msgid "skipped previously applied commit %s"
 msgstr "hoppade över tidigare applicerad incheckning %s"
 
-#: sequencer.c:5262 sequencer.c:5437
+#: sequencer.c:5259 sequencer.c:5434
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr "använd --reapply-cherry-picks för att ta med överhoppade incheckningar"
 
-#: sequencer.c:5408
+#: sequencer.c:5405
 msgid "make_script: unhandled options"
 msgstr "make_script: flaggor som inte stöds"
 
-#: sequencer.c:5411
+#: sequencer.c:5408
 msgid "make_script: error preparing revisions"
 msgstr "make_script: fel när revisioner skulle förberedas"
 
-#: sequencer.c:5669 sequencer.c:5686
+#: sequencer.c:5666 sequencer.c:5683
 msgid "nothing to do"
 msgstr "inget att göra"
 
-#: sequencer.c:5705
+#: sequencer.c:5702
 msgid "could not skip unnecessary pick commands"
 msgstr "kunde inte hoppa över onödiga \"pick\"-kommandon"
 
-#: sequencer.c:5805
+#: sequencer.c:5802
 msgid "the script was already rearranged."
 msgstr "skriptet har redan omordnats."
 
-#: setup.c:133
+#: setup.c:134
 #, c-format
 msgid "'%s' is outside repository at '%s'"
 msgstr "\"%s\" är utanför arkivet på \"%s\""
 
-#: setup.c:185
+#: setup.c:186
 #, c-format
 msgid ""
 "%s: no such path in the working tree.\n"
@@ -8594,7 +8544,7 @@ msgstr ""
 "Använd \"git <kommando> -- <sökväg>..\" för att ange sökvägar som inte finns "
 "lokalt."
 
-#: setup.c:198
+#: setup.c:199
 #, c-format
 msgid ""
 "ambiguous argument '%s': unknown revision or path not in the working tree.\n"
@@ -8606,12 +8556,12 @@ msgstr ""
 "Använd \"--\" för att skilja sökvägar från revisioner, så här:\n"
 "\"git <kommando> [<revision>...] -- [<fil>...]\""
 
-#: setup.c:264
+#: setup.c:265
 #, c-format
 msgid "option '%s' must come before non-option arguments"
 msgstr "flaggan \"%s\" måste anges före argument som inte är flaggor"
 
-#: setup.c:283
+#: setup.c:284
 #, c-format
 msgid ""
 "ambiguous argument '%s': both revision and filename\n"
@@ -8622,100 +8572,100 @@ msgstr ""
 "Använd \"--\" för att skilja sökvägar från revisioner, så här:\n"
 "\"git <kommando> [<revision>...] -- [<fil>...]\""
 
-#: setup.c:419
+#: setup.c:420
 msgid "unable to set up work tree using invalid config"
 msgstr "kan inte skapa arbetskatalog med felaktig konfiguration"
 
-#: setup.c:423 builtin/rev-parse.c:895
+#: setup.c:424 builtin/rev-parse.c:895
 msgid "this operation must be run in a work tree"
 msgstr "funktionen måste köras i en arbetskatalog"
 
-#: setup.c:658
+#: setup.c:722
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr "Förväntade git-arkivversion <= %d, hittade %d"
 
-#: setup.c:666
+#: setup.c:730
 msgid "unknown repository extension found:"
 msgid_plural "unknown repository extensions found:"
 msgstr[0] "okänd arkivutökning hittades:"
 msgstr[1] "okända arkivutökningar hittades:"
 
-#: setup.c:680
+#: setup.c:744
 msgid "repo version is 0, but v1-only extension found:"
 msgid_plural "repo version is 0, but v1-only extensions found:"
 msgstr[0] "arkivversionen är 0, men utökning som bara finns i v1 upptäcktes:"
 msgstr[1] "arkivversionen är 0, men utökningar som bara finns i v1 upptäcktes:"
 
-#: setup.c:701
+#: setup.c:765
 #, c-format
 msgid "error opening '%s'"
 msgstr "fel vid öppning av \"%s\""
 
-#: setup.c:703
+#: setup.c:767
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr "för stor för att vara en .git-fil: \"%s\""
 
-#: setup.c:705
+#: setup.c:769
 #, c-format
 msgid "error reading %s"
 msgstr "fel vid läsning av %s"
 
-#: setup.c:707
+#: setup.c:771
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr "ogiltigt gitfilformat: %s"
 
-#: setup.c:709
+#: setup.c:773
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr "ingen sökväg i gitfil: %s"
 
-#: setup.c:711
+#: setup.c:775
 #, c-format
 msgid "not a git repository: %s"
 msgstr "inte ett git-arkiv: %s"
 
-#: setup.c:813
+#: setup.c:877
 #, c-format
 msgid "'$%s' too big"
 msgstr "\"$%s\" för stor"
 
-#: setup.c:827
+#: setup.c:891
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr "inte ett git-arkiv: \"%s\""
 
-#: setup.c:856 setup.c:858 setup.c:889
+#: setup.c:920 setup.c:922 setup.c:953
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr "kan inte byta katalog (chdir) till \"%s\""
 
-#: setup.c:861 setup.c:917 setup.c:927 setup.c:966 setup.c:974
+#: setup.c:925 setup.c:981 setup.c:991 setup.c:1030 setup.c:1038
 msgid "cannot come back to cwd"
 msgstr "kan inte gå tillbaka till arbetskatalogen (cwd)"
 
-#: setup.c:988
+#: setup.c:1052
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "misslyckades ta status på \"%*ss%s%s\""
 
-#: setup.c:1231
+#: setup.c:1295
 msgid "Unable to read current working directory"
 msgstr "Kan inte läsa aktuell arbetskatalog"
 
-#: setup.c:1240 setup.c:1246
+#: setup.c:1304 setup.c:1310
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "kan inte byta till \"%s\""
 
-#: setup.c:1251
+#: setup.c:1315
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr "inte ett git-arkiv (eller någon av föräldrakatalogerna): %s"
 
-#: setup.c:1257
+#: setup.c:1321
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -8725,7 +8675,7 @@ msgstr ""
 "monteringspunkten %s)\n"
 "Stoppar vid filsystemsgräns (GIT_DISCOVERY_ACROSS_FILESYSTEM är inte satt)."
 
-#: setup.c:1381
+#: setup.c:1446
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -8734,15 +8684,15 @@ msgstr ""
 "problem med filläges-värdet i core.sharedRepository (0%.3o).\n"
 "Ägaren av filerna måste alltid ha läs- och skrivbehörighet."
 
-#: setup.c:1443
+#: setup.c:1508
 msgid "fork failed"
 msgstr "\"fork\" misslyckades"
 
-#: setup.c:1448
+#: setup.c:1513
 msgid "setsid failed"
 msgstr "\"setsid\" misslyckades"
 
-#: sparse-index.c:273
+#: sparse-index.c:289
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "indexposten är en katalog, men inte gles (%08x)"
@@ -8799,13 +8749,13 @@ msgid_plural "%u bytes/s"
 msgstr[0] "%u byte/s"
 msgstr[1] "%u bytes/s"
 
-#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: strbuf.c:1186 wrapper.c:207 wrapper.c:377 builtin/am.c:765
 #: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "kunde inte öppna \"%s\" för skrivning"
 
-#: strbuf.c:1183
+#: strbuf.c:1195
 #, c-format
 msgid "could not edit '%s'"
 msgstr "kunde inte redigera \"%s\""
@@ -8897,7 +8847,7 @@ msgstr ""
 msgid "process for submodule '%s' failed"
 msgstr "process för undermodulen \"%s\" misslyckades"
 
-#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
+#: submodule.c:1194 builtin/branch.c:699 builtin/submodule--helper.c:2714
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Misslyckades slå upp HEAD som giltig referens."
 
@@ -9146,7 +9096,7 @@ msgstr "protkollet stöder inte att sätta sökväg till fjärrtjänst"
 msgid "invalid remote service path"
 msgstr "felaktig sökväg till fjärrtjänst"
 
-#: transport-helper.c:661 transport.c:1475
+#: transport-helper.c:661 transport.c:1474
 msgid "operation not supported by protocol"
 msgstr "funktionen stöds inte av protokollet"
 
@@ -9367,7 +9317,7 @@ msgstr ""
 msgid "Aborting."
 msgstr "Avbryter."
 
-#: transport.c:1344
+#: transport.c:1343
 msgid "failed to push all needed submodules"
 msgstr "kunde inte sända alla nödvändiga undermoduler"
 
@@ -9387,7 +9337,7 @@ msgstr "tomt filnamn i trädpost"
 msgid "too-short tree file"
 msgstr "trädfil för kort"
 
-#: unpack-trees.c:115
+#: unpack-trees.c:118
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9396,7 +9346,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av utcheckning:\n"
 "%%sChecka in dina ändringar eller använd \"stash\" innan du byter gren."
 
-#: unpack-trees.c:117
+#: unpack-trees.c:120
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9405,7 +9355,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av utcheckning:\n"
 "%%s"
 
-#: unpack-trees.c:120
+#: unpack-trees.c:123
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9415,7 +9365,7 @@ msgstr ""
 "sammanslagning:\n"
 "%%sChecka in dina ändringar eller använd \"stash\" innan du byter gren."
 
-#: unpack-trees.c:122
+#: unpack-trees.c:125
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9425,7 +9375,7 @@ msgstr ""
 "sammanslagning:\n"
 "%%s"
 
-#: unpack-trees.c:125
+#: unpack-trees.c:128
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9434,7 +9384,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av \"%s\":\n"
 "%%sChecka in dina ändringar eller använd \"stash\" innan du \"%s\"."
 
-#: unpack-trees.c:127
+#: unpack-trees.c:130
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9443,7 +9393,7 @@ msgstr ""
 "Dina lokala ändringar av följande filer skulle skrivas över av \"%s\":\n"
 "%%s"
 
-#: unpack-trees.c:132
+#: unpack-trees.c:135
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
@@ -9453,7 +9403,16 @@ msgstr ""
 "dem:\n"
 "%s"
 
-#: unpack-trees.c:136
+#: unpack-trees.c:138
+#, c-format
+msgid ""
+"Refusing to remove the current working directory:\n"
+"%s"
+msgstr ""
+"Vägrar ta bort aktuell arbetskatalog:\n"
+"%s"
+
+#: unpack-trees.c:142
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9462,7 +9421,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av utcheckningen:\n"
 "%%sFlytta eller ta bort dem innan du byter gren."
 
-#: unpack-trees.c:138
+#: unpack-trees.c:144
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9471,7 +9430,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av utcheckningen:\n"
 "%%s"
 
-#: unpack-trees.c:141
+#: unpack-trees.c:147
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9481,7 +9440,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%sFlytta eller ta bort dem innan du slår samman."
 
-#: unpack-trees.c:143
+#: unpack-trees.c:149
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9491,7 +9450,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%s"
 
-#: unpack-trees.c:146
+#: unpack-trees.c:152
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9500,7 +9459,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av \"%s\":\n"
 "%%sFlytta eller ta bort dem innan du \"%s\"."
 
-#: unpack-trees.c:148
+#: unpack-trees.c:154
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9509,7 +9468,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle tas bort av \"%s\":\n"
 "%%s"
 
-#: unpack-trees.c:154
+#: unpack-trees.c:160
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -9520,7 +9479,7 @@ msgstr ""
 "utcheckningen:\n"
 "%%sFlytta eller ta bort dem innan du byter gren."
 
-#: unpack-trees.c:156
+#: unpack-trees.c:162
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -9531,7 +9490,7 @@ msgstr ""
 "utcheckningen:\n"
 "%%s"
 
-#: unpack-trees.c:159
+#: unpack-trees.c:165
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9541,7 +9500,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%sFlytta eller ta bort dem innan du byter gren."
 
-#: unpack-trees.c:161
+#: unpack-trees.c:167
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9551,7 +9510,7 @@ msgstr ""
 "sammanslagningen:\n"
 "%%s"
 
-#: unpack-trees.c:164
+#: unpack-trees.c:170
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9560,7 +9519,7 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle skrivas över av \"%s\":\n"
 "%%sFlytta eller ta bort dem innan du \"%s\"."
 
-#: unpack-trees.c:166
+#: unpack-trees.c:172
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9569,12 +9528,12 @@ msgstr ""
 "Följande ospårade filer i arbetskatalogen skulle skrivas över av \"%s\":\n"
 "%%s"
 
-#: unpack-trees.c:174
+#: unpack-trees.c:180
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
 msgstr "Posten \"%s\" överlappar \"%s\". Kan inte binda."
 
-#: unpack-trees.c:177
+#: unpack-trees.c:183
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
@@ -9583,7 +9542,7 @@ msgstr ""
 "Kan inte uppdatera undermodul:\n"
 "%s"
 
-#: unpack-trees.c:180
+#: unpack-trees.c:186
 #, c-format
 msgid ""
 "The following paths are not up to date and were left despite sparse "
@@ -9593,7 +9552,7 @@ msgstr ""
 "Följande sökvägar är inte àjour och lämnades till trots för gles-mönster:\n"
 "%s"
 
-#: unpack-trees.c:182
+#: unpack-trees.c:188
 #, c-format
 msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
@@ -9603,7 +9562,7 @@ msgstr ""
 "mönster:\n"
 "%s"
 
-#: unpack-trees.c:184
+#: unpack-trees.c:190
 #, c-format
 msgid ""
 "The following paths were already present and thus not updated despite sparse "
@@ -9614,12 +9573,12 @@ msgstr ""
 "gles-mönster:\n"
 "%s"
 
-#: unpack-trees.c:264
+#: unpack-trees.c:270
 #, c-format
 msgid "Aborting\n"
 msgstr "Avbryter\n"
 
-#: unpack-trees.c:291
+#: unpack-trees.c:297
 #, c-format
 msgid ""
 "After fixing the above paths, you may want to run `git sparse-checkout "
@@ -9628,11 +9587,11 @@ msgstr ""
 "Du bör köra \"git sparse-checkout reapply\" efter att ha fixat sökvägarna "
 "ovan.\n"
 
-#: unpack-trees.c:352
+#: unpack-trees.c:358
 msgid "Updating files"
 msgstr "Uppdaterar filer"
 
-#: unpack-trees.c:384
+#: unpack-trees.c:390
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
@@ -9642,16 +9601,16 @@ msgstr ""
 "sökvägar på ett okänsligt filsystem) och endast en från samma\n"
 "kollisionsgrupp finns i arbetskatalogen:\n"
 
-#: unpack-trees.c:1620
+#: unpack-trees.c:1636
 msgid "Updating index flags"
 msgstr "Uppdaterar indexflaggor"
 
-#: unpack-trees.c:2772
+#: unpack-trees.c:2803
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr "arbetskatalog och ospårad incheckning har dublettposter: %s"
 
-#: upload-pack.c:1561
+#: upload-pack.c:1565
 msgid "expected flush after fetch arguments"
 msgstr "förväntade \"flush\" efter \"fetch\"-argument"
 
@@ -9688,99 +9647,99 @@ msgstr "felaktigt \"..\"-sökvägssegment"
 msgid "Fetching objects"
 msgstr "Hämtar objekt"
 
-#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
+#: worktree.c:238 builtin/am.c:2209 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "misslyckades läsa \"%s\""
 
-#: worktree.c:303
+#: worktree.c:305
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr "\"%s\" i huvudarbetskatalogen är inte arkivkatalogen"
 
-#: worktree.c:314
+#: worktree.c:316
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr "filen \"%s\" innehåller inte absolut sökväg till arbetskatalogen"
 
-#: worktree.c:326
+#: worktree.c:328
 #, c-format
 msgid "'%s' does not exist"
 msgstr "\"%s\" finns inte"
 
-#: worktree.c:332
+#: worktree.c:334
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "\"%s\" är inte en .git-fil, felkod %d"
 
-#: worktree.c:341
+#: worktree.c:343
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "\"%s\" pekar inte tillbaka till \"%s\""
 
-#: worktree.c:603
+#: worktree.c:604
 msgid "not a directory"
 msgstr "inte en katalog"
 
-#: worktree.c:612
+#: worktree.c:613
 msgid ".git is not a file"
 msgstr ".git är inte en fil"
 
-#: worktree.c:614
+#: worktree.c:615
 msgid ".git file broken"
 msgstr ".git-filen är trasig"
 
-#: worktree.c:616
+#: worktree.c:617
 msgid ".git file incorrect"
 msgstr ".git-filen är felaktig"
 
-#: worktree.c:722
+#: worktree.c:723
 msgid "not a valid path"
 msgstr "inte en giltig sökväg"
 
-#: worktree.c:728
+#: worktree.c:729
 msgid "unable to locate repository; .git is not a file"
 msgstr "hittar inte arkivet; .git är inte en fil"
 
-#: worktree.c:732
+#: worktree.c:733
 msgid "unable to locate repository; .git file does not reference a repository"
 msgstr "hittar inte arkivet; .git-filen hänvisar inte till ett arkiv"
 
-#: worktree.c:736
+#: worktree.c:737
 msgid "unable to locate repository; .git file broken"
 msgstr "hittar inte arkivet; .git-filen är trasig"
 
-#: worktree.c:742
+#: worktree.c:743
 msgid "gitdir unreadable"
 msgstr "gitdir är oläsbar"
 
-#: worktree.c:746
+#: worktree.c:747
 msgid "gitdir incorrect"
 msgstr "gitdir är felaktig"
 
-#: worktree.c:771
+#: worktree.c:772
 msgid "not a valid directory"
 msgstr "inte i en giltig katalog"
 
-#: worktree.c:777
+#: worktree.c:778
 msgid "gitdir file does not exist"
 msgstr "gitdir-filen existerar inte"
 
-#: worktree.c:782 worktree.c:791
+#: worktree.c:783 worktree.c:792
 #, c-format
 msgid "unable to read gitdir file (%s)"
 msgstr "kunde inte läsa gitdir-filen (%s)"
 
-#: worktree.c:801
+#: worktree.c:802
 #, c-format
 msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
 msgstr "kort läsning (förväntade %<PRIuMAX> byte, läste %<PRIuMAX>)"
 
-#: worktree.c:809
+#: worktree.c:810
 msgid "invalid gitdir file"
 msgstr "ogiltig gitdir-fil"
 
-#: worktree.c:817
+#: worktree.c:818
 msgid "gitdir file points to non-existent location"
 msgstr "gitdir-filen pekar på en ickeexisterande plats"
 
@@ -9839,11 +9798,11 @@ msgstr "  (använd \"git add/rm <fil>...\" som lämpligt för att ange lösning)
 msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr "  (använd \"git rm <fil>...\" för att ange lösning)"
 
-#: wt-status.c:211 wt-status.c:1125
+#: wt-status.c:211 wt-status.c:1131
 msgid "Changes to be committed:"
 msgstr "Ändringar att checka in:"
 
-#: wt-status.c:234 wt-status.c:1134
+#: wt-status.c:234 wt-status.c:1140
 msgid "Changes not staged for commit:"
 msgstr "Ändringar ej i incheckningskön:"
 
@@ -9946,22 +9905,22 @@ msgstr "ändrat innehåll, "
 msgid "untracked content, "
 msgstr "ospårat innehåll, "
 
-#: wt-status.c:958
+#: wt-status.c:964
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Stashen innehåller just nu %d post"
 msgstr[1] "Stashen innehåller just nu %d poster"
 
-#: wt-status.c:989
+#: wt-status.c:995
 msgid "Submodules changed but not updated:"
 msgstr "Undermoduler ändrade men inte uppdaterade:"
 
-#: wt-status.c:991
+#: wt-status.c:997
 msgid "Submodule changes to be committed:"
 msgstr "Undermodulers ändringar att checka in:"
 
-#: wt-status.c:1073
+#: wt-status.c:1079
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -9969,7 +9928,7 @@ msgstr ""
 "Raden ovan får inte ändras eller tas bort.\n"
 "Allt under den kommer tas bort."
 
-#: wt-status.c:1165
+#: wt-status.c:1171
 #, c-format
 msgid ""
 "\n"
@@ -9980,107 +9939,114 @@ msgstr ""
 "Det tog %.2f sekunder att räkna före/bakom-värden.\n"
 "Du kan använda \"--no-ahead-behind\" för undvika detta.\n"
 
-#: wt-status.c:1195
+#: wt-status.c:1201
 msgid "You have unmerged paths."
 msgstr "Du har ej sammanslagna sökvägar."
 
-#: wt-status.c:1198
+#: wt-status.c:1204
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (rätta konflikter och kör \"git commit\")"
 
-#: wt-status.c:1200
+#: wt-status.c:1206
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (använd \"git merge --abort\" för att avbryta sammanslagningen)"
 
-#: wt-status.c:1204
+#: wt-status.c:1210
 msgid "All conflicts fixed but you are still merging."
 msgstr "Alla konflikter har rättats men du är fortfarande i en sammanslagning."
 
-#: wt-status.c:1207
+#: wt-status.c:1213
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (använd \"git commit\" för att slutföra sammanslagningen)"
 
-#: wt-status.c:1216
+#: wt-status.c:1224
 msgid "You are in the middle of an am session."
 msgstr "Du är i mitten av en körning av \"git am\"."
 
-#: wt-status.c:1219
+#: wt-status.c:1227
 msgid "The current patch is empty."
 msgstr "Aktuell patch är tom."
 
-#: wt-status.c:1223
+#: wt-status.c:1232
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git am --continue\")"
 
-#: wt-status.c:1225
+#: wt-status.c:1234
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (använd \"git am --skip\" för att hoppa över patchen)"
 
-#: wt-status.c:1227
+#: wt-status.c:1237
+msgid ""
+"  (use \"git am --allow-empty\" to record this patch as an empty commit)"
+msgstr ""
+"  (använd \"git am --allow-empty\" för att registrera patchen som en tom "
+"incheckning)"
+
+#: wt-status.c:1239
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr "  (använd \"git am --abort\" för att återställa ursprungsgrenen)"
 
-#: wt-status.c:1360
+#: wt-status.c:1372
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo saknas."
 
-#: wt-status.c:1362
+#: wt-status.c:1374
 msgid "No commands done."
 msgstr "Inga kommandon utförda."
 
-#: wt-status.c:1365
+#: wt-status.c:1377
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Sista kommandot utfört (%d kommando utfört):"
 msgstr[1] "Sista kommandot utfört (%d kommandon utfört):"
 
-#: wt-status.c:1376
+#: wt-status.c:1388
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (se fler i filen %s)"
 
-#: wt-status.c:1381
+#: wt-status.c:1393
 msgid "No commands remaining."
 msgstr "Inga kommandon återstår."
 
-#: wt-status.c:1384
+#: wt-status.c:1396
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Nästa kommando att utföra (%d kommando återstår):"
 msgstr[1] "Följande kommandon att utföra (%d kommandon återstår):"
 
-#: wt-status.c:1392
+#: wt-status.c:1404
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (använd \"git rebase --edit-todo\" för att visa och redigera)"
 
-#: wt-status.c:1404
+#: wt-status.c:1416
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Du håller på att ombasera grenen \"%s\" ovanpå \"%s\"."
 
-#: wt-status.c:1409
+#: wt-status.c:1421
 msgid "You are currently rebasing."
 msgstr "Du håller på med en ombasering."
 
-#: wt-status.c:1422
+#: wt-status.c:1434
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git rebase --continue\")"
 
-#: wt-status.c:1424
+#: wt-status.c:1436
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (använd \"git rebase --skip\" för att hoppa över patchen)"
 
-#: wt-status.c:1426
+#: wt-status.c:1438
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr "  (använd \"git rebase --abort\" för att checka ut ursprungsgrenen)"
 
-#: wt-status.c:1433
+#: wt-status.c:1445
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (alla konflikter rättade: kör \"git rebase --continue\")"
 
-#: wt-status.c:1437
+#: wt-status.c:1449
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -10088,159 +10054,159 @@ msgstr ""
 "Du håller på att dela upp en incheckning medan du ombaserar grenen \"%s\" "
 "ovanpå \"%s\"."
 
-#: wt-status.c:1442
+#: wt-status.c:1454
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Du håller på att dela upp en incheckning i en ombasering."
 
-#: wt-status.c:1445
+#: wt-status.c:1457
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr "  (Så fort din arbetskatalog är ren, kör \"git rebase --continue\")"
 
-#: wt-status.c:1449
+#: wt-status.c:1461
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Du håller på att redigera en incheckning medan du ombaserar grenen \"%s\" "
 "ovanpå \"%s\"."
 
-#: wt-status.c:1454
+#: wt-status.c:1466
 msgid "You are currently editing a commit during a rebase."
 msgstr "Du håller på att redigera en incheckning under en ombasering."
 
-#: wt-status.c:1457
+#: wt-status.c:1469
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr ""
 "  (använd \"git commit --amend\" för att lägga till på aktuell incheckning)"
 
-#: wt-status.c:1459
+#: wt-status.c:1471
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr "  (använd \"git rebase --continue\" när du är nöjd med dina ändringar)"
 
-#: wt-status.c:1470
+#: wt-status.c:1482
 msgid "Cherry-pick currently in progress."
 msgstr "Cherry-pick pågår."
 
-#: wt-status.c:1473
+#: wt-status.c:1485
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Du håller på med en \"cherry-pick\" av incheckningen %s."
 
-#: wt-status.c:1480
+#: wt-status.c:1492
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git cherry-pick --continue\")"
 
-#: wt-status.c:1483
+#: wt-status.c:1495
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (kör \"git cherry-pick --continue\" för att fortsätta)"
 
-#: wt-status.c:1486
+#: wt-status.c:1498
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr "  (alla konflikter rättade: kör \"git cherry-pick --continue\")"
 
-#: wt-status.c:1488
+#: wt-status.c:1500
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr "  (använd \"git cherry-pick --skip\" för att hoppa över patchen)"
 
-#: wt-status.c:1490
+#: wt-status.c:1502
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (använd \"git cherry-pick --abort\" för att avbryta \"cherry-pick\"-"
 "operationen)"
 
-#: wt-status.c:1500
+#: wt-status.c:1512
 msgid "Revert currently in progress."
 msgstr "Ångring pågår."
 
-#: wt-status.c:1503
+#: wt-status.c:1515
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Du håller på med att ångra incheckningen %s."
 
-#: wt-status.c:1509
+#: wt-status.c:1521
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (rätta konflikter och kör sedan \"git revert --continue\")"
 
-#: wt-status.c:1512
+#: wt-status.c:1524
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (kör \"git revert --continue\" för att fortsätta)"
 
-#: wt-status.c:1515
+#: wt-status.c:1527
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (alla konflikter rättade: kör \"git revert --continue\")"
 
-#: wt-status.c:1517
+#: wt-status.c:1529
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (använd \"git revert --skip\" för att hoppa över patchen)"
 
-#: wt-status.c:1519
+#: wt-status.c:1531
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr "  (använd \"git revert --abort\" för att avbryta ångrandet)"
 
-#: wt-status.c:1529
+#: wt-status.c:1541
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Du håller på med en \"bisect\", startad från grenen \"%s\"."
 
-#: wt-status.c:1533
+#: wt-status.c:1545
 msgid "You are currently bisecting."
 msgstr "Du håller på med en \"bisect\"."
 
-#: wt-status.c:1536
+#: wt-status.c:1548
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr ""
 "  (använd \"git bisect reset\" för att komma tillbaka till ursprungsgrenen)"
 
-#: wt-status.c:1547
+#: wt-status.c:1559
 msgid "You are in a sparse checkout."
 msgstr "Du är i en gles utcheckning."
 
-#: wt-status.c:1550
+#: wt-status.c:1562
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr "Du är i en gles utcheckning med %d%% spårade filer på plats."
 
-#: wt-status.c:1794
+#: wt-status.c:1806
 msgid "On branch "
 msgstr "På grenen "
 
-#: wt-status.c:1801
+#: wt-status.c:1813
 msgid "interactive rebase in progress; onto "
 msgstr "interaktiv ombasering pågår; ovanpå "
 
-#: wt-status.c:1803
+#: wt-status.c:1815
 msgid "rebase in progress; onto "
 msgstr "ombasering pågår; ovanpå "
 
-#: wt-status.c:1808
+#: wt-status.c:1820
 msgid "HEAD detached at "
 msgstr "HEAD frånkopplad vid "
 
-#: wt-status.c:1810
+#: wt-status.c:1822
 msgid "HEAD detached from "
 msgstr "HEAD frånkopplad från "
 
-#: wt-status.c:1813
+#: wt-status.c:1825
 msgid "Not currently on any branch."
 msgstr "Inte på någon gren för närvarande."
 
-#: wt-status.c:1830
+#: wt-status.c:1842
 msgid "Initial commit"
 msgstr "Första incheckning"
 
-#: wt-status.c:1831
+#: wt-status.c:1843
 msgid "No commits yet"
 msgstr "Inga incheckningar ännu"
 
-#: wt-status.c:1845
+#: wt-status.c:1857
 msgid "Untracked files"
 msgstr "Ospårade filer"
 
-#: wt-status.c:1847
+#: wt-status.c:1859
 msgid "Ignored files"
 msgstr "Ignorerade filer"
 
-#: wt-status.c:1851
+#: wt-status.c:1863
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -10252,32 +10218,32 @@ msgstr ""
 "lägga till nya filer själv (se \"git help status\")."
 
 # %s är nästa sträng eller tom.
-#: wt-status.c:1857
+#: wt-status.c:1869
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Ospårade filer visas ej%s"
 
-#: wt-status.c:1859
+#: wt-status.c:1871
 msgid " (use -u option to show untracked files)"
 msgstr " (använd flaggan -u för att visa ospårade filer)"
 
-#: wt-status.c:1865
+#: wt-status.c:1877
 msgid "No changes"
 msgstr "Inga ändringar"
 
-#: wt-status.c:1870
+#: wt-status.c:1882
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "inga ändringar att checka in (använd \"git add\" och/eller \"git commit -a"
 "\")\n"
 
-#: wt-status.c:1874
+#: wt-status.c:1886
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "inga ändringar att checka in\n"
 
-#: wt-status.c:1878
+#: wt-status.c:1890
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -10286,80 +10252,80 @@ msgstr ""
 "inget köat för incheckning, men ospårade filer finns (spåra med \"git add"
 "\")\n"
 
-#: wt-status.c:1882
+#: wt-status.c:1894
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "inget köat för incheckning, men ospårade filer finns\n"
 
-#: wt-status.c:1886
+#: wt-status.c:1898
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr "inget att checka in (skapa/kopiera filer och spåra med \"git add\")\n"
 
-#: wt-status.c:1890 wt-status.c:1896
+#: wt-status.c:1902 wt-status.c:1908
 #, c-format
 msgid "nothing to commit\n"
 msgstr "inget att checka in\n"
 
-#: wt-status.c:1893
+#: wt-status.c:1905
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr "inget att checka in (använd -u för att visa ospårade filer)\n"
 
-#: wt-status.c:1898
+#: wt-status.c:1910
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "inget att checka in, arbetskatalogen ren\n"
 
-#: wt-status.c:2003
+#: wt-status.c:2015
 msgid "No commits yet on "
 msgstr "Inga incheckningar ännu på "
 
-#: wt-status.c:2007
+#: wt-status.c:2019
 msgid "HEAD (no branch)"
 msgstr "HEAD (ingen gren)"
 
-#: wt-status.c:2038
+#: wt-status.c:2050
 msgid "different"
 msgstr "olika"
 
-#: wt-status.c:2040 wt-status.c:2048
+#: wt-status.c:2052 wt-status.c:2060
 msgid "behind "
 msgstr "efter "
 
-#: wt-status.c:2043 wt-status.c:2046
+#: wt-status.c:2055 wt-status.c:2058
 msgid "ahead "
 msgstr "före "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2569
+#: wt-status.c:2596
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "kan inte %s: Du har oköade ändringar."
 
-#: wt-status.c:2575
+#: wt-status.c:2602
 msgid "additionally, your index contains uncommitted changes."
 msgstr "dessutom innehåller dit index ändringar som inte har checkats in."
 
-#: wt-status.c:2577
+#: wt-status.c:2604
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "kan inte %s: Ditt index innehåller ändringar som inte checkats in."
 
-#: compat/simple-ipc/ipc-unix-socket.c:183
+#: compat/simple-ipc/ipc-unix-socket.c:205
 msgid "could not send IPC command"
 msgstr "kunde inte sända IPC-kommando"
 
-#: compat/simple-ipc/ipc-unix-socket.c:190
+#: compat/simple-ipc/ipc-unix-socket.c:212
 msgid "could not read IPC response"
 msgstr "kunde inte läsa IPC-svar"
 
-#: compat/simple-ipc/ipc-unix-socket.c:870
+#: compat/simple-ipc/ipc-unix-socket.c:892
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "kunde inte ta status \"accept_thread\" \"%s\""
 
-#: compat/simple-ipc/ipc-unix-socket.c:882
+#: compat/simple-ipc/ipc-unix-socket.c:904
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr "kunde inte starta \"worker[0]\" för \"%s\""
@@ -10396,107 +10362,113 @@ msgstr "ta bort \"%s\"\n"
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Oköade ändringar efter att ha uppdaterat indexet:"
 
-#: builtin/add.c:317 builtin/rev-parse.c:993
+#: builtin/add.c:313 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Kunde inte läsa indexet"
 
-#: builtin/add.c:330
+#: builtin/add.c:326
 msgid "Could not write patch"
 msgstr "Kunde inte skriva patch"
 
-#: builtin/add.c:333
+#: builtin/add.c:329
 msgid "editing patch failed"
 msgstr "redigering av patch misslyckades"
 
-#: builtin/add.c:336
+#: builtin/add.c:332
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Kunde inte ta status på \"%s\""
 
-#: builtin/add.c:338
+#: builtin/add.c:334
 msgid "Empty patch. Aborted."
 msgstr "Tom patch. Avbryter."
 
-#: builtin/add.c:343
+#: builtin/add.c:340
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Kunde inte tillämpa \"%s\""
 
-#: builtin/add.c:351
+#: builtin/add.c:348
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "Följande sökvägar ignoreras av en av dina .gitignore-filer:\n"
 
-#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:368 builtin/clean.c:927 builtin/fetch.c:174 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "testkörning"
 
-#: builtin/add.c:374
+#: builtin/add.c:369 builtin/check-ignore.c:22 builtin/commit.c:1484
+#: builtin/count-objects.c:98 builtin/fsck.c:789 builtin/log.c:2313
+#: builtin/mv.c:123 builtin/read-tree.c:120
+msgid "be verbose"
+msgstr "var pratsam"
+
+#: builtin/add.c:371
 msgid "interactive picking"
 msgstr "plocka interaktivt"
 
-#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
+#: builtin/add.c:372 builtin/checkout.c:1581 builtin/reset.c:409
 msgid "select hunks interactively"
 msgstr "välj stycken interaktivt"
 
-#: builtin/add.c:376
+#: builtin/add.c:373
 msgid "edit current diff and apply"
 msgstr "redigera aktuell diff och applicera"
 
-#: builtin/add.c:377
+#: builtin/add.c:374
 msgid "allow adding otherwise ignored files"
 msgstr "tillåt lägga till annars ignorerade filer"
 
-#: builtin/add.c:378
+#: builtin/add.c:375
 msgid "update tracked files"
 msgstr "uppdatera spårade filer"
 
-#: builtin/add.c:379
+#: builtin/add.c:376
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "åternormalisera radslut i spårade filer (implicerar -u)"
 
-#: builtin/add.c:380
+#: builtin/add.c:377
 msgid "record only the fact that the path will be added later"
 msgstr "registrera endast att sökvägen kommer läggas till senare"
 
-#: builtin/add.c:381
+#: builtin/add.c:378
 msgid "add changes from all tracked and untracked files"
 msgstr "lägg till ändringar från alla spårade och ospårade filer"
 
-#: builtin/add.c:384
+#: builtin/add.c:381
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "ignorera sökvägar borttagna i arbetskatalogen (samma som --no-all)"
 
-#: builtin/add.c:386
+#: builtin/add.c:383
 msgid "don't add, only refresh the index"
 msgstr "lägg inte till, uppdatera endast indexet"
 
-#: builtin/add.c:387
+#: builtin/add.c:384
 msgid "just skip files which cannot be added because of errors"
 msgstr "hoppa bara över filer som inte kan läggas till på grund av fel"
 
-#: builtin/add.c:388
+#: builtin/add.c:385
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "se om - även saknade - filer ignoreras i testkörning"
 
-#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+#: builtin/add.c:386 builtin/mv.c:128 builtin/rm.c:251
 msgid "allow updating entries outside of the sparse-checkout cone"
 msgstr "tillåt uppdatera poster utanför området angivet i \"sparse-checkout\""
 
-#: builtin/add.c:391 builtin/update-index.c:1004
+#: builtin/add.c:388 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "överstyr exekveringsbiten för angivna filer"
 
-#: builtin/add.c:393
+#: builtin/add.c:390
 msgid "warn when adding an embedded repository"
 msgstr "varna när ett inbyggt arkiv läggs till"
 
-#: builtin/add.c:395
+#: builtin/add.c:392
 msgid "backend for `git stash -p`"
 msgstr "bakända för \"git stash -p\""
 
-#: builtin/add.c:413
+#: builtin/add.c:410
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10527,12 +10499,12 @@ msgstr ""
 "\n"
 "Se \"git help submodule\" för ytterligare information."
 
-#: builtin/add.c:442
+#: builtin/add.c:439
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "lägger till inbäddat git-arkiv: %s"
 
-#: builtin/add.c:462
+#: builtin/add.c:459
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10542,51 +10514,27 @@ msgstr ""
 "Slå av detta meddelande med\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:477
+#: builtin/add.c:474
 msgid "adding files failed"
 msgstr "misslyckades lägga till filer"
 
-#: builtin/add.c:513
-msgid "--dry-run is incompatible with --interactive/--patch"
-msgstr "--dry-run är inkompatibelt med --interactive/--patch"
-
-#: builtin/add.c:515 builtin/commit.c:358
-msgid "--pathspec-from-file is incompatible with --interactive/--patch"
-msgstr "--pathspec-from-file är inkompatibelt med --interactive/--patch"
-
-#: builtin/add.c:532
-msgid "--pathspec-from-file is incompatible with --edit"
-msgstr "--pathspec-from-file är inkompatibelt med --edit"
-
-#: builtin/add.c:544
-msgid "-A and -u are mutually incompatible"
-msgstr "-A och -u är ömsesidigt inkompatibla"
-
-#: builtin/add.c:547
-msgid "Option --ignore-missing can only be used together with --dry-run"
-msgstr "Flaggan --ignore-missing kan endast användas tillsammans med --dry-run"
-
-#: builtin/add.c:551
+#: builtin/add.c:548
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "\"--chmod\"-parametern \"%s\" måste antingen vara -x eller +x"
 
-#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
-#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
-msgid "--pathspec-from-file is incompatible with pathspec arguments"
-msgstr "--pathspec-from-file är inkompatibelt med sökvägsangivelsesparametrar"
+#: builtin/add.c:569 builtin/checkout.c:1751 builtin/commit.c:364
+#: builtin/reset.c:429 builtin/rm.c:275 builtin/stash.c:1713
+#, c-format
+msgid "'%s' and pathspec arguments cannot be used together"
+msgstr "\"%s\" kan inte användas tillsammans med sökvägsangivelser"
 
-#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
-#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
-msgid "--pathspec-file-nul requires --pathspec-from-file"
-msgstr "--pathspec-file-nul kräver --pathspec-from-file"
-
-#: builtin/add.c:583
+#: builtin/add.c:580
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Inget angivet, inget tillagt.\n"
 
-#: builtin/add.c:585
+#: builtin/add.c:582
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10596,109 +10544,117 @@ msgstr ""
 "Slå av detta meddelande genom att köra\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:366
+#: builtin/am.c:202
+#, c-format
+msgid "Invalid value for --empty: %s"
+msgstr "Felaktigt värde för --empty: %s"
+
+#: builtin/am.c:392
 msgid "could not parse author script"
 msgstr "kunde inte tolka författarskript"
 
-#: builtin/am.c:456
+#: builtin/am.c:482
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "\"%s\" togs bort av kroken applypatch-msg"
 
-#: builtin/am.c:498
+#: builtin/am.c:524
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Felaktig indatarad: \"%s\"."
 
-#: builtin/am.c:536
+#: builtin/am.c:562
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Misslyckades kopiera anteckningar från \"%s\" till \"%s\""
 
-#: builtin/am.c:562
+#: builtin/am.c:588
 msgid "fseek failed"
 msgstr "\"fseek\" misslyckades"
 
-#: builtin/am.c:750
+#: builtin/am.c:776
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "kunde inte tolka patchen \"%s\""
 
-#: builtin/am.c:815
+#: builtin/am.c:841
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Endast en StGIT-patchserie kan tillämpas åt gången"
 
-#: builtin/am.c:863
+#: builtin/am.c:889
 msgid "invalid timestamp"
 msgstr "ogiltig tidsstämpel"
 
-#: builtin/am.c:868 builtin/am.c:880
+#: builtin/am.c:894 builtin/am.c:906
 msgid "invalid Date line"
 msgstr "ogiltig \"Date\"-rad"
 
-#: builtin/am.c:875
+#: builtin/am.c:901
 msgid "invalid timezone offset"
 msgstr "ogiltig tidszons-offset"
 
-#: builtin/am.c:968
+#: builtin/am.c:994
 msgid "Patch format detection failed."
 msgstr "Misslyckades detektera patchformat."
 
-#: builtin/am.c:973 builtin/clone.c:300
+#: builtin/am.c:999 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "misslyckades skapa katalogen \"%s\""
 
-#: builtin/am.c:978
+#: builtin/am.c:1004
 msgid "Failed to split patches."
 msgstr "Misslyckades dela patchar."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1153
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "När du har löst problemet, kör \"%s --continue\"."
 
-#: builtin/am.c:1128
+#: builtin/am.c:1154
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr "Om du hellre vill hoppa över patchen, kör \"%s --skip\" i stället."
 
-#: builtin/am.c:1129
+#: builtin/am.c:1159
+#, c-format
+msgid "To record the empty patch as an empty commit, run \"%s --allow-empty\"."
+msgstr ""
+"För att registrera den tomma patchen som en tom incheckning, kör \"%s --"
+"allow-empty\"."
+
+#: builtin/am.c:1161
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "För att återgå till ursprunglig gren och sluta patcha, kör \"%s --abort\"."
 
-#: builtin/am.c:1224
+#: builtin/am.c:1256
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch sänd med format=flowed; blanksteg på slut av rader kan ha tappats."
 
-#: builtin/am.c:1252
-msgid "Patch is empty."
-msgstr "Patchen är tom."
-
-#: builtin/am.c:1317
+#: builtin/am.c:1344
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "saknad \"author\"-rad i incheckningen %s"
 
-#: builtin/am.c:1320
+#: builtin/am.c:1347
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "ogiltig ident-rad: %.*s"
 
-#: builtin/am.c:1539
+#: builtin/am.c:1566
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Arkivet saknar objekt som behövs för att falla tillbaka på 3-"
 "vägssammanslagning."
 
-#: builtin/am.c:1541
+#: builtin/am.c:1568
 msgid "Using index info to reconstruct a base tree..."
 msgstr "Använder indexinfo för att återskapa ett basträd..."
 
-#: builtin/am.c:1560
+#: builtin/am.c:1587
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10706,25 +10662,25 @@ msgstr ""
 "Har du handredigerat din patch?\n"
 "Den kan inte tillämpas på blobbar som antecknats i dess index."
 
-#: builtin/am.c:1566
+#: builtin/am.c:1593
 msgid "Falling back to patching base and 3-way merge..."
 msgstr ""
 "Faller tillbaka på att patcha grundversionen och trevägssammanslagning..."
 
-#: builtin/am.c:1592
+#: builtin/am.c:1619
 msgid "Failed to merge in the changes."
 msgstr "Misslyckades slå ihop ändringarna."
 
-#: builtin/am.c:1624
+#: builtin/am.c:1651
 msgid "applying to an empty history"
 msgstr "tillämpar på en tom historik"
 
-#: builtin/am.c:1676 builtin/am.c:1680
+#: builtin/am.c:1703 builtin/am.c:1707
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "kan inte återuppta: %s finns inte."
 
-#: builtin/am.c:1698
+#: builtin/am.c:1725
 msgid "Commit Body is:"
 msgstr "Incheckningskroppen är:"
 
@@ -10732,41 +10688,59 @@ msgstr "Incheckningskroppen är:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1708
+#: builtin/am.c:1735
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr "Tillämpa? Y=ja/N=nej/E=redigera/V=visa patch/A=godta alla: "
 
-#: builtin/am.c:1754 builtin/commit.c:409
+#: builtin/am.c:1781 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "kan inte skriva indexfil"
 
-#: builtin/am.c:1758
+#: builtin/am.c:1785
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Smutsigt index: kan inte tillämpa patchar (smutsiga: %s)"
 
-#: builtin/am.c:1798 builtin/am.c:1865
+#: builtin/am.c:1827
+#, c-format
+msgid "Skipping: %.*s"
+msgstr "Hoppar över: %.*s"
+
+#: builtin/am.c:1832
+#, c-format
+msgid "Creating an empty commit: %.*s"
+msgstr "Skapar en tom incheckningar: %.*s"
+
+#: builtin/am.c:1836
+msgid "Patch is empty."
+msgstr "Patchen är tom."
+
+#: builtin/am.c:1847 builtin/am.c:1916
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Tillämpar: %.*s"
 
-#: builtin/am.c:1815
+#: builtin/am.c:1864
 msgid "No changes -- Patch already applied."
 msgstr "Inga ändringar -- Patchen har redan tillämpats."
 
-#: builtin/am.c:1821
+#: builtin/am.c:1870
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Patch misslyckades på %s %.*s"
 
-#: builtin/am.c:1825
+#: builtin/am.c:1874
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "Använd \"git am --show-current-patch=diff\" för att se patchen som "
 "misslyckades"
 
-#: builtin/am.c:1868
+#: builtin/am.c:1920
+msgid "No changes - recorded it as an empty commit."
+msgstr "Inga ändringar - sparat som en tom incheckning."
+
+#: builtin/am.c:1922
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10776,7 +10750,7 @@ msgstr ""
 "Om det inte är något kvar att köa kan det hända att något annat redan\n"
 "introducerat samma ändringar; kanske du bör hoppa över patchen."
 
-#: builtin/am.c:1875
+#: builtin/am.c:1930
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -10788,17 +10762,17 @@ msgstr ""
 "lösta.\n"
 "Du kan köra \"git rm\" för att godta \"borttagen av dem\" för den."
 
-#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
-#: builtin/reset.c:361
+#: builtin/am.c:2038 builtin/am.c:2042 builtin/am.c:2054 builtin/reset.c:448
+#: builtin/reset.c:456
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Kan inte tolka objektet \"%s\"."
 
-#: builtin/am.c:2035 builtin/am.c:2111
+#: builtin/am.c:2090 builtin/am.c:2166
 msgid "failed to clean index"
 msgstr "misslyckades städa upp indexet"
 
-#: builtin/am.c:2079
+#: builtin/am.c:2134
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10806,159 +10780,167 @@ msgstr ""
 "Du verkar ha flyttat HEAD sedan \"am\" sist misslyckades.\n"
 "Återställer inte till ORIG_HEAD"
 
-#: builtin/am.c:2187
+#: builtin/am.c:2242
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Felaktigt värde för --patch-format: %s"
 
-#: builtin/am.c:2229
+#: builtin/am.c:2285
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Felaktigt värde för --show-current-patch: %s"
 
-#: builtin/am.c:2233
+#: builtin/am.c:2289
 #, c-format
-msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
-msgstr "--show-current-patch=%s är inkompatibelt med --show-current-patch=%s"
+msgid "options '%s=%s' and '%s=%s' cannot be used together"
+msgstr "flaggorna \"%s=%s\" och \"%s=%s\" kan inte användas samtidigt"
 
-#: builtin/am.c:2264
+#: builtin/am.c:2320
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<flaggor>] [(<mbox> | <Maildir>)...]"
 
-#: builtin/am.c:2265
+#: builtin/am.c:2321
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<flaggor>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2327
 msgid "run interactively"
 msgstr "kör interaktivt"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2329
 msgid "historical option -- no-op"
 msgstr "historisk flagga -- no-op"
 
-#: builtin/am.c:2275
+#: builtin/am.c:2331
 msgid "allow fall back on 3way merging if needed"
 msgstr "tillåt falla tillbaka på trevägssammanslagning om nödvändigt"
 
-#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:640 builtin/stash.c:961
+#: builtin/am.c:2332 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:642 builtin/stash.c:962
 msgid "be quiet"
 msgstr "var tyst"
 
-#: builtin/am.c:2278
+#: builtin/am.c:2334
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "lägg till \"Signed-off-by\"-släprad i incheckningsmeddelandet"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2337
 msgid "recode into utf8 (default)"
 msgstr "koda om till utf8 (standard)"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2339
 msgid "pass -k flag to git-mailinfo"
 msgstr "sänd flaggan -k till git-mailinfo"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2341
 msgid "pass -b flag to git-mailinfo"
 msgstr "sänd flaggan -b till git-mailinfo"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2343
 msgid "pass -m flag to git-mailinfo"
 msgstr "sänd flaggan -m till git-mailinfo"
 
-#: builtin/am.c:2289
+#: builtin/am.c:2345
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "sänd flaggan --keep-cr till git-mailsplit för mbox-formatet"
 
-#: builtin/am.c:2292
+#: builtin/am.c:2348
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr "sänd inte flaggan --keep-cr till git-mailsplit oberoende av am.keepcr"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2351
 msgid "strip everything before a scissors line"
 msgstr "ta bort allting före en saxlinje"
 
-#: builtin/am.c:2297
+#: builtin/am.c:2353
 msgid "pass it through git-mailinfo"
 msgstr "sänd det genom git-mailinfo"
 
-#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
-#: builtin/am.c:2327
+#: builtin/am.c:2356 builtin/am.c:2359 builtin/am.c:2362 builtin/am.c:2365
+#: builtin/am.c:2368 builtin/am.c:2371 builtin/am.c:2374 builtin/am.c:2377
+#: builtin/am.c:2383
 msgid "pass it through git-apply"
 msgstr "sänd det genom git-apply"
 
-#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
+#: builtin/am.c:2373 builtin/commit.c:1515 builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:21 builtin/grep.c:919 builtin/merge.c:263
 #: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
-#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
-#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/rebase.c:1046 builtin/repack.c:653 builtin/repack.c:657
+#: builtin/repack.c:659 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:315
+#: parse-options.h:317
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
+#: builtin/am.c:2379 builtin/branch.c:680 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:41 builtin/replace.c:555 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "format"
 
-#: builtin/am.c:2324
+#: builtin/am.c:2380
 msgid "format the patch(es) are in"
 msgstr "format för patch(ar)"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2386
 msgid "override error message when patch failure occurs"
 msgstr "överstyr felmeddelanden när patchfel uppstår"
 
-#: builtin/am.c:2332
+#: builtin/am.c:2388
 msgid "continue applying patches after resolving a conflict"
 msgstr "fortsätt applicera patchar efter att ha löst en konflikt"
 
-#: builtin/am.c:2335
+#: builtin/am.c:2391
 msgid "synonyms for --continue"
 msgstr "synonymer till --continue"
 
-#: builtin/am.c:2338
+#: builtin/am.c:2394
 msgid "skip the current patch"
 msgstr "hoppa över den aktuella grenen"
 
-#: builtin/am.c:2341
+#: builtin/am.c:2397
 msgid "restore the original branch and abort the patching operation"
 msgstr "återställ originalgrenen och avbryt patchningen"
 
-#: builtin/am.c:2344
+#: builtin/am.c:2400
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "avbryt patchningen men behåll HEAD där det är"
 
-#: builtin/am.c:2348
+#: builtin/am.c:2404
 msgid "show the patch being applied"
 msgstr "visa patchen som tillämpas"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2408
+msgid "record the empty patch as an empty commit"
+msgstr "lagra den tomma patchen som en tom incheckning"
+
+#: builtin/am.c:2412
 msgid "lie about committer date"
 msgstr "ljug om incheckningsdatum"
 
-#: builtin/am.c:2355
+#: builtin/am.c:2414
 msgid "use current timestamp for author date"
 msgstr "använd nuvarande tidsstämpel för författardatum"
 
-#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
+#: builtin/am.c:2416 builtin/commit-tree.c:118 builtin/commit.c:1643
+#: builtin/merge.c:302 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "nyckel-id"
 
-#: builtin/am.c:2358 builtin/rebase.c:1100
+#: builtin/am.c:2417 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "GPG-signera incheckningar"
 
-#: builtin/am.c:2361
+#: builtin/am.c:2420
+msgid "how to handle empty patches"
+msgstr "hantering av tomma patchar"
+
+#: builtin/am.c:2423
 msgid "(internal use for git-rebase)"
 msgstr "(används internt av git-rebase)"
 
-#: builtin/am.c:2379
+#: builtin/am.c:2441
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10966,16 +10948,16 @@ msgstr ""
 "Flaggan -b/--binary har varit utan funktion länge, och\n"
 "kommer tas bort. Vi ber dig att inte använda den längre."
 
-#: builtin/am.c:2386
+#: builtin/am.c:2448
 msgid "failed to read the index"
 msgstr "misslyckades läsa indexet"
 
-#: builtin/am.c:2401
+#: builtin/am.c:2463
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "tidigare rebase-katalog %s finns fortfarande, men mbox angavs."
 
-#: builtin/am.c:2425
+#: builtin/am.c:2487
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10984,11 +10966,11 @@ msgstr ""
 "Kvarbliven katalog %s hittades.\n"
 "Använd \"git am --abort\" för att ta bort den."
 
-#: builtin/am.c:2431
+#: builtin/am.c:2493
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Lösningsoperation pågår inte, vi återupptar inte."
 
-#: builtin/am.c:2441
+#: builtin/am.c:2503
 msgid "interactive mode requires patches on the command line"
 msgstr "interaktivt läge kräver patchar på kommandoraden"
 
@@ -11448,11 +11430,11 @@ msgstr "vehandla inte rotincheckningar som gränser (Standard: av)"
 msgid "show work cost statistics"
 msgstr "visa statistik över arbetskostnad"
 
-#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
-#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
-#: builtin/merge.c:298 builtin/multi-pack-index.c:103
-#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
+#: builtin/blame.c:867 builtin/checkout.c:1536 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:180
+#: builtin/merge.c:301 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:180
+#: builtin/multi-pack-index.c:208 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "tvinga förloppsrapportering"
@@ -11501,7 +11483,7 @@ msgstr "visa författarens e-post istället för namn (Standard: av)"
 msgid "ignore whitespace differences"
 msgstr "ignorera ändringar i blanksteg"
 
-#: builtin/blame.c:879 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1838
 msgid "rev"
 msgstr "incheckning"
 
@@ -11554,7 +11536,7 @@ msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr ""
 "behandla endast intervallet <start>,<slut> eller funktionen :<funknamn>"
 
-#: builtin/blame.c:944
+#: builtin/blame.c:947
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr "--progress kan inte användas med --incremental eller porslinsformat"
 
@@ -11566,18 +11548,18 @@ msgstr "--progress kan inte användas med --incremental eller porslinsformat"
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:995
+#: builtin/blame.c:998
 msgid "4 years, 11 months ago"
 msgstr "4 år, 11 månader sedan"
 
-#: builtin/blame.c:1111
+#: builtin/blame.c:1114
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "filen %s har bara %lu rad"
 msgstr[1] "filen %s har bara %lu rader"
 
-#: builtin/blame.c:1156
+#: builtin/blame.c:1159
 msgid "Blaming lines"
 msgstr "Klandra rader"
 
@@ -11609,7 +11591,7 @@ msgstr "git branch [<flaggor>] [-r | -a] [--points-at]"
 msgid "git branch [<options>] [-r | -a] [--format]"
 msgstr "git branch [<flaggor>] [-r | -a] [--format]"
 
-#: builtin/branch.c:154
+#: builtin/branch.c:153
 #, c-format
 msgid ""
 "deleting branch '%s' that has been merged to\n"
@@ -11618,7 +11600,7 @@ msgstr ""
 "tar bort grenen \"%s\" som har slagits ihop med\n"
 "         \"%s\", men ännu inte slagits ihop med HEAD."
 
-#: builtin/branch.c:158
+#: builtin/branch.c:157
 #, c-format
 msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
@@ -11627,12 +11609,12 @@ msgstr ""
 "tar inte bort grenen \"%s\" som inte har slagits ihop med\n"
 "         \"%s\", trots att den har slagits ihop med HEAD."
 
-#: builtin/branch.c:172
+#: builtin/branch.c:171
 #, c-format
 msgid "Couldn't look up commit object for '%s'"
 msgstr "Kunde inte slå upp incheckningsobjekt för \"%s\""
 
-#: builtin/branch.c:176
+#: builtin/branch.c:175
 #, c-format
 msgid ""
 "The branch '%s' is not fully merged.\n"
@@ -11641,7 +11623,7 @@ msgstr ""
 "Grenen \"%s\" har inte slagits samman i sin helhet.\n"
 "Om du är säker på att du vill ta bort den, kör \"git branch -D %s\"."
 
-#: builtin/branch.c:189
+#: builtin/branch.c:188
 msgid "Update of config-file failed"
 msgstr "Misslyckades uppdatera konfigurationsfil"
 
@@ -11653,100 +11635,100 @@ msgstr "kan inte ange -a med -d"
 msgid "Couldn't look up commit object for HEAD"
 msgstr "Kunde inte slå upp incheckningsobjekt för HEAD"
 
-#: builtin/branch.c:244
+#: builtin/branch.c:247
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
 msgstr "Kan inte ta bort grenen \"%s\" som är utcheckad på \"%s\""
 
-#: builtin/branch.c:259
+#: builtin/branch.c:262
 #, c-format
 msgid "remote-tracking branch '%s' not found."
 msgstr "fjärrspårande grenen \"%s\" hittades inte."
 
-#: builtin/branch.c:260
+#: builtin/branch.c:263
 #, c-format
 msgid "branch '%s' not found."
 msgstr "grenen \"%s\" hittades inte."
 
-#: builtin/branch.c:291
+#: builtin/branch.c:294
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
 msgstr "Tog bort fjärrspårande grenen %s (var %s).\n"
 
-#: builtin/branch.c:292
+#: builtin/branch.c:295
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Tog bort grenen %s (var %s).\n"
 
-#: builtin/branch.c:441 builtin/tag.c:63
+#: builtin/branch.c:445 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "kan inte tolka formatsträng"
 
-#: builtin/branch.c:472
+#: builtin/branch.c:476
 msgid "could not resolve HEAD"
 msgstr "kunde inte slå upp HEAD"
 
-#: builtin/branch.c:478
+#: builtin/branch.c:482
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) pekar utenför refs/heads/"
 
-#: builtin/branch.c:493
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Grenen %s ombaseras på %s"
 
-#: builtin/branch.c:497
+#: builtin/branch.c:501
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Grenen %s är i en \"bisect\" på %s"
 
-#: builtin/branch.c:514
+#: builtin/branch.c:518
 msgid "cannot copy the current branch while not on any."
 msgstr "kunde inte kopiera aktuell gren när du inte befinner dig på någon."
 
-#: builtin/branch.c:516
+#: builtin/branch.c:520
 msgid "cannot rename the current branch while not on any."
 msgstr ""
 "kunde inte byta namn på aktuell gren när du inte befinner dig på någon."
 
-#: builtin/branch.c:527
+#: builtin/branch.c:531
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Felaktigt namn på gren: \"%s\""
 
-#: builtin/branch.c:556
+#: builtin/branch.c:560
 msgid "Branch rename failed"
 msgstr "Misslyckades byta namn på gren"
 
-#: builtin/branch.c:558
+#: builtin/branch.c:562
 msgid "Branch copy failed"
 msgstr "Misslyckades kopiera gren"
 
-#: builtin/branch.c:562
+#: builtin/branch.c:566
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Skapade kopia av felaktigt namngiven gren \"%s\""
 
-#: builtin/branch.c:565
+#: builtin/branch.c:569
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Bytte bort namn på en felaktigt namngiven gren \"%s\""
 
-#: builtin/branch.c:571
+#: builtin/branch.c:575
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Grenen namnbytt till %s, men HEAD har inte uppdaterats!"
 
-#: builtin/branch.c:580
+#: builtin/branch.c:584
 msgid "Branch is renamed, but update of config-file failed"
 msgstr "Grenen namnbytt, men misslyckades uppdatera konfigurationsfilen"
 
-#: builtin/branch.c:582
+#: builtin/branch.c:586
 msgid "Branch is copied, but update of config-file failed"
 msgstr "Grenen kopierades, men misslyckades uppdatera konfigurationsfilen"
 
-#: builtin/branch.c:598
+#: builtin/branch.c:602
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11757,211 +11739,207 @@ msgstr ""
 "  %s\n"
 "Rader som inleds med \"%c\" ignoreras.\n"
 
-#: builtin/branch.c:632
+#: builtin/branch.c:637
 msgid "Generic options"
 msgstr "Allmänna flaggor"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:639
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "visa hash och ärenderad, ange två gånger för uppströmsgren"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:640
 msgid "suppress informational messages"
 msgstr "undertryck informationsmeddelanden"
 
-#: builtin/branch.c:636
-msgid "set up tracking mode (see git-pull(1))"
-msgstr "ställ in spårningsläge (se git-pull(1))"
+#: builtin/branch.c:642
+msgid "set branch tracking configuration"
+msgstr "ställ in inställningar för spårad gren"
 
-#: builtin/branch.c:638
+#: builtin/branch.c:645
 msgid "do not use"
 msgstr "använd ej"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "upstream"
 msgstr "uppströms"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "change the upstream info"
 msgstr "ändra uppströmsinformationen"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:648
 msgid "unset the upstream info"
 msgstr "ta bort uppströmsinformationen"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:649
 msgid "use colored output"
 msgstr "använd färgad utdata"
 
-#: builtin/branch.c:643
+#: builtin/branch.c:650
 msgid "act on remote-tracking branches"
 msgstr "arbeta på fjärrspårande grenar"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:652 builtin/branch.c:654
 msgid "print only branches that contain the commit"
 msgstr "visa endast grenar som innehåller incheckningen"
 
-#: builtin/branch.c:646 builtin/branch.c:648
+#: builtin/branch.c:653 builtin/branch.c:655
 msgid "print only branches that don't contain the commit"
 msgstr "visa endast grenar som inte innehåller incheckningen"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:658
 msgid "Specific git-branch actions:"
 msgstr "Specifika git-branch-åtgärder:"
 
-#: builtin/branch.c:652
+#: builtin/branch.c:659
 msgid "list both remote-tracking and local branches"
 msgstr "visa både fjärrspårande och lokala grenar"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:661
 msgid "delete fully merged branch"
 msgstr "ta bort helt sammanslagen gren"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:662
 msgid "delete branch (even if not merged)"
 msgstr "ta bort gren (även om inte helt sammanslagen)"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:663
 msgid "move/rename a branch and its reflog"
 msgstr "flytta/ta bort en gren och dess reflogg"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:664
 msgid "move/rename a branch, even if target exists"
 msgstr "flytta/ta bort en gren, även om målet finns"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:665
 msgid "copy a branch and its reflog"
 msgstr "kopiera en gren och dess reflogg"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:666
 msgid "copy a branch, even if target exists"
 msgstr "kopiera en gren, även om målet finns"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:667
 msgid "list branch names"
 msgstr "lista namn på grenar"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:668
 msgid "show current branch name"
 msgstr "visa namn på aktuell gren"
 
-#: builtin/branch.c:662
+#: builtin/branch.c:669
 msgid "create the branch's reflog"
 msgstr "skapa grenens reflogg"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:671
 msgid "edit the description for the branch"
 msgstr "redigera beskrivning för grenen"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:672
 msgid "force creation, move/rename, deletion"
 msgstr "tvinga skapande, flytt/namnändring, borttagande"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:673
 msgid "print only branches that are merged"
 msgstr "visa endast sammanslagna grenar"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:674
 msgid "print only branches that are not merged"
 msgstr "visa endast ej sammanslagna grenar"
 
-#: builtin/branch.c:668
+#: builtin/branch.c:675
 msgid "list branches in columns"
 msgstr "visa grenar i spalter"
 
-#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/branch.c:677 builtin/for-each-ref.c:45 builtin/notes.c:413
 #: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
 #: builtin/tag.c:475
 msgid "object"
 msgstr "objekt"
 
-#: builtin/branch.c:671
+#: builtin/branch.c:678
 msgid "print only branches of the object"
 msgstr "visa endast grenar för objektet"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
+#: builtin/branch.c:679 builtin/for-each-ref.c:51 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "sortering och filtrering skiljer gemener och VERSALER"
 
-#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
+#: builtin/branch.c:680 builtin/for-each-ref.c:41 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "format att använda för utdata"
 
-#: builtin/branch.c:696 builtin/clone.c:678
+#: builtin/branch.c:703 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD hittades inte under refs/heads!"
 
-#: builtin/branch.c:720
-msgid "--column and --verbose are incompatible"
-msgstr "--column och --verbose är inkompatibla"
-
-#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
+#: builtin/branch.c:742 builtin/branch.c:798 builtin/branch.c:807
 msgid "branch name required"
 msgstr "grennamn krävs"
 
-#: builtin/branch.c:768
+#: builtin/branch.c:774
 msgid "Cannot give description to detached HEAD"
 msgstr "Kan inte beskriva frånkopplad HEAD"
 
-#: builtin/branch.c:773
+#: builtin/branch.c:779
 msgid "cannot edit description of more than one branch"
 msgstr "kan inte redigera beskrivning för mer än en gren"
 
-#: builtin/branch.c:780
+#: builtin/branch.c:786
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Inga incheckningar på grenen \"%s\" ännu."
 
-#: builtin/branch.c:783
+#: builtin/branch.c:789
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Ingen gren vid namnet \"%s\"."
 
-#: builtin/branch.c:798
+#: builtin/branch.c:804
 msgid "too many branches for a copy operation"
 msgstr "för många grenar för kopiering"
 
-#: builtin/branch.c:807
+#: builtin/branch.c:813
 msgid "too many arguments for a rename operation"
 msgstr "för många flaggor för namnbyte"
 
-#: builtin/branch.c:812
+#: builtin/branch.c:818
 msgid "too many arguments to set new upstream"
 msgstr "för många flaggor för att byta uppström"
 
-#: builtin/branch.c:816
+#: builtin/branch.c:822
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
 msgstr ""
 "kunde inte sätta uppström för HEAD till %s när det inte pekar mot någon gren."
 
-#: builtin/branch.c:819 builtin/branch.c:842
+#: builtin/branch.c:825 builtin/branch.c:848
 #, c-format
 msgid "no such branch '%s'"
 msgstr "okänd gren \"%s\""
 
-#: builtin/branch.c:823
+#: builtin/branch.c:829
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "grenen \"%s\" finns inte"
 
-#: builtin/branch.c:836
+#: builtin/branch.c:842
 msgid "too many arguments to unset upstream"
 msgstr "för många flaggor för att ta bort uppström"
 
-#: builtin/branch.c:840
+#: builtin/branch.c:846
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "kunde inte ta bort uppström för HEAD när det inte pekar mot någon gren."
 
-#: builtin/branch.c:846
+#: builtin/branch.c:852
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Grenen \"%s\" har ingen uppströmsinformation"
 
-#: builtin/branch.c:856
+#: builtin/branch.c:862
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11969,7 +11947,7 @@ msgstr ""
 "Flaggorna -a och -r på \"git branch\" tar inte ett namn på gren.\n"
 "Menade du att använda: -a|-r --list <mönster>?"
 
-#: builtin/branch.c:860
+#: builtin/branch.c:866
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -12240,8 +12218,8 @@ msgstr "läs filnamn från standard in"
 msgid "terminate input and output records by a NUL character"
 msgstr "avsluta in- och utdataposter med NUL-tecken"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
-#: builtin/worktree.c:494
+#: builtin/check-ignore.c:21 builtin/checkout.c:1532 builtin/gc.c:550
+#: builtin/worktree.c:493
 msgid "suppress progress reporting"
 msgstr "undertryck förloppsrapportering"
 
@@ -12299,10 +12277,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [<flaggor>]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
-#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
-#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1867 builtin/submodule--helper.c:1875
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/worktree.c:491 builtin/worktree.c:728
 msgid "string"
 msgstr "sträng"
 
@@ -12366,98 +12344,93 @@ msgstr "git switch [<flaggor>] [<gren>]"
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [<flaggor>] [--source=<gren>] <fil>..."
 
-#: builtin/checkout.c:190 builtin/checkout.c:229
+#: builtin/checkout.c:198 builtin/checkout.c:237
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "sökvägen \"%s\" har inte vår version"
 
-#: builtin/checkout.c:192 builtin/checkout.c:231
+#: builtin/checkout.c:200 builtin/checkout.c:239
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "sökvägen \"%s\" har inte deras version"
 
-#: builtin/checkout.c:208
+#: builtin/checkout.c:216
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "sökvägen \"%s\" innehåller inte alla nödvändiga versioner"
 
-#: builtin/checkout.c:261
+#: builtin/checkout.c:269
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "sökvägen \"%s\" innehåller inte nödvändiga versioner"
 
-#: builtin/checkout.c:278
+#: builtin/checkout.c:286
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "sökväg \"%s\": kan inte slå ihop"
 
-#: builtin/checkout.c:294
+#: builtin/checkout.c:302
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Kunde inte lägga till sammanslagningsresultat för \"%s\""
 
-#: builtin/checkout.c:411
+#: builtin/checkout.c:419
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Återskapade %d sammanslagningskonflikt"
 msgstr[1] "Återskapade %d sammanslagningskonflikter"
 
-#: builtin/checkout.c:416
+#: builtin/checkout.c:424
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "Uppdaterade %d sökväg från %s"
 msgstr[1] "Uppdaterade %d sökvägar från %s"
 
-#: builtin/checkout.c:423
+#: builtin/checkout.c:431
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "Uppdaterade %d sökväg från indexet"
 msgstr[1] "Uppdaterade %d sökvägar från indexet"
 
-#: builtin/checkout.c:446 builtin/checkout.c:449 builtin/checkout.c:452
-#: builtin/checkout.c:456
+#: builtin/checkout.c:454 builtin/checkout.c:457 builtin/checkout.c:460
+#: builtin/checkout.c:464
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "\"%s\" kan inte användas vid uppdatering av sökvägar"
 
-#: builtin/checkout.c:459 builtin/checkout.c:462
-#, c-format
-msgid "'%s' cannot be used with %s"
-msgstr "\"%s\" kan inte användas med %s"
-
-#: builtin/checkout.c:466
+#: builtin/checkout.c:474
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr "Kan inte uppdatera sökvägar och växla till grenen \"%s\" samtidigt."
 
-#: builtin/checkout.c:470
+#: builtin/checkout.c:478
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "varken \"%s\" eller \"%s\" har angivits"
 
-#: builtin/checkout.c:474
+#: builtin/checkout.c:482
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "\"%s\" måste användas när \"%s\" inte anges"
 
-#: builtin/checkout.c:479 builtin/checkout.c:484
+#: builtin/checkout.c:487 builtin/checkout.c:492
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "\"%s\" eller \"%s\" kan inte användas med %s"
 
-#: builtin/checkout.c:558 builtin/checkout.c:565
+#: builtin/checkout.c:566 builtin/checkout.c:573
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "sökvägen \"%s\" har inte slagits ihop"
 
-#: builtin/checkout.c:736
+#: builtin/checkout.c:747
 msgid "you need to resolve your current index first"
 msgstr "du måste lösa ditt befintliga index först"
 
-#: builtin/checkout.c:786
+#: builtin/checkout.c:797
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12466,50 +12439,50 @@ msgstr ""
 "kan inte fortsätta med köade ändringar i följande filer:\n"
 "%s"
 
-#: builtin/checkout.c:879
+#: builtin/checkout.c:890
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Kan inte skapa referenslogg för \"%s\": %s\n"
 
-#: builtin/checkout.c:921
+#: builtin/checkout.c:934
 msgid "HEAD is now at"
 msgstr "HEAD är nu på"
 
-#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:938 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "kan inte uppdatera HEAD"
 
-#: builtin/checkout.c:929
+#: builtin/checkout.c:942
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Återställ gren \"%s\"\n"
 
-#: builtin/checkout.c:932
+#: builtin/checkout.c:945
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Redan på \"%s\"\n"
 
-#: builtin/checkout.c:936
+#: builtin/checkout.c:949
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Växlade till och nollställde grenen \"%s\"\n"
 
-#: builtin/checkout.c:938 builtin/checkout.c:1369
+#: builtin/checkout.c:951 builtin/checkout.c:1388
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Växlade till en ny gren \"%s\"\n"
 
-#: builtin/checkout.c:940
+#: builtin/checkout.c:953
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Växlade till grenen \"%s\"\n"
 
-#: builtin/checkout.c:991
+#: builtin/checkout.c:1004
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... och %d till.\n"
 
-#: builtin/checkout.c:997
+#: builtin/checkout.c:1010
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12532,7 +12505,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1016
+#: builtin/checkout.c:1029
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12559,19 +12532,19 @@ msgstr[1] ""
 " git branch <nytt_grennamn> %s\n"
 "\n"
 
-#: builtin/checkout.c:1051
+#: builtin/checkout.c:1064
 msgid "internal error in revision walk"
 msgstr "internt fel vid genomgång av revisioner (revision walk)"
 
-#: builtin/checkout.c:1055
+#: builtin/checkout.c:1068
 msgid "Previous HEAD position was"
 msgstr "Tidigare position för HEAD var"
 
-#: builtin/checkout.c:1095 builtin/checkout.c:1364
+#: builtin/checkout.c:1114 builtin/checkout.c:1383
 msgid "You are on a branch yet to be born"
 msgstr "Du är på en gren som ännu inte är född"
 
-#: builtin/checkout.c:1177
+#: builtin/checkout.c:1196
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12580,7 +12553,7 @@ msgstr ""
 "\"%s\" kan vara både en lokal fil och en spårande gren.\n"
 "Använd -- (och möjligen --no-guess) för att göra otvetydig"
 
-#: builtin/checkout.c:1184
+#: builtin/checkout.c:1203
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12600,51 +12573,51 @@ msgstr ""
 "föredra en fjärr, t.ex fjärren \"origin\" kan du ställa in\n"
 "checkout.defaultRemote=origin i din konfiguration."
 
-#: builtin/checkout.c:1194
+#: builtin/checkout.c:1213
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "\"%s\" motsvarar flera (%d) spårade fjärrgrenar"
 
-#: builtin/checkout.c:1260
+#: builtin/checkout.c:1279
 msgid "only one reference expected"
 msgstr "endast en referens förväntades"
 
-#: builtin/checkout.c:1277
+#: builtin/checkout.c:1296
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "endast en referens förväntades, %d gavs."
 
-#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
+#: builtin/checkout.c:1342 builtin/worktree.c:269 builtin/worktree.c:436
 #, c-format
 msgid "invalid reference: %s"
 msgstr "felaktig referens: %s"
 
-#: builtin/checkout.c:1336 builtin/checkout.c:1705
+#: builtin/checkout.c:1355 builtin/checkout.c:1725
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "referensen är inte ett träd: %s"
 
-#: builtin/checkout.c:1383
+#: builtin/checkout.c:1402
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "förväntade gren, fick taggen \"%s\""
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1404
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "förväntade gren, fick fjärrgrenen \"%s\""
 
-#: builtin/checkout.c:1386 builtin/checkout.c:1394
+#: builtin/checkout.c:1405 builtin/checkout.c:1413
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "förväntade gren, fick \"%s\""
 
-#: builtin/checkout.c:1389
+#: builtin/checkout.c:1408
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "förväntade gren, fick incheckningen \"%s\""
 
-#: builtin/checkout.c:1405
+#: builtin/checkout.c:1424
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12652,7 +12625,7 @@ msgstr ""
 "kan inte växla gren vid sammanslagning\n"
 "Överväg \"git merge --quit\" eller \"git worktree add\"."
 
-#: builtin/checkout.c:1409
+#: builtin/checkout.c:1428
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12660,7 +12633,7 @@ msgstr ""
 "kan inte växla gren mitt i en \"am\"-körning\n"
 "Överväg \"git am --quit\" eller \"git worktree add\"."
 
-#: builtin/checkout.c:1413
+#: builtin/checkout.c:1432
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12668,7 +12641,7 @@ msgstr ""
 "kan inte växla gren vid ombasering\n"
 "Överväg \"git rebase --quit\" eller \"git worktree add\"."
 
-#: builtin/checkout.c:1417
+#: builtin/checkout.c:1436
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12676,7 +12649,7 @@ msgstr ""
 "kan inte växla gren i en \"cherry-pick\"\n"
 "Överväg \"git cherry-pick --quit\" eller \"git worktree add\"."
 
-#: builtin/checkout.c:1421
+#: builtin/checkout.c:1440
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12684,139 +12657,127 @@ msgstr ""
 "kan inte växla gren i en \"revert\"\n"
 "Överväg \"git revert --quit\" eller \"git worktree add\"."
 
-#: builtin/checkout.c:1425
+#: builtin/checkout.c:1444
 msgid "you are switching branch while bisecting"
 msgstr "då växlar grenar medan du gör en \"bisect\""
 
-#: builtin/checkout.c:1432
+#: builtin/checkout.c:1451
 msgid "paths cannot be used with switching branches"
 msgstr "sökvägar kan inte användas vid byte av gren"
 
-#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
+#: builtin/checkout.c:1454 builtin/checkout.c:1458 builtin/checkout.c:1462
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "\"%s\" kan inte användas vid byte av gren"
 
-#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
-#: builtin/checkout.c:1458 builtin/checkout.c:1463
+#: builtin/checkout.c:1466 builtin/checkout.c:1469 builtin/checkout.c:1472
+#: builtin/checkout.c:1477 builtin/checkout.c:1482
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "\"%s\" kan inte användas med \"%s\""
 
-#: builtin/checkout.c:1460
+#: builtin/checkout.c:1479
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "\"%s\" kan inte ta <startpunkt>"
 
-#: builtin/checkout.c:1468
+#: builtin/checkout.c:1487
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Kan inte växla gren till icke-incheckningen \"%s\""
 
-#: builtin/checkout.c:1475
+#: builtin/checkout.c:1494
 msgid "missing branch or commit argument"
 msgstr "saknar gren- eller incheckingsargument"
 
-#: builtin/checkout.c:1518
+#: builtin/checkout.c:1537
 msgid "perform a 3-way merge with the new branch"
 msgstr "utför en 3-vägssammanslagning för den nya grenen"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
+#: builtin/checkout.c:1538 builtin/log.c:1825 parse-options.h:323
 msgid "style"
 msgstr "stil"
 
-#: builtin/checkout.c:1520
-msgid "conflict style (merge or diff3)"
-msgstr "konfliktstil (merge eller diff3)"
+#: builtin/checkout.c:1539
+msgid "conflict style (merge, diff3, or zdiff3)"
+msgstr "konfliktstil (merge, diff3 eller zdiff3)"
 
-#: builtin/checkout.c:1532 builtin/worktree.c:489
+#: builtin/checkout.c:1551 builtin/worktree.c:488
 msgid "detach HEAD at named commit"
 msgstr "koppla från HEAD vid namngiven incheckning"
 
-#: builtin/checkout.c:1533
-msgid "set upstream info for new branch"
-msgstr "sätt uppströmsinformation för ny gren"
+#: builtin/checkout.c:1553
+msgid "set up tracking mode (see git-pull(1))"
+msgstr "ställ in spårningsläge (se git-pull(1))"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1556
 msgid "force checkout (throw away local modifications)"
 msgstr "tvinga utcheckning (kasta bort lokala ändringar)"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new-branch"
 msgstr "ny-gren"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new unparented branch"
 msgstr "ny gren utan förälder"
 
-#: builtin/checkout.c:1539 builtin/merge.c:302
+#: builtin/checkout.c:1560 builtin/merge.c:305
 msgid "update ignored files (default)"
 msgstr "uppdatera ignorerade filer (standard)"
 
-#: builtin/checkout.c:1542
+#: builtin/checkout.c:1563
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "kontrollera inte om en annan arbetskatalog håller den angivna referensen"
 
-#: builtin/checkout.c:1555
+#: builtin/checkout.c:1576
 msgid "checkout our version for unmerged files"
 msgstr "checka ut vår version för ej sammanslagna filer"
 
-#: builtin/checkout.c:1558
+#: builtin/checkout.c:1579
 msgid "checkout their version for unmerged files"
 msgstr "checka ut deras version för ej sammanslagna filer"
 
-#: builtin/checkout.c:1562
+#: builtin/checkout.c:1583
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "begränsa inte sökvägar till endast glesa poster"
 
-#: builtin/checkout.c:1620
+#: builtin/checkout.c:1640
 #, c-format
-msgid "-%c, -%c and --orphan are mutually exclusive"
-msgstr "-%c, -%c och --orphan är ömsesidigt uteslutande"
+msgid "options '-%c', '-%c', and '%s' cannot be used together"
+msgstr "flaggorna \"%-c\", \"-%c\" och \"%s\" kan inte användas samtidigt"
 
-#: builtin/checkout.c:1624
-msgid "-p and --overlay are mutually exclusive"
-msgstr "-p och --overlay är ömsesidigt uteslutande"
-
-#: builtin/checkout.c:1661
+#: builtin/checkout.c:1681
 msgid "--track needs a branch name"
 msgstr "--track behöver ett namn på en gren"
 
-#: builtin/checkout.c:1666
+#: builtin/checkout.c:1686
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "grennamn saknas; försök med -%c"
 
-#: builtin/checkout.c:1698
+#: builtin/checkout.c:1718
 #, c-format
 msgid "could not resolve %s"
 msgstr "kunde inte upplösa %s"
 
-#: builtin/checkout.c:1714
+#: builtin/checkout.c:1734
 msgid "invalid path specification"
 msgstr "felaktig sökvägsangivelse"
 
-#: builtin/checkout.c:1721
+#: builtin/checkout.c:1741
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "\"%s\" är inte en incheckning och grenen \"%s\" kan inte skapas från den"
 
-#: builtin/checkout.c:1725
+#: builtin/checkout.c:1745
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach tar inte en sökväg som argument \"%s\""
 
-#: builtin/checkout.c:1734
-msgid "--pathspec-from-file is incompatible with --detach"
-msgstr "--pathspec-from-file är inkompatibelt med --detach"
-
-#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
-msgid "--pathspec-from-file is incompatible with --patch"
-msgstr "--pathspec-from-file är inkompatibelt med --patch"
-
-#: builtin/checkout.c:1750
+#: builtin/checkout.c:1770
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12824,71 +12785,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force och --merge är inkompatibla när\n"
 "du checkar ut från indexet."
 
-#: builtin/checkout.c:1755
+#: builtin/checkout.c:1775
 msgid "you must specify path(s) to restore"
 msgstr "du måste ange katalog(er) att återställa"
 
-#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
-#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2958
-#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
-#: builtin/worktree.c:487
+#: builtin/checkout.c:1800 builtin/checkout.c:1802 builtin/checkout.c:1854
+#: builtin/checkout.c:1856 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2959
+#: builtin/submodule--helper.c:3253 builtin/worktree.c:484
+#: builtin/worktree.c:486
 msgid "branch"
 msgstr "gren"
 
-#: builtin/checkout.c:1782
+#: builtin/checkout.c:1801
 msgid "create and checkout a new branch"
 msgstr "skapa och checka ut en ny gren"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1803
 msgid "create/reset and checkout a branch"
 msgstr "skapa/nollställ och checka ut en gren"
 
-#: builtin/checkout.c:1785
+#: builtin/checkout.c:1804
 msgid "create reflog for new branch"
 msgstr "skapa reflogg för ny gren"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1806
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "förutspå \"git checkout <gren-saknas>\" (förval)"
 
-#: builtin/checkout.c:1788
+#: builtin/checkout.c:1807
 msgid "use overlay mode (default)"
 msgstr "använd överläggsläge (standard)"
 
-#: builtin/checkout.c:1833
+#: builtin/checkout.c:1855
 msgid "create and switch to a new branch"
 msgstr "skapa och växla till en ny gren"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1857
 msgid "create/reset and switch to a branch"
 msgstr "skapa/nollställ och växla till en gren"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1859
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "förutspå \"git checkout <gren-saknas>\""
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1861
 msgid "throw away local modifications"
 msgstr "kasta bort lokala ändringar"
 
-#: builtin/checkout.c:1873
+#: builtin/checkout.c:1897
 msgid "which tree-ish to checkout from"
 msgstr "vilken träd-igt att checka ut från"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1899
 msgid "restore the index"
 msgstr "återställ indexet"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1901
 msgid "restore the working tree (default)"
 msgstr "återställ arbetskatalogen (förval)"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1903
 msgid "ignore unmerged entries"
 msgstr "ignorera ej sammanslagna poster"
 
-#: builtin/checkout.c:1880
+#: builtin/checkout.c:1904
 msgid "use overlay mode"
 msgstr "använd överläggsläge"
 
@@ -12924,7 +12885,15 @@ msgstr "Skulle hoppa över arkivet %s\n"
 msgid "could not lstat %s\n"
 msgstr "kunde inte ta status (\"lstat\") på %s\n"
 
-#: builtin/clean.c:300 git-add--interactive.perl:593
+#: builtin/clean.c:39
+msgid "Refusing to remove current working directory\n"
+msgstr "Vägrar ta bort aktuell arbetskatalog\n"
+
+#: builtin/clean.c:40
+msgid "Would refuse to remove current working directory\n"
+msgstr "Skulle vägra ta bort aktuell arbetskatalog\n"
+
+#: builtin/clean.c:326 git-add--interactive.perl:593
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -12937,7 +12906,7 @@ msgstr ""
 "foo        - markera post baserad på unikt prefix\n"
 "           - (tomt) markera ingenting\n"
 
-#: builtin/clean.c:304 git-add--interactive.perl:602
+#: builtin/clean.c:330 git-add--interactive.perl:602
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -12958,33 +12927,33 @@ msgstr ""
 "*          - välj alla poster\n"
 "           - (tomt) avsluta markering\n"
 
-#: builtin/clean.c:519 git-add--interactive.perl:568
+#: builtin/clean.c:545 git-add--interactive.perl:568
 #: git-add--interactive.perl:573
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
 msgstr "Vadå (%s)?\n"
 
-#: builtin/clean.c:659
+#: builtin/clean.c:685
 #, c-format
 msgid "Input ignore patterns>> "
 msgstr "Ange ignoreringsmönster>>"
 
-#: builtin/clean.c:693
+#: builtin/clean.c:719
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
 msgstr "VARNING: Hittar inte poster som motsvarar: %s"
 
-#: builtin/clean.c:714
+#: builtin/clean.c:740
 msgid "Select items to delete"
 msgstr "Välj poster att ta bort"
 
 #. TRANSLATORS: Make sure to keep [y/N] as is
-#: builtin/clean.c:755
+#: builtin/clean.c:781
 #, c-format
 msgid "Remove %s [y/N]? "
 msgstr "Ta bort %s [Y=ja / N=nej]? "
 
-#: builtin/clean.c:786
+#: builtin/clean.c:812
 msgid ""
 "clean               - start cleaning\n"
 "filter by pattern   - exclude items from deletion\n"
@@ -13002,52 +12971,52 @@ msgstr ""
 "help                - denna skärm\n"
 "?                   - hjälp för kommandoval"
 
-#: builtin/clean.c:822
+#: builtin/clean.c:848
 msgid "Would remove the following item:"
 msgid_plural "Would remove the following items:"
 msgstr[0] "Skulle ta bort följande post:"
 msgstr[1] "Skulle ta bort följande poster:"
 
-#: builtin/clean.c:838
+#: builtin/clean.c:864
 msgid "No more files to clean, exiting."
 msgstr "Inga fler filer att städa, avslutar."
 
-#: builtin/clean.c:900
+#: builtin/clean.c:926
 msgid "do not print names of files removed"
 msgstr "skriv inte ut namn på borttagna filer"
 
-#: builtin/clean.c:902
+#: builtin/clean.c:928
 msgid "force"
 msgstr "tvinga"
 
-#: builtin/clean.c:903
+#: builtin/clean.c:929
 msgid "interactive cleaning"
 msgstr "städa interaktivt"
 
-#: builtin/clean.c:905
+#: builtin/clean.c:931
 msgid "remove whole directories"
 msgstr "ta bort hela kataloger"
 
-#: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
+#: builtin/clean.c:932 builtin/describe.c:565 builtin/describe.c:567
 #: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/ls-files.c:651 builtin/name-rev.c:535 builtin/name-rev.c:537
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "mönster"
 
-#: builtin/clean.c:907
+#: builtin/clean.c:933
 msgid "add <pattern> to ignore rules"
 msgstr "lägg till <mönster> till ignoreringsregler"
 
-#: builtin/clean.c:908
+#: builtin/clean.c:934
 msgid "remove ignored files, too"
 msgstr "ta även bort ignorerade filer"
 
-#: builtin/clean.c:910
+#: builtin/clean.c:936
 msgid "remove only ignored files"
 msgstr "ta endast bort ignorerade filer"
 
-#: builtin/clean.c:925
+#: builtin/clean.c:951
 msgid ""
 "clean.requireForce set to true and neither -i, -n, nor -f given; refusing to "
 "clean"
@@ -13055,7 +13024,7 @@ msgstr ""
 "clean.requireForce satt till true, men varken -i, -n eller -f angavs; vägrar "
 "städa"
 
-#: builtin/clean.c:928
+#: builtin/clean.c:954
 msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
@@ -13063,7 +13032,7 @@ msgstr ""
 "clean.requireForce har standardvärdet true och varken -i, -n eller -f "
 "angavs; vägrar städa"
 
-#: builtin/clean.c:940
+#: builtin/clean.c:966
 msgid "-x and -X cannot be used together"
 msgstr "-x och -X kan inte användas samtidigt"
 
@@ -13119,19 +13088,20 @@ msgstr "mallkatalog"
 msgid "directory from which templates will be used"
 msgstr "katalog att använda mallar från"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
-#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1871
+#: builtin/submodule--helper.c:2514 builtin/submodule--helper.c:3260
 msgid "reference repository"
 msgstr "referensarkiv"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1872
-#: builtin/submodule--helper.c:2515
+#: builtin/clone.c:123 builtin/submodule--helper.c:1873
+#: builtin/submodule--helper.c:2516
 msgid "use --reference only while cloning"
 msgstr "använd --reference endast under kloningen"
 
-#: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
-#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: builtin/clone.c:124 builtin/column.c:27 builtin/fmt-merge-msg.c:27
+#: builtin/init-db.c:550 builtin/merge-file.c:48 builtin/merge.c:290
+#: builtin/pack-objects.c:3944 builtin/repack.c:665
+#: builtin/submodule--helper.c:3262 t/helper/test-simple-ipc.c:595
 #: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "namn"
@@ -13148,7 +13118,7 @@ msgstr "checka ut <gren> istället för fjärrens HEAD"
 msgid "path to git-upload-pack on the remote"
 msgstr "sökväg till git-upload-pack på fjärren"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
+#: builtin/clone.c:130 builtin/fetch.c:181 builtin/grep.c:876
 #: builtin/pull.c:212
 msgid "depth"
 msgstr "djup"
@@ -13157,7 +13127,7 @@ msgstr "djup"
 msgid "create a shallow clone of that depth"
 msgstr "skapa en grund klon på detta djup"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
+#: builtin/clone.c:132 builtin/fetch.c:183 builtin/pack-objects.c:3933
 #: builtin/pull.c:215
 msgid "time"
 msgstr "tid"
@@ -13166,17 +13136,17 @@ msgstr "tid"
 msgid "create a shallow clone since a specific time"
 msgstr "skapa en grund klon från en angiven tidpunkt"
 
-#: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
+#: builtin/clone.c:134 builtin/fetch.c:185 builtin/fetch.c:208
 #: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "revision"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
+#: builtin/clone.c:135 builtin/fetch.c:186 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "fördjupa historik för grund klon, exkludera revisionen"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1882
-#: builtin/submodule--helper.c:2529
+#: builtin/clone.c:137 builtin/submodule--helper.c:1883
+#: builtin/submodule--helper.c:2530
 msgid "clone only one branch, HEAD or --branch"
 msgstr "klona endast en gren, HEAD eller --branch"
 
@@ -13204,22 +13174,22 @@ msgstr "nyckel=värde"
 msgid "set config inside the new repository"
 msgstr "ställ in konfiguration i det nya arkivet"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
 #: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "serverspecifik"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
 #: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "flagga att sända"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
+#: builtin/clone.c:148 builtin/fetch.c:204 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "använd endast IPv4-adresser"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
+#: builtin/clone.c:150 builtin/fetch.c:206 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "använd endast IPv6-adresser"
@@ -13230,7 +13200,7 @@ msgstr "klonade undermoduler kommer använda sin fjärrspårningsgren"
 
 #: builtin/clone.c:156
 msgid "initialize sparse-checkout file to include only files at root"
-msgstr "initiera sparse-checkout-filen till att bara inkludera filer i roten"
+msgstr "initiera sparse-checkout-filen till att bara ta med filer i roten"
 
 #: builtin/clone.c:231
 #, c-format
@@ -13312,29 +13282,25 @@ msgstr "kan inte packa om för att städa upp"
 msgid "cannot unlink temporary alternates file"
 msgstr "kunde inte ta bort temporär \"alternates\"-fil"
 
-#: builtin/clone.c:886 builtin/receive-pack.c:2493
+#: builtin/clone.c:886
 msgid "Too many arguments."
 msgstr "För många argument."
 
-#: builtin/clone.c:890
+#: builtin/clone.c:890 contrib/scalar/scalar.c:414
 msgid "You must specify a repository to clone."
 msgstr "Du måste ange ett arkiv att klona."
 
 #: builtin/clone.c:903
 #, c-format
-msgid "--bare and --origin %s options are incompatible."
-msgstr "flaggorna --bare och --origin %s är inkompatibla."
-
-#: builtin/clone.c:906
-msgid "--bare and --separate-git-dir are incompatible."
-msgstr "flaggorna --bare och --separate-git-dir är inkompatibla."
+msgid "options '%s' and '%s %s' cannot be used together"
+msgstr "flaggorna \"%s\" och \"%s %s\" kan inte användas samtidigt"
 
 #: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "arkivet \"%s\" finns inte"
 
-#: builtin/clone.c:924 builtin/fetch.c:2029
+#: builtin/clone.c:924 builtin/fetch.c:2047
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "djupet %s är inte ett positivt tal"
@@ -13354,8 +13320,8 @@ msgstr "arkivsökvägen \"%s\" finns redan och är inte en tom katalog."
 msgid "working tree '%s' already exists."
 msgstr "arbetsträdet \"%s\" finns redan."
 
-#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
-#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:256
+#: builtin/log.c:2012 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "kunde inte skapa inledande kataloger för \"%s\""
@@ -13473,7 +13439,7 @@ msgstr ""
 "split[=<strategi>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] <delnings-flaggor>"
 
-#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:192 builtin/log.c:1794
 msgid "dir"
 msgstr "kat"
 
@@ -13554,7 +13520,7 @@ msgstr "använd som mest en av --reachable, --stdin-commits och --stdin-packs"
 msgid "Collecting commits from input"
 msgstr "Hämtar incheckningar från indata"
 
-#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:259
 #, c-format
 msgid "unrecognized subcommand: %s"
 msgstr "okänt underkommando: %s"
@@ -13572,7 +13538,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "duplicerad förälder %s ignorerades"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:577
 #, c-format
 msgid "not a valid object name %s"
 msgstr "objektnamnet är inte giltigt: %s"
@@ -13595,13 +13561,13 @@ msgstr "förälder"
 msgid "id of a parent commit object"
 msgstr "id på ett förälderincheckningsobjekt"
 
-#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
-#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/commit-tree.c:112 builtin/commit.c:1627 builtin/merge.c:284
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1677
 #: builtin/tag.c:454
 msgid "message"
 msgstr "meddelande"
 
-#: builtin/commit-tree.c:113 builtin/commit.c:1626
+#: builtin/commit-tree.c:113 builtin/commit.c:1627
 msgid "commit message"
 msgstr "incheckningsmeddelande"
 
@@ -13609,7 +13575,7 @@ msgstr "incheckningsmeddelande"
 msgid "read commit log message from file"
 msgstr "läs incheckningsloggmeddelande från fil"
 
-#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
+#: builtin/commit-tree.c:119 builtin/commit.c:1644 builtin/merge.c:303
 #: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "GPG-signera incheckning"
@@ -13687,10 +13653,6 @@ msgstr ""
 #: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "misslyckades packa upp HEAD:s trädobjekt"
-
-#: builtin/commit.c:361
-msgid "--pathspec-from-file with -a does not make sense"
-msgstr "--pathspec-from-file med -a ger ingen mening"
 
 #: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
@@ -13779,8 +13741,8 @@ msgstr "kunde inte läsa loggfilen \"%s\""
 
 #: builtin/commit.c:802
 #, c-format
-msgid "cannot combine -m with --fixup:%s"
-msgstr "kan inte kombinera -m med --fixup:%s"
+msgid "options '%s' and '%s:%s' cannot be used together"
+msgstr "flaggorna \"%s\" och \"%s:%s\" kan inte användas samtidigt"
 
 #: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
@@ -13888,7 +13850,7 @@ msgstr "kan inte sända släprader till --trailers"
 msgid "Error building trees"
 msgstr "Fel vid byggande av träd"
 
-#: builtin/commit.c:1080 builtin/tag.c:317
+#: builtin/commit.c:1080 builtin/tag.c:316
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Ange meddelandet en av flaggorna -m eller -F.\n"
@@ -13904,14 +13866,10 @@ msgstr ""
 msgid "Invalid ignored mode '%s'"
 msgstr "Ogiltigt ignorerat läge \"%s\""
 
-#: builtin/commit.c:1156 builtin/commit.c:1450
+#: builtin/commit.c:1156 builtin/commit.c:1451
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Ogiltigt läge för ospårade filer: \"%s\""
-
-#: builtin/commit.c:1196
-msgid "--long and -z are incompatible"
-msgstr "--long och -z är inkompatibla"
 
 #: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
@@ -13923,113 +13881,110 @@ msgstr "Du är i mitten av en cherry-pick -- kan inte omformulera."
 
 #: builtin/commit.c:1232
 #, c-format
-msgid "cannot combine reword option of --fixup with path '%s'"
+msgid "reword option of '%s' and path '%s' cannot be used together"
 msgstr ""
-"kan inte kombinera omformuleringsflaggor för --fixup med sökvägen \"%s\""
+"reword-flaggan till \"%s\" och sökvägen \"%s\" kan inte användas tillsammans"
 
 #: builtin/commit.c:1234
-msgid ""
-"reword option of --fixup is mutually exclusive with --patch/--interactive/--"
-"all/--include/--only"
-msgstr ""
-"omformuleringsflaggan i --fixup är ömsesidigt uteslutande med --patch/--"
-"interactive/--all/--include/--only"
+#, c-format
+msgid "reword option of '%s' and '%s' cannot be used together"
+msgstr "reword-flaggan till \"%s\" och \"%s\" kan inte användas tillsammans"
 
-#: builtin/commit.c:1253
+#: builtin/commit.c:1254
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "Kan inte använda både --reset-author och --author"
 
-#: builtin/commit.c:1260
+#: builtin/commit.c:1261
 msgid "You have nothing to amend."
 msgstr "Du har inget att utöka."
 
-#: builtin/commit.c:1263
+#: builtin/commit.c:1264
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Du är i mitten av en sammanslagning -- kan inte utöka."
 
-#: builtin/commit.c:1265
+#: builtin/commit.c:1266
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "Du är i mitten av en cherry-pick -- kan inte utöka."
 
-#: builtin/commit.c:1267
+#: builtin/commit.c:1268
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Du är i mitten av en ombasering -- kan inte utöka."
 
-#: builtin/commit.c:1270
+#: builtin/commit.c:1271
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Flaggorna --squash och --fixup kan inte användas samtidigt"
 
-#: builtin/commit.c:1280
+#: builtin/commit.c:1281
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Endast en av -c/-C/-F/--fixup kan användas."
 
-#: builtin/commit.c:1282
+#: builtin/commit.c:1283
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Flaggan -m kan inte kombineras med -c/-C/-F."
 
-#: builtin/commit.c:1291
+#: builtin/commit.c:1292
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset-author kan endast användas med -C, -c eller --amend."
 
-#: builtin/commit.c:1309
+#: builtin/commit.c:1310
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Endast en av --include/--only/--all/--interactive/--patch kan användas."
 
-#: builtin/commit.c:1337
+#: builtin/commit.c:1338
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "okänd flagga: --fixup=%s:%s"
 
-#: builtin/commit.c:1354
+#: builtin/commit.c:1355
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "sökvägarna \"%s ...\" med -a ger ingen mening"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1486 builtin/commit.c:1655
 msgid "show status concisely"
 msgstr "visa koncis status"
 
-#: builtin/commit.c:1487 builtin/commit.c:1656
+#: builtin/commit.c:1488 builtin/commit.c:1657
 msgid "show branch information"
 msgstr "visa information om gren"
 
-#: builtin/commit.c:1489
+#: builtin/commit.c:1490
 msgid "show stash information"
 msgstr "visa information om stash"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658
+#: builtin/commit.c:1492 builtin/commit.c:1659
 msgid "compute full ahead/behind values"
 msgstr "beräkna fullständiga före-/efter-värden"
 
-#: builtin/commit.c:1493
+#: builtin/commit.c:1494
 msgid "version"
 msgstr "version"
 
-#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
-#: builtin/worktree.c:691
+#: builtin/commit.c:1494 builtin/commit.c:1661 builtin/push.c:551
+#: builtin/worktree.c:690
 msgid "machine-readable output"
 msgstr "maskinläsbar utdata"
 
-#: builtin/commit.c:1496 builtin/commit.c:1662
+#: builtin/commit.c:1497 builtin/commit.c:1663
 msgid "show status in long format (default)"
 msgstr "visa status i långt format (standard)"
 
-#: builtin/commit.c:1499 builtin/commit.c:1665
+#: builtin/commit.c:1500 builtin/commit.c:1666
 msgid "terminate entries with NUL"
 msgstr "terminera poster med NUL"
 
-#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
-#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
+#: builtin/commit.c:1502 builtin/commit.c:1506 builtin/commit.c:1669
+#: builtin/fast-export.c:1172 builtin/fast-export.c:1175
+#: builtin/fast-export.c:1178 builtin/rebase.c:1111 parse-options.h:337
 msgid "mode"
 msgstr "läge"
 
-#: builtin/commit.c:1502 builtin/commit.c:1668
+#: builtin/commit.c:1503 builtin/commit.c:1669
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr "visa ospårade filer, valfria lägen: all, normal, no. (Standard: all)"
 
-#: builtin/commit.c:1506
+#: builtin/commit.c:1507
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -14037,11 +13992,11 @@ msgstr ""
 "visa ignorerade filer, valfria lägen: traditional, matching, no (Standard: "
 "traditional)"
 
-#: builtin/commit.c:1508 parse-options.h:192
+#: builtin/commit.c:1509 parse-options.h:192
 msgid "when"
 msgstr "när"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1510
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -14049,194 +14004,194 @@ msgstr ""
 "ignorera ändringar i undermoduler, valfritt när: all, dirty, untracked. "
 "(Default: all)"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1512
 msgid "list untracked files in columns"
 msgstr "visa ospårade filer i spalter"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1513
 msgid "do not detect renames"
 msgstr "detektera inte namnändringar"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1515
 msgid "detect renames, optionally set similarity index"
 msgstr "detektera namnändringar, möjligen sätt likhetsindex"
 
-#: builtin/commit.c:1537
+#: builtin/commit.c:1538
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr "Kombinationen av argument för ignorerade och ospårade filer stöds ej"
 
-#: builtin/commit.c:1619
+#: builtin/commit.c:1620
 msgid "suppress summary after successful commit"
 msgstr "undertryck sammanfattning efter framgångsrik incheckning"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1621
 msgid "show diff in commit message template"
 msgstr "visa diff i mallen för incheckningsmeddelandet"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1623
 msgid "Commit message options"
 msgstr "Alternativ för incheckningsmeddelande"
 
-#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
+#: builtin/commit.c:1624 builtin/merge.c:288 builtin/tag.c:456
 msgid "read message from file"
 msgstr "läs meddelande från fil"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "author"
 msgstr "författare"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "override author for commit"
 msgstr "överstyr författare för incheckningen"
 
-#: builtin/commit.c:1625 builtin/gc.c:550
+#: builtin/commit.c:1626 builtin/gc.c:551
 msgid "date"
 msgstr "datum"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1626
 msgid "override date for commit"
 msgstr "överstyr datum för incheckningen"
 
-#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:327 ref-filter.h:92
+#: builtin/commit.c:1628 builtin/commit.c:1629 builtin/commit.c:1635
+#: parse-options.h:329 ref-filter.h:89
 msgid "commit"
 msgstr "incheckning"
 
-#: builtin/commit.c:1627
+#: builtin/commit.c:1628
 msgid "reuse and edit message from specified commit"
 msgstr "återanvänd och redigera meddelande från angiven incheckning"
 
-#: builtin/commit.c:1628
+#: builtin/commit.c:1629
 msgid "reuse message from specified commit"
 msgstr "återanvänd meddelande från angiven incheckning"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1633
+#: builtin/commit.c:1634
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]incheckning"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1634
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "använd autosquash-formaterat meddelande för att fixa/omformulera angiven "
 "incheckning"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1635
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "använd autosquash-formaterat meddelande för att slå ihop med angiven "
 "incheckning"
 
-#: builtin/commit.c:1635
+#: builtin/commit.c:1636
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "jag är nu författare av incheckningen (används med -C/-c/--amend)"
 
-#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1637 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "släprad"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1637
 msgid "add custom trailer(s)"
 msgstr "använd skräddarsydd(a) släprad(er)"
 
-#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
+#: builtin/commit.c:1638 builtin/log.c:1769 builtin/merge.c:306
 #: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "lägg till Signed-off-by-släprad"
 
-#: builtin/commit.c:1638
+#: builtin/commit.c:1639
 msgid "use specified template file"
 msgstr "använd angiven mallfil"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1640
 msgid "force edit of commit"
 msgstr "tvinga redigering av incheckning"
 
-#: builtin/commit.c:1641
+#: builtin/commit.c:1642
 msgid "include status in commit message template"
-msgstr "inkludera status i mallen för incheckningsmeddelandet"
+msgstr "ta med status i mallen för incheckningsmeddelandet"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1647
 msgid "Commit contents options"
 msgstr "Alternativ för incheckningens innehåll"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1648
 msgid "commit all changed files"
 msgstr "checka in alla ändrade filer"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1649
 msgid "add specified files to index for commit"
 msgstr "lägg till angivna filer till indexet för incheckning"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1650
 msgid "interactively add files"
 msgstr "lägg till filer interaktivt"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1651
 msgid "interactively add changes"
 msgstr "lägg till ändringar interaktivt"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1652
 msgid "commit only specified files"
 msgstr "checka endast in angivna filer"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1653
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "förbigå pre-commit- och commit-msg-krokar"
 
-#: builtin/commit.c:1653
+#: builtin/commit.c:1654
 msgid "show what would be committed"
 msgstr "visa vad som skulle checkas in"
 
-#: builtin/commit.c:1666
+#: builtin/commit.c:1667
 msgid "amend previous commit"
 msgstr "lägg till föregående incheckning"
 
-#: builtin/commit.c:1667
+#: builtin/commit.c:1668
 msgid "bypass post-rewrite hook"
 msgstr "förbigå post-rewrite-krok"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1675
 msgid "ok to record an empty change"
 msgstr "ok att registrera en tom ändring"
 
-#: builtin/commit.c:1676
+#: builtin/commit.c:1677
 msgid "ok to record a change with an empty message"
 msgstr "ok att registrera en ändring med tomt meddelande"
 
-#: builtin/commit.c:1752
+#: builtin/commit.c:1753
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Trasig MERGE_HEAD-fil (%s)"
 
-#: builtin/commit.c:1759
+#: builtin/commit.c:1760
 msgid "could not read MERGE_MODE"
 msgstr "kunde inte läsa MERGE_MODE"
 
-#: builtin/commit.c:1780
+#: builtin/commit.c:1781
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "kunde inte läsa incheckningsmeddelande: %s"
 
-#: builtin/commit.c:1787
+#: builtin/commit.c:1788
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Avbryter på grund av tomt incheckningsmeddelande.\n"
 
-#: builtin/commit.c:1792
+#: builtin/commit.c:1793
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Avbryter incheckning; meddelandet inte redigerat.\n"
 
-#: builtin/commit.c:1803
+#: builtin/commit.c:1804
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr "Avbryter på grund av tom incheckningsmeddelandekropp.\n"
 
-#: builtin/commit.c:1839
+#: builtin/commit.c:1840
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -14743,7 +14698,7 @@ msgstr "överväg endast taggar som motsvarar <mönster>"
 msgid "do not consider tags matching <pattern>"
 msgstr "överväg inte taggar som motsvarar <mönster>"
 
-#: builtin/describe.c:570 builtin/name-rev.c:535
+#: builtin/describe.c:570 builtin/name-rev.c:544
 msgid "show abbreviated commit object as fallback"
 msgstr "visa förkortade incheckningsobjekt som standard"
 
@@ -14759,25 +14714,14 @@ msgstr "lägg till <märke> på lortigt arbetsträd (standard: \"-dirty\")"
 msgid "append <mark> on broken working tree (default: \"-broken\")"
 msgstr "lägg till <märke> på trasigt arbetsträd (standard: \"-broken\")"
 
-#: builtin/describe.c:593
-msgid "--long is incompatible with --abbrev=0"
-msgstr "--long är inkompatibel med --abbrev=0"
-
 #: builtin/describe.c:622
 msgid "No names found, cannot describe anything."
 msgstr "Inga namn hittades, kan inte beskriva något."
 
-#: builtin/describe.c:673
-msgid "--dirty is incompatible with commit-ishes"
-msgstr "--dirty är inkompatibelt med \"commit-ish\"-värden"
-
-#: builtin/describe.c:675
-msgid "--broken is incompatible with commit-ishes"
-msgstr "--broken är inkompatibelt med \"commit-ish\"-värden"
-
-#: builtin/diff-tree.c:155
-msgid "--stdin and --merge-base are mutually exclusive"
-msgstr "--stdin och --merge-base är ömsesidigt uteslutande"
+#: builtin/describe.c:673 builtin/describe.c:675
+#, c-format
+msgid "option '%s' and commit-ishes cannot be used together"
+msgstr "flaggorna \"%s\" och incheckning-igter kan inte användas samtidigt"
 
 #: builtin/diff-tree.c:157
 msgid "--merge-base only works with two commits"
@@ -14798,26 +14742,26 @@ msgstr "ogiltig flagga: %s"
 msgid "%s...%s: no merge base"
 msgstr "%s...%s: ingen sammanslagningsbas"
 
-#: builtin/diff.c:486
+#: builtin/diff.c:491
 msgid "Not a git repository"
 msgstr "Inte ett git-arkiv"
 
-#: builtin/diff.c:532 builtin/grep.c:698
+#: builtin/diff.c:537 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "objektet \"%s\" som angavs är felaktigt."
 
-#: builtin/diff.c:543
+#: builtin/diff.c:548
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "mer än två blobbar angavs: \"%s\""
 
-#: builtin/diff.c:548
+#: builtin/diff.c:553
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "ej hanterat objekt \"%s\" angavs."
 
-#: builtin/diff.c:582
+#: builtin/diff.c:587
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: flera sammanslagningsbaser, använder %s"
@@ -14827,22 +14771,22 @@ msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr ""
 "git difftool [<flaggor>] [<incheckning> [<incheckning>]] [--] [<sökväg>...]"
 
-#: builtin/difftool.c:293
+#: builtin/difftool.c:287
 #, c-format
 msgid "could not read symlink %s"
 msgstr "kunde inte läsa symboliska länken %s"
 
-#: builtin/difftool.c:295
+#: builtin/difftool.c:289
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "kunde inte läsa symbolisk länk-fil %s"
 
-#: builtin/difftool.c:303
+#: builtin/difftool.c:297
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "kunde inte läsa objektet %s för symboliska länken %s"
 
-#: builtin/difftool.c:427
+#: builtin/difftool.c:421
 msgid ""
 "combined diff formats ('-c' and '--cc') are not supported in\n"
 "directory diff mode ('-d' and '--dir-diff')."
@@ -14850,58 +14794,58 @@ msgstr ""
 "kombinerade diff-format (\"-c\" och \"--cc\") stöds inte i\n"
 "katalogdiffläge (\"-d\" och \"--dir-diff\")."
 
-#: builtin/difftool.c:632
+#: builtin/difftool.c:626
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "bägge filerna ändrade: \"%s\" och \"%s\"."
 
-#: builtin/difftool.c:634
+#: builtin/difftool.c:628
 msgid "working tree file has been left."
 msgstr "filen i arbetskatalogen lämnades kvar."
 
-#: builtin/difftool.c:645
+#: builtin/difftool.c:639
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "temporära filer finns i \"%s\"."
 
-#: builtin/difftool.c:646
+#: builtin/difftool.c:640
 msgid "you may want to cleanup or recover these."
 msgstr "du kanske vill städa eller rädda dem."
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:645
 #, c-format
 msgid "failed: %d"
 msgstr "misslyckades: %d"
 
-#: builtin/difftool.c:696
+#: builtin/difftool.c:690
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "använd \"diff.guitool\" istället för \"diff.tool\""
 
-#: builtin/difftool.c:698
+#: builtin/difftool.c:692
 msgid "perform a full-directory diff"
 msgstr "utför diff för hela katalogen"
 
-#: builtin/difftool.c:700
+#: builtin/difftool.c:694
 msgid "do not prompt before launching a diff tool"
 msgstr "fråga inte vid start av diff-verktyg"
 
-#: builtin/difftool.c:705
+#: builtin/difftool.c:699
 msgid "use symlinks in dir-diff mode"
 msgstr "använd symboliska länkar i katalogdiffläge"
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:700
 msgid "tool"
 msgstr "verktyg"
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:701
 msgid "use the specified diff tool"
 msgstr "använd angivet diff-verktyg"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:703
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr "visa en lista över diff-verktyg som kan användas med \"--tool\""
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:706
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
@@ -14909,31 +14853,23 @@ msgstr ""
 "låt \"git-difftool\" avsluta när ett anropat diff-verktyg ger returvärde "
 "skilt från noll"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:709
 msgid "specify a custom command for viewing diffs"
 msgstr "ange eget kommando för att visa diffar"
 
-#: builtin/difftool.c:716
+#: builtin/difftool.c:710
 msgid "passed to `diff`"
 msgstr "sändes till \"diff\""
 
-#: builtin/difftool.c:732
+#: builtin/difftool.c:726
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool kräver en arbetskatalog eller --no-index"
 
-#: builtin/difftool.c:739
-msgid "--dir-diff is incompatible with --no-index"
-msgstr "--dir-diff är inkompatibelt med --no-index"
-
-#: builtin/difftool.c:742
-msgid "--gui, --tool and --extcmd are mutually exclusive"
-msgstr "--gui, --tool och --extcmd är ömsesidigt uteslutande"
-
-#: builtin/difftool.c:750
+#: builtin/difftool.c:744
 msgid "no <tool> given for --tool=<tool>"
 msgstr "inget <verktyg> angavs för --tool=<verktyg>"
 
-#: builtin/difftool.c:757
+#: builtin/difftool.c:751
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "inget <kommando> angavs för --extcmd=<kommando>"
 
@@ -14973,123 +14909,115 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [rev-list-flaggor]"
 
-#: builtin/fast-export.c:869
+#: builtin/fast-export.c:843
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr "Fel: Kan inte exportera nästlade taggar såvida inte --mark-tags anges."
 
-#: builtin/fast-export.c:1178
+#: builtin/fast-export.c:1152
 msgid "--anonymize-map token cannot be empty"
 msgstr "symbolen för --anonymize-map kan inte vara tom"
 
-#: builtin/fast-export.c:1198
+#: builtin/fast-export.c:1171
 msgid "show progress after <n> objects"
 msgstr "visa förlopp efter <n> objekt"
 
-#: builtin/fast-export.c:1200
+#: builtin/fast-export.c:1173
 msgid "select handling of signed tags"
 msgstr "välj hantering av signerade taggar"
 
-#: builtin/fast-export.c:1203
+#: builtin/fast-export.c:1176
 msgid "select handling of tags that tag filtered objects"
 msgstr "välj hantering av taggar som har taggfiltrerade objekt"
 
-#: builtin/fast-export.c:1206
+#: builtin/fast-export.c:1179
 msgid "select handling of commit messages in an alternate encoding"
 msgstr "välj hantering av incheckningsmeddelanden i alternativ teckenkodning"
 
-#: builtin/fast-export.c:1209
+#: builtin/fast-export.c:1182
 msgid "dump marks to this file"
 msgstr "dumpa märken till filen"
 
-#: builtin/fast-export.c:1211
+#: builtin/fast-export.c:1184
 msgid "import marks from this file"
 msgstr "importera märken från filen"
 
-#: builtin/fast-export.c:1215
+#: builtin/fast-export.c:1188
 msgid "import marks from this file if it exists"
 msgstr "importera märken från filen, om den finns"
 
-#: builtin/fast-export.c:1217
+#: builtin/fast-export.c:1190
 msgid "fake a tagger when tags lack one"
 msgstr "fejka taggare när taggen saknar en"
 
-#: builtin/fast-export.c:1219
+#: builtin/fast-export.c:1192
 msgid "output full tree for each commit"
 msgstr "skriv ut hela trädet för varje incheckning"
 
-#: builtin/fast-export.c:1221
+#: builtin/fast-export.c:1194
 msgid "use the done feature to terminate the stream"
 msgstr "använd done-funktionen för att avsluta strömmen"
 
-#: builtin/fast-export.c:1222
+#: builtin/fast-export.c:1195
 msgid "skip output of blob data"
 msgstr "hoppa över skrivning av blob-data"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1826
+#: builtin/fast-export.c:1196 builtin/log.c:1841
 msgid "refspec"
 msgstr "referensspecifikation"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1197
 msgid "apply refspec to exported refs"
 msgstr "applicera referensspecifikation på exporterade referenser"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1198
 msgid "anonymize output"
 msgstr "anonymisera utdata"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1199
 msgid "from:to"
 msgstr "från:till"
 
-#: builtin/fast-export.c:1227
+#: builtin/fast-export.c:1200
 msgid "convert <from> to <to> in anonymized output"
 msgstr "konvertera <från> till <till> i anonymiserad utdata"
 
-#: builtin/fast-export.c:1230
+#: builtin/fast-export.c:1203
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr "referera föräldrar som inte finns i fast-export-ström med objekt-id"
 
-#: builtin/fast-export.c:1232
+#: builtin/fast-export.c:1205
 msgid "show original object ids of blobs/commits"
 msgstr "visa ursprungliga objekt-id för blobbar/incheckningar"
 
-#: builtin/fast-export.c:1234
+#: builtin/fast-export.c:1207
 msgid "label tags with mark ids"
 msgstr "märk taggar med märke-id"
 
-#: builtin/fast-export.c:1257
-msgid "--anonymize-map without --anonymize does not make sense"
-msgstr "--anonymize-map utan --anonymize ger ingen mening"
-
-#: builtin/fast-export.c:1272
-msgid "Cannot pass both --import-marks and --import-marks-if-exists"
-msgstr "Kan inte ange både --import-marks och --import-marks-if-exists"
-
-#: builtin/fast-import.c:3088
+#: builtin/fast-import.c:3090
 #, c-format
 msgid "Missing from marks for submodule '%s'"
 msgstr "Saknar från-märken för undermodulen \"%s\""
 
-#: builtin/fast-import.c:3090
+#: builtin/fast-import.c:3092
 #, c-format
 msgid "Missing to marks for submodule '%s'"
 msgstr "Saknar till-märken för undermodulen \"%s\""
 
-#: builtin/fast-import.c:3225
+#: builtin/fast-import.c:3227
 #, c-format
 msgid "Expected 'mark' command, got %s"
 msgstr "Förväntade \"mark\"-kommando, fick %s"
 
-#: builtin/fast-import.c:3230
+#: builtin/fast-import.c:3232
 #, c-format
 msgid "Expected 'to' command, got %s"
 msgstr "Förväntade \"to\"-kommando, fick %s"
 
-#: builtin/fast-import.c:3322
+#: builtin/fast-import.c:3324
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr "Förvändae formatet namn:filnamn för undermodul-omskrivningsflaggan"
 
-#: builtin/fast-import.c:3377
+#: builtin/fast-import.c:3379
 #, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
 msgstr "funktionen \"%s\" förbjuden i indata utan --allow-unsafe-features"
@@ -15099,119 +15027,119 @@ msgstr "funktionen \"%s\" förbjuden i indata utan --allow-unsafe-features"
 msgid "Lockfile created but not reported: %s"
 msgstr "Låsfil skapad men inte rapporterad: %s"
 
-#: builtin/fetch.c:35
+#: builtin/fetch.c:36
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
 msgstr "git fetch [<flaggor>] [<arkiv> [<refspec>...]]"
 
-#: builtin/fetch.c:36
+#: builtin/fetch.c:37
 msgid "git fetch [<options>] <group>"
 msgstr "git fetch [<flaggor>] <grupp>"
 
-#: builtin/fetch.c:37
+#: builtin/fetch.c:38
 msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
 msgstr "git fetch --multiple [<flaggor>] [(<arkiv> | <grupp>)...]"
 
-#: builtin/fetch.c:38
+#: builtin/fetch.c:39
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<flaggor>]"
 
-#: builtin/fetch.c:122
+#: builtin/fetch.c:123
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel kan inte vara negativt"
 
-#: builtin/fetch.c:145 builtin/pull.c:189
+#: builtin/fetch.c:146 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "hämta från alla fjärrar"
 
-#: builtin/fetch.c:147 builtin/pull.c:249
+#: builtin/fetch.c:148 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "ställ in uppström för git pull/fetch"
 
-#: builtin/fetch.c:149 builtin/pull.c:192
+#: builtin/fetch.c:150 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "lägg till i .git/FETCH_HEAD istället för att skriva över"
 
-#: builtin/fetch.c:151
+#: builtin/fetch.c:152
 msgid "use atomic transaction to update references"
 msgstr "använd atomiska transaktioner för att uppdatera referenser"
 
-#: builtin/fetch.c:153 builtin/pull.c:195
+#: builtin/fetch.c:154 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "sökväg till upload pack på fjärren"
 
-#: builtin/fetch.c:154
+#: builtin/fetch.c:155
 msgid "force overwrite of local reference"
 msgstr "tvinga överskrivning av lokal referens"
 
-#: builtin/fetch.c:156
+#: builtin/fetch.c:157
 msgid "fetch from multiple remotes"
 msgstr "hämta från flera fjärrar"
 
-#: builtin/fetch.c:158 builtin/pull.c:199
+#: builtin/fetch.c:159 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "hämta alla taggar och associerade objekt"
 
-#: builtin/fetch.c:160
+#: builtin/fetch.c:161
 msgid "do not fetch all tags (--no-tags)"
 msgstr "hämta inte alla taggar (--no-tags)"
 
-#: builtin/fetch.c:162
+#: builtin/fetch.c:163
 msgid "number of submodules fetched in parallel"
 msgstr "antal undermoduler som hämtas parallellt"
 
-#: builtin/fetch.c:164
+#: builtin/fetch.c:165
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
 "modifiera referensspecifikationen så att alla referenser hamnar i refs/"
 "prefetch/"
 
-#: builtin/fetch.c:166 builtin/pull.c:202
+#: builtin/fetch.c:167 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "rensa fjärrspårande grenar ej längre på fjärren"
 
-#: builtin/fetch.c:168
+#: builtin/fetch.c:169
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "rensa lokala taggar inte längre på fjärren och skriv över ändrade taggar"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
+#: builtin/fetch.c:170 builtin/fetch.c:195 builtin/pull.c:123
 msgid "on-demand"
 msgstr "on-demand"
 
-#: builtin/fetch.c:170
+#: builtin/fetch.c:171
 msgid "control recursive fetching of submodules"
 msgstr "styr rekursiv hämtning av undermoduler"
 
-#: builtin/fetch.c:175
+#: builtin/fetch.c:176
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "skriv hämtade referenser till FETCH_HEAD-filen"
 
-#: builtin/fetch.c:176 builtin/pull.c:210
+#: builtin/fetch.c:177 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "behåll hämtade paket"
 
-#: builtin/fetch.c:178
+#: builtin/fetch.c:179
 msgid "allow updating of HEAD ref"
 msgstr "tillåt uppdatering av HEAD-referens"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/fetch.c:182 builtin/fetch.c:188 builtin/pull.c:213
 #: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "fördjupa historik för grund klon"
 
-#: builtin/fetch.c:183 builtin/pull.c:216
+#: builtin/fetch.c:184 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "fördjupa historik för grund klon baserad på tid"
 
-#: builtin/fetch.c:189 builtin/pull.c:225
+#: builtin/fetch.c:190 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "konvertera till komplett arkiv"
 
-#: builtin/fetch.c:192
+#: builtin/fetch.c:193
 msgid "prepend this to submodule path output"
 msgstr "lägg till i början av undermodulens sökvägsutdata"
 
-#: builtin/fetch.c:195
+#: builtin/fetch.c:196
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -15219,47 +15147,47 @@ msgstr ""
 "standard för rekursiv hämtning av undermoduler (lägre prioritet än "
 "konfigurationsfiler)"
 
-#: builtin/fetch.c:199 builtin/pull.c:228
+#: builtin/fetch.c:200 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "tar emot referenser som uppdaterar .git/shallow"
 
-#: builtin/fetch.c:200 builtin/pull.c:230
+#: builtin/fetch.c:201 builtin/pull.c:230
 msgid "refmap"
 msgstr "referenskarta"
 
-#: builtin/fetch.c:201 builtin/pull.c:231
+#: builtin/fetch.c:202 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "ange referenskarta för \"fetch\""
 
-#: builtin/fetch.c:208 builtin/pull.c:244
+#: builtin/fetch.c:209 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "rapportera att vi bara har objekt nåbara från detta objektet"
 
-#: builtin/fetch.c:210
+#: builtin/fetch.c:211
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr "hämta inte paketfil; skriv istället förfäder till förhandlingstips"
 
-#: builtin/fetch.c:213 builtin/fetch.c:215
+#: builtin/fetch.c:214 builtin/fetch.c:216
 msgid "run 'maintenance --auto' after fetching"
 msgstr "kör \"maintenance --auto\" efter hämtning"
 
-#: builtin/fetch.c:217 builtin/pull.c:247
+#: builtin/fetch.c:218 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "se efter tvingade uppdateringar i alla uppdaterade grenar"
 
-#: builtin/fetch.c:219
+#: builtin/fetch.c:220
 msgid "write the commit-graph after fetching"
 msgstr "skriv incheckingsgrafen efter hämtning"
 
-#: builtin/fetch.c:221
+#: builtin/fetch.c:222
 msgid "accept refspecs from stdin"
 msgstr "ta emot referenser från standard in"
 
-#: builtin/fetch.c:586
-msgid "Couldn't find remote ref HEAD"
-msgstr "Kunde inte hitta fjärr-referensen HEAD"
+#: builtin/fetch.c:587
+msgid "couldn't find remote ref HEAD"
+msgstr "kunde inte hitta fjärr-referensen HEAD"
 
-#: builtin/fetch.c:760
+#: builtin/fetch.c:761
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "konfigurationen för fetch.output innehåller ogiltigt värde %s"
@@ -15273,7 +15201,7 @@ msgstr "objektet %s hittades inte"
 msgid "[up to date]"
 msgstr "[àjour]"
 
-#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
+#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
 msgid "[rejected]"
 msgstr "[refuserad]"
 
@@ -15281,79 +15209,83 @@ msgstr "[refuserad]"
 msgid "can't fetch in current branch"
 msgstr "kan inte hämta i aktuell gren"
 
-#: builtin/fetch.c:890
+#: builtin/fetch.c:881
+msgid "checked out in another worktree"
+msgstr "utcheckat i en annan arbetskatalog"
+
+#: builtin/fetch.c:891
 msgid "[tag update]"
 msgstr "[uppdaterad tagg]"
 
-#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
-#: builtin/fetch.c:962
+#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
+#: builtin/fetch.c:963
 msgid "unable to update local ref"
 msgstr "kunde inte uppdatera lokal ref"
 
-#: builtin/fetch.c:895
+#: builtin/fetch.c:896
 msgid "would clobber existing tag"
 msgstr "skulle skriva över befintlig tagg"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:918
 msgid "[new tag]"
 msgstr "[ny tagg]"
 
-#: builtin/fetch.c:920
+#: builtin/fetch.c:921
 msgid "[new branch]"
 msgstr "[ny gren]"
 
-#: builtin/fetch.c:923
+#: builtin/fetch.c:924
 msgid "[new ref]"
 msgstr "[ny ref]"
 
-#: builtin/fetch.c:962
+#: builtin/fetch.c:963
 msgid "forced update"
 msgstr "tvingad uppdatering"
 
-#: builtin/fetch.c:967
+#: builtin/fetch.c:968
 msgid "non-fast-forward"
 msgstr "ej snabbspolad"
 
-#: builtin/fetch.c:1070
+#: builtin/fetch.c:1071
 msgid ""
-"Fetch normally indicates which branches had a forced update,\n"
-"but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
-"flag or run 'git config fetch.showForcedUpdates true'."
+"fetch normally indicates which branches had a forced update,\n"
+"but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
+"flag or run 'git config fetch.showForcedUpdates true'"
 msgstr ""
-"Fetch visar normalt vilka grenar som tvångsuppdaterats, men testet har "
+"fetch visar normalt vilka grenar som tvångsuppdaterats, men testet har "
 "slagits\n"
-"av. För att slå på igen, använd flaggan \"--show-forced-updates\" eller kör\n"
-"\"git config fetch.showForcedUpdates true\"."
+"av; för att slå på igen, använd flaggan \"--show-forced-updates\" eller kör\n"
+"\"git config fetch.showForcedUpdates true\""
 
-#: builtin/fetch.c:1074
+#: builtin/fetch.c:1075
 #, c-format
 msgid ""
-"It took %.2f seconds to check forced updates. You can use\n"
+"it took %.2f seconds to check forced updates; you can use\n"
 "'--no-show-forced-updates' or run 'git config fetch.showForcedUpdates "
 "false'\n"
-" to avoid this check.\n"
+"to avoid this check\n"
 msgstr ""
-"Det tog %.2f sekunder att se efter tvångsuppdateringar. Du kan använda\n"
+"det tog %.2f sekunder att se efter tvångsuppdateringar; Du kan använda\n"
 "\"--no-show-forced-updates\" eller köra \"git config fetch."
 "showForcedUpdates\n"
-"false\" för att undvika testet.\n"
+"false\" för att undvika testet\n"
 
-#: builtin/fetch.c:1105
+#: builtin/fetch.c:1107
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s sände inte alla nödvändiga objekt\n"
 
-#: builtin/fetch.c:1134
+#: builtin/fetch.c:1136
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "avvisade %s då grunda rötter inte tillåts uppdateras"
 
-#: builtin/fetch.c:1223 builtin/fetch.c:1371
+#: builtin/fetch.c:1226 builtin/fetch.c:1374
 #, c-format
 msgid "From %.*s\n"
 msgstr "Från %.*s\n"
 
-#: builtin/fetch.c:1244
+#: builtin/fetch.c:1247
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15362,141 +15294,142 @@ msgstr ""
 "vissa lokala referenser kunde inte uppdateras; testa att köra\n"
 " \"git remote prune %s\" för att ta bort gamla grenar som står i konflikt"
 
-#: builtin/fetch.c:1341
+#: builtin/fetch.c:1344
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s kommer bli dinglande)"
 
-#: builtin/fetch.c:1342
+#: builtin/fetch.c:1345
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s har blivit dinglande)"
 
-#: builtin/fetch.c:1374
+#: builtin/fetch.c:1377
 msgid "[deleted]"
 msgstr "[borttagen]"
 
-#: builtin/fetch.c:1375 builtin/remote.c:1128
+#: builtin/fetch.c:1378 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(ingen)"
 
-#: builtin/fetch.c:1398
+#: builtin/fetch.c:1400
 #, c-format
-msgid "Refusing to fetch into current branch %s of non-bare repository"
-msgstr "Vägrar hämta till aktuell gren %s i ett icke-naket arkiv"
-
-#: builtin/fetch.c:1417
-#, c-format
-msgid "Option \"%s\" value \"%s\" is not valid for %s"
-msgstr "Flaggan \"%s\" och värdet \"%s\" är inte giltigt för %s"
+msgid "refusing to fetch into branch '%s' checked out at '%s'"
+msgstr "vägrar hämta till grenen \"%s\" som är utcheckad på \"%s\""
 
 #: builtin/fetch.c:1420
 #, c-format
-msgid "Option \"%s\" is ignored for %s\n"
-msgstr "Flaggan \"%s\" ignoreras för %s\n"
+msgid "option \"%s\" value \"%s\" is not valid for %s"
+msgstr "flaggan \"%s\" med värdet \"%s\" är inte giltigt för %s"
 
-#: builtin/fetch.c:1447
+#: builtin/fetch.c:1423
+#, c-format
+msgid "option \"%s\" is ignored for %s\n"
+msgstr "flaggan \"%s\" ignoreras för %s\n"
+
+#: builtin/fetch.c:1450
 #, c-format
 msgid "the object %s does not exist"
 msgstr "objektet %s finns inte"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1638
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "flera grenar upptäcktes, inkompatibelt med --set-upstream"
 
-#: builtin/fetch.c:1648
+#: builtin/fetch.c:1650
+#, c-format
+msgid ""
+"could not set upstream of HEAD to '%s' from '%s' when it does not point to "
+"any branch."
+msgstr ""
+"kunde inte sätta uppström för HEAD till \"%s\" från \"%s\" när det inte "
+"pekar mot någon gren."
+
+#: builtin/fetch.c:1663
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "ställer inte in uppströmsgren för en fjärrspårande gren på fjärren"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1665
 msgid "not setting upstream for a remote tag"
 msgstr "ställer inte in uppström för en fjärrtag"
 
-#: builtin/fetch.c:1652
+#: builtin/fetch.c:1667
 msgid "unknown branch type"
 msgstr "okänd grentyp"
 
-#: builtin/fetch.c:1654
+#: builtin/fetch.c:1669
 msgid ""
-"no source branch found.\n"
-"you need to specify exactly one branch with the --set-upstream option."
+"no source branch found;\n"
+"you need to specify exactly one branch with the --set-upstream option"
 msgstr ""
-"hittade ingen källgren.\n"
-"du måste ange exakt en gren med flaggan --set-upstream."
+"hittade ingen källgren;\n"
+"du måste ange exakt en gren med flaggan --set-upstream"
 
-#: builtin/fetch.c:1783 builtin/fetch.c:1846
+#: builtin/fetch.c:1799 builtin/fetch.c:1862
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Hämtar %s\n"
 
-#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
+#: builtin/fetch.c:1809 builtin/fetch.c:1864
 #, c-format
-msgid "Could not fetch %s"
-msgstr "Kunde inte hämta %s"
+msgid "could not fetch %s"
+msgstr "kunde inte hämta %s"
 
-#: builtin/fetch.c:1805
+#: builtin/fetch.c:1821
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "kunde inte hämta \"%s\" (felkod: %d)\n"
 
-#: builtin/fetch.c:1909
+#: builtin/fetch.c:1925
 msgid ""
-"No remote repository specified.  Please, specify either a URL or a\n"
-"remote name from which new revisions should be fetched."
+"no remote repository specified; please specify either a URL or a\n"
+"remote name from which new revisions should be fetched"
 msgstr ""
-"Inget fjärrarkiv angavs. Ange antingen en URL eller namnet på ett\n"
-"fjärrarkiv som nya incheckningar ska hämtas från."
+"inget fjärrarkiv angavs; ange antingen en URL eller namnet på ett\n"
+"fjärrarkiv som nya incheckningar ska hämtas från"
 
-#: builtin/fetch.c:1945
-msgid "You need to specify a tag name."
-msgstr "Du måste ange namnet på en tagg."
+#: builtin/fetch.c:1961
+msgid "you need to specify a tag name"
+msgstr "du måste ange namnet på en tagg"
 
-#: builtin/fetch.c:2009
+#: builtin/fetch.c:2027
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only behöver en eller flera --negotiate-tip=*"
 
-#: builtin/fetch.c:2013
-msgid "Negative depth in --deepen is not supported"
-msgstr "Negativa djup stöds inte i --deepen"
+#: builtin/fetch.c:2031
+msgid "negative depth in --deepen is not supported"
+msgstr "negativa djup stöds inte i --deepen"
 
-#: builtin/fetch.c:2015
-msgid "--deepen and --depth are mutually exclusive"
-msgstr "--deepen och --depth är ömsesidigt uteslutande"
-
-#: builtin/fetch.c:2020
-msgid "--depth and --unshallow cannot be used together"
-msgstr "--depth och --unshallow kan inte användas samtidigt"
-
-#: builtin/fetch.c:2022
+#: builtin/fetch.c:2040
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow kan inte användas på ett komplett arkiv"
 
-#: builtin/fetch.c:2039
+#: builtin/fetch.c:2057
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all tar inte namnet på ett arkiv som argument"
 
-#: builtin/fetch.c:2041
+#: builtin/fetch.c:2059
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all kan inte anges med referensspecifikationer"
 
-#: builtin/fetch.c:2050
+#: builtin/fetch.c:2068
 #, c-format
-msgid "No such remote or remote group: %s"
-msgstr "Fjärren eller fjärrgruppen finns inte: %s"
+msgid "no such remote or remote group: %s"
+msgstr "fjärren eller fjärrgruppen finns inte: %s"
 
-#: builtin/fetch.c:2057
-msgid "Fetching a group and specifying refspecs does not make sense"
-msgstr "Kan inte hämta från grupp och ange referensspecifikationer"
+#: builtin/fetch.c:2076
+msgid "fetching a group and specifying refspecs does not make sense"
+msgstr "kan inte hämta från grupp och ange referensspecifikationer"
 
-#: builtin/fetch.c:2073
+#: builtin/fetch.c:2092
 msgid "must supply remote when using --negotiate-only"
 msgstr "måste ange fjärr när --negotiate-only anges"
 
-#: builtin/fetch.c:2078
-msgid "Protocol does not support --negotiate-only, exiting."
-msgstr "Protokollet stöder inte --negotiate-only, avslutar."
-
 #: builtin/fetch.c:2097
+msgid "protocol does not support --negotiate-only, exiting"
+msgstr "protokollet stöder inte --negotiate-only, avslutar"
+
+#: builtin/fetch.c:2116
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15504,11 +15437,11 @@ msgstr ""
 "--filter kan endast användas med fjärren konfigurerad i extensions."
 "partialclone"
 
-#: builtin/fetch.c:2101
+#: builtin/fetch.c:2120
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic kan bara användas vid hämtning från en fjärr"
 
-#: builtin/fetch.c:2105
+#: builtin/fetch.c:2124
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin kan bara användas vid hämtning fårn en fjärr"
 
@@ -15518,23 +15451,27 @@ msgid ""
 msgstr ""
 "git fmt-merge-msg [-m <meddelande>] [--log[=<n>] | --no-log] [--file <fil>]"
 
-#: builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:19
 msgid "populate log with at most <n> entries from shortlog"
 msgstr "fyll i loggen med som mest <n> poster från shortlog"
 
-#: builtin/fmt-merge-msg.c:21
+#: builtin/fmt-merge-msg.c:22
 msgid "alias for --log (deprecated)"
 msgstr "alias för --log (avråds)"
 
-#: builtin/fmt-merge-msg.c:24
+#: builtin/fmt-merge-msg.c:25
 msgid "text"
 msgstr "text"
 
-#: builtin/fmt-merge-msg.c:25
+#: builtin/fmt-merge-msg.c:26
 msgid "use <text> as start of message"
 msgstr "inled meddelande med <text>"
 
-#: builtin/fmt-merge-msg.c:26
+#: builtin/fmt-merge-msg.c:28
+msgid "use <name> instead of the real target branch"
+msgstr "använd <namn> istället för den verkliga målgrenen"
+
+#: builtin/fmt-merge-msg.c:29
 msgid "file to read from"
 msgstr "fil att läsa från"
 
@@ -15556,47 +15493,47 @@ msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
 msgstr ""
 "git for-each-ref [--contains [<incheckning>]] [--no-contains [<incheckning>]]"
 
-#: builtin/for-each-ref.c:30
+#: builtin/for-each-ref.c:31
 msgid "quote placeholders suitably for shells"
 msgstr "citera platshållare passande för skal"
 
-#: builtin/for-each-ref.c:32
+#: builtin/for-each-ref.c:33
 msgid "quote placeholders suitably for perl"
 msgstr "citera platshållare passande för perl"
 
-#: builtin/for-each-ref.c:34
+#: builtin/for-each-ref.c:35
 msgid "quote placeholders suitably for python"
 msgstr "citera platshållare passande för python"
 
-#: builtin/for-each-ref.c:36
+#: builtin/for-each-ref.c:37
 msgid "quote placeholders suitably for Tcl"
 msgstr "citera platshållare passande för Tcl"
 
-#: builtin/for-each-ref.c:39
+#: builtin/for-each-ref.c:40
 msgid "show only <n> matched refs"
 msgstr "visa endast <n> träffade refs"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:481
+#: builtin/for-each-ref.c:42 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "använd formatfärger"
 
-#: builtin/for-each-ref.c:44
+#: builtin/for-each-ref.c:45
 msgid "print only refs which points at the given object"
 msgstr "visa endast referenser som pekar på objektet"
 
-#: builtin/for-each-ref.c:46
+#: builtin/for-each-ref.c:47
 msgid "print only refs that are merged"
 msgstr "visa endast referenser som slagits samman"
 
-#: builtin/for-each-ref.c:47
+#: builtin/for-each-ref.c:48
 msgid "print only refs that are not merged"
 msgstr "visa endast referenser som ej slagits samman"
 
-#: builtin/for-each-ref.c:48
+#: builtin/for-each-ref.c:49
 msgid "print only refs which contain the commit"
 msgstr "visa endast referenser som innehåller incheckningen"
 
-#: builtin/for-each-ref.c:49
+#: builtin/for-each-ref.c:50
 msgid "print only refs which don't contain the commit"
 msgstr "visa endast referenser som inte innehåller incheckningen"
 
@@ -15749,126 +15686,126 @@ msgstr "%s: objektet trasigt eller saknas: %s"
 msgid "%s: object is of unknown type '%s': %s"
 msgstr "%s: objektet har okänd typ \"%s\": %s"
 
-#: builtin/fsck.c:644
+#: builtin/fsck.c:645
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: objektet kunde inte tolkas: %s"
 
-#: builtin/fsck.c:664
+#: builtin/fsck.c:665
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "ogiltig sha1-fil: %s"
 
-#: builtin/fsck.c:685
+#: builtin/fsck.c:686
 msgid "Checking object directory"
 msgstr "Kontrollerar objektkatalog"
 
-#: builtin/fsck.c:688
+#: builtin/fsck.c:689
 msgid "Checking object directories"
 msgstr "Kontrollerar objektkataloger"
 
-#: builtin/fsck.c:704
+#: builtin/fsck.c:705
 #, c-format
 msgid "Checking %s link"
 msgstr "Kontrollerar %s-länk"
 
-#: builtin/fsck.c:709 builtin/index-pack.c:859
+#: builtin/fsck.c:710 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "ogiltigt %s"
 
-#: builtin/fsck.c:716
+#: builtin/fsck.c:717
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s pekar på något konstigt (%s)"
 
-#: builtin/fsck.c:722
+#: builtin/fsck.c:723
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: frånkopplat HEAD pekar på ingenting"
 
-#: builtin/fsck.c:726
+#: builtin/fsck.c:727
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "obs: %s pekar på en ofödd gren (%s)"
 
-#: builtin/fsck.c:738
+#: builtin/fsck.c:739
 msgid "Checking cache tree"
 msgstr "Kontrollerar cacheträd"
 
-#: builtin/fsck.c:743
+#: builtin/fsck.c:744
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "%s: ogiltig sha1-pekare i cacheträd"
 
-#: builtin/fsck.c:752
+#: builtin/fsck.c:753
 msgid "non-tree in cache-tree"
 msgstr "icke-träd i cacheträd"
 
-#: builtin/fsck.c:783
+#: builtin/fsck.c:784
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<flaggor>] [<objekt>...]"
 
-#: builtin/fsck.c:789
+#: builtin/fsck.c:790
 msgid "show unreachable objects"
 msgstr "visa onåbara objekt"
 
-#: builtin/fsck.c:790
+#: builtin/fsck.c:791
 msgid "show dangling objects"
 msgstr "visa dinglande objekt"
 
-#: builtin/fsck.c:791
+#: builtin/fsck.c:792
 msgid "report tags"
 msgstr "rapportera taggar"
 
-#: builtin/fsck.c:792
+#: builtin/fsck.c:793
 msgid "report root nodes"
 msgstr "rapportera rotnoder"
 
-#: builtin/fsck.c:793
+#: builtin/fsck.c:794
 msgid "make index objects head nodes"
 msgstr "gör indexojekt till huvudnoder"
 
-#: builtin/fsck.c:794
+#: builtin/fsck.c:795
 msgid "make reflogs head nodes (default)"
 msgstr "gör refloggar till huvudnoder (standard)"
 
-#: builtin/fsck.c:795
+#: builtin/fsck.c:796
 msgid "also consider packs and alternate objects"
 msgstr "ta även hänsyn till paket och supplerande objekt"
 
 # Vague original, not networking-related, but rather related to the actual
 # objects in the database.
-#: builtin/fsck.c:796
+#: builtin/fsck.c:797
 msgid "check only connectivity"
 msgstr "kontrollera endast konnektivitet"
 
-#: builtin/fsck.c:797 builtin/mktag.c:76
+#: builtin/fsck.c:798 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "aktivera striktare kontroll"
 
-#: builtin/fsck.c:799
+#: builtin/fsck.c:800
 msgid "write dangling objects in .git/lost-found"
 msgstr "skriv dinglande objekt i .git/lost-found"
 
-#: builtin/fsck.c:800 builtin/prune.c:134
+#: builtin/fsck.c:801 builtin/prune.c:146
 msgid "show progress"
 msgstr "visa förlopp"
 
-#: builtin/fsck.c:801
+#: builtin/fsck.c:802
 msgid "show verbose names for reachable objects"
 msgstr "visa ordrika namn för nåbara objekt"
 
-#: builtin/fsck.c:861 builtin/index-pack.c:261
+#: builtin/fsck.c:862 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Kontrollerar objekt"
 
-#: builtin/fsck.c:889
+#: builtin/fsck.c:890
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: objekt saknas"
 
-#: builtin/fsck.c:900
+#: builtin/fsck.c:901
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "ogiltig parameter: förväntade sha1, fick \"%s\""
@@ -15887,17 +15824,12 @@ msgstr "Misslyckades ta status (fstat) på %s: %s"
 msgid "failed to parse '%s' value '%s'"
 msgstr "misslyckades tolka \"%s\" värde \"%s\""
 
-#: builtin/gc.c:487 builtin/init-db.c:57
+#: builtin/gc.c:488 builtin/init-db.c:57
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "kan inte ta status på \"%s\""
 
-#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
-#, c-format
-msgid "cannot read '%s'"
-msgstr "kunde inte läsa \"%s\""
-
-#: builtin/gc.c:503
+#: builtin/gc.c:504
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
@@ -15912,52 +15844,52 @@ msgstr ""
 "\n"
 "%s"
 
-#: builtin/gc.c:551
+#: builtin/gc.c:552
 msgid "prune unreferenced objects"
 msgstr "rensa ej refererade objekt"
 
-#: builtin/gc.c:553
+#: builtin/gc.c:554
 msgid "be more thorough (increased runtime)"
 msgstr "var mer grundlig (ökar körtiden)"
 
-#: builtin/gc.c:554
+#: builtin/gc.c:555
 msgid "enable auto-gc mode"
 msgstr "aktivera auto-gc-läge"
 
-#: builtin/gc.c:557
+#: builtin/gc.c:558
 msgid "force running gc even if there may be another gc running"
 msgstr "tvinga gc-körning även om en annan gc kanske körs"
 
-#: builtin/gc.c:560
+#: builtin/gc.c:561
 msgid "repack all other packs except the largest pack"
 msgstr "packa om alla paket förutom det största paketet"
 
-#: builtin/gc.c:576
+#: builtin/gc.c:577
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "kunde inte tolka värdet %s för gc.logexpiry"
 
-#: builtin/gc.c:587
+#: builtin/gc.c:588
 #, c-format
 msgid "failed to parse prune expiry value %s"
 msgstr "kunde inte tolka värdet %s för prune expiry"
 
-#: builtin/gc.c:607
+#: builtin/gc.c:608
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr "Packar arkivet automatiskt i bakgrunden för optimal prestanda.\n"
 
-#: builtin/gc.c:609
+#: builtin/gc.c:610
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr "Packar arkivet automatiskt för optimal prestanda.\n"
 
-#: builtin/gc.c:610
+#: builtin/gc.c:611
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Se \"git help gc\" för manuell hushållning.\n"
 
-#: builtin/gc.c:650
+#: builtin/gc.c:652
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -15965,212 +15897,212 @@ msgstr ""
 "gc körs redan på maskinen \"%s\" pid %<PRIuMAX> (använd --force om så inte "
 "är fallet)"
 
-#: builtin/gc.c:705
+#: builtin/gc.c:707
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Det finns för många onåbara lösa objekt; kör \"git prune\" för att ta bort "
 "dem."
 
-#: builtin/gc.c:715
+#: builtin/gc.c:717
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<uppgift>] [--schedule]"
 
-#: builtin/gc.c:745
+#: builtin/gc.c:747
 msgid "--no-schedule is not allowed"
 msgstr "--no-schedule tillåts inte"
 
-#: builtin/gc.c:750
+#: builtin/gc.c:752
 #, c-format
 msgid "unrecognized --schedule argument '%s'"
 msgstr "okänt argument för --schedule, %s"
 
-#: builtin/gc.c:868
+#: builtin/gc.c:870
 msgid "failed to write commit-graph"
 msgstr "kunde inte skriva incheckningsgraf"
 
-#: builtin/gc.c:904
+#: builtin/gc.c:906
 msgid "failed to prefetch remotes"
 msgstr "kunde inte förhämta fjärrar"
 
-#: builtin/gc.c:1020
+#: builtin/gc.c:1022
 msgid "failed to start 'git pack-objects' process"
 msgstr "kunde inte starta \"git pack-objects\"-process"
 
-#: builtin/gc.c:1037
+#: builtin/gc.c:1039
 msgid "failed to finish 'git pack-objects' process"
 msgstr "kunde inte avsluta \"git pack-objects\"-process"
 
-#: builtin/gc.c:1088
+#: builtin/gc.c:1090
 msgid "failed to write multi-pack-index"
 msgstr "kunde inte skriva multi-pack-index"
 
-#: builtin/gc.c:1104
+#: builtin/gc.c:1106
 msgid "'git multi-pack-index expire' failed"
 msgstr "\"git multi-pack-index expire\" misslyckades"
 
-#: builtin/gc.c:1163
+#: builtin/gc.c:1165
 msgid "'git multi-pack-index repack' failed"
 msgstr "\"git multi-pack-index repack\" misslyckades"
 
-#: builtin/gc.c:1172
+#: builtin/gc.c:1174
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "hoppar över \"incremental-repack\"-uppgift eftersom core.multiPackIndex är "
 "inaktiverat"
 
-#: builtin/gc.c:1276
+#: builtin/gc.c:1278
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "låsfilen \"%s\" finns, hoppar över underhåll"
 
-#: builtin/gc.c:1306
+#: builtin/gc.c:1308
 #, c-format
 msgid "task '%s' failed"
 msgstr "uppgiften \"%s\" misslyckades"
 
-#: builtin/gc.c:1388
+#: builtin/gc.c:1390
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "\"%s\" är inte en giltig uppgift"
 
-#: builtin/gc.c:1393
+#: builtin/gc.c:1395
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "uppgiften \"%s\" kan inte väljas flera gånger"
 
-#: builtin/gc.c:1408
+#: builtin/gc.c:1410
 msgid "run tasks based on the state of the repository"
 msgstr "kör uppgifter baserad på arkivets tillstånd"
 
-#: builtin/gc.c:1409
+#: builtin/gc.c:1411
 msgid "frequency"
 msgstr "frekvens"
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1412
 msgid "run tasks based on frequency"
 msgstr "kör uppgifter baserat på frekvens"
 
-#: builtin/gc.c:1413
+#: builtin/gc.c:1415
 msgid "do not report progress or other information over stderr"
 msgstr "rapportera inte framgång eller annan information över standard fel"
 
-#: builtin/gc.c:1414
+#: builtin/gc.c:1416
 msgid "task"
 msgstr "uppgift"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1417
 msgid "run a specific task"
 msgstr "utför en specifik uppgift"
 
-#: builtin/gc.c:1432
+#: builtin/gc.c:1434
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr "använd som mest en av --auto och --schedule=<frekvens>"
 
-#: builtin/gc.c:1475
+#: builtin/gc.c:1477
 msgid "failed to run 'git config'"
 msgstr "misslyckades köra \"git config\""
 
-#: builtin/gc.c:1627
+#: builtin/gc.c:1629
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "misslyckades expandera sökvägen \"%s\""
 
-#: builtin/gc.c:1654 builtin/gc.c:1692
+#: builtin/gc.c:1656 builtin/gc.c:1694
 msgid "failed to start launchctl"
 msgstr "misslyckades starta launchctl"
 
-#: builtin/gc.c:1767 builtin/gc.c:2220
+#: builtin/gc.c:1769 builtin/gc.c:2237
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "misslyckades skapa kataloger för \"%s\""
 
-#: builtin/gc.c:1794
+#: builtin/gc.c:1796
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "misslyckades starta tjänsten %s"
 
-#: builtin/gc.c:1887
+#: builtin/gc.c:1889
 msgid "failed to create temp xml file"
 msgstr "misslyckades skapa temporär xml-fil"
 
-#: builtin/gc.c:1977
+#: builtin/gc.c:1979
 msgid "failed to start schtasks"
 msgstr "misslyckades starta schtasks"
 
-#: builtin/gc.c:2046
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "kunde inte köra \"crontab -l\"; ditt system kanske inte stöder \"cron\""
 
-#: builtin/gc.c:2063
+#: builtin/gc.c:2080
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr "kunde inte köra \"crontab\"; ditt system kanske inte stöder \"cron\""
 
-#: builtin/gc.c:2067
+#: builtin/gc.c:2084
 msgid "failed to open stdin of 'crontab'"
 msgstr "misslyckades öppna standard in för \"crontab\""
 
-#: builtin/gc.c:2109
+#: builtin/gc.c:2126
 msgid "'crontab' died"
 msgstr "\"crontab\" dog"
 
-#: builtin/gc.c:2174
+#: builtin/gc.c:2191
 msgid "failed to start systemctl"
 msgstr "misslyckades starta systemctl"
 
-#: builtin/gc.c:2184
+#: builtin/gc.c:2201
 msgid "failed to run systemctl"
 msgstr "misslyckades att köra systemctl"
 
-#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
-#: builtin/worktree.c:945
+#: builtin/gc.c:2210 builtin/gc.c:2215 builtin/worktree.c:62
+#: builtin/worktree.c:944
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "misslyckades ta bort \"%s\""
 
-#: builtin/gc.c:2378
+#: builtin/gc.c:2395
 #, c-format
 msgid "unrecognized --scheduler argument '%s'"
 msgstr "okänt argument för --scheduler, \"%s\""
 
-#: builtin/gc.c:2403
+#: builtin/gc.c:2420
 msgid "neither systemd timers nor crontab are available"
 msgstr "varken systemd-timer eller crontab är tillgänglig"
 
-#: builtin/gc.c:2418
+#: builtin/gc.c:2435
 #, c-format
 msgid "%s scheduler is not available"
 msgstr "%s-schemaläggare är inte tillgänglig"
 
-#: builtin/gc.c:2432
+#: builtin/gc.c:2449
 msgid "another process is scheduling background maintenance"
 msgstr "en annan process schemalägger bakgrundsunderhåll"
 
-#: builtin/gc.c:2454
+#: builtin/gc.c:2471
 msgid "git maintenance start [--scheduler=<scheduler>]"
 msgstr "git maintenance start [--scheduler=<schemaläggare>]"
 
-#: builtin/gc.c:2463
+#: builtin/gc.c:2480
 msgid "scheduler"
 msgstr "schemaläggare"
 
-#: builtin/gc.c:2464
+#: builtin/gc.c:2481
 msgid "scheduler to trigger git maintenance run"
 msgstr "schemaläggare som utlöser \"git maintenance\"-körning"
 
-#: builtin/gc.c:2478
+#: builtin/gc.c:2495
 msgid "failed to add repo to global config"
 msgstr "misslyckades lägga till arkiv till global konfiguration"
 
-#: builtin/gc.c:2487
+#: builtin/gc.c:2504
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance <underkommando> [<flaggor>]"
 
-#: builtin/gc.c:2506
+#: builtin/gc.c:2523
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "felaktigt underkommando: %s"
@@ -16539,25 +16471,25 @@ msgstr "git help [-c|--config]"
 msgid "unrecognized help format '%s'"
 msgstr "okänt hjälpformat: \"%s\""
 
-#: builtin/help.c:223
+#: builtin/help.c:222
 msgid "Failed to start emacsclient."
 msgstr "Misslyckades starta emacsclient."
 
-#: builtin/help.c:236
+#: builtin/help.c:235
 msgid "Failed to parse emacsclient version."
 msgstr "Kunde inte tolka emacsclient-version."
 
-#: builtin/help.c:244
+#: builtin/help.c:243
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "emacsclient version \"%d\" för gammal (< 22)."
 
-#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
+#: builtin/help.c:261 builtin/help.c:283 builtin/help.c:293 builtin/help.c:301
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "exec misslyckades för \"%s\""
 
-#: builtin/help.c:340
+#: builtin/help.c:339
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -16566,7 +16498,7 @@ msgstr ""
 "\"%s\": sökväg för man-visare som ej stöds.\n"
 "Använd \"man.<verktyg>.cmd\" istället."
 
-#: builtin/help.c:352
+#: builtin/help.c:351
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -16575,39 +16507,39 @@ msgstr ""
 "\"%s\": kommando för man-visare som stöds.\n"
 "Använd \"man.<verktyg>.path\" istället."
 
-#: builtin/help.c:467
+#: builtin/help.c:466
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "\"%s\": okänd man-visare."
 
-#: builtin/help.c:483
+#: builtin/help.c:482
 msgid "no man viewer handled the request"
 msgstr "ingen man-visare hanterade förfrågan"
 
-#: builtin/help.c:490
+#: builtin/help.c:489
 msgid "no info viewer handled the request"
 msgstr "ingen info-visare hanterade förfrågan"
 
-#: builtin/help.c:551 builtin/help.c:562 git.c:348
+#: builtin/help.c:550 builtin/help.c:561 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "\"%s\" är ett alias för \"%s\""
 
-#: builtin/help.c:565 git.c:380
+#: builtin/help.c:564 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "felaktig alias.%s-sträng: %s"
 
-#: builtin/help.c:581
+#: builtin/help.c:580
 msgid "this option doesn't take any other arguments"
 msgstr "flaggan tar inte några andra argument"
 
-#: builtin/help.c:602 builtin/help.c:629
+#: builtin/help.c:601 builtin/help.c:628
 #, c-format
 msgid "usage: %s%s"
 msgstr "användning: %s%s"
 
-#: builtin/help.c:624
+#: builtin/help.c:623
 msgid "'git help config' for more information"
 msgstr "\"git help config\" för mer information"
 
@@ -16874,17 +16806,9 @@ msgstr "felaktig %s"
 msgid "unknown hash algorithm '%s'"
 msgstr "okänd hashningsalgoritm \"%s\""
 
-#: builtin/index-pack.c:1848
-msgid "--fix-thin cannot be used without --stdin"
-msgstr "--fix-thin kan inte användas med --stdin"
-
 #: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "--stdin kräver ett git-arkiv"
-
-#: builtin/index-pack.c:1852
-msgid "--object-format cannot be used with --stdin"
-msgstr "--object-format kan inte användas med --stdin"
 
 #: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
@@ -17010,10 +16934,6 @@ msgstr "hash"
 #: builtin/init-db.c:553 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "ange hashningsalgoritm att använda"
-
-#: builtin/init-db.c:560
-msgid "--separate-git-dir and --bare are mutually exclusive"
-msgstr "--separate-git-dir och --bare är ömsesidigt uteslutande"
 
 #: builtin/init-db.c:591 builtin/init-db.c:596
 #, c-format
@@ -17148,85 +17068,85 @@ msgstr ""
 msgid "-L<range>:<file> cannot be used with pathspec"
 msgstr "-L<intervall>:<fil> kan inte användas med sökvägsspecifikation"
 
-#: builtin/log.c:306
+#: builtin/log.c:321
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Slututdata: %d %s\n"
 
-#: builtin/log.c:571
+#: builtin/log.c:586
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: felaktig fil"
 
-#: builtin/log.c:586 builtin/log.c:676
+#: builtin/log.c:601 builtin/log.c:691
 #, c-format
 msgid "could not read object %s"
 msgstr "kunde inte läsa objektet %s"
 
-#: builtin/log.c:701
+#: builtin/log.c:716
 #, c-format
 msgid "unknown type: %d"
 msgstr "okänd typ: %d"
 
-#: builtin/log.c:846
+#: builtin/log.c:861
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr "%s: ogiltigt omslag från beskrivningsläge"
 
-#: builtin/log.c:853
+#: builtin/log.c:868
 msgid "format.headers without value"
 msgstr "format.headers utan värde"
 
-#: builtin/log.c:982
+#: builtin/log.c:997
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "kan inte öppna patchfilen %s"
 
-#: builtin/log.c:999
+#: builtin/log.c:1014
 msgid "need exactly one range"
 msgstr "behöver precis ett intervall"
 
-#: builtin/log.c:1009
+#: builtin/log.c:1024
 msgid "not a range"
 msgstr "inte ett intervall"
 
-#: builtin/log.c:1173
+#: builtin/log.c:1188
 msgid "cover letter needs email format"
 msgstr "omslagsbrevet behöver e-postformat"
 
-#: builtin/log.c:1179
+#: builtin/log.c:1194
 msgid "failed to create cover-letter file"
 msgstr "misslyckades skapa fil för omslagsbrev"
 
-#: builtin/log.c:1266
+#: builtin/log.c:1281
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "tokigt in-reply-to: %s"
 
-#: builtin/log.c:1293
+#: builtin/log.c:1308
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<flaggor>] [<sedan> | <revisionsintervall>]"
 
-#: builtin/log.c:1351
+#: builtin/log.c:1366
 msgid "two output directories?"
 msgstr "två utdatakataloger?"
 
-#: builtin/log.c:1502 builtin/log.c:2328 builtin/log.c:2330 builtin/log.c:2342
+#: builtin/log.c:1517 builtin/log.c:2344 builtin/log.c:2346 builtin/log.c:2358
 #, c-format
 msgid "unknown commit %s"
 msgstr "okänd incheckning %s"
 
-#: builtin/log.c:1513 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1528 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "misslyckades slå upp \"%s\" som en giltig referens"
 
-#: builtin/log.c:1522
+#: builtin/log.c:1537
 msgid "could not find exact merge base"
 msgstr "kunde inte hitta exakt sammanslagningsbas"
 
-#: builtin/log.c:1532
+#: builtin/log.c:1547
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -17236,404 +17156,392 @@ msgstr ""
 "använd git branch --set-upstream-to för att spåra en fjärrgren.\n"
 "Eller så kan du ange basincheckning med --base=<bas-inchecknings-id> manuellt"
 
-#: builtin/log.c:1555
+#: builtin/log.c:1570
 msgid "failed to find exact merge base"
 msgstr "kunde inte hitta exakt sammanslagningsbas"
 
-#: builtin/log.c:1572
+#: builtin/log.c:1587
 msgid "base commit should be the ancestor of revision list"
 msgstr "basincheckningen bör vara förfader till revisionslistan"
 
-#: builtin/log.c:1582
+#: builtin/log.c:1597
 msgid "base commit shouldn't be in revision list"
 msgstr "basincheckningen bör inte vara i revisionslistan"
 
-#: builtin/log.c:1640
+#: builtin/log.c:1655
 msgid "cannot get patch id"
 msgstr "kan inte hämta patch-id"
 
-#: builtin/log.c:1703
+#: builtin/log.c:1718
 msgid "failed to infer range-diff origin of current series"
 msgstr "misslyckades räkna ut intervalldiff-ursprung för aktuell serie"
 
-#: builtin/log.c:1705
+#: builtin/log.c:1720
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
 msgstr "använd \"%s\" som intervalldiff-ursprung för aktuell serie"
 
-#: builtin/log.c:1749
+#: builtin/log.c:1764
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "använd [PATCH n/m] även för en ensam patch"
 
-#: builtin/log.c:1752
+#: builtin/log.c:1767
 msgid "use [PATCH] even with multiple patches"
 msgstr "använd [PATCH] även för flera patchar"
 
-#: builtin/log.c:1756
+#: builtin/log.c:1771
 msgid "print patches to standard out"
 msgstr "skriv patcharna på standard ut"
 
-#: builtin/log.c:1758
+#: builtin/log.c:1773
 msgid "generate a cover letter"
 msgstr "generera ett följebrev"
 
-#: builtin/log.c:1760
+#: builtin/log.c:1775
 msgid "use simple number sequence for output file names"
 msgstr "använd enkel nummersekvens för utdatafilnamn"
 
-#: builtin/log.c:1761
+#: builtin/log.c:1776
 msgid "sfx"
 msgstr "sfx"
 
-#: builtin/log.c:1762
+#: builtin/log.c:1777
 msgid "use <sfx> instead of '.patch'"
 msgstr "använd <sfx> istället för \".patch\""
 
-#: builtin/log.c:1764
+#: builtin/log.c:1779
 msgid "start numbering patches at <n> instead of 1"
 msgstr "börja numrera patchar på <n> istället för 1"
 
-#: builtin/log.c:1765
+#: builtin/log.c:1780
 msgid "reroll-count"
 msgstr "antal iterationer"
 
-#: builtin/log.c:1766
+#: builtin/log.c:1781
 msgid "mark the series as Nth re-roll"
 msgstr "markera serien som N:te försök"
 
-#: builtin/log.c:1768
+#: builtin/log.c:1783
 msgid "max length of output filename"
 msgstr "maximal längd för utdatafilnamn"
 
-#: builtin/log.c:1770
+#: builtin/log.c:1785
 msgid "use [RFC PATCH] instead of [PATCH]"
 msgstr "använd [RFC PATCH] istället för [PATCH]"
 
-#: builtin/log.c:1773
+#: builtin/log.c:1788
 msgid "cover-from-description-mode"
 msgstr "cover-from-description-läge"
 
-#: builtin/log.c:1774
+#: builtin/log.c:1789
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr "skapa delar av omslagsbrevet baserat på grenbeskrivelsen"
 
-#: builtin/log.c:1776
+#: builtin/log.c:1791
 msgid "use [<prefix>] instead of [PATCH]"
 msgstr "använd [<prefix>] istället för [PATCH]"
 
-#: builtin/log.c:1779
+#: builtin/log.c:1794
 msgid "store resulting files in <dir>"
 msgstr "spara filerna i <katalog>"
 
-#: builtin/log.c:1782
+#: builtin/log.c:1797
 msgid "don't strip/add [PATCH]"
 msgstr "ta inte bort eller lägg till [PATCH]"
 
-#: builtin/log.c:1785
+#: builtin/log.c:1800
 msgid "don't output binary diffs"
 msgstr "skriv inte binära diffar"
 
-#: builtin/log.c:1787
+#: builtin/log.c:1802
 msgid "output all-zero hash in From header"
 msgstr "använd hashvärde med nollor i From-huvud"
 
-#: builtin/log.c:1789
+#: builtin/log.c:1804
 msgid "don't include a patch matching a commit upstream"
 msgstr "ta inte med patchar som motsvarar en uppströmsincheckning"
 
-#: builtin/log.c:1791
+#: builtin/log.c:1806
 msgid "show patch format instead of default (patch + stat)"
 msgstr "visa patchformat istället för standard (patch + stat)"
 
-#: builtin/log.c:1793
+#: builtin/log.c:1808
 msgid "Messaging"
 msgstr "E-post"
 
-#: builtin/log.c:1794
+#: builtin/log.c:1809
 msgid "header"
 msgstr "huvud"
 
-#: builtin/log.c:1795
+#: builtin/log.c:1810
 msgid "add email header"
 msgstr "lägg till e-posthuvud"
 
-#: builtin/log.c:1796 builtin/log.c:1797
+#: builtin/log.c:1811 builtin/log.c:1812
 msgid "email"
 msgstr "epost"
 
-#: builtin/log.c:1796
+#: builtin/log.c:1811
 msgid "add To: header"
 msgstr "lägg till mottagarhuvud (\"To:\")"
 
-#: builtin/log.c:1797
+#: builtin/log.c:1812
 msgid "add Cc: header"
 msgstr "lägg till kopiehuvud (\"Cc:\")"
 
-#: builtin/log.c:1798
+#: builtin/log.c:1813
 msgid "ident"
 msgstr "ident"
 
-#: builtin/log.c:1799
+#: builtin/log.c:1814
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr "sätt Från-adress till <ident> (eller incheckare om ident saknas)"
 
-#: builtin/log.c:1801
+#: builtin/log.c:1816
 msgid "message-id"
 msgstr "meddelande-id"
 
-#: builtin/log.c:1802
+#: builtin/log.c:1817
 msgid "make first mail a reply to <message-id>"
 msgstr "gör det första brevet ett svar till <meddelande-id>"
 
-#: builtin/log.c:1803 builtin/log.c:1806
+#: builtin/log.c:1818 builtin/log.c:1821
 msgid "boundary"
 msgstr "gräns"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1819
 msgid "attach the patch"
 msgstr "bifoga patchen"
 
-#: builtin/log.c:1807
+#: builtin/log.c:1822
 msgid "inline the patch"
 msgstr "gör patchen ett inline-objekt"
 
-#: builtin/log.c:1811
+#: builtin/log.c:1826
 msgid "enable message threading, styles: shallow, deep"
 msgstr "aktivera brevtrådning, typer: shallow, deep"
 
-#: builtin/log.c:1813
+#: builtin/log.c:1828
 msgid "signature"
 msgstr "signatur"
 
-#: builtin/log.c:1814
+#: builtin/log.c:1829
 msgid "add a signature"
 msgstr "lägg till signatur"
 
-#: builtin/log.c:1815
+#: builtin/log.c:1830
 msgid "base-commit"
 msgstr "basincheckning"
 
-#: builtin/log.c:1816
+#: builtin/log.c:1831
 msgid "add prerequisite tree info to the patch series"
 msgstr "lägg till förhandskrävd trädinfo i patchserien"
 
-#: builtin/log.c:1819
+#: builtin/log.c:1834
 msgid "add a signature from a file"
 msgstr "lägg till signatur från fil"
 
-#: builtin/log.c:1820
+#: builtin/log.c:1835
 msgid "don't print the patch filenames"
 msgstr "visa inte filnamn för patchar"
 
-#: builtin/log.c:1822
+#: builtin/log.c:1837
 msgid "show progress while generating patches"
 msgstr "visa förloppsindikator medan patchar skapas"
 
-#: builtin/log.c:1824
+#: builtin/log.c:1839
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr "visa ändringar mot <rev> i omslagsbrev eller ensam patch"
 
-#: builtin/log.c:1827
+#: builtin/log.c:1842
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr "visa ändringar mot <refspec> i omslagsbrev eller ensam patch"
 
-#: builtin/log.c:1829 builtin/range-diff.c:28
+#: builtin/log.c:1844 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
 msgstr "procent som skapelse vägs med"
 
-#: builtin/log.c:1916
+#: builtin/log.c:1931
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "ogiltig ident-rad: %s"
 
-#: builtin/log.c:1931
-msgid "-n and -k are mutually exclusive"
-msgstr "-n och -k kan inte användas samtidigt"
-
-#: builtin/log.c:1933
-msgid "--subject-prefix/--rfc and -k are mutually exclusive"
-msgstr "--subject-prefix/--rfc och -k kan inte användas samtidigt"
-
-#: builtin/log.c:1941
+#: builtin/log.c:1956
 msgid "--name-only does not make sense"
 msgstr "kan inte använda --name-only"
 
-#: builtin/log.c:1943
+#: builtin/log.c:1958
 msgid "--name-status does not make sense"
 msgstr "kan inte använda --name-status"
 
-#: builtin/log.c:1945
+#: builtin/log.c:1960
 msgid "--check does not make sense"
 msgstr "kan inte använda --check"
 
-#: builtin/log.c:1967
-msgid "--stdout, --output, and --output-directory are mutually exclusive"
-msgstr "--stdout, --output, och --output-directory är ömsesidigt uteslutande"
-
-#: builtin/log.c:2089
+#: builtin/log.c:2104
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff kräver --cover-letter eller ensam patch"
 
-#: builtin/log.c:2093
+#: builtin/log.c:2108
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:2094
+#: builtin/log.c:2109
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff mot v%d:"
 
-#: builtin/log.c:2100
-msgid "--creation-factor requires --range-diff"
-msgstr "--creation-factor kräver --range-diff"
-
-#: builtin/log.c:2104
+#: builtin/log.c:2119
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff kräver --cover-letter eller ensam patch"
 
-#: builtin/log.c:2112
+#: builtin/log.c:2127
 msgid "Range-diff:"
 msgstr "Intervall-diff:"
 
-#: builtin/log.c:2113
+#: builtin/log.c:2128
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Intervall-diff mot v%d:"
 
-#: builtin/log.c:2124
+#: builtin/log.c:2139
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "kunde inte läsa signaturfil \"%s\""
 
-#: builtin/log.c:2160
+#: builtin/log.c:2175
 msgid "Generating patches"
 msgstr "Skapar patchar"
 
-#: builtin/log.c:2204
+#: builtin/log.c:2219
 msgid "failed to create output files"
 msgstr "misslyckades skapa utdatafiler"
 
-#: builtin/log.c:2263
+#: builtin/log.c:2279
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<uppström> [<huvud> [<gräns>]]]"
 
-#: builtin/log.c:2317
+#: builtin/log.c:2333
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
 msgstr "Kunde inte hitta en spårad fjärrgren, ange <uppström> manuellt.\n"
 
-#: builtin/ls-files.c:561
+#: builtin/ls-files.c:564
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<flaggor>] [<fil>...]"
 
-#: builtin/ls-files.c:615
+#: builtin/ls-files.c:618
 msgid "separate paths with the NUL character"
 msgstr "sökvägar avdelas med NUL-tecken"
 
-#: builtin/ls-files.c:617
+#: builtin/ls-files.c:620
 msgid "identify the file status with tags"
 msgstr "identifiera filstatus med taggar"
 
-#: builtin/ls-files.c:619
+#: builtin/ls-files.c:622
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr "använd små bokstäver för \"anta oförändrade\"-filer"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:624
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "använd små bokstäver för \"fsmonitor clean\"-filer"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:626
 msgid "show cached files in the output (default)"
 msgstr "visa cachade filer i utdata (standard)"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:628
 msgid "show deleted files in the output"
 msgstr "visa borttagna filer i utdata"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:630
 msgid "show modified files in the output"
 msgstr "visa modifierade filer i utdata"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:632
 msgid "show other files in the output"
 msgstr "visa andra filer i utdata"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:634
 msgid "show ignored files in the output"
 msgstr "visa ignorerade filer i utdata"
 
-#: builtin/ls-files.c:634
+#: builtin/ls-files.c:637
 msgid "show staged contents' object name in the output"
 msgstr "visa köat innehålls objektnamn i utdata"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:639
 msgid "show files on the filesystem that need to be removed"
 msgstr "visa filer i filsystemet som behöver tas bort"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:641
 msgid "show 'other' directories' names only"
 msgstr "visa endast namn för \"andra\" kataloger"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:643
 msgid "show line endings of files"
 msgstr "visa radslut i filer"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:645
 msgid "don't show empty directories"
 msgstr "visa inte tomma kataloger"
 
-#: builtin/ls-files.c:645
+#: builtin/ls-files.c:648
 msgid "show unmerged files in the output"
 msgstr "visa ej sammanslagna filer i utdata"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:650
 msgid "show resolve-undo information"
 msgstr "visa \"resolve-undo\"-information"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:652
 msgid "skip files matching pattern"
 msgstr "hoppa över filer som motsvarar mönster"
 
-#: builtin/ls-files.c:652
+#: builtin/ls-files.c:655
 msgid "read exclude patterns from <file>"
 msgstr "läs exkluderingsmönster från <fil>"
 
-#: builtin/ls-files.c:655
+#: builtin/ls-files.c:658
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "läs ytterligare per-katalog-exkluderingsmönster från <fil>"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:660
 msgid "add the standard git exclusions"
 msgstr "lägg till git:s standardexkluderingar"
 
-#: builtin/ls-files.c:661
+#: builtin/ls-files.c:664
 msgid "make the output relative to the project top directory"
 msgstr "gör utdata relativ till projektets toppkatalog"
 
-#: builtin/ls-files.c:664
+#: builtin/ls-files.c:667
 msgid "recurse through submodules"
 msgstr "rekursera ner i undermoduler"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:669
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "om en <fil> inte är indexet, betrakta det som ett fel"
 
-#: builtin/ls-files.c:667
+#: builtin/ls-files.c:670
 msgid "tree-ish"
 msgstr "träd-igt"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:671
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr "låtsas att sökvägar borttagna sedan <träd-igt> fortfarande finns"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:673
 msgid "show debugging data"
 msgstr "visa felsökningsutdata"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:675
 msgid "suppress duplicate entries"
 msgstr "undertyck dublettposter"
+
+#: builtin/ls-files.c:677
+msgid "show sparse directories in the presence of a sparse index"
+msgstr "visa glesa kataloger när et glest index existerar"
 
 #: builtin/ls-remote.c:9
 msgid ""
@@ -17703,7 +17611,7 @@ msgstr "terminera poster med NUL-byte"
 
 #: builtin/ls-tree.c:136
 msgid "include object size"
-msgstr "inkludera objektstorlek"
+msgstr "ta med objektstorlek"
 
 #: builtin/ls-tree.c:138 builtin/ls-tree.c:140
 msgid "list only filenames"
@@ -17828,26 +17736,30 @@ msgid "use a diff3 based merge"
 msgstr "använd diff3-baserad sammanslagning"
 
 #: builtin/merge-file.c:37
+msgid "use a zealous diff3 based merge"
+msgstr "använd nitisk diff3-baserad sammanslagning"
+
+#: builtin/merge-file.c:39
 msgid "for conflicts, use our version"
 msgstr "för konflikter, använd vår version"
 
-#: builtin/merge-file.c:39
+#: builtin/merge-file.c:41
 msgid "for conflicts, use their version"
 msgstr "för konflikter, använd deras version"
 
-#: builtin/merge-file.c:41
+#: builtin/merge-file.c:43
 msgid "for conflicts, use a union version"
 msgstr "för konflikter, använd en förenad version"
 
-#: builtin/merge-file.c:44
+#: builtin/merge-file.c:46
 msgid "for conflicts, use this marker size"
 msgstr "för konflikter, använd denna markörstorlek"
 
-#: builtin/merge-file.c:45
+#: builtin/merge-file.c:47
 msgid "do not warn about conflicts"
 msgstr "varna inte om konflikter"
 
-#: builtin/merge-file.c:47
+#: builtin/merge-file.c:49
 msgid "set labels for file1/orig-file/file2"
 msgstr "sätt etiketter för fil1/origfil/fil2"
 
@@ -17886,180 +17798,184 @@ msgstr "Slår ihop %s med %s\n"
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<flaggor>] [<incheckning>...]"
 
-#: builtin/merge.c:124
+#: builtin/merge.c:125
 msgid "switch `m' requires a value"
 msgstr "flaggan \"m\" behöver ett värde"
 
-#: builtin/merge.c:147
+#: builtin/merge.c:148
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "flaggan \"%s\" behöver ett värde"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Kunde inte hitta sammanslagningsstrategin \"%s\".\n"
 
-#: builtin/merge.c:201
+#: builtin/merge.c:202
 #, c-format
 msgid "Available strategies are:"
 msgstr "Tillgängliga strategier är:"
 
-#: builtin/merge.c:206
+#: builtin/merge.c:207
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Tillgängliga skräddarsydda strategier är:"
 
-#: builtin/merge.c:257 builtin/pull.c:134
+#: builtin/merge.c:258 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "visa inte en diffstat när sammanslagningen är färdig"
 
-#: builtin/merge.c:260 builtin/pull.c:137
+#: builtin/merge.c:261 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "visa en diffstat när sammanslagningen är färdig"
 
-#: builtin/merge.c:261 builtin/pull.c:140
+#: builtin/merge.c:262 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(synonym till --stat)"
 
-#: builtin/merge.c:263 builtin/pull.c:143
+#: builtin/merge.c:264 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "lägg till (som mest <n>) poster från shortlog till incheckningsmeddelandet"
 
-#: builtin/merge.c:266 builtin/pull.c:149
+#: builtin/merge.c:267 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "skapa en ensam incheckning istället för en sammanslagning"
 
-#: builtin/merge.c:268 builtin/pull.c:152
+#: builtin/merge.c:269 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "utför en incheckning om sammanslagningen lyckades (standard)"
 
-#: builtin/merge.c:270 builtin/pull.c:155
+#: builtin/merge.c:271 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "redigera meddelande innan incheckning"
 
-#: builtin/merge.c:272
+#: builtin/merge.c:273
 msgid "allow fast-forward (default)"
 msgstr "tillåt snabbspolning (standard)"
 
-#: builtin/merge.c:274 builtin/pull.c:162
+#: builtin/merge.c:275 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "avbryt om snabbspolning inte är möjlig"
 
-#: builtin/merge.c:278 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "bekräfta att den namngivna incheckningen har en giltig GPG-signatur"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
+#: builtin/merge.c:280 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "strategi"
 
-#: builtin/merge.c:280 builtin/pull.c:173
+#: builtin/merge.c:281 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "sammanslagningsstrategi att använda"
 
-#: builtin/merge.c:281 builtin/pull.c:176
+#: builtin/merge.c:282 builtin/pull.c:176
 msgid "option=value"
 msgstr "alternativ=värde"
 
-#: builtin/merge.c:282 builtin/pull.c:177
+#: builtin/merge.c:283 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "alternativ för vald sammanslagningsstrategi"
 
-#: builtin/merge.c:284
+#: builtin/merge.c:285
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "incheckningsmeddelande för (icke snabbspolande) sammanslagning"
 
 #: builtin/merge.c:291
+msgid "use <name> instead of the real target"
+msgstr "använd <namn> istället för det verkliga målet"
+
+#: builtin/merge.c:294
 msgid "abort the current in-progress merge"
 msgstr "avbryt den pågående sammanslagningen"
 
-#: builtin/merge.c:293
+#: builtin/merge.c:296
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort men lämna index och arbetskatalog ensamma"
 
-#: builtin/merge.c:295
+#: builtin/merge.c:298
 msgid "continue the current in-progress merge"
 msgstr "fortsätt den pågående sammanslagningen"
 
-#: builtin/merge.c:297 builtin/pull.c:184
+#: builtin/merge.c:300 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "tillåt sammanslagning av orelaterade historier"
 
-#: builtin/merge.c:304
+#: builtin/merge.c:307
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "förbigå pre-merge-commit- och commit-msg-krokar"
 
-#: builtin/merge.c:321
+#: builtin/merge.c:323
 msgid "could not run stash."
 msgstr "kunde köra stash."
 
-#: builtin/merge.c:326
+#: builtin/merge.c:328
 msgid "stash failed"
 msgstr "stash misslyckades"
 
-#: builtin/merge.c:331
+#: builtin/merge.c:333
 #, c-format
 msgid "not a valid object: %s"
 msgstr "inte ett giltigt objekt: %s"
 
-#: builtin/merge.c:353 builtin/merge.c:370
+#: builtin/merge.c:355 builtin/merge.c:372
 msgid "read-tree failed"
 msgstr "read-tree misslyckades"
 
-#: builtin/merge.c:401
+#: builtin/merge.c:403
 msgid "Already up to date. (nothing to squash)"
 msgstr "Redan à jour. (inget att platta till)"
 
-#: builtin/merge.c:415
+#: builtin/merge.c:417
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Tillplattningsincheckning -- uppdaterar inte HEAD\n"
 
-#: builtin/merge.c:465
+#: builtin/merge.c:467
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Inget sammanslagningsmeddelande -- uppdaterar inte HEAD\n"
 
-#: builtin/merge.c:515
+#: builtin/merge.c:517
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "\"%s\" verkar inte peka på en incheckning"
 
-#: builtin/merge.c:603
+#: builtin/merge.c:605
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Felaktig branch.%s.mergeoptions-sträng: %s"
 
-#: builtin/merge.c:730
+#: builtin/merge.c:732
 msgid "Not handling anything other than two heads merge."
 msgstr "Hanterar inte något annat än en sammanslagning av två huvuden."
 
-#: builtin/merge.c:743
+#: builtin/merge.c:745
 #, c-format
 msgid "unknown strategy option: -X%s"
 msgstr "okänd strategiflagga: -X%s"
 
-#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:764 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "kunde inte skriva %s"
 
-#: builtin/merge.c:814
+#: builtin/merge.c:816
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "Kunde inte läsa från \"%s\""
 
-#: builtin/merge.c:823
+#: builtin/merge.c:825
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Checkar inte in sammanslagningen; använd \"git commit\" för att slutföra "
 "den.\n"
 
-#: builtin/merge.c:829
+#: builtin/merge.c:831
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -18070,11 +17986,11 @@ msgstr ""
 "temagren.\n"
 "\n"
 
-#: builtin/merge.c:834
+#: builtin/merge.c:836
 msgid "An empty message aborts the commit.\n"
 msgstr "Ett tomt meddelande avbryter incheckningen.\n"
 
-#: builtin/merge.c:837
+#: builtin/merge.c:839
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -18083,73 +17999,73 @@ msgstr ""
 "Rader som inleds med \"%c\" kommer ignoreras, och ett tomt meddelande\n"
 "avbryter incheckningen.\n"
 
-#: builtin/merge.c:892
+#: builtin/merge.c:894
 msgid "Empty commit message."
 msgstr "Tomt incheckningsmeddelande."
 
-#: builtin/merge.c:907
+#: builtin/merge.c:909
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Underbart.\n"
 
-#: builtin/merge.c:968
+#: builtin/merge.c:970
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Kunde inte slå ihop automatiskt; fixa konflikter och checka in resultatet.\n"
 
-#: builtin/merge.c:1007
+#: builtin/merge.c:1009
 msgid "No current branch."
 msgstr "Inte på någon gren."
 
-#: builtin/merge.c:1009
+#: builtin/merge.c:1011
 msgid "No remote for the current branch."
 msgstr "Ingen fjärr för aktuell gren."
 
-#: builtin/merge.c:1011
+#: builtin/merge.c:1013
 msgid "No default upstream defined for the current branch."
 msgstr "Ingen standarduppström angiven för aktuell gren."
 
-#: builtin/merge.c:1016
+#: builtin/merge.c:1018
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Ingen fjärrspårande gren för %s från %s"
 
-#: builtin/merge.c:1073
+#: builtin/merge.c:1075
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Felaktigt värde \"%s\" i miljövariabeln \"%s\""
 
-#: builtin/merge.c:1174
+#: builtin/merge.c:1177
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "inte något vi kan slå ihop med %s: %s"
 
-#: builtin/merge.c:1208
+#: builtin/merge.c:1211
 msgid "not something we can merge"
 msgstr "inte något vi kan slå ihop"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1324
 msgid "--abort expects no arguments"
 msgstr "--abort tar inga argument"
 
-#: builtin/merge.c:1325
+#: builtin/merge.c:1328
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Ingen sammanslagning att avbryta (MERGE_HEAD saknas)."
 
-#: builtin/merge.c:1343
+#: builtin/merge.c:1346
 msgid "--quit expects no arguments"
 msgstr "--quit tar inga argument"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1359
 msgid "--continue expects no arguments"
 msgstr "--continue tar inga argument"
 
-#: builtin/merge.c:1360
+#: builtin/merge.c:1363
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Ingen sammanslagning pågår (MERGE_HEAD saknas)."
 
-#: builtin/merge.c:1376
+#: builtin/merge.c:1379
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18157,7 +18073,7 @@ msgstr ""
 "Du har inte avslutat sammanslagningen (MERGE_HEAD finns).\n"
 "Checka in dina ändringar innan du slår ihop."
 
-#: builtin/merge.c:1383
+#: builtin/merge.c:1386
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18165,84 +18081,76 @@ msgstr ""
 "Du har inte avslutat din \"cherry-pick\" (CHERRY_PICK_HEAD finns).\n"
 "Checka in dina ändringar innan du slår ihop."
 
-#: builtin/merge.c:1386
+#: builtin/merge.c:1389
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Du har inte avslutat din \"cherry-pick\" (CHERRY_PICK_HEAD finns)."
 
-#: builtin/merge.c:1400
-msgid "You cannot combine --squash with --no-ff."
-msgstr "Du kan inte kombinera --squash med --no-ff."
-
-#: builtin/merge.c:1402
-msgid "You cannot combine --squash with --commit."
-msgstr "Du kan inte kombinera --squash med --commit."
-
-#: builtin/merge.c:1418
+#: builtin/merge.c:1421
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Ingen incheckning angiven och merge.defaultToUpstream är ej satt."
 
-#: builtin/merge.c:1435
+#: builtin/merge.c:1438
 msgid "Squash commit into empty head not supported yet"
 msgstr "Stöder inte en tillplattningsincheckning på ett tomt huvud ännu"
 
-#: builtin/merge.c:1437
+#: builtin/merge.c:1440
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Icke-snabbspolad incheckning kan inte användas med ett tomt huvud"
 
-#: builtin/merge.c:1442
+#: builtin/merge.c:1445
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - inte något vi kan slå ihop"
 
-#: builtin/merge.c:1444
+#: builtin/merge.c:1447
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Kan endast slå ihop en enda incheckning i ett tomt huvud"
 
-#: builtin/merge.c:1531
+#: builtin/merge.c:1534
 msgid "refusing to merge unrelated histories"
 msgstr "vägrar slå samman orelaterad historik"
 
-#: builtin/merge.c:1550
+#: builtin/merge.c:1553
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Uppdaterar %s..%s\n"
 
-#: builtin/merge.c:1598
+#: builtin/merge.c:1601
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Försöker riktigt enkel sammanslagning i indexet...\n"
 
-#: builtin/merge.c:1605
+#: builtin/merge.c:1608
 #, c-format
 msgid "Nope.\n"
 msgstr "Nej.\n"
 
-#: builtin/merge.c:1664 builtin/merge.c:1730
+#: builtin/merge.c:1667 builtin/merge.c:1733
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Återspolar trädet till orört...\n"
 
-#: builtin/merge.c:1668
+#: builtin/merge.c:1671
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Försöker sammanslagningsstrategin %s...\n"
 
-#: builtin/merge.c:1720
+#: builtin/merge.c:1723
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Ingen sammanslagningsstrategi hanterade sammanslagningen.\n"
 
-#: builtin/merge.c:1722
+#: builtin/merge.c:1725
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Sammanslagning med strategin %s misslyckades.\n"
 
-#: builtin/merge.c:1732
+#: builtin/merge.c:1735
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "Använder strategin %s för att förbereda lösning för hand.\n"
 
-#: builtin/merge.c:1746
+#: builtin/merge.c:1749
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18285,7 +18193,7 @@ msgstr "tagg på stdin godkänns inte av vår strikta fsck-kontroll"
 msgid "tag on stdin did not refer to a valid object"
 msgstr "taggen på stdin pekar inte på ett giltigt objekt"
 
-#: builtin/mktag.c:104 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:242
 msgid "unable to write tag file"
 msgstr "kunde inte skriva tagg-filen"
 
@@ -18349,7 +18257,7 @@ msgstr "skriv flerpaketsindex som endast innehåller angivna index"
 msgid "refs snapshot for selecting bitmap commits"
 msgstr "refs-ögonblicksbild för att välja bitkarte-incheckningar"
 
-#: builtin/multi-pack-index.c:202
+#: builtin/multi-pack-index.c:206
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
@@ -18449,52 +18357,52 @@ msgstr "%s, källa=%s, mål=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Byter namn på %s till %s\n"
 
-#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:857
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "misslyckades byta namn på \"%s\""
 
-#: builtin/name-rev.c:465
+#: builtin/name-rev.c:474
 msgid "git name-rev [<options>] <commit>..."
 msgstr "git name-rev [<flaggor>] <incheckning>..."
 
-#: builtin/name-rev.c:466
+#: builtin/name-rev.c:475
 msgid "git name-rev [<options>] --all"
 msgstr "git name-rev [<flaggor>] --all"
 
-#: builtin/name-rev.c:467
+#: builtin/name-rev.c:476
 msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [<flaggor>] --stdin"
 
-#: builtin/name-rev.c:524
+#: builtin/name-rev.c:533
 msgid "print only ref-based names (no object names)"
 msgstr "skriv endast referensbaserade namn (inga objektnamn)"
 
-#: builtin/name-rev.c:525
+#: builtin/name-rev.c:534
 msgid "only use tags to name the commits"
 msgstr "använd endast taggar för att namnge incheckningar"
 
-#: builtin/name-rev.c:527
+#: builtin/name-rev.c:536
 msgid "only use refs matching <pattern>"
 msgstr "använd endast referenser som motsvarar <mönster>"
 
-#: builtin/name-rev.c:529
+#: builtin/name-rev.c:538
 msgid "ignore refs matching <pattern>"
 msgstr "ignorera referenser som motsvarar <mönster>"
 
-#: builtin/name-rev.c:531
+#: builtin/name-rev.c:540
 msgid "list all commits reachable from all refs"
 msgstr "lista alla incheckningar som kan nås alla referenser"
 
-#: builtin/name-rev.c:532
+#: builtin/name-rev.c:541
 msgid "read from stdin"
 msgstr "läs från standard in"
 
-#: builtin/name-rev.c:533
+#: builtin/name-rev.c:542
 msgid "allow to print `undefined` names (default)"
 msgstr "tillåt att skriva \"odefinierade\" namn (standard)"
 
-#: builtin/name-rev.c:539
+#: builtin/name-rev.c:548
 msgid "dereference tags in the input (internal use)"
 msgstr "avreferera taggar i indata (används internt)"
 
@@ -18614,25 +18522,25 @@ msgstr "git notes get-ref"
 msgid "Write/edit the notes for the following object:"
 msgstr "Skriv/redigera anteckningar för följande objekt:"
 
-#: builtin/notes.c:150
+#: builtin/notes.c:149
 #, c-format
 msgid "unable to start 'show' for object '%s'"
 msgstr "kunde inte starta \"show\" för objektet \"%s\""
 
-#: builtin/notes.c:154
+#: builtin/notes.c:153
 msgid "could not read 'show' output"
 msgstr "kunde inte läsa utdata från \"show\""
 
-#: builtin/notes.c:162
+#: builtin/notes.c:161
 #, c-format
 msgid "failed to finish 'show' for object '%s'"
 msgstr "kunde inte avsluta \"show\" för objektet \"%s\""
 
-#: builtin/notes.c:195
+#: builtin/notes.c:194
 msgid "please supply the note contents using either -m or -F option"
 msgstr "ange innehåll för anteckningen med antingen -m eller -F"
 
-#: builtin/notes.c:204
+#: builtin/notes.c:203
 msgid "unable to write note object"
 msgstr "kunde inte skriva anteckningsobjekt"
 
@@ -18641,7 +18549,7 @@ msgstr "kunde inte skriva anteckningsobjekt"
 msgid "the note contents have been left in %s"
 msgstr "anteckningens innehåll har lämnats kvar i %s"
 
-#: builtin/notes.c:240 builtin/tag.c:577
+#: builtin/notes.c:240 builtin/tag.c:581
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "kunde inte öppna eller läsa \"%s\""
@@ -18683,8 +18591,8 @@ msgstr "vägrar utföra \"%s\" på anteckningar i %s (utanför refs/notes/)"
 
 #: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
 #: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
-#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
-#: builtin/prune-packed.c:25 builtin/tag.c:587
+#: builtin/notes.c:813 builtin/notes.c:965 builtin/notes.c:987
+#: builtin/prune-packed.c:25 builtin/receive-pack.c:2487 builtin/tag.c:591
 msgid "too many arguments"
 msgstr "för många argument"
 
@@ -18731,7 +18639,7 @@ msgstr ""
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Skriver över befintliga anteckningar för objektet %s\n"
 
-#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:904
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Tar bort anteckning för objektet %s\n"
@@ -18855,17 +18763,17 @@ msgstr "måste ange en antecknings-referens att slå ihop"
 msgid "unknown -s/--strategy: %s"
 msgstr "okänd -s/--strategy: %s"
 
-#: builtin/notes.c:871
+#: builtin/notes.c:874
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "sammanslagning av anteckningar till %s är redan igångsatt på %s"
 
-#: builtin/notes.c:874
+#: builtin/notes.c:878
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr "misslyckades lagra länk till aktuell anteckningsreferens (%s)"
 
-#: builtin/notes.c:876
+#: builtin/notes.c:880
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -18876,41 +18784,41 @@ msgstr ""
 "%s och checka in resultatet med \"git notes merge --commit\", eller avbryt "
 "sammanslagningen med \"git notes merge --abort\".\n"
 
-#: builtin/notes.c:895 builtin/tag.c:590
+#: builtin/notes.c:899 builtin/tag.c:594
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Kunde inte slå upp \"%s\" som en giltig referens."
 
-#: builtin/notes.c:898
+#: builtin/notes.c:902
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "Objektet %s har ingen anteckning\n"
 
-#: builtin/notes.c:910
+#: builtin/notes.c:914
 msgid "attempt to remove non-existent note is not an error"
 msgstr "försök att ta bort icke-existerande anteckningar är inte ett fel"
 
-#: builtin/notes.c:913
+#: builtin/notes.c:917
 msgid "read object names from the standard input"
 msgstr "läs objektnamn från standard in"
 
-#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
+#: builtin/notes.c:956 builtin/prune.c:144 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "ta inte bort, bara visa"
 
-#: builtin/notes.c:953
+#: builtin/notes.c:957
 msgid "report pruned notes"
 msgstr "rapportera borttagna anteckningar"
 
-#: builtin/notes.c:996
+#: builtin/notes.c:1000
 msgid "notes-ref"
 msgstr "anteckningar-ref"
 
-#: builtin/notes.c:997
+#: builtin/notes.c:1001
 msgid "use notes from <notes-ref>"
 msgstr "använd anteckningar från <anteckningsref>"
 
-#: builtin/notes.c:1032 builtin/stash.c:1752
+#: builtin/notes.c:1036 builtin/stash.c:1818
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "okänt underkommando: %s"
@@ -19188,15 +19096,15 @@ msgstr "begränsa objekt till dem som ännu inte packats"
 
 #: builtin/pack-objects.c:3915
 msgid "include objects reachable from any reference"
-msgstr "inkludera objekt som kan nås från någon referens"
+msgstr "ta med objekt som kan nås från någon referens"
 
 #: builtin/pack-objects.c:3918
 msgid "include objects referred by reflog entries"
-msgstr "inkludera objekt som refereras från referensloggposter"
+msgstr "ta med objekt som refereras från referensloggposter"
 
 #: builtin/pack-objects.c:3921
 msgid "include objects referred to by the index"
-msgstr "inkludera objekt som refereras från indexet"
+msgstr "ta med objekt som refereras från indexet"
 
 #: builtin/pack-objects.c:3924
 msgid "read packs from stdin"
@@ -19208,7 +19116,7 @@ msgstr "skriv paket på standard ut"
 
 #: builtin/pack-objects.c:3928
 msgid "include tag objects that refer to objects to be packed"
-msgstr "inkludera taggobjekt som refererar objekt som ska packas"
+msgstr "ta med taggobjekt som refererar objekt som ska packas"
 
 #: builtin/pack-objects.c:3930
 msgid "keep unreachable objects"
@@ -19306,11 +19214,6 @@ msgstr "minsta packstorlek är 1 MiB"
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin kan inte användas för att bygga ett indexerbart paket"
 
-#: builtin/pack-objects.c:4073
-msgid "--keep-unreachable and --unpack-unreachable are incompatible"
-msgstr ""
-"--keep-unreachable och --unpack-unreachable kan inte användas samtidigt"
-
 #: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr "kan inte använda --filter utan --stdout"
@@ -19327,7 +19230,7 @@ msgstr "kan inte använda intern revisionslista med --stdin-packs"
 msgid "Enumerating objects"
 msgstr "Räknar upp objekt"
 
-#: builtin/pack-objects.c:4181
+#: builtin/pack-objects.c:4180
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19370,19 +19273,19 @@ msgstr "git prune-packed [-n | --dry-run] [-q | --quiet]"
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
 msgstr "git prune [-n] [-v] [--progress] [--expire <tid>] [--] [<huvud>...]"
 
-#: builtin/prune.c:133
+#: builtin/prune.c:145
 msgid "report pruned objects"
 msgstr "rapportera borttagna objekt"
 
-#: builtin/prune.c:136
+#: builtin/prune.c:148
 msgid "expire objects older than <time>"
 msgstr "låt tid gå ut för objekt äldre än <tid>"
 
-#: builtin/prune.c:138
+#: builtin/prune.c:150
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr "begränsa vandring av objekt utanför kontraktspackfiler."
 
-#: builtin/prune.c:151
+#: builtin/prune.c:163
 msgid "cannot prune in a precious-objects repo"
 msgstr "kan inte rensa i ett \"precious-objekt\"-arkiv"
 
@@ -19415,7 +19318,7 @@ msgstr "tillåt snabbspolning"
 msgid "control use of pre-merge-commit and commit-msg hooks"
 msgstr "styr användning av pre-merge-commit- och commit-msg-krokar"
 
-#: builtin/pull.c:171 parse-options.h:338
+#: builtin/pull.c:171 parse-options.h:340
 msgid "automatically stash/stash pop before and after"
 msgstr "utför automatiskt stash/stash pop före och efter"
 
@@ -19492,6 +19395,7 @@ msgid "<remote>"
 msgstr "<fjärr>"
 
 #: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
+#: contrib/scalar/scalar.c:375
 msgid "<branch>"
 msgstr "<gren>"
 
@@ -19522,13 +19426,13 @@ msgstr "kunde inte komma åt incheckningen %s"
 msgid "ignoring --verify-signatures for rebase"
 msgstr "ignorera --verify-signatures för ombasering"
 
-#: builtin/pull.c:942
+#: builtin/pull.c:969
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
 "your next pull:\n"
 "\n"
-"  git config pull.rebase false  # merge (the default strategy)\n"
+"  git config pull.rebase false  # merge\n"
 "  git config pull.rebase true   # rebase\n"
 "  git config pull.ff only       # fast-forward only\n"
 "\n"
@@ -19542,7 +19446,7 @@ msgstr ""
 "Du kan göra detta genom att köra ett av följande kommando innan du\n"
 "gör \"pull\" nästa gång: \n"
 "\n"
-"  git config pull.rebase false  # sammanslagning (förvald strategi)\n"
+"  git config pull.rebase false  # sammanslagning\n"
 "  git config pull.rebase true   # ombasering\n"
 "  git config pull.ff only       # endast snabbspolning\n"
 "\n"
@@ -19551,19 +19455,19 @@ msgstr ""
 "eller --ff-only på kommandoraden för att överstyra det konfigurerade\n"
 "förvalet vid körning.\n"
 
-#: builtin/pull.c:1016
+#: builtin/pull.c:1046
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Uppdaterar en ofödd gren med ändringar som lagts till i indexet."
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1050
 msgid "pull with rebase"
 msgstr "pull med ombasering"
 
-#: builtin/pull.c:1021
+#: builtin/pull.c:1051
 msgid "please commit or stash them."
 msgstr "checka in eller använd \"stash\" på dem."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1076
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19574,7 +19478,7 @@ msgstr ""
 "snabbspolar din arbetskatalog från\n"
 "incheckningen %s."
 
-#: builtin/pull.c:1052
+#: builtin/pull.c:1082
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19591,23 +19495,23 @@ msgstr ""
 "$ git reset --hard\n"
 "för att återgå."
 
-#: builtin/pull.c:1067
+#: builtin/pull.c:1097
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kan inte slå ihop flera grenar i ett tomt huvud."
 
-#: builtin/pull.c:1072
+#: builtin/pull.c:1102
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kan inte ombasera ovanpå flera grenar."
 
-#: builtin/pull.c:1074
+#: builtin/pull.c:1104
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Kan inte snabbspola till flera grenar."
 
-#: builtin/pull.c:1088
+#: builtin/pull.c:1119
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "Måste ange hur avvikande grenar skall förlikas."
 
-#: builtin/pull.c:1102
+#: builtin/pull.c:1133
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr "kan inte ombasera med lokalt lagrade ändringar i undermoful"
 
@@ -19783,7 +19687,7 @@ msgstr "Sänder till %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "misslyckades sända vissa referenser till \"%s\""
 
-#: builtin/push.c:544 builtin/submodule--helper.c:3258
+#: builtin/push.c:544 builtin/submodule--helper.c:3259
 msgid "repository"
 msgstr "arkiv"
 
@@ -19856,10 +19760,6 @@ msgstr "GPG-signera insändningen"
 msgid "request atomic transaction on remote side"
 msgstr "begär atomiska transaktioner på fjärrsidan"
 
-#: builtin/push.c:592
-msgid "--delete is incompatible with --all, --mirror and --tags"
-msgstr "--delete är inkompatibel med --all, --mirror och --tags"
-
 #: builtin/push.c:594
 msgid "--delete doesn't make sense without any refs"
 msgstr "--delete kan inte användas utan referenser"
@@ -19890,25 +19790,13 @@ msgstr ""
 "\n"
 "    git push <namn>\n"
 
-#: builtin/push.c:630
-msgid "--all and --tags are incompatible"
-msgstr "--all och --tags är inkompatibla"
-
 #: builtin/push.c:632
 msgid "--all can't be combined with refspecs"
 msgstr "--all kan inte kombineras med referensspecifikationer"
 
-#: builtin/push.c:636
-msgid "--mirror and --tags are incompatible"
-msgstr "--mirror och --tags är inkompatibla"
-
 #: builtin/push.c:638
 msgid "--mirror can't be combined with refspecs"
 msgstr "--mirror kan inte kombineras med referensspecifikationer"
-
-#: builtin/push.c:641
-msgid "--all and --mirror are incompatible"
-msgstr "--all och --mirror är inkompatibla"
 
 #: builtin/push.c:648
 msgid "push options must not have new line characters"
@@ -20329,18 +20217,6 @@ msgstr "Det verkar som en \"git am\" körs. Kan inte ombasera."
 msgid "--preserve-merges was replaced by --rebase-merges"
 msgstr "--preserve-merges har ersatts av --rebase-merges"
 
-#: builtin/rebase.c:1193
-msgid "cannot combine '--keep-base' with '--onto'"
-msgstr "kan inte kombinera \"--keep-base\" med \"--onto\""
-
-#: builtin/rebase.c:1195
-msgid "cannot combine '--keep-base' with '--root'"
-msgstr "kan inte kombinera \"--keep-base\" med \"--root\""
-
-#: builtin/rebase.c:1199
-msgid "cannot combine '--root' with '--fork-point'"
-msgstr "kan inte kombinera \"--root\" med \"--fork-point\""
-
 #: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "Ingen ombasering pågår?"
@@ -20405,8 +20281,9 @@ msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy kräver --merge eller --interactive"
 
 #: builtin/rebase.c:1463
-msgid "cannot combine apply options with merge options"
-msgstr "kan inte kombinera apply-flaggor med merge-flaggor"
+msgid "apply options and merge options cannot be used together"
+msgstr ""
+"appliceringsflaggor och sammanslagningsflaggor kan inte användas tillsammans"
 
 #: builtin/rebase.c:1476
 #, c-format
@@ -20447,7 +20324,7 @@ msgid "no such branch/commit '%s'"
 msgstr "ingen sådan gren/incheckning: \"%s\""
 
 #: builtin/rebase.c:1618 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2658
+#: builtin/submodule--helper.c:2659
 #, c-format
 msgid "No such ref: %s"
 msgstr "Ingen sådan referens: %s"
@@ -20516,7 +20393,7 @@ msgstr "Snabbspolade %s till %s.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <git-katalog>"
 
-#: builtin/receive-pack.c:1280
+#: builtin/receive-pack.c:1275
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -20546,7 +20423,7 @@ msgstr ""
 "För att undvika detta meddelande och fortfarande behålla det\n"
 "normala beteendet, sätt \"receive.denyCurrentBranch\" till \"refuse\"."
 
-#: builtin/receive-pack.c:1300
+#: builtin/receive-pack.c:1295
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -20567,13 +20444,13 @@ msgstr ""
 "\n"
 "För att undvika detta meddelande kan du sätta det till \"refuse\"."
 
-#: builtin/receive-pack.c:2480
+#: builtin/receive-pack.c:2474
 msgid "quiet"
 msgstr "tyst"
 
-#: builtin/receive-pack.c:2495
-msgid "You must specify a directory."
-msgstr "Du måste ange en katalog."
+#: builtin/receive-pack.c:2489
+msgid "you must specify a directory"
+msgstr "du måste ange en katalog"
 
 #: builtin/reflog.c:17
 msgid ""
@@ -20597,41 +20474,41 @@ msgstr ""
 msgid "git reflog exists <ref>"
 msgstr "git reflog exists <referens>"
 
-#: builtin/reflog.c:568 builtin/reflog.c:573
+#: builtin/reflog.c:585 builtin/reflog.c:590
 #, c-format
 msgid "'%s' is not a valid timestamp"
 msgstr "\"%s\" är inte en giltig tidsstämpel"
 
-#: builtin/reflog.c:609
+#: builtin/reflog.c:631
 #, c-format
 msgid "Marking reachable objects..."
 msgstr "Markerar nåbara objekt..."
 
-#: builtin/reflog.c:647
+#: builtin/reflog.c:675
 #, c-format
 msgid "%s points nowhere!"
 msgstr "%s pekar ingenstans!"
 
-#: builtin/reflog.c:700
+#: builtin/reflog.c:731
 msgid "no reflog specified to delete"
 msgstr "ingen referenslogg att ta bort angavs"
 
-#: builtin/reflog.c:708
+#: builtin/reflog.c:742
 #, c-format
 msgid "not a reflog: %s"
 msgstr "inte en referenslogg: %s"
 
-#: builtin/reflog.c:713
+#: builtin/reflog.c:747
 #, c-format
 msgid "no reflog for '%s'"
 msgstr "ingen referenslogg för \"%s\""
 
-#: builtin/reflog.c:759
+#: builtin/reflog.c:794
 #, c-format
 msgid "invalid ref format: %s"
 msgstr "felaktigt referensformat: %s"
 
-#: builtin/reflog.c:768
+#: builtin/reflog.c:803
 msgid "git reflog [ show | expire | delete | exists ]"
 msgstr "git reflog [ show | expire | delete | exists ]"
 
@@ -20721,6 +20598,11 @@ msgstr "git remote update [<flaggor>] [<grupp> | <fjärr>]..."
 #, c-format
 msgid "Updating %s"
 msgstr "Uppdaterar %s"
+
+#: builtin/remote.c:101
+#, c-format
+msgid "Could not fetch %s"
+msgstr "Kunde inte hämta %s"
 
 #: builtin/remote.c:131
 msgid ""
@@ -21169,149 +21051,141 @@ msgstr ""
 msgid "could not start pack-objects to repack promisor objects"
 msgstr "kunde inte starta pack-objects för att packa om kontraktsobjekt"
 
-#: builtin/repack.c:273 builtin/repack.c:816
+#: builtin/repack.c:275 builtin/repack.c:820
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Förväntar kompletta hex-objekt-id-rader endast från pack-objects."
 
-#: builtin/repack.c:297
+#: builtin/repack.c:299
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr "kunde inte avsluta pack-objects för att packa om kontraktsobjekt"
 
-#: builtin/repack.c:312
+#: builtin/repack.c:314
 #, c-format
 msgid "cannot open index for %s"
 msgstr "kunde inte öppna indexet för %s"
 
-#: builtin/repack.c:371
+#: builtin/repack.c:373
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr "paketet %s för stort för att tas med i geometriskt förlopp"
 
-#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
+#: builtin/repack.c:406 builtin/repack.c:413 builtin/repack.c:418
 #, c-format
 msgid "pack %s too large to roll up"
 msgstr "paketet %s för stort att rulla upp"
 
-#: builtin/repack.c:496
+#: builtin/repack.c:498
 #, c-format
 msgid "could not open tempfile %s for writing"
 msgstr "kunde inte öppna temporär fil %s för skrivning"
 
-#: builtin/repack.c:514
+#: builtin/repack.c:516
 msgid "could not close refs snapshot tempfile"
 msgstr "kunde inte stänga temporär fil för refs-ögonblicksbild"
 
-#: builtin/repack.c:628
+#: builtin/repack.c:630
 msgid "pack everything in a single pack"
 msgstr "packa allt i ett enda paket"
 
-#: builtin/repack.c:630
+#: builtin/repack.c:632
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "samma som -a, och gör onåbara objekt lösa"
 
-#: builtin/repack.c:633
+#: builtin/repack.c:635
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "ta bort överflödiga paket, och kör git-prune-packed"
 
-#: builtin/repack.c:635
+#: builtin/repack.c:637
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "sänd --no-reuse-delta till git-pack-objects"
 
-#: builtin/repack.c:637
+#: builtin/repack.c:639
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "sänd --no-reuse-object till git-pack-objects"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:641
 msgid "do not run git-update-server-info"
 msgstr "kör inte git-update-server-info"
 
-#: builtin/repack.c:642
+#: builtin/repack.c:644
 msgid "pass --local to git-pack-objects"
 msgstr "sänd --local till git-pack-objects"
 
-#: builtin/repack.c:644
+#: builtin/repack.c:646
 msgid "write bitmap index"
 msgstr "skriv bitkartindex"
 
-#: builtin/repack.c:646
+#: builtin/repack.c:648
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "sänd --delta-islands till git-pack-objects"
 
-#: builtin/repack.c:647
+#: builtin/repack.c:649
 msgid "approxidate"
 msgstr "cirkadatum"
 
-#: builtin/repack.c:648
+#: builtin/repack.c:650
 msgid "with -A, do not loosen objects older than this"
 msgstr "med -A, lös inte upp objekt äldre än detta"
 
-#: builtin/repack.c:650
+#: builtin/repack.c:652
 msgid "with -a, repack unreachable objects"
 msgstr "med -a, packa om onåbara objekt"
 
-#: builtin/repack.c:652
+#: builtin/repack.c:654
 msgid "size of the window used for delta compression"
 msgstr "storlek på fönster använt för deltakomprimering"
 
-#: builtin/repack.c:653 builtin/repack.c:659
+#: builtin/repack.c:655 builtin/repack.c:661
 msgid "bytes"
 msgstr "byte"
 
-#: builtin/repack.c:654
+#: builtin/repack.c:656
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr "samma som ovan, men begränsa minnesstorleken istället för postantal"
 
-#: builtin/repack.c:656
+#: builtin/repack.c:658
 msgid "limits the maximum delta depth"
 msgstr "begränsa maximalt deltadjup"
 
-#: builtin/repack.c:658
+#: builtin/repack.c:660
 msgid "limits the maximum number of threads"
 msgstr "begränsar maximalt antal trådar"
 
-#: builtin/repack.c:660
+#: builtin/repack.c:662
 msgid "maximum size of each packfile"
 msgstr "maximal storlek på varje paketfil"
 
-#: builtin/repack.c:662
+#: builtin/repack.c:664
 msgid "repack objects in packs marked with .keep"
 msgstr "packa om objekt i paket märkta med .keep"
 
-#: builtin/repack.c:664
+#: builtin/repack.c:666
 msgid "do not repack this pack"
 msgstr "packa inte om detta paket"
 
-#: builtin/repack.c:666
+#: builtin/repack.c:668
 msgid "find a geometric progression with factor <N>"
 msgstr "hitta ett geometrisk förlopp med faktor <N>"
 
-#: builtin/repack.c:668
+#: builtin/repack.c:670
 msgid "write a multi-pack index of the resulting packs"
 msgstr "skriv ett flerpaketsindex för de skapade paketen"
 
-#: builtin/repack.c:678
+#: builtin/repack.c:680
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "kan inte ta bort paket i ett \"precious-objects\"-arkiv"
 
-#: builtin/repack.c:682
-msgid "--keep-unreachable and -A are incompatible"
-msgstr "--keep-unreachable och -A kan inte användas samtidigt"
-
-#: builtin/repack.c:713
-msgid "--geometric is incompatible with -A, -a"
-msgstr "--geometric är inkompatibel med -A, -a"
-
-#: builtin/repack.c:825
+#: builtin/repack.c:829
 msgid "Nothing new to pack."
 msgstr "Inget nytt att packa."
 
-#: builtin/repack.c:855
+#: builtin/repack.c:859
 #, c-format
 msgid "missing required file: %s"
 msgstr "nödvändig fil saknas: %s"
 
-#: builtin/repack.c:857
+#: builtin/repack.c:861
 #, c-format
 msgid "could not unlink: %s"
 msgstr "kunde inte ta bort: \"%s\""
@@ -21394,67 +21268,61 @@ msgstr "cat-file rapporterade misslyckande"
 msgid "unable to open %s for reading"
 msgstr "kan inte öppna %s för läsning"
 
-#: builtin/replace.c:272
+#: builtin/replace.c:271
 msgid "unable to spawn mktree"
 msgstr "kan inte starta mktree"
 
-#: builtin/replace.c:276
+#: builtin/replace.c:275
 msgid "unable to read from mktree"
 msgstr "kan inte läsa från mktree"
 
-#: builtin/replace.c:285
+#: builtin/replace.c:284
 msgid "mktree reported failure"
 msgstr "mktree rapporterade misslyckande"
 
-#: builtin/replace.c:289
+#: builtin/replace.c:288
 msgid "mktree did not return an object name"
 msgstr "mktree returnerade inte ett objektnamn"
 
-#: builtin/replace.c:298
+#: builtin/replace.c:297
 #, c-format
 msgid "unable to fstat %s"
 msgstr "kan inte utföra \"fstat\" på %s"
 
-#: builtin/replace.c:303
+#: builtin/replace.c:302
 msgid "unable to write object to database"
 msgstr "kan inte skriva objektet till databasen"
 
-#: builtin/replace.c:322 builtin/replace.c:378 builtin/replace.c:424
-#: builtin/replace.c:454
-#, c-format
-msgid "not a valid object name: '%s'"
-msgstr "objektnamnet är inte giltigt: \"%s\""
-
-#: builtin/replace.c:326
+#: builtin/replace.c:325
 #, c-format
 msgid "unable to get object type for %s"
 msgstr "kan inte läsa objekttyp för %s"
 
-#: builtin/replace.c:342
+#: builtin/replace.c:341
 msgid "editing object file failed"
 msgstr "misslyckades redigera objektfilen"
 
-#: builtin/replace.c:351
+#: builtin/replace.c:350
 #, c-format
 msgid "new object is the same as the old one: '%s'"
 msgstr "nytt objekt är samma som det gamla: \"%s\""
 
-#: builtin/replace.c:384
+#: builtin/replace.c:383
 #, c-format
 msgid "could not parse %s as a commit"
 msgstr "kunde inte tolka %s som incheckning"
 
-#: builtin/replace.c:416
+#: builtin/replace.c:415
 #, c-format
 msgid "bad mergetag in commit '%s'"
 msgstr "felaktig sammanslagningstagg i incheckningen \"%s\""
 
-#: builtin/replace.c:418
+#: builtin/replace.c:417
 #, c-format
 msgid "malformed mergetag in commit '%s'"
 msgstr "felformad sammanslagningstagg i incheckningen \"%s\""
 
-#: builtin/replace.c:430
+#: builtin/replace.c:429
 #, c-format
 msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
@@ -21463,31 +21331,31 @@ msgstr ""
 "den ursprungliga incheckningen \"%s\" innehåller sammanslagningstaggen \"%s"
 "\" som har förkastats; använd --edit istället för --graft"
 
-#: builtin/replace.c:469
+#: builtin/replace.c:468
 #, c-format
 msgid "the original commit '%s' has a gpg signature"
 msgstr "den ursprungliga incheckningen \"%s\" har en gpg-signatur"
 
-#: builtin/replace.c:470
+#: builtin/replace.c:469
 msgid "the signature will be removed in the replacement commit!"
 msgstr "signaturen kommer att tas bort i ersättningsincheckningen!"
 
-#: builtin/replace.c:480
+#: builtin/replace.c:479
 #, c-format
 msgid "could not write replacement commit for: '%s'"
 msgstr "kunde inte skriva ersättningsincheckning för: \"%s\""
 
-#: builtin/replace.c:488
+#: builtin/replace.c:487
 #, c-format
 msgid "graft for '%s' unnecessary"
 msgstr "ympning för \"%s\" behövs inte"
 
-#: builtin/replace.c:492
+#: builtin/replace.c:491
 #, c-format
 msgid "new commit is the same as the old one: '%s'"
 msgstr "ny incheckning är samma som den gamla: \"%s\""
 
-#: builtin/replace.c:527
+#: builtin/replace.c:526
 #, c-format
 msgid ""
 "could not convert the following graft(s):\n"
@@ -21496,71 +21364,71 @@ msgstr ""
 "kunde inte konvertera följande ympning(ar):\n"
 "%s"
 
-#: builtin/replace.c:548
+#: builtin/replace.c:547
 msgid "list replace refs"
 msgstr "visa ersättningsreferenser"
 
-#: builtin/replace.c:549
+#: builtin/replace.c:548
 msgid "delete replace refs"
 msgstr "ta bort ersättningsreferenser"
 
-#: builtin/replace.c:550
+#: builtin/replace.c:549
 msgid "edit existing object"
 msgstr "redigera befintligt objekt"
 
-#: builtin/replace.c:551
+#: builtin/replace.c:550
 msgid "change a commit's parents"
 msgstr "ändra en inchecknings föräldrar"
 
-#: builtin/replace.c:552
+#: builtin/replace.c:551
 msgid "convert existing graft file"
 msgstr "konvertera befintlig ympningsfil"
 
-#: builtin/replace.c:553
+#: builtin/replace.c:552
 msgid "replace the ref if it exists"
 msgstr "ersätt referensen om den finns"
 
-#: builtin/replace.c:555
+#: builtin/replace.c:554
 msgid "do not pretty-print contents for --edit"
 msgstr "använd inte snygg visning av innehåll för --edit"
 
-#: builtin/replace.c:556
+#: builtin/replace.c:555
 msgid "use this format"
 msgstr "använd detta format"
 
-#: builtin/replace.c:569
+#: builtin/replace.c:568
 msgid "--format cannot be used when not listing"
 msgstr "--format kan inte användas utanför listning"
 
-#: builtin/replace.c:577
+#: builtin/replace.c:576
 msgid "-f only makes sense when writing a replacement"
 msgstr "-f kan endast användas vid skrivning av ersättning"
 
-#: builtin/replace.c:581
+#: builtin/replace.c:580
 msgid "--raw only makes sense with --edit"
 msgstr "--raw kan bara användas med --edit"
 
-#: builtin/replace.c:587
+#: builtin/replace.c:586
 msgid "-d needs at least one argument"
 msgstr "-d behöver minst ett argument"
 
-#: builtin/replace.c:593
+#: builtin/replace.c:592
 msgid "bad number of arguments"
 msgstr "fel antal argument"
 
-#: builtin/replace.c:599
+#: builtin/replace.c:598
 msgid "-e needs exactly one argument"
 msgstr "-e tar exakt ett argument"
 
-#: builtin/replace.c:605
+#: builtin/replace.c:604
 msgid "-g needs at least one argument"
 msgstr "-g tar minst ett argument"
 
-#: builtin/replace.c:611
+#: builtin/replace.c:610
 msgid "--convert-graft-file takes no argument"
 msgstr "--convert-graft-file tar inga argument"
 
-#: builtin/replace.c:617
+#: builtin/replace.c:616
 msgid "only one pattern can be given with -l"
 msgstr "endast ett mönster kan anges med -l"
 
@@ -21581,132 +21449,124 @@ msgstr "\"git rerere forget\" utan sökvägar är föråldrat"
 msgid "unable to generate diff for '%s'"
 msgstr "misslyckades skapa diff för \"%s\""
 
-#: builtin/reset.c:32
+#: builtin/reset.c:33
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 msgstr ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<incheckning>]"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
 msgstr "git reset [-q] [<träd-igt>] [--] <sökvägar>..."
 
-#: builtin/reset.c:34
+#: builtin/reset.c:35
 msgid ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 msgstr ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<träd-igt>]"
 
-#: builtin/reset.c:35
+#: builtin/reset.c:36
 msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
 msgstr "git reset --patch [<träd-igt>] [--] [<sökvägar>...]"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "mixed"
 msgstr "blandad"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "soft"
 msgstr "mjuk"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "hard"
 msgstr "hård"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "merge"
 msgstr "sammanslagning"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "keep"
 msgstr "behåll"
 
-#: builtin/reset.c:89
+#: builtin/reset.c:90
 msgid "You do not have a valid HEAD."
 msgstr "Du har inte en giltig HEAD."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:92
 msgid "Failed to find tree of HEAD."
 msgstr "Kunde inte hitta trädet för HEAD."
 
-#: builtin/reset.c:97
+#: builtin/reset.c:98
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Kunde inte hitta trädet för %s."
 
-#: builtin/reset.c:122
+#: builtin/reset.c:123
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD är nu på %s"
 
-#: builtin/reset.c:201
+#: builtin/reset.c:299
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Kan inte utföra en %s återställning mitt i en sammanslagning."
 
-#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
-#: builtin/stash.c:703
+#: builtin/reset.c:396 builtin/stash.c:606 builtin/stash.c:680
+#: builtin/stash.c:704
 msgid "be quiet, only report errors"
 msgstr "var tyst, rapportera endast fel"
 
-#: builtin/reset.c:303
+#: builtin/reset.c:398
 msgid "reset HEAD and index"
 msgstr "återställ HEAD och index"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:399
 msgid "reset only HEAD"
 msgstr "återställ endast HEAD"
 
-#: builtin/reset.c:306 builtin/reset.c:308
+#: builtin/reset.c:401 builtin/reset.c:403
 msgid "reset HEAD, index and working tree"
 msgstr "återställ HEAD, index och arbetskatalog"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:405
 msgid "reset HEAD but keep local changes"
 msgstr "återställ HEAD men behåll lokala ändringar"
 
-#: builtin/reset.c:316
+#: builtin/reset.c:411
 msgid "record only the fact that removed paths will be added later"
 msgstr "registrera endast att borttagna sökvägar kommer läggas till senare"
 
-#: builtin/reset.c:350
+#: builtin/reset.c:445
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Kunde inte slå upp \"%s\" som en giltig revision."
 
-#: builtin/reset.c:358
+#: builtin/reset.c:453
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Kunde inte slå upp \"%s\" som ett giltigt träd."
 
-#: builtin/reset.c:367
-msgid "--patch is incompatible with --{hard,mixed,soft}"
-msgstr "--patch är inkompatibel med --{hard,mixed,soft}"
-
-#: builtin/reset.c:377
+#: builtin/reset.c:472
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed rekommenderas inte med sökvägar; använd \"git reset -- <sökvägar>\"."
 
-#: builtin/reset.c:379
+#: builtin/reset.c:474
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Kan inte göra %s återställning med sökvägar."
 
-#: builtin/reset.c:394
+#: builtin/reset.c:489
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "%s återställning tillåts inte i ett naket arkiv"
 
-#: builtin/reset.c:398
-msgid "-N can only be used with --mixed"
-msgstr "-N kan endast användas med --mixed"
-
-#: builtin/reset.c:419
+#: builtin/reset.c:520
 msgid "Unstaged changes after reset:"
 msgstr "Oköade ändringar efter återställning:"
 
-#: builtin/reset.c:422
+#: builtin/reset.c:523
 #, c-format
 msgid ""
 "\n"
@@ -21720,18 +21580,14 @@ msgstr ""
 "konfigurationsvariabeln\n"
 "reset.quiet till true för att göra detta till förval.\n"
 
-#: builtin/reset.c:440
+#: builtin/reset.c:541
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Kunde inte återställa indexfilen till versionen \"%s\"."
 
-#: builtin/reset.c:445
+#: builtin/reset.c:546
 msgid "Could not write new index file."
 msgstr "Kunde inte skriva ny indexfil."
-
-#: builtin/rev-list.c:541
-msgid "cannot combine --exclude-promisor-objects and --missing"
-msgstr "kan inte kombinera --exclude-promisor-objects och --missing"
 
 #: builtin/rev-list.c:602
 msgid "object filtering requires --objects"
@@ -21742,8 +21598,9 @@ msgid "rev-list does not support display of notes"
 msgstr "rev-list stöder inte visning av anteckningar"
 
 #: builtin/rev-list.c:679
-msgid "marked counting is incompatible with --objects"
-msgstr "markerad räkning är inkompatibelt med --objects"
+#, c-format
+msgid "marked counting and '%s' cannot be used together"
+msgstr "markerad räkning och \"%s\" kan inte användas samtidigt."
 
 #: builtin/rev-parse.c:409
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
@@ -22144,7 +22001,7 @@ msgstr "undertyck namnsträngar"
 
 #: builtin/show-branch.c:655
 msgid "include the current branch"
-msgstr "inkludera aktuell gren"
+msgstr "ta med aktuell gren"
 
 #: builtin/show-branch.c:657
 msgid "name commits with their object names"
@@ -22182,13 +22039,6 @@ msgstr "<n>[,<bas>]"
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "visa <n> nyaste refloggposter med början på bas"
 
-#: builtin/show-branch.c:710
-msgid ""
-"--reflog is incompatible with --all, --remotes, --independent or --merge-base"
-msgstr ""
-"--reflog är inkompatibel med --all, --remotes, --independent eller --merge-"
-"base"
-
 #: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "inga grenar angavs, och HEAD är inte giltigt"
@@ -22209,19 +22059,19 @@ msgstr[1] "maximalt %d poster kan visas samtidigt."
 msgid "no such ref %s"
 msgstr "ingen sådan referens %s"
 
-#: builtin/show-branch.c:828
+#: builtin/show-branch.c:830
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "kan inte hantera mer än %d revision."
 msgstr[1] "kan inte hantera mer än %d revisioner."
 
-#: builtin/show-branch.c:832
+#: builtin/show-branch.c:834
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "\"%s\" är inte en giltig referens."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:837
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "hittar inte incheckning %s (%s)"
@@ -22286,12 +22136,16 @@ msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <flaggor>"
 msgid "git sparse-checkout list"
 msgstr "git sparse-checkout list"
 
-#: builtin/sparse-checkout.c:72
+#: builtin/sparse-checkout.c:60
+msgid "this worktree is not sparse"
+msgstr "arbetskatalogen är inte gren"
+
+#: builtin/sparse-checkout.c:75
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "arbetskatalogen är inte glest (sparse-checkout-filen kanske inte finns)"
 
-#: builtin/sparse-checkout.c:173
+#: builtin/sparse-checkout.c:176
 #, c-format
 msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
@@ -22300,75 +22154,98 @@ msgstr ""
 "katalogen \"%s\" innehåller ospårade filer, men är inte i området som ages i "
 "\"sparse-checkout\""
 
-#: builtin/sparse-checkout.c:181
+#: builtin/sparse-checkout.c:184
 #, c-format
 msgid "failed to remove directory '%s'"
 msgstr "misslyckades ta bort katalogen \"%s\""
 
-#: builtin/sparse-checkout.c:321
+#: builtin/sparse-checkout.c:324
 msgid "failed to create directory for sparse-checkout file"
 msgstr "misslyckades skapa katalog för \"sparse-checkout\"-filen"
 
-#: builtin/sparse-checkout.c:362
+#: builtin/sparse-checkout.c:365
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr "kunde inte uppgradera arkivformat för att aktivera worktreeConfig"
 
-#: builtin/sparse-checkout.c:364
+#: builtin/sparse-checkout.c:367
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "misslyckades ändra inställningen extensions.worktreeConfig"
 
-#: builtin/sparse-checkout.c:384
-msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-
-#: builtin/sparse-checkout.c:404
-msgid "initialize the sparse-checkout in cone mode"
-msgstr "initiera sparse-checkout i konläge"
-
-#: builtin/sparse-checkout.c:406
-msgid "toggle the use of a sparse index"
-msgstr "slå på/av använding av glest index"
-
-#: builtin/sparse-checkout.c:434
+#: builtin/sparse-checkout.c:411
 msgid "failed to modify sparse-index config"
 msgstr "misslyckades ändra inställning för sparse-index"
 
-#: builtin/sparse-checkout.c:455
+#: builtin/sparse-checkout.c:422
+msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:441 builtin/sparse-checkout.c:729
+#: builtin/sparse-checkout.c:778
+msgid "initialize the sparse-checkout in cone mode"
+msgstr "initiera sparse-checkout i konläge"
+
+#: builtin/sparse-checkout.c:443 builtin/sparse-checkout.c:731
+#: builtin/sparse-checkout.c:780
+msgid "toggle the use of a sparse index"
+msgstr "slå på/av använding av glest index"
+
+#: builtin/sparse-checkout.c:476
 #, c-format
 msgid "failed to open '%s'"
 msgstr "misslyckades öppna \"%s\""
 
-#: builtin/sparse-checkout.c:507
+#: builtin/sparse-checkout.c:528
 #, c-format
 msgid "could not normalize path %s"
 msgstr "kunde inte normalisera sökvägen \"%s\""
 
-#: builtin/sparse-checkout.c:519
-msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
-msgstr "git sparse-checkout (set|add) (--stdin | <mönster>)"
-
-#: builtin/sparse-checkout.c:544
+#: builtin/sparse-checkout.c:557
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "kan inte ta bort citering av C-sträng \"%s\""
 
-#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
+#: builtin/sparse-checkout.c:612 builtin/sparse-checkout.c:640
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "kunde inte läsa in existerande mönster för gles utcheckning"
 
-#: builtin/sparse-checkout.c:667
+#: builtin/sparse-checkout.c:616
+msgid "existing sparse-checkout patterns do not use cone mode"
+msgstr "befintliga filter för gles utcheckning använder inte konläge"
+
+#: builtin/sparse-checkout.c:682
+msgid "git sparse-checkout add (--stdin | <patterns>)"
+msgstr "git sparse-checkout add (--stdin | <mönster>)"
+
+#: builtin/sparse-checkout.c:694 builtin/sparse-checkout.c:733
 msgid "read patterns from standard in"
 msgstr "läs mönster från standard in"
 
-#: builtin/sparse-checkout.c:682
-msgid "git sparse-checkout reapply"
-msgstr "git sparse-checkout reapply"
+#: builtin/sparse-checkout.c:699
+msgid "no sparse-checkout to add to"
+msgstr "ingen sparse-checkout att utöka"
 
-#: builtin/sparse-checkout.c:701
+#: builtin/sparse-checkout.c:712
+msgid ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
+"<patterns>)"
+msgstr ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
+"<mönster>)"
+
+#: builtin/sparse-checkout.c:765
+msgid "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:785
+msgid "must be in a sparse-checkout to reapply sparsity patterns"
+msgstr ""
+"måste vara i en gles utcheckning för att tillämpa gleshetsmönster på nytt"
+
+#: builtin/sparse-checkout.c:803
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:732
+#: builtin/sparse-checkout.c:845
 msgid "error while refreshing working directory"
 msgstr "fel vid uppdatering av arbetskatalog"
 
@@ -22394,22 +22271,26 @@ msgstr "git stash branch <grennamn> [<stash>]"
 
 #: builtin/stash.c:30
 msgid ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
 "          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash [push [-p|--patch] [S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <meddelande>]\n"
 "          [--pathspec-from-file=<fil> [--pathspec-file-nul]]\n"
 "          [--] [<sökväg>...]]"
 
 #: builtin/stash.c:34
 msgid ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
 msgstr ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<meddelande>]"
 
 #: builtin/stash.c:55
@@ -22502,140 +22383,157 @@ msgstr "Slår ihop %s med %s"
 msgid "Index was not unstashed."
 msgstr "Indexet har inte tagits upp ur \"stash\":en"
 
-#: builtin/stash.c:575
+#: builtin/stash.c:576
 msgid "could not restore untracked files from stash"
 msgstr "kunde inte återställa ospårade filer från stash-post"
 
-#: builtin/stash.c:607 builtin/stash.c:705
+#: builtin/stash.c:608 builtin/stash.c:706
 msgid "attempt to recreate the index"
 msgstr "försök återskapa indexet"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:652
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Kastade %s (%s)"
 
-#: builtin/stash.c:654
+#: builtin/stash.c:655
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Kunde inte kasta \"stash\"-post"
 
-#: builtin/stash.c:667
+#: builtin/stash.c:668
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "\"%s\" är inte en \"stash\"-referens"
 
-#: builtin/stash.c:717
+#: builtin/stash.c:718
 msgid "The stash entry is kept in case you need it again."
 msgstr "Stash-posten behålls ifall du behöver den igen."
 
-#: builtin/stash.c:740
+#: builtin/stash.c:741
 msgid "No branch name specified"
 msgstr "Inget grennamn angavs"
 
-#: builtin/stash.c:824
+#: builtin/stash.c:825
 msgid "failed to parse tree"
 msgstr "misslyckades tolka träd"
 
-#: builtin/stash.c:835
+#: builtin/stash.c:836
 msgid "failed to unpack trees"
 msgstr "misslyckades packa upp träd"
 
-#: builtin/stash.c:855
+#: builtin/stash.c:856
 msgid "include untracked files in the stash"
 msgstr "ta med ospårade filer i \"stash\""
 
-#: builtin/stash.c:858
+#: builtin/stash.c:859
 msgid "only show untracked files in the stash"
 msgstr "visa bara ospårade filer i \"stash\""
 
-#: builtin/stash.c:945 builtin/stash.c:982
+#: builtin/stash.c:946 builtin/stash.c:983
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Kan inte uppdatera %s med %s"
 
-#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
+#: builtin/stash.c:964 builtin/stash.c:1678 builtin/stash.c:1750
 msgid "stash message"
 msgstr "\"stash\"-meddelande"
 
-#: builtin/stash.c:973
+#: builtin/stash.c:974
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" kräver ett <incheckning>-argument"
 
-#: builtin/stash.c:1187
+#: builtin/stash.c:1159
+msgid "No staged changes"
+msgstr "Inga köade ändringar"
+
+#: builtin/stash.c:1220
 msgid "No changes selected"
 msgstr "Inga ändringar valda"
 
-#: builtin/stash.c:1287
+#: builtin/stash.c:1320
 msgid "You do not have the initial commit yet"
 msgstr "Du har inte den första incheckningen ännu"
 
-#: builtin/stash.c:1314
+#: builtin/stash.c:1347
 msgid "Cannot save the current index state"
 msgstr "Kan inte spara aktuellt tillstånd för indexet"
 
-#: builtin/stash.c:1323
+#: builtin/stash.c:1356
 msgid "Cannot save the untracked files"
 msgstr "Kan inte spara ospårade filer"
 
-#: builtin/stash.c:1334 builtin/stash.c:1343
+#: builtin/stash.c:1367 builtin/stash.c:1386
 msgid "Cannot save the current worktree state"
 msgstr "Kan inte spara aktuellt tillstånd för arbetskatalogen"
 
-#: builtin/stash.c:1371
+#: builtin/stash.c:1377
+msgid "Cannot save the current staged state"
+msgstr "Kan inte spara aktuellt tillstånd kö"
+
+#: builtin/stash.c:1414
 msgid "Cannot record working tree state"
 msgstr "Kan inte registrera tillstånd för arbetskatalog"
 
-#: builtin/stash.c:1420
+#: builtin/stash.c:1463
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "Kan inte använda --patch och --include-untracked eller --all samtidigt"
 
-#: builtin/stash.c:1438
+#: builtin/stash.c:1474
+msgid "Can't use --staged and --include-untracked or --all at the same time"
+msgstr ""
+"Kan inte använda --staged och --include-untracked eller --all samtidigt"
+
+#: builtin/stash.c:1492
 msgid "Did you forget to 'git add'?"
 msgstr "Glömde du använda \"git add\"?"
 
-#: builtin/stash.c:1453
+#: builtin/stash.c:1507
 msgid "No local changes to save"
 msgstr "Inga lokala ändringar att spara"
 
-#: builtin/stash.c:1460
+#: builtin/stash.c:1514
 msgid "Cannot initialize stash"
 msgstr "Kan inte initiera \"stash\""
 
-#: builtin/stash.c:1475
+#: builtin/stash.c:1529
 msgid "Cannot save the current status"
 msgstr "Kan inte spara aktuell status"
 
-#: builtin/stash.c:1480
+#: builtin/stash.c:1534
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Sparade arbetskatalogen och indexstatus %s"
 
-#: builtin/stash.c:1571
+#: builtin/stash.c:1627
 msgid "Cannot remove worktree changes"
 msgstr "Kan inte ta bort ändringar i arbetskatalogen"
 
-#: builtin/stash.c:1610 builtin/stash.c:1675
+#: builtin/stash.c:1667 builtin/stash.c:1739
 msgid "keep index"
 msgstr "behåll indexet"
 
-#: builtin/stash.c:1612 builtin/stash.c:1677
+#: builtin/stash.c:1669 builtin/stash.c:1741
+msgid "stash staged changes only"
+msgstr "stash:a endast köade ändringar"
+
+#: builtin/stash.c:1671 builtin/stash.c:1743
 msgid "stash in patch mode"
 msgstr "\"stash\" i \"patch\"-läge"
 
-#: builtin/stash.c:1613 builtin/stash.c:1678
+#: builtin/stash.c:1672 builtin/stash.c:1744
 msgid "quiet mode"
 msgstr "tyst läge"
 
-#: builtin/stash.c:1615 builtin/stash.c:1680
+#: builtin/stash.c:1674 builtin/stash.c:1746
 msgid "include untracked files in stash"
 msgstr "ta med ospårade filer i \"stash\""
 
-#: builtin/stash.c:1617 builtin/stash.c:1682
+#: builtin/stash.c:1676 builtin/stash.c:1748
 msgid "include ignore files"
 msgstr "ta med ignorerade filer"
 
-#: builtin/stash.c:1717
+#: builtin/stash.c:1783
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -22659,7 +22557,7 @@ msgstr "hoppa över och ta bort alla rader som inleds med kommentarstecken"
 msgid "prepend comment character and space to each line"
 msgstr "lägg in kommentarstecken och blanksteg först på varje rad"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2668
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Förväntade fullt referensnamn, fick %s"
@@ -22682,7 +22580,7 @@ msgstr ""
 "kunde inte slå upp konfigurationen \"%s\". Antar att arkivet är sin eget "
 "officiella uppström."
 
-#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1859
 msgid "alternative anchor for relative paths"
 msgstr "alternativa ankare för relativa sökvägar"
 
@@ -22777,7 +22675,7 @@ msgstr "kunde inte bestämma HEAD:s incheckning i undermodulen \"%s\""
 msgid "failed to recurse into submodule '%s'"
 msgstr "misslyckades rekursera in i undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1590
 msgid "suppress submodule status output"
 msgstr "hindra statusutskrift för undermodul"
 
@@ -22848,10 +22746,6 @@ msgstr ""
 msgid "could not fetch a revision for HEAD"
 msgstr "kunde inte hämta en version för HEAD"
 
-#: builtin/submodule--helper.c:1316
-msgid "--cached and --files are mutually exclusive"
-msgstr "--cached och --files är ömsesidigt uteslutande"
-
 #: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
@@ -22880,16 +22774,16 @@ msgstr "dölj utdata från synkronisering av undermodul-url"
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<sökväg>]"
 
-#: builtin/submodule--helper.c:1512
+#: builtin/submodule--helper.c:1508
 #, c-format
 msgid ""
-"Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
-"really want to remove it including all of its history)"
+"Submodule work tree '%s' contains a .git directory. This will be replaced "
+"with a .git file by using absorbgitdirs."
 msgstr ""
-"Undermodulsarbetskatalogen \"%s\" innehåller en .git-katalog (använd \"rm -rf"
-"\" om du verkligen vill ta bort den och all dess historik)"
+"Undermodulsarbetskatalogen \"%s\" innehåller en .git-katalog. Denna kommer "
+"ersättas med en .git-fil med absorbgitdirs."
 
-#: builtin/submodule--helper.c:1524
+#: builtin/submodule--helper.c:1525
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -22898,46 +22792,46 @@ msgstr ""
 "Undermodulens arbetskatalog \"%s\" har lokala ändringar; \"-f\" kastar bort "
 "dem"
 
-#: builtin/submodule--helper.c:1532
+#: builtin/submodule--helper.c:1533
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Rensade katalogen \"%s\"\n"
 
-#: builtin/submodule--helper.c:1534
+#: builtin/submodule--helper.c:1535
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Kunde inte ta bort undermodulens arbetskatalog \"%s\"\n"
 
-#: builtin/submodule--helper.c:1545
+#: builtin/submodule--helper.c:1546
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "kunde inte skapa tom undermodulskatalog %s"
 
-#: builtin/submodule--helper.c:1561
+#: builtin/submodule--helper.c:1562
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Undermodulen \"%s\" (%s) registrerad för sökvägen \"%s\"\n"
 
-#: builtin/submodule--helper.c:1590
+#: builtin/submodule--helper.c:1591
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "ta bort undermodulers arbetskataloger även om de innehåller lokala ändringar"
 
-#: builtin/submodule--helper.c:1591
+#: builtin/submodule--helper.c:1592
 msgid "unregister all submodules"
 msgstr "avregistrera alla undermoduler"
 
-#: builtin/submodule--helper.c:1596
+#: builtin/submodule--helper.c:1597
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<sökväg>...]]"
 
-#: builtin/submodule--helper.c:1610
+#: builtin/submodule--helper.c:1611
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Använd \"--all\" om du verkligen vill avinitiera alla undermoduler"
 
-#: builtin/submodule--helper.c:1655
+#: builtin/submodule--helper.c:1656
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -22949,67 +22843,67 @@ msgstr ""
 "submodule.alternateErrorStrategy till \"info\" eller, likvärdigt, klona\n"
 "med \"--reference-if-able\" istället för \"--reference\"."
 
-#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
+#: builtin/submodule--helper.c:1701 builtin/submodule--helper.c:1704
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "undermodulen \"%s\" kan inte lägga till suppleant: %s"
 
-#: builtin/submodule--helper.c:1739
+#: builtin/submodule--helper.c:1740
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Värdet \"%s\" i submodule.alternateErrorStrategy förstås inte"
 
-#: builtin/submodule--helper.c:1746
+#: builtin/submodule--helper.c:1747
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Värdet \"%s\" i submodule.alternateLocation förstås inte"
 
-#: builtin/submodule--helper.c:1771
+#: builtin/submodule--helper.c:1772
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr "vägrar skapa/använda \"%s\" i en annan undermoduls gitkatalog"
 
-#: builtin/submodule--helper.c:1812
+#: builtin/submodule--helper.c:1813
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "misslyckades klona \"%s\" till undermodulsökvägen \"%s\""
 
-#: builtin/submodule--helper.c:1817
+#: builtin/submodule--helper.c:1818
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "katalogen inte tom: \"%s\""
 
-#: builtin/submodule--helper.c:1829
+#: builtin/submodule--helper.c:1830
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "kunde inte få tag i undermodulkatalog för \"%s\""
 
-#: builtin/submodule--helper.c:1861
+#: builtin/submodule--helper.c:1862
 msgid "where the new submodule will be cloned to"
 msgstr "var den nya undermodulen ska klonas till"
 
-#: builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1865
 msgid "name of the new submodule"
 msgstr "namn på den nya undermodulen"
 
-#: builtin/submodule--helper.c:1867
+#: builtin/submodule--helper.c:1868
 msgid "url where to clone the submodule from"
 msgstr "URL att klona undermodulen från"
 
-#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
+#: builtin/submodule--helper.c:1876 builtin/submodule--helper.c:3265
 msgid "depth for shallow clones"
 msgstr "djup för grunda kloner"
 
-#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
-#: builtin/submodule--helper.c:3257
+#: builtin/submodule--helper.c:1879 builtin/submodule--helper.c:2526
+#: builtin/submodule--helper.c:3258
 msgid "force cloning progress"
 msgstr "tvinga kloningsförlopp"
 
-#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
+#: builtin/submodule--helper.c:1881 builtin/submodule--helper.c:2528
 msgid "disallow cloning into non-empty directory"
 msgstr "förhindra kloning till icke-tom katalog"
 
-#: builtin/submodule--helper.c:1887
+#: builtin/submodule--helper.c:1888
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -23019,92 +22913,92 @@ msgstr ""
 "<arkiv>] [--name <namn>] [--depth <djup>] [--single-branch] --url <url> --"
 "path <sökväg>"
 
-#: builtin/submodule--helper.c:1924
+#: builtin/submodule--helper.c:1925
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Ogiltigt uppdateringsläge \"%s\" för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:1928
+#: builtin/submodule--helper.c:1929
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Ogiltigt uppdateringsläge \"%s\" konfigurerat för undermodulsökväg \"%s\""
 
-#: builtin/submodule--helper.c:2043
+#: builtin/submodule--helper.c:2044
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Undermodulsökvägen \"%s\" har inte initierats"
 
-#: builtin/submodule--helper.c:2047
+#: builtin/submodule--helper.c:2048
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Kanske menade du att använda \"update --init\"?"
 
-#: builtin/submodule--helper.c:2077
+#: builtin/submodule--helper.c:2078
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Hoppar över ej sammanslagen undermodul %s"
 
-#: builtin/submodule--helper.c:2106
+#: builtin/submodule--helper.c:2107
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Hoppar över undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:2256
+#: builtin/submodule--helper.c:2257
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Misslyckades klona \"%s\". Nytt försök planlagt"
 
-#: builtin/submodule--helper.c:2267
+#: builtin/submodule--helper.c:2268
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Misslyckades klona \"%s\" för andra gången, avbryter"
 
-#: builtin/submodule--helper.c:2372
+#: builtin/submodule--helper.c:2373
 #, c-format
 msgid "Unable to checkout '%s' in submodule path '%s'"
 msgstr "Kan inte checka ut \"%s\" i undermodulsökvägen \"%s\""
 
-#: builtin/submodule--helper.c:2376
+#: builtin/submodule--helper.c:2377
 #, c-format
 msgid "Unable to rebase '%s' in submodule path '%s'"
 msgstr "Kan inte ombasera \"%s\" i undermodulsökvägen \"%s\""
 
-#: builtin/submodule--helper.c:2380
+#: builtin/submodule--helper.c:2381
 #, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
 msgstr "Kan inte slå ihop \"%s\" i undermodulsökvägen \"%s\""
 
-#: builtin/submodule--helper.c:2384
+#: builtin/submodule--helper.c:2385
 #, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
 msgstr "Misslyckades köra \"%s %s\" i undermodulsökvägen \"%s\""
 
-#: builtin/submodule--helper.c:2408
+#: builtin/submodule--helper.c:2409
 #, c-format
 msgid "Submodule path '%s': checked out '%s'\n"
 msgstr "Undermodulsökvägen \"%s\": checkade ut \"%s\"\n"
 
-#: builtin/submodule--helper.c:2412
+#: builtin/submodule--helper.c:2413
 #, c-format
 msgid "Submodule path '%s': rebased into '%s'\n"
 msgstr "Undermodulsökvägen \"%s\": ombaserade in i \"%s\"\n"
 
-#: builtin/submodule--helper.c:2416
+#: builtin/submodule--helper.c:2417
 #, c-format
 msgid "Submodule path '%s': merged in '%s'\n"
 msgstr "Undermodulsökvägen \"%s\": sammanslagen i \"%s\"\n"
 
-#: builtin/submodule--helper.c:2420
+#: builtin/submodule--helper.c:2421
 #, c-format
 msgid "Submodule path '%s': '%s %s'\n"
 msgstr "Undermodulsökvägen \"%s\": \"%s %s\"\n"
 
-#: builtin/submodule--helper.c:2444
+#: builtin/submodule--helper.c:2445
 #, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr "Kan inte hämta i undermodulsökväg \"%s\"; försökte hämta %s direkt:"
 
-#: builtin/submodule--helper.c:2453
+#: builtin/submodule--helper.c:2454
 #, c-format
 msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
@@ -23113,84 +23007,84 @@ msgstr ""
 "Hämtade i undermodulssökvägen \"%s\", men den innehöll inte %s. Direkt "
 "hämtning av incheckningen misslyckades."
 
-#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
-#: builtin/submodule--helper.c:2812
+#: builtin/submodule--helper.c:2505 builtin/submodule--helper.c:2575
+#: builtin/submodule--helper.c:2813
 msgid "path into the working tree"
 msgstr "sökväg inuti arbetskatalogen"
 
-#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
+#: builtin/submodule--helper.c:2508 builtin/submodule--helper.c:2580
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "sökväg inuti arbetskatalogen, genom nästlade undermodulgränser"
 
-#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/submodule--helper.c:2512 builtin/submodule--helper.c:2578
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout eller none"
 
-#: builtin/submodule--helper.c:2517
+#: builtin/submodule--helper.c:2518
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr "skapa en grund klon trunkerad till angivet antal revisioner"
 
-#: builtin/submodule--helper.c:2520
+#: builtin/submodule--helper.c:2521
 msgid "parallel jobs"
 msgstr "parallella jobb"
 
-#: builtin/submodule--helper.c:2522
+#: builtin/submodule--helper.c:2523
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "om den första klonen ska följa rekommendation för grund kloning"
 
-#: builtin/submodule--helper.c:2523
+#: builtin/submodule--helper.c:2524
 msgid "don't print cloning progress"
 msgstr "skriv inte klonförlopp"
 
-#: builtin/submodule--helper.c:2534
+#: builtin/submodule--helper.c:2535
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=<sökväg>] [<sökväg>...]"
 
-#: builtin/submodule--helper.c:2547
+#: builtin/submodule--helper.c:2548
 msgid "bad value for update parameter"
 msgstr "felaktigt värde för parametern update"
 
-#: builtin/submodule--helper.c:2565
+#: builtin/submodule--helper.c:2566
 msgid "suppress output for update by rebase or merge"
 msgstr "dölj utdata för uppdatering via ombasering eller sammanslagning{"
 
-#: builtin/submodule--helper.c:2566
+#: builtin/submodule--helper.c:2567
 msgid "force checkout updates"
 msgstr "tvinga utcheckningsuppdateringar"
 
-#: builtin/submodule--helper.c:2568
+#: builtin/submodule--helper.c:2569
 msgid "don't fetch new objects from the remote site"
 msgstr "hämta inte nya objekt från fjärrplatsen"
 
-#: builtin/submodule--helper.c:2570
+#: builtin/submodule--helper.c:2571
 msgid "overrides update mode in case the repository is a fresh clone"
 msgstr "överstyr uppdateringsläge om arkviet är en färsk klon"
 
-#: builtin/submodule--helper.c:2571
+#: builtin/submodule--helper.c:2572
 msgid "depth for shallow fetch"
 msgstr "djup för grund hämtning"
 
-#: builtin/submodule--helper.c:2581
+#: builtin/submodule--helper.c:2582
 msgid "sha1"
 msgstr "sha1"
 
-#: builtin/submodule--helper.c:2582
+#: builtin/submodule--helper.c:2583
 msgid "SHA1 expected by superproject"
 msgstr "SHA1 förväntades av överprojekt{"
 
-#: builtin/submodule--helper.c:2584
+#: builtin/submodule--helper.c:2585
 msgid "subsha1"
 msgstr "subsha1"
 
-#: builtin/submodule--helper.c:2585
+#: builtin/submodule--helper.c:2586
 msgid "SHA1 of submodule's HEAD"
 msgstr "SHA1 för undermodulens \"HEAD\""
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2592
 msgid "git submodule--helper run-update-procedure [<options>] <path>"
 msgstr "git submodule--helper run-update-procedure [<flaggor>] <sökväg>"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2663
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -23199,94 +23093,90 @@ msgstr ""
 "Undermodulens (%s) gren inställd på att ärva gren från huvudprojektet, men "
 "huvudprojektet är inte på någon gren"
 
-#: builtin/submodule--helper.c:2780
+#: builtin/submodule--helper.c:2781
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "kunde inte få tag i arkivhandtag för undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:2813
+#: builtin/submodule--helper.c:2814
 msgid "recurse into submodules"
 msgstr "rekursera ner i undermoduler"
 
-#: builtin/submodule--helper.c:2819
+#: builtin/submodule--helper.c:2820
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<flaggor>] [<sökväg>...]"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:2876
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "se om det är säkert att skriva till .gitmodules-filen"
 
-#: builtin/submodule--helper.c:2878
+#: builtin/submodule--helper.c:2879
 msgid "unset the config in the .gitmodules file"
 msgstr "ta bort konfigurationen från .gitmodules-filen"
 
-#: builtin/submodule--helper.c:2883
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <namn> [<värde>]"
 
-#: builtin/submodule--helper.c:2884
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <namn>"
 
-#: builtin/submodule--helper.c:2885
+#: builtin/submodule--helper.c:2886
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
-#: builtin/submodule--helper.c:3276
+#: builtin/submodule--helper.c:2905 builtin/submodule--helper.c:3121
+#: builtin/submodule--helper.c:3277
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "se till att .gitmodules finns i arbetskatalogen"
 
-#: builtin/submodule--helper.c:2920
+#: builtin/submodule--helper.c:2921
 msgid "suppress output for setting url of a submodule"
 msgstr "dölj utdata från inställning av url för undermodul"
 
-#: builtin/submodule--helper.c:2924
+#: builtin/submodule--helper.c:2925
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <sökväg> <nyurl>"
 
-#: builtin/submodule--helper.c:2957
+#: builtin/submodule--helper.c:2958
 msgid "set the default tracking branch to master"
 msgstr "välj master som förvald spårad gren"
 
-#: builtin/submodule--helper.c:2959
+#: builtin/submodule--helper.c:2960
 msgid "set the default tracking branch"
 msgstr "välj förvald spårad gren"
 
-#: builtin/submodule--helper.c:2963
+#: builtin/submodule--helper.c:2964
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) <sökväg>"
 
-#: builtin/submodule--helper.c:2964
+#: builtin/submodule--helper.c:2965
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <gren> <sökväg>"
 
-#: builtin/submodule--helper.c:2971
+#: builtin/submodule--helper.c:2972
 msgid "--branch or --default required"
 msgstr "--branch eller --default krävs"
 
-#: builtin/submodule--helper.c:2974
-msgid "--branch and --default are mutually exclusive"
-msgstr "--branch och --default är ömsesidigt uteslutande"
-
-#: builtin/submodule--helper.c:3037
+#: builtin/submodule--helper.c:3038
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Lägger till befintligt arkiv i \"%s\" i indexet\n"
 
-#: builtin/submodule--helper.c:3040
+#: builtin/submodule--helper.c:3041
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "\"%s\" finns redan och är inte ett giltigt git-arkiv"
 
-#: builtin/submodule--helper.c:3053
+#: builtin/submodule--helper.c:3054
 #, c-format
 msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr "En git-katalog för \"%s\" hittades lokalt med fjärr(ar):\n"
 
-#: builtin/submodule--helper.c:3060
+#: builtin/submodule--helper.c:3061
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -23304,54 +23194,54 @@ msgstr ""
 "arkiv eller om du är osäker på vad det här betyder, välj ett annat namn med\n"
 "flaggan \"--name\"."
 
-#: builtin/submodule--helper.c:3072
+#: builtin/submodule--helper.c:3073
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Aktiverar lokal git-katalog för undermodulen \"%s\" på nytt.\n"
 
-#: builtin/submodule--helper.c:3109
+#: builtin/submodule--helper.c:3110
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "Kan inte checka ut undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:3148
+#: builtin/submodule--helper.c:3149
 #, c-format
 msgid "Failed to add submodule '%s'"
 msgstr "Misslyckades lägga till undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
-#: builtin/submodule--helper.c:3165
+#: builtin/submodule--helper.c:3153 builtin/submodule--helper.c:3158
+#: builtin/submodule--helper.c:3166
 #, c-format
 msgid "Failed to register submodule '%s'"
 msgstr "Misslyckades registrera undermodulen \"%s\""
 
-#: builtin/submodule--helper.c:3221
+#: builtin/submodule--helper.c:3222
 #, c-format
 msgid "'%s' already exists in the index"
 msgstr "\"%s\" finns redan i indexet"
 
-#: builtin/submodule--helper.c:3224
+#: builtin/submodule--helper.c:3225
 #, c-format
 msgid "'%s' already exists in the index and is not a submodule"
 msgstr "\"%s\" finns redan i indexet och är inte en undermodul"
 
-#: builtin/submodule--helper.c:3253
+#: builtin/submodule--helper.c:3254
 msgid "branch of repository to add as submodule"
 msgstr "gren från arkivet att lägga till som undermodul"
 
-#: builtin/submodule--helper.c:3254
+#: builtin/submodule--helper.c:3255
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "tillåt lägga till en annars ignorerad undermodulsökväg"
 
-#: builtin/submodule--helper.c:3256
+#: builtin/submodule--helper.c:3257
 msgid "print only error messages"
 msgstr "visa endast felmeddelanden"
 
-#: builtin/submodule--helper.c:3260
+#: builtin/submodule--helper.c:3261
 msgid "borrow the objects from reference repositories"
 msgstr "låna objekt från referensarkiv"
 
-#: builtin/submodule--helper.c:3262
+#: builtin/submodule--helper.c:3263
 msgid ""
 "sets the submodule’s name to the given string instead of defaulting to its "
 "path"
@@ -23359,30 +23249,30 @@ msgstr ""
 "sätter undermodulens namn till den angivna strängen istället för att använda "
 "sökvägen"
 
-#: builtin/submodule--helper.c:3269
+#: builtin/submodule--helper.c:3270
 msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
 msgstr "git submodule--helper add [<flaggor>] [--] <arkiv> [<sökväg>]"
 
-#: builtin/submodule--helper.c:3297
+#: builtin/submodule--helper.c:3298
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr "Relativ sökväg kan endast användas från arbetskatalogens toppnivå"
 
-#: builtin/submodule--helper.c:3305
+#: builtin/submodule--helper.c:3306
 #, c-format
 msgid "repo URL: '%s' must be absolute or begin with ./|../"
 msgstr "arkiv-URL: \"%s\" måste vara absolut eller börja med ./|../"
 
-#: builtin/submodule--helper.c:3340
+#: builtin/submodule--helper.c:3341
 #, c-format
 msgid "'%s' is not a valid submodule name"
 msgstr "\"%s\" är inte ett giltigt namn på undermodul"
 
-#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
+#: builtin/submodule--helper.c:3405 git.c:452 git.c:726
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s stöder inte --super-prefix"
 
-#: builtin/submodule--helper.c:3410
+#: builtin/submodule--helper.c:3411
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "\"%s\" är inte ett giltigt underkommando till submodule--helper"
@@ -23482,11 +23372,11 @@ msgstr ""
 "Rader som inleds med \"%c\" kommer behållas; du kan själv ta bort dem om\n"
 "du vill.\n"
 
-#: builtin/tag.c:241
+#: builtin/tag.c:240
 msgid "unable to sign the tag"
 msgstr "kunde inte signera taggen"
 
-#: builtin/tag.c:259
+#: builtin/tag.c:258
 #, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -23499,15 +23389,15 @@ msgstr ""
 "\n"
 "\tgit tag -f %s %s^{}"
 
-#: builtin/tag.c:275
+#: builtin/tag.c:274
 msgid "bad object type."
 msgstr "felaktig objekttyp."
 
-#: builtin/tag.c:326
+#: builtin/tag.c:325
 msgid "no tag message?"
 msgstr "inget taggmeddelande?"
 
-#: builtin/tag.c:333
+#: builtin/tag.c:332
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Taggmeddelandet har lämnats i %s\n"
@@ -23588,45 +23478,22 @@ msgstr "visa endast taggar som ej slagits samman"
 msgid "print only tags of the object"
 msgstr "visa endast taggar för objektet"
 
-#: builtin/tag.c:525
-msgid "--column and -n are incompatible"
-msgstr "--column och -n är inkompatibla"
+#: builtin/tag.c:558
+#, c-format
+msgid "the '%s' option is only allowed in list mode"
+msgstr "flaggan \"%s\" är endast tillåten i listläge"
 
-#: builtin/tag.c:546
-msgid "-n option is only allowed in list mode"
-msgstr "Flaggan -n är endast tillåten i listläge"
-
-#: builtin/tag.c:548
-msgid "--contains option is only allowed in list mode"
-msgstr "Flaggan --contains är endast tillåten i listläge"
-
-#: builtin/tag.c:550
-msgid "--no-contains option is only allowed in list mode"
-msgstr "Flaggan --no-contains är endast tillåten i listläge"
-
-#: builtin/tag.c:552
-msgid "--points-at option is only allowed in list mode"
-msgstr "Flaggan --points-at är endast tillåten i listläge"
-
-#: builtin/tag.c:554
-msgid "--merged and --no-merged options are only allowed in list mode"
-msgstr "Flaggorna --merged och --no-merged är endast tillåtna i listläge"
-
-#: builtin/tag.c:568
-msgid "only one -F or -m option is allowed."
-msgstr "endast en av flaggorna -F eller -m tillåts."
-
-#: builtin/tag.c:593
+#: builtin/tag.c:597
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "\"%s\" är inte ett giltigt taggnamn."
 
-#: builtin/tag.c:598
+#: builtin/tag.c:602
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "taggen \"%s\" finns redan"
 
-#: builtin/tag.c:629
+#: builtin/tag.c:633
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Uppdaterad tagg \"%s\" (var %s)\n"
@@ -24053,132 +23920,120 @@ msgstr "kunde inte skapa katalogen \"%s\""
 msgid "initializing"
 msgstr "initierar"
 
-#: builtin/worktree.c:421 builtin/worktree.c:427
+#: builtin/worktree.c:420 builtin/worktree.c:426
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Förbereder arbetskatalog (ny gren \"%s\")"
 
-#: builtin/worktree.c:423
+#: builtin/worktree.c:422
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr "Förbereder arbetskatalog (återställer gren \"%s\"; var på %s)"
 
-#: builtin/worktree.c:432
+#: builtin/worktree.c:431
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Förbereder arbetskatalog (checkar ut \"%s\")"
 
-#: builtin/worktree.c:438
+#: builtin/worktree.c:437
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Förbereder arbetskatalog (frånkopplat HEAD %s)"
 
-#: builtin/worktree.c:483
+#: builtin/worktree.c:482
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 "checka ut <gren> även om den redan är utcheckad i en annan arbetskatalog"
 
-#: builtin/worktree.c:486
+#: builtin/worktree.c:485
 msgid "create a new branch"
 msgstr "skapa en ny gren"
 
-#: builtin/worktree.c:488
+#: builtin/worktree.c:487
 msgid "create or reset a branch"
 msgstr "skapa eller återställ en gren"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:489
 msgid "populate the new working tree"
 msgstr "befolka den nya arbetskatalogen"
 
-#: builtin/worktree.c:491
+#: builtin/worktree.c:490
 msgid "keep the new working tree locked"
 msgstr "låt arbetskatalogen förbli låst"
 
-#: builtin/worktree.c:493 builtin/worktree.c:730
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "reason for locking"
 msgstr "orsak till lås"
 
-#: builtin/worktree.c:496
+#: builtin/worktree.c:495
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "ställ in spårningsläge (se git-branch(1))"
 
-#: builtin/worktree.c:499
+#: builtin/worktree.c:498
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr "försök träffa namn på ny gren mot en fjärrspårande gren"
 
-#: builtin/worktree.c:507
-msgid "-b, -B, and --detach are mutually exclusive"
-msgstr "-b, -B och --detach är ömsesidigt uteslutande"
-
-#: builtin/worktree.c:509
-msgid "--reason requires --lock"
-msgstr "--reason kräver --lock"
-
-#: builtin/worktree.c:513
+#: builtin/worktree.c:512
 msgid "added with --lock"
 msgstr "lagt till med --lock"
 
-#: builtin/worktree.c:575
+#: builtin/worktree.c:574
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "--[no-]track kan endast användas när ny gran skapas"
 
-#: builtin/worktree.c:692
+#: builtin/worktree.c:691
 msgid "show extended annotations and reasons, if available"
 msgstr "visa utökade annoteringar och grunder, om tillgängliga"
 
-#: builtin/worktree.c:694
+#: builtin/worktree.c:693
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 "lägg till \"prunable\"-annoteringar till arbetskataloger äldre än <tid>"
 
-#: builtin/worktree.c:703
-msgid "--verbose and --porcelain are mutually exclusive"
-msgstr "--verbose och --porcelain är ömsesidigt uteslutande"
-
-#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
-#: builtin/worktree.c:973
+#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
+#: builtin/worktree.c:972
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "\"%s\" är inte en arbetskatalog"
 
-#: builtin/worktree.c:744 builtin/worktree.c:777
+#: builtin/worktree.c:743 builtin/worktree.c:776
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Huvudarbetskatalogen kan inte låsas eller låsas upp"
 
-#: builtin/worktree.c:749
+#: builtin/worktree.c:748
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "\"%s\" är redan låst, orsak: %s"
 
-#: builtin/worktree.c:751
+#: builtin/worktree.c:750
 #, c-format
 msgid "'%s' is already locked"
 msgstr "\"%s\" är redan låst"
 
-#: builtin/worktree.c:779
+#: builtin/worktree.c:778
 #, c-format
 msgid "'%s' is not locked"
 msgstr "\"%s\" är inte låst"
 
-#: builtin/worktree.c:820
+#: builtin/worktree.c:819
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr "arbetskataloger med undermoduler kan inte flyttas eller tas bort"
 
-#: builtin/worktree.c:828
+#: builtin/worktree.c:827
 msgid "force move even if worktree is dirty or locked"
 msgstr "tvinga flyttning även om arbetskatalogen är smutsig eller låst"
 
-#: builtin/worktree.c:851 builtin/worktree.c:975
+#: builtin/worktree.c:850 builtin/worktree.c:974
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "\"%s\" är inte en huvudarbetskatalog"
 
-#: builtin/worktree.c:856
+#: builtin/worktree.c:855
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "kunde inte lista ut målnamn från \"%s\""
 
-#: builtin/worktree.c:869
+#: builtin/worktree.c:868
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -24187,7 +24042,7 @@ msgstr ""
 "kan inte flytta en låst arbetskatalog, orsak till lås: %s\n"
 "använd \"move -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:871
+#: builtin/worktree.c:870
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -24195,38 +24050,38 @@ msgstr ""
 "kan inte flytta en låst arbetskatalog;\n"
 "använd \"move -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:874
+#: builtin/worktree.c:873
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "kontroll misslyckades, kan inte flytta arbetskatalog: %s"
 
-#: builtin/worktree.c:879
+#: builtin/worktree.c:878
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "misslyckades flytta \"%s\" till \"%s\""
 
-#: builtin/worktree.c:925
+#: builtin/worktree.c:924
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "misslyckades köra \"git status\" på \"%s\""
 
-#: builtin/worktree.c:929
+#: builtin/worktree.c:928
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "\"%s\" innehåller ändrade eller ospårade filer, använd --force för att ta "
 "bort det"
 
-#: builtin/worktree.c:934
+#: builtin/worktree.c:933
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "misslyckades köra \"git status\" på \"%s\", kod %d"
 
-#: builtin/worktree.c:957
+#: builtin/worktree.c:956
 msgid "force removal even if worktree is dirty or locked"
 msgstr "tvinga ta bort även om arbetskatalogen är smutsig eller låst"
 
-#: builtin/worktree.c:980
+#: builtin/worktree.c:979
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -24235,7 +24090,7 @@ msgstr ""
 "kan inte ta bort en låst arbetskatalog, orsak till låset: %s\n"
 "använd \"remove -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:982
+#: builtin/worktree.c:981
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -24243,17 +24098,17 @@ msgstr ""
 "kan inte ta bort en låst arbetskatalog;\n"
 "använd \"remove -f -f\" för att överstyra, eller lås upp först"
 
-#: builtin/worktree.c:985
+#: builtin/worktree.c:984
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "kontroll misslyckades, kan inte ta bort arbetskatalog: %s"
 
-#: builtin/worktree.c:1009
+#: builtin/worktree.c:1008
 #, c-format
 msgid "repair: %s: %s"
 msgstr "reparera: %s: %s"
 
-#: builtin/worktree.c:1012
+#: builtin/worktree.c:1011
 #, c-format
 msgid "error: %s: %s"
 msgstr "fel: %s: %s"
@@ -24305,20 +24160,15 @@ msgstr ""
 "<koncept>\" för att läsa mer om specifika underkommandon och koncept.\n"
 "See \"git help git\" för en översikt över systemet."
 
-#: git.c:188
+#: git.c:188 git.c:216 git.c:300
 #, c-format
-msgid "no directory given for --git-dir\n"
-msgstr "ingen katalog angavs för --git-dir\n"
+msgid "no directory given for '%s' option\n"
+msgstr "ingen katalog angavs för flaggan \"%s\"\n"
 
 #: git.c:202
 #, c-format
 msgid "no namespace given for --namespace\n"
 msgstr "ingen namnrymd angavs för --namespace\n"
-
-#: git.c:216
-#, c-format
-msgid "no directory given for --work-tree\n"
-msgstr "ingen katalog angavs för --work-tree\n"
 
 #: git.c:230
 #, c-format
@@ -24334,11 +24184,6 @@ msgstr "-c förväntar en konfigurationssträng\n"
 #, c-format
 msgid "no config key given for --config-env\n"
 msgstr "ingen konfigurationsnyckel angavs för --config-env\n"
-
-#: git.c:300
-#, c-format
-msgid "no directory given for -C\n"
-msgstr "ingen katalog angavs för -C\n"
 
 #: git.c:326
 #, c-format
@@ -24369,29 +24214,29 @@ msgstr "tomt alias för %s"
 msgid "recursive alias: %s"
 msgstr "rekursivt alias: %s"
 
-#: git.c:476
+#: git.c:479
 msgid "write failure on standard output"
 msgstr "skrivfel på standard ut"
 
-#: git.c:478
+#: git.c:481
 msgid "unknown write failure on standard output"
 msgstr "okänt skrivfel på standard ut"
 
-#: git.c:480
+#: git.c:483
 msgid "close failed on standard output"
 msgstr "stäng misslyckades på standard ut"
 
-#: git.c:832
+#: git.c:835
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "alias-slinga detekterades: expansionen av \"%s\" avslutas aldrig:%s"
 
-#: git.c:882
+#: git.c:885
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "kan inte hantera %s som inbyggd"
 
-#: git.c:895
+#: git.c:898
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -24400,34 +24245,26 @@ msgstr ""
 "användning: %s\n"
 "\n"
 
-#: git.c:915
+#: git.c:918
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr ""
 "expandering av alias \"%s\" misslyckades; \"%s\" är inte ett git-kommando\n"
 
-#: git.c:927
+#: git.c:930
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "misslyckades köra kommandot \"%s\": %s\n"
 
-#: http-fetch.c:118
+#: http-fetch.c:128
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr ""
 "argumentet till --packfile måste vara ett giltigt hashvärde (fick '%s')"
 
-#: http-fetch.c:128
+#: http-fetch.c:138
 msgid "not a git repository"
 msgstr "inte ett git-arkiv"
-
-#: http-fetch.c:134
-msgid "--packfile requires --index-pack-args"
-msgstr "--packfile kräver --index-pack-args"
-
-#: http-fetch.c:143
-msgid "--index-pack-args can only be used with --packfile"
-msgstr "--index-pack-args kan endast användas med --packfile"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"
@@ -24707,6 +24544,176 @@ msgstr "remote-curl: försökte ta emot utan lokalt arkiv"
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: okänt kommando \"%s\" från git"
 
+#: contrib/scalar/scalar.c:49
+msgid "need a working directory"
+msgstr "behöver en arbetskatalog"
+
+#: contrib/scalar/scalar.c:86
+msgid "could not find enlistment root"
+msgstr "kunde inte hitta enrolleringsroten"
+
+#: contrib/scalar/scalar.c:89 contrib/scalar/scalar.c:351
+#: contrib/scalar/scalar.c:436 contrib/scalar/scalar.c:579
+#, c-format
+msgid "could not switch to '%s'"
+msgstr "kunde inte växla till \"%s\""
+
+#: contrib/scalar/scalar.c:180
+#, c-format
+msgid "could not configure %s=%s"
+msgstr "kunde inte ställa in %s=%s"
+
+#: contrib/scalar/scalar.c:198
+msgid "could not configure log.excludeDecoration"
+msgstr "kunde inte ställa in log.excludeDecoration"
+
+#: contrib/scalar/scalar.c:219
+msgid "Scalar enlistments require a worktree"
+msgstr "Scalar-enrolleringar kräver en arbetskatalog"
+
+#: contrib/scalar/scalar.c:311
+#, c-format
+msgid "remote HEAD is not a branch: '%.*s'"
+msgstr "HEAD hos fjärren är inte en gren: \"%.*s\""
+
+#: contrib/scalar/scalar.c:317
+msgid "failed to get default branch name from remote; using local default"
+msgstr ""
+"misslyckades hämta namn på standardgren för fjärr; använder lokalt förval"
+
+#: contrib/scalar/scalar.c:330
+msgid "failed to get default branch name"
+msgstr "misslyckades hämta namn på standardgren"
+
+#: contrib/scalar/scalar.c:341
+msgid "failed to unregister repository"
+msgstr "misslyckades avregistrera arkivet"
+
+#: contrib/scalar/scalar.c:356
+msgid "failed to delete enlistment directory"
+msgstr "misslyckades ta bort enrolleringskatalogen"
+
+#: contrib/scalar/scalar.c:376
+msgid "branch to checkout after clone"
+msgstr "gren att checka ut efter kloning"
+
+#: contrib/scalar/scalar.c:378
+msgid "when cloning, create full working directory"
+msgstr "skapa komplett arbetskatalog vid kloning"
+
+#: contrib/scalar/scalar.c:380
+msgid "only download metadata for the branch that will be checked out"
+msgstr "hämta endast metadata för grenen som skall checkas ut"
+
+#: contrib/scalar/scalar.c:385
+msgid "scalar clone [<options>] [--] <repo> [<dir>]"
+msgstr "scalar clone [<flaggor>] [--] <arkiv> [<kat>]"
+
+#: contrib/scalar/scalar.c:410
+#, c-format
+msgid "cannot deduce worktree name from '%s'"
+msgstr "Kan inte härleda arbetsträdsnamn från \"%s\""
+
+#: contrib/scalar/scalar.c:419
+#, c-format
+msgid "directory '%s' exists already"
+msgstr "katalogen \"%s\" finns redan"
+
+#: contrib/scalar/scalar.c:446
+#, c-format
+msgid "failed to get default branch for '%s'"
+msgstr "misslyckades hämta standardgren för \"%s\""
+
+#: contrib/scalar/scalar.c:457
+#, c-format
+msgid "could not configure remote in '%s'"
+msgstr "kunde inte ställa in fjärr i \"%s\""
+
+#: contrib/scalar/scalar.c:466
+#, c-format
+msgid "could not configure '%s'"
+msgstr "kunde inte ställa in \"%s\""
+
+#: contrib/scalar/scalar.c:469
+msgid "partial clone failed; attempting full clone"
+msgstr "delvis klon misslyckades; försöker med fullständig klon"
+
+#: contrib/scalar/scalar.c:473
+msgid "could not configure for full clone"
+msgstr "kunde inte ställa in för komplett klon"
+
+#: contrib/scalar/scalar.c:505
+msgid "`scalar list` does not take arguments"
+msgstr "\"scalar list\" tar inte argument"
+
+#: contrib/scalar/scalar.c:518
+msgid "scalar register [<enlistment>]"
+msgstr "scalar register [<enrollering>]"
+
+#: contrib/scalar/scalar.c:545
+msgid "reconfigure all registered enlistments"
+msgstr "konfigurera alla registrerade enrolleringar på nytt"
+
+#: contrib/scalar/scalar.c:549
+msgid "scalar reconfigure [--all | <enlistment>]"
+msgstr "scalar reconfigure [--all | <enrollering>]"
+
+#: contrib/scalar/scalar.c:567
+msgid "--all or <enlistment>, but not both"
+msgstr "--all eller <enrollering>, men inte bägge"
+
+#: contrib/scalar/scalar.c:582
+#, c-format
+msgid "git repository gone in '%s'"
+msgstr "git-arkiv försvunnet i \"%s\""
+
+#: contrib/scalar/scalar.c:622
+msgid ""
+"scalar run <task> [<enlistment>]\n"
+"Tasks:\n"
+msgstr ""
+"scalar run <uppgift> [<enrollering>]\n"
+"Uppgifter:\n"
+
+#: contrib/scalar/scalar.c:640
+#, c-format
+msgid "no such task: '%s'"
+msgstr "okänd uppgift: \"%s\""
+
+#: contrib/scalar/scalar.c:690
+msgid "scalar unregister [<enlistment>]"
+msgstr "scalar unregister [<enrollering>]"
+
+#: contrib/scalar/scalar.c:737
+msgid "scalar delete <enlistment>"
+msgstr "scalar delete <enrollering>"
+
+#: contrib/scalar/scalar.c:752
+msgid "refusing to delete current working directory"
+msgstr "vägrar ta bort aktuell arbetskatalog"
+
+#: contrib/scalar/scalar.c:767
+msgid "include Git version"
+msgstr "ta med Git-version"
+
+#: contrib/scalar/scalar.c:769
+msgid "include Git's build options"
+msgstr "ta med Gits byggflaggor"
+
+#: contrib/scalar/scalar.c:773
+msgid "scalar verbose [-v | --verbose] [--build-options]"
+msgstr "scalar verbose [-v | --verbose] [--build-options]"
+
+#: contrib/scalar/scalar.c:821
+msgid ""
+"scalar <command> [<options>]\n"
+"\n"
+"Commands:\n"
+msgstr ""
+"scalar <kommando> [<flaggor>]\n"
+"\n"
+"Kommandon:\n"
+
 #: compat/compiler.h:26
 msgid "no compiler information available\n"
 msgstr "ingen kompilatorinformation tillgänglig\n"
@@ -24731,36 +24738,36 @@ msgstr "giltig-till"
 msgid "no-op (backward compatibility)"
 msgstr "ingen funktion (bakåtkompatibilitet)"
 
-#: parse-options.h:308
+#: parse-options.h:310
 msgid "be more verbose"
 msgstr "var mer pratsam"
 
-#: parse-options.h:310
+#: parse-options.h:312
 msgid "be more quiet"
 msgstr "var mer tyst"
 
-#: parse-options.h:316
+#: parse-options.h:318
 msgid "use <n> digits to display object names"
 msgstr "använd <n> siffror för att visa objektnamn"
 
-#: parse-options.h:335
+#: parse-options.h:337
 msgid "how to strip spaces and #comments from message"
 msgstr "hur blanksteg och #kommentarer ska tas bort från meddelande"
 
-#: parse-options.h:336
+#: parse-options.h:338
 msgid "read pathspec from file"
 msgstr "läs sökvägsangivelse från fil"
 
-#: parse-options.h:337
+#: parse-options.h:339
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr "med --pathspec-from-file, sökvägsangivelser avdelas med NUL-tecken"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "key"
 msgstr "nyckel"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "field name to sort on"
 msgstr "fältnamn att sortera på"
 
@@ -24830,16 +24837,16 @@ msgid "Show canonical names and email addresses of contacts"
 msgstr "Visa kanoniska namn och e-postadresser för kontakter"
 
 #: command-list.h:65
+msgid "Ensures that a reference name is well formed"
+msgstr "Se till att referensen är välformad"
+
+#: command-list.h:66
 msgid "Switch branches or restore working tree files"
 msgstr "Byt till en ny gren eller återställ filer i arbetskatalogen"
 
-#: command-list.h:66
+#: command-list.h:67
 msgid "Copy files from the index to the working tree"
 msgstr "Kopiera filer från indexet till arbetskatalogen"
-
-#: command-list.h:67
-msgid "Ensures that a reference name is well formed"
-msgstr "Se till att referensen är välformad"
 
 #: command-list.h:68
 msgid "Find commits yet to be applied to upstream"
@@ -25035,412 +25042,412 @@ msgstr ""
 "Lägg till eller tolka strukturerad information i incheckningsmeddelanden"
 
 #: command-list.h:116
-msgid "The Git repository browser"
-msgstr "Bläddraren för Git-arkiv"
-
-#: command-list.h:117
 msgid "Show commit logs"
 msgstr "Visa incheckningsloggar"
 
-#: command-list.h:118
+#: command-list.h:117
 msgid "Show information about files in the index and the working tree"
 msgstr "Visa information om filer i indexet och arbetskatalogen"
 
-#: command-list.h:119
+#: command-list.h:118
 msgid "List references in a remote repository"
 msgstr "Lista referenser i ett fjärrarkiv"
 
-#: command-list.h:120
+#: command-list.h:119
 msgid "List the contents of a tree object"
 msgstr "Visa innehållet i ett trädobjekt"
 
-#: command-list.h:121
+#: command-list.h:120
 msgid "Extracts patch and authorship from a single e-mail message"
 msgstr "Hämta patch och ägarskap från ett enkelt e-postmeddelande"
 
-#: command-list.h:122
+#: command-list.h:121
 msgid "Simple UNIX mbox splitter program"
 msgstr "Enkelt program för att dela en UNIX mbox"
 
-#: command-list.h:123
+#: command-list.h:122
 msgid "Run tasks to optimize Git repository data"
 msgstr "Utför uppgifter för att optimera Git-arkivdata"
 
-#: command-list.h:124
+#: command-list.h:123
 msgid "Join two or more development histories together"
 msgstr "Slå ihop två eller flera utvecklingshistorier"
 
-#: command-list.h:125
+#: command-list.h:124
 msgid "Find as good common ancestors as possible for a merge"
 msgstr "Hitta en så bra anfader som möjligt för sammanslagning"
 
-#: command-list.h:126
+#: command-list.h:125
 msgid "Run a three-way file merge"
 msgstr "Kör en trevägs-filsammanslagning"
 
-#: command-list.h:127
+#: command-list.h:126
 msgid "Run a merge for files needing merging"
 msgstr "Kör en sammanslagning för filer som behöver det"
 
-#: command-list.h:128
+#: command-list.h:127
 msgid "The standard helper program to use with git-merge-index"
 msgstr "Förvalt hjälpprogram att använda tillsammans med git-merge-index"
+
+#: command-list.h:128
+msgid "Show three-way merge without touching index"
+msgstr "Visa trevägssammanslagning utan att röra indexet"
 
 #: command-list.h:129
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr "Kör verktyg för lösning av sammanslagningskonflikter"
 
 #: command-list.h:130
-msgid "Show three-way merge without touching index"
-msgstr "Visa trevägssammanslagning utan att röra indexet"
-
-#: command-list.h:131
-msgid "Write and verify multi-pack-indexes"
-msgstr "Skriv och verifiera multi-pack-index"
-
-#: command-list.h:132
 msgid "Creates a tag object with extra validation"
 msgstr "skapar ett taggobjekt med extra validering"
 
-#: command-list.h:133
+#: command-list.h:131
 msgid "Build a tree-object from ls-tree formatted text"
 msgstr "Bygg ett trädobjekt från ls-tree-formaterad text"
 
-#: command-list.h:134
+#: command-list.h:132
+msgid "Write and verify multi-pack-indexes"
+msgstr "Skriv och verifiera multi-pack-index"
+
+#: command-list.h:133
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr "Flytta eller byt namn på en fil, katalog eller symbolisk länk"
 
-#: command-list.h:135
+#: command-list.h:134
 msgid "Find symbolic names for given revs"
 msgstr "Hitta symboliska namn för givna referenser"
 
-#: command-list.h:136
+#: command-list.h:135
 msgid "Add or inspect object notes"
 msgstr "Lägg till eller inspektera objektanteckningar"
 
-#: command-list.h:137
+#: command-list.h:136
 msgid "Import from and submit to Perforce repositories"
 msgstr "Importera från eller sänd till Perforce-arkiv"
 
-#: command-list.h:138
+#: command-list.h:137
 msgid "Create a packed archive of objects"
 msgstr "Skapa ett packat arkiv med objekt"
 
-#: command-list.h:139
+#: command-list.h:138
 msgid "Find redundant pack files"
 msgstr "Hitta redundanta pack-filer"
 
-#: command-list.h:140
+#: command-list.h:139
 msgid "Pack heads and tags for efficient repository access"
 msgstr "Packa huvuden och taggar för effektiv arkivåtkomst"
 
-#: command-list.h:141
+#: command-list.h:140
 msgid "Compute unique ID for a patch"
 msgstr "Beräkna unik ID för en patch"
 
-#: command-list.h:142
+#: command-list.h:141
 msgid "Prune all unreachable objects from the object database"
 msgstr "Ta bort alla onåbara objekt från objektdatabasen"
 
-#: command-list.h:143
+#: command-list.h:142
 msgid "Remove extra objects that are already in pack files"
 msgstr "Ta bort extraobjekt som redan finns i pack-filerna"
 
-#: command-list.h:144
+#: command-list.h:143
 msgid "Fetch from and integrate with another repository or a local branch"
 msgstr "Hämta från och integrera med annat arkiv eller en lokal gren"
 
-#: command-list.h:145
+#: command-list.h:144
 msgid "Update remote refs along with associated objects"
 msgstr "Uppdatera fjärr-referenser och tillhörande objekt"
 
-#: command-list.h:146
+#: command-list.h:145
 msgid "Applies a quilt patchset onto the current branch"
 msgstr "Tillämpar en quilt-patchuppsättning på aktiv gren"
 
-#: command-list.h:147
+#: command-list.h:146
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
 msgstr "Jämför två incheckningsintervall (dvs. två versioner av en gren)"
 
-#: command-list.h:148
+#: command-list.h:147
 msgid "Reads tree information into the index"
 msgstr "Läser trädinformation in i indexet"
 
-#: command-list.h:149
+#: command-list.h:148
 msgid "Reapply commits on top of another base tip"
 msgstr "Applicera incheckningar på nytt ovanpå en annan bastopp"
 
-#: command-list.h:150
+#: command-list.h:149
 msgid "Receive what is pushed into the repository"
 msgstr "Ta emot det som sänds till arkivet"
 
-#: command-list.h:151
+#: command-list.h:150
 msgid "Manage reflog information"
 msgstr "Hantera referenslogg-information"
 
-#: command-list.h:152
+#: command-list.h:151
 msgid "Manage set of tracked repositories"
 msgstr "Hantera uppsättningen spårade arkiv"
 
-#: command-list.h:153
+#: command-list.h:152
 msgid "Pack unpacked objects in a repository"
 msgstr "Packa opackade objekt i ett arkiv"
 
-#: command-list.h:154
+#: command-list.h:153
 msgid "Create, list, delete refs to replace objects"
 msgstr "Skapa, visa, ta bort referenser för att ersätta objekt"
 
-#: command-list.h:155
+#: command-list.h:154
 msgid "Generates a summary of pending changes"
 msgstr "Skapar en sammanfattning av väntande ändringar"
 
-#: command-list.h:156
+#: command-list.h:155
 msgid "Reuse recorded resolution of conflicted merges"
 msgstr "Återanvänd sparad lösning av sammanslagningskonflikter"
 
-#: command-list.h:157
+#: command-list.h:156
 msgid "Reset current HEAD to the specified state"
 msgstr "Återställ aktuell HEAD till angivet tillstånd"
 
-#: command-list.h:158
+#: command-list.h:157
 msgid "Restore working tree files"
 msgstr "Återställ filer i arbetskatalogen"
 
-#: command-list.h:159
-msgid "Revert some existing commits"
-msgstr "Återställ några befintliga incheckningar"
-
-#: command-list.h:160
+#: command-list.h:158
 msgid "Lists commit objects in reverse chronological order"
 msgstr "Visa incheckningsobjekt i omvänd kronologisk ordning"
 
-#: command-list.h:161
+#: command-list.h:159
 msgid "Pick out and massage parameters"
 msgstr "Plocka ut och massera parametrar"
 
-#: command-list.h:162
+#: command-list.h:160
+msgid "Revert some existing commits"
+msgstr "Återställ några befintliga incheckningar"
+
+#: command-list.h:161
 msgid "Remove files from the working tree and from the index"
 msgstr "Ta bort filer från arbetskatalogen och från indexet"
 
-#: command-list.h:163
+#: command-list.h:162
 msgid "Send a collection of patches as emails"
 msgstr "Sänd en uppsättning patchar som e-post"
 
-#: command-list.h:164
+#: command-list.h:163
 msgid "Push objects over Git protocol to another repository"
 msgstr "Sänd objekt över Git-protokollet till annat arkiv"
 
-#: command-list.h:165
-msgid "Restricted login shell for Git-only SSH access"
-msgstr "Begränsat inloggningsskal för SSH-åtkomst till bara Git"
-
-#: command-list.h:166
-msgid "Summarize 'git log' output"
-msgstr "Summera \"git log\"-utdata"
-
-#: command-list.h:167
-msgid "Show various types of objects"
-msgstr "Visa olika sorters objekt"
-
-#: command-list.h:168
-msgid "Show branches and their commits"
-msgstr "Visa grenar och deras incheckningar"
-
-#: command-list.h:169
-msgid "Show packed archive index"
-msgstr "Skapa packat arkivindex"
-
-#: command-list.h:170
-msgid "List references in a local repository"
-msgstr "Visa referenser i ett lokalt arkiv"
-
-#: command-list.h:171
+#: command-list.h:164
 msgid "Git's i18n setup code for shell scripts"
 msgstr "Git:s i18n-startkod för skalskript"
 
-#: command-list.h:172
+#: command-list.h:165
 msgid "Common Git shell script setup code"
 msgstr "Gemensam skriptstartkod för Git"
 
-#: command-list.h:173
+#: command-list.h:166
+msgid "Restricted login shell for Git-only SSH access"
+msgstr "Begränsat inloggningsskal för SSH-åtkomst till bara Git"
+
+#: command-list.h:167
+msgid "Summarize 'git log' output"
+msgstr "Summera \"git log\"-utdata"
+
+#: command-list.h:168
+msgid "Show various types of objects"
+msgstr "Visa olika sorters objekt"
+
+#: command-list.h:169
+msgid "Show branches and their commits"
+msgstr "Visa grenar och deras incheckningar"
+
+#: command-list.h:170
+msgid "Show packed archive index"
+msgstr "Skapa packat arkivindex"
+
+#: command-list.h:171
+msgid "List references in a local repository"
+msgstr "Visa referenser i ett lokalt arkiv"
+
+#: command-list.h:172
 msgid "Initialize and modify the sparse-checkout"
 msgstr "Initiera och modifiera sparse-checkout"
+
+#: command-list.h:173
+msgid "Add file contents to the staging area"
+msgstr "Lägg filinnehållet till indexet"
 
 #: command-list.h:174
 msgid "Stash the changes in a dirty working directory away"
 msgstr "Spara undan ändringar i en lortig arbetskatalog"
 
 #: command-list.h:175
-msgid "Add file contents to the staging area"
-msgstr "Lägg filinnehållet till indexet"
-
-#: command-list.h:176
 msgid "Show the working tree status"
 msgstr "Visa status för arbetskatalogen"
 
-#: command-list.h:177
+#: command-list.h:176
 msgid "Remove unnecessary whitespace"
 msgstr "Ta bort onödiga blanksteg"
 
-#: command-list.h:178
+#: command-list.h:177
 msgid "Initialize, update or inspect submodules"
 msgstr "Initiera, uppdatera eller inspektera undermoduler"
 
-#: command-list.h:179
+#: command-list.h:178
 msgid "Bidirectional operation between a Subversion repository and Git"
 msgstr "Dubbelriktad verkan mellan ett Subversion-arkiv och Git"
 
-#: command-list.h:180
+#: command-list.h:179
 msgid "Switch branches"
 msgstr "Byt gren"
 
-#: command-list.h:181
+#: command-list.h:180
 msgid "Read, modify and delete symbolic refs"
 msgstr "Läs, modifiera eller ta bort symbolisk referens"
 
-#: command-list.h:182
+#: command-list.h:181
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr "Skapa, visa, ta bort eller verifiera GPG-signerat taggobjekt"
 
-#: command-list.h:183
+#: command-list.h:182
 msgid "Creates a temporary file with a blob's contents"
 msgstr "Skapar temporära filer med innehållet från en blob"
 
-#: command-list.h:184
+#: command-list.h:183
 msgid "Unpack objects from a packed archive"
 msgstr "Packa upp objekt från ett pakat arkiv"
 
-#: command-list.h:185
+#: command-list.h:184
 msgid "Register file contents in the working tree to the index"
 msgstr "Registrera filinnehållet från arbetskatalogen i indexet"
 
-#: command-list.h:186
+#: command-list.h:185
 msgid "Update the object name stored in a ref safely"
 msgstr "Uppdatera objektnamnet i en referens på ett säkert sätt"
 
-#: command-list.h:187
+#: command-list.h:186
 msgid "Update auxiliary info file to help dumb servers"
 msgstr "Uppdatera tilläggsinfofil för att hjälpa dumma servrar"
 
-#: command-list.h:188
+#: command-list.h:187
 msgid "Send archive back to git-archive"
 msgstr "Sänd arkivet tillbaka till git-archive"
 
-#: command-list.h:189
+#: command-list.h:188
 msgid "Send objects packed back to git-fetch-pack"
 msgstr "Sänd packade objekt tillbaka till git-fetch-pack"
 
-#: command-list.h:190
+#: command-list.h:189
 msgid "Show a Git logical variable"
 msgstr "Visa en logisk Git-variabel"
 
-#: command-list.h:191
+#: command-list.h:190
 msgid "Check the GPG signature of commits"
 msgstr "Kontrollera GPG-signaturer för incheckningar"
 
-#: command-list.h:192
+#: command-list.h:191
 msgid "Validate packed Git archive files"
 msgstr "Bekräfta packade Git-arkivfiler"
 
-#: command-list.h:193
+#: command-list.h:192
 msgid "Check the GPG signature of tags"
 msgstr "Kontrollera GPG-signaturer i taggar"
 
-#: command-list.h:194
-msgid "Git web interface (web frontend to Git repositories)"
-msgstr "Git-webbgränssnitt (webbframända för Git-arkiv)"
-
-#: command-list.h:195
+#: command-list.h:193
 msgid "Show logs with difference each commit introduces"
 msgstr "Visa loggar med differenser varje incheckning introducerar"
 
-#: command-list.h:196
+#: command-list.h:194
 msgid "Manage multiple working trees"
 msgstr "Hantera ytterligare arbetskataloger"
 
-#: command-list.h:197
+#: command-list.h:195
 msgid "Create a tree object from the current index"
 msgstr "Skapa ett trädobjekt från aktuellt index"
 
-#: command-list.h:198
+#: command-list.h:196
 msgid "Defining attributes per path"
 msgstr "Definierar attribut per sökväg"
 
-#: command-list.h:199
+#: command-list.h:197
 msgid "Git command-line interface and conventions"
 msgstr "Gits kommandoradsgränssnitt och -konventioner"
 
-#: command-list.h:200
+#: command-list.h:198
 msgid "A Git core tutorial for developers"
 msgstr "Grundläggande Git-handledning för utvecklare"
 
-#: command-list.h:201
+#: command-list.h:199
 msgid "Providing usernames and passwords to Git"
 msgstr "Tillhandahåll användarnamn och lösenord till Git"
 
-#: command-list.h:202
+#: command-list.h:200
 msgid "Git for CVS users"
 msgstr "Git för CVS-användare"
 
-#: command-list.h:203
+#: command-list.h:201
 msgid "Tweaking diff output"
 msgstr "Justrea diff-utdata"
 
-#: command-list.h:204
+#: command-list.h:202
 msgid "A useful minimum set of commands for Everyday Git"
 msgstr "Ett användbart minsta uppsättning kommandon för vardags-Git"
 
-#: command-list.h:205
+#: command-list.h:203
 msgid "Frequently asked questions about using Git"
 msgstr "Ofta ställda frågor om att använda Git"
 
-#: command-list.h:206
+#: command-list.h:204
 msgid "A Git Glossary"
 msgstr "En Git-ordlista"
 
-#: command-list.h:207
+#: command-list.h:205
 msgid "Hooks used by Git"
 msgstr "Krokar som används av Git"
 
-#: command-list.h:208
+#: command-list.h:206
 msgid "Specifies intentionally untracked files to ignore"
 msgstr "Ange avsiktligen ospårade filer att ignorera"
 
-#: command-list.h:209
+#: command-list.h:207
+msgid "The Git repository browser"
+msgstr "Bläddraren för Git-arkiv"
+
+#: command-list.h:208
 msgid "Map author/committer names and/or E-Mail addresses"
 msgstr "Kopplar författar-/incheckarnamn och/eller -e-postadresser"
 
-#: command-list.h:210
+#: command-list.h:209
 msgid "Defining submodule properties"
 msgstr "Ange egenskaper för undermoduler"
 
-#: command-list.h:211
+#: command-list.h:210
 msgid "Git namespaces"
 msgstr "Git-namnrymder"
 
-#: command-list.h:212
+#: command-list.h:211
 msgid "Helper programs to interact with remote repositories"
 msgstr "Hjälpprogram för att interagera med fjärrarkiv"
 
-#: command-list.h:213
+#: command-list.h:212
 msgid "Git Repository Layout"
 msgstr "Gits arkivlayout"
 
-#: command-list.h:214
+#: command-list.h:213
 msgid "Specifying revisions and ranges for Git"
 msgstr "Ange versioner och intervall i Git"
 
-#: command-list.h:215
+#: command-list.h:214
 msgid "Mounting one repository inside another"
 msgstr "Monterar ett arkiv inuti ett annat"
+
+#: command-list.h:215
+msgid "A tutorial introduction to Git"
+msgstr "Introduktion till Git"
 
 #: command-list.h:216
 msgid "A tutorial introduction to Git: part two"
 msgstr "Introduktion till Git: del två"
 
 #: command-list.h:217
-msgid "A tutorial introduction to Git"
-msgstr "Introduktion till Git"
+msgid "Git web interface (web frontend to Git repositories)"
+msgstr "Git-webbgränssnitt (webbframända för Git-arkiv)"
 
 #: command-list.h:218
 msgid "An overview of recommended workflows with Git"
@@ -25515,40 +25522,40 @@ msgstr "Misslyckades rekursera in i undermodulsökvägen \"$displaypath\""
 msgid "usage: $dashless $USAGE"
 msgstr "använd: $dashless $USAGE"
 
-#: git-sh-setup.sh:191
+#: git-sh-setup.sh:183
 #, sh-format
 msgid "Cannot chdir to $cdup, the toplevel of the working tree"
 msgstr "Kunde inte byta katalog till $cdup, toppnivån på arbetskatalogen"
 
-#: git-sh-setup.sh:200 git-sh-setup.sh:207
+#: git-sh-setup.sh:192 git-sh-setup.sh:199
 #, sh-format
 msgid "fatal: $program_name cannot be used without a working tree."
 msgstr "ödesdigetrt: $program_name kan inte användas utan arbetskatalog."
 
-#: git-sh-setup.sh:221
+#: git-sh-setup.sh:213
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr "Kan inte skriva om grenar: Du har oköade ändringar."
 
-#: git-sh-setup.sh:224
+#: git-sh-setup.sh:216
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr "Kan inte $action: Du har oköade ändringar."
 
-#: git-sh-setup.sh:235
+#: git-sh-setup.sh:227
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 "Kan inte $action: Ditt index innehåller ändringar som inte checkats in."
 
-#: git-sh-setup.sh:237
+#: git-sh-setup.sh:229
 msgid "Additionally, your index contains uncommitted changes."
 msgstr "Dessutom innehåller dit index ändringar som inte har checkats in."
 
-#: git-sh-setup.sh:357
+#: git-sh-setup.sh:349
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr "Du måste köra kommandot från arbetskatalogens toppnivå."
 
-#: git-sh-setup.sh:362
+#: git-sh-setup.sh:354
 msgid "Unable to determine absolute path of git directory"
 msgstr "Kunde inte bestämma absolut sökväg till git-katalogen"
 
@@ -25630,7 +25637,7 @@ msgstr ""
 msgid "failed to open hunk edit file for reading: %s"
 msgstr "misslyckades öppna styckesredigeringsfil för läsning: %s"
 
-#: git-add--interactive.perl:1251
+#: git-add--interactive.perl:1253
 msgid ""
 "y - stage this hunk\n"
 "n - do not stage this hunk\n"
@@ -25644,7 +25651,7 @@ msgstr ""
 "a - köa stycket och alla följande i filen\n"
 "d - köa inte stycket eller något av de följande i filen"
 
-#: git-add--interactive.perl:1257
+#: git-add--interactive.perl:1259
 msgid ""
 "y - stash this hunk\n"
 "n - do not stash this hunk\n"
@@ -25658,7 +25665,7 @@ msgstr ""
 "a - \"stash\":a stycket och alla följande i filen\n"
 "d - \"stash\":a inte stycket eller något av de följande i filen"
 
-#: git-add--interactive.perl:1263
+#: git-add--interactive.perl:1265
 msgid ""
 "y - unstage this hunk\n"
 "n - do not unstage this hunk\n"
@@ -25672,7 +25679,7 @@ msgstr ""
 "a - ta bort stycket och alla följande i filen från kön\n"
 "d - ta inte bort stycket eller något av de följande i filen från kön"
 
-#: git-add--interactive.perl:1269
+#: git-add--interactive.perl:1271
 msgid ""
 "y - apply this hunk to index\n"
 "n - do not apply this hunk to index\n"
@@ -25686,7 +25693,7 @@ msgstr ""
 "a - applicera stycket och alla följande i filen\n"
 "d - applicera inte stycket eller något av de följande i filen"
 
-#: git-add--interactive.perl:1275 git-add--interactive.perl:1293
+#: git-add--interactive.perl:1277 git-add--interactive.perl:1295
 msgid ""
 "y - discard this hunk from worktree\n"
 "n - do not discard this hunk from worktree\n"
@@ -25700,7 +25707,7 @@ msgstr ""
 "a - förkasta stycket och alla följande i filen\n"
 "d - förkasta inte stycket eller något av de följande i filen"
 
-#: git-add--interactive.perl:1281
+#: git-add--interactive.perl:1283
 msgid ""
 "y - discard this hunk from index and worktree\n"
 "n - do not discard this hunk from index and worktree\n"
@@ -25714,7 +25721,7 @@ msgstr ""
 "a - förkasta stycket och alla följande i filen\n"
 "d - förkasta inte stycket eller något av de följande i filen"
 
-#: git-add--interactive.perl:1287
+#: git-add--interactive.perl:1289
 msgid ""
 "y - apply this hunk to index and worktree\n"
 "n - do not apply this hunk to index and worktree\n"
@@ -25728,7 +25735,7 @@ msgstr ""
 "a - applicera stycket och alla följande i filen\n"
 "d - applicera inte stycket eller något av de följande i filen"
 
-#: git-add--interactive.perl:1299
+#: git-add--interactive.perl:1301
 msgid ""
 "y - apply this hunk to worktree\n"
 "n - do not apply this hunk to worktree\n"
@@ -25742,7 +25749,7 @@ msgstr ""
 "a - applicera stycket och alla följande i filen\n"
 "d - applicera inte stycket eller något av de följande i filen"
 
-#: git-add--interactive.perl:1314
+#: git-add--interactive.perl:1316
 msgid ""
 "g - select a hunk to go to\n"
 "/ - search for a hunk matching the given regex\n"
@@ -25764,90 +25771,90 @@ msgstr ""
 "e - redigera aktuellt stycke manuellt\n"
 "? - visa hjälp\n"
 
-#: git-add--interactive.perl:1345
+#: git-add--interactive.perl:1347
 msgid "The selected hunks do not apply to the index!\n"
 msgstr "Markerade stycken kan inte appliceras på indexet!\n"
 
-#: git-add--interactive.perl:1360
+#: git-add--interactive.perl:1362
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "ignorerar ej sammanslagen: %s\n"
 
-#: git-add--interactive.perl:1479
+#: git-add--interactive.perl:1481
 #, perl-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera ändrat läge på arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1480
+#: git-add--interactive.perl:1482
 #, perl-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera borttagning på arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1481
+#: git-add--interactive.perl:1483
 #, perl-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera tillägg på arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1482
+#: git-add--interactive.perl:1484
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
 msgstr "Applicera stycket på arbetskatalogen [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1599
+#: git-add--interactive.perl:1601
 msgid "No other hunks to goto\n"
 msgstr "Inga andra stycken att gå till\n"
 
-#: git-add--interactive.perl:1617
+#: git-add--interactive.perl:1619
 #, perl-format
 msgid "Invalid number: '%s'\n"
 msgstr "Ogiltigt siffervärde: \"%s\"\n"
 
-#: git-add--interactive.perl:1622
+#: git-add--interactive.perl:1624
 #, perl-format
 msgid "Sorry, only %d hunk available.\n"
 msgid_plural "Sorry, only %d hunks available.\n"
 msgstr[0] "Beklagar, det finns bara %d stycke.\n"
 msgstr[1] "Beklagar, det finns bara %d stycken.\n"
 
-#: git-add--interactive.perl:1657
+#: git-add--interactive.perl:1659
 msgid "No other hunks to search\n"
 msgstr "Inga andra stycken att söka efter\n"
 
-#: git-add--interactive.perl:1674
+#: git-add--interactive.perl:1676
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
 msgstr "Felaktigt format på reguljärt sökuttryck %s: %s\n"
 
-#: git-add--interactive.perl:1684
+#: git-add--interactive.perl:1686
 msgid "No hunk matches the given pattern\n"
 msgstr "Inga stycken motsvarar givet mönster\n"
 
-#: git-add--interactive.perl:1696 git-add--interactive.perl:1718
+#: git-add--interactive.perl:1698 git-add--interactive.perl:1720
 msgid "No previous hunk\n"
 msgstr "Inget föregående stycke\n"
 
-#: git-add--interactive.perl:1705 git-add--interactive.perl:1724
+#: git-add--interactive.perl:1707 git-add--interactive.perl:1726
 msgid "No next hunk\n"
 msgstr "Inget följande stycke\n"
 
-#: git-add--interactive.perl:1730
+#: git-add--interactive.perl:1732
 msgid "Sorry, cannot split this hunk\n"
 msgstr "Beklagar, kan inte dela stycket\n"
 
-#: git-add--interactive.perl:1736
+#: git-add--interactive.perl:1738
 #, perl-format
 msgid "Split into %d hunk.\n"
 msgid_plural "Split into %d hunks.\n"
 msgstr[0] "Dela i %d stycke.\n"
 msgstr[1] "Dela i %d stycken.\n"
 
-#: git-add--interactive.perl:1746
+#: git-add--interactive.perl:1748
 msgid "Sorry, cannot edit this hunk\n"
 msgstr "Beklagar, kan inte redigera stycket\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
-#: git-add--interactive.perl:1811
+#: git-add--interactive.perl:1813
 msgid ""
 "status        - show paths with changes\n"
 "update        - add working tree state to the staged set of changes\n"
@@ -25864,57 +25871,57 @@ msgstr ""
 "diff          - visa diff mellan HEAD och index\n"
 "add untracked - lägg till innehåll i ospårade filer till köade ändringar\n"
 
-#: git-add--interactive.perl:1828 git-add--interactive.perl:1840
-#: git-add--interactive.perl:1843 git-add--interactive.perl:1850
-#: git-add--interactive.perl:1853 git-add--interactive.perl:1860
-#: git-add--interactive.perl:1864 git-add--interactive.perl:1870
+#: git-add--interactive.perl:1830 git-add--interactive.perl:1842
+#: git-add--interactive.perl:1845 git-add--interactive.perl:1852
+#: git-add--interactive.perl:1855 git-add--interactive.perl:1862
+#: git-add--interactive.perl:1866 git-add--interactive.perl:1872
 msgid "missing --"
 msgstr "saknad --"
 
-#: git-add--interactive.perl:1866
+#: git-add--interactive.perl:1868
 #, perl-format
 msgid "unknown --patch mode: %s"
 msgstr "okänt läge för --patch: %s"
 
-#: git-add--interactive.perl:1872 git-add--interactive.perl:1878
+#: git-add--interactive.perl:1874 git-add--interactive.perl:1880
 #, perl-format
 msgid "invalid argument %s, expecting --"
 msgstr "felaktigt argument %s, förväntar --"
 
-#: git-send-email.perl:129
+#: git-send-email.perl:159
 msgid "local zone differs from GMT by a non-minute interval\n"
 msgstr "lokal zon skiljer sig från GMT med delar av minuter\n"
 
-#: git-send-email.perl:136 git-send-email.perl:142
+#: git-send-email.perl:166 git-send-email.perl:172
 msgid "local time offset greater than or equal to 24 hours\n"
 msgstr "lokal tidszonförskjutning större än eller lika med 24 timmar\n"
 
-#: git-send-email.perl:214
+#: git-send-email.perl:244
 #, perl-format
 msgid "fatal: command '%s' died with exit code %d"
 msgstr "ödesdigert: kommandot \"%s\" dog med slutkoden %d"
 
-#: git-send-email.perl:227
+#: git-send-email.perl:257
 msgid "the editor exited uncleanly, aborting everything"
 msgstr "textredigeringsprogrammet avslutades med fel, avbryter allting"
 
-#: git-send-email.perl:316
+#: git-send-email.perl:346
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr ""
 "\"%s\" innehåller en mellanliggande version av e-postbrevet du skrev.\n"
 
-#: git-send-email.perl:321
+#: git-send-email.perl:351
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr "\"%s.final\" innehåller det skrivna brevet.\n"
 
-#: git-send-email.perl:450
+#: git-send-email.perl:484
 msgid "--dump-aliases incompatible with other options\n"
 msgstr "--dump-aliases är inkompatibelt med andra flaggor\n"
 
-#: git-send-email.perl:525
+#: git-send-email.perl:561
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
@@ -25926,11 +25933,11 @@ msgstr ""
 "Sätt sendemail.forbidSendmailVariables till false för att inaktivera denna "
 "kontroll.\n"
 
-#: git-send-email.perl:530 git-send-email.perl:746
+#: git-send-email.perl:566 git-send-email.perl:782
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr "Kan inte köra git format-patch från utanför arkivet\n"
 
-#: git-send-email.perl:533
+#: git-send-email.perl:569
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
@@ -25938,37 +25945,37 @@ msgstr ""
 "\"batch-size\" och \"relogin\" måste anges tillsammans (via kommandorad "
 "eller konfigurationsflagga)\n"
 
-#: git-send-email.perl:546
+#: git-send-email.perl:582
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr "Okänt fält i --suppress-cc: \"%s\"\n"
 
-#: git-send-email.perl:577
+#: git-send-email.perl:613
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr "Okänd inställning i --confirm: \"%s\"\n"
 
-#: git-send-email.perl:617
+#: git-send-email.perl:653
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr "varning: sendmail-alias med citationstecken stöds inte. %s\n"
 
-#: git-send-email.perl:619
+#: git-send-email.perl:655
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr "varning: \":include:\" stöds inte: %s\n"
 
-#: git-send-email.perl:621
+#: git-send-email.perl:657
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr "varning: omdirigering til \"/fil\" eller \"|rör\" stöds inte: %s\n"
 
-#: git-send-email.perl:626
+#: git-send-email.perl:662
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr "varning: sendmail-raden känns inte igen: %s\n"
 
-#: git-send-email.perl:711
+#: git-send-email.perl:747
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -25983,12 +25990,12 @@ msgstr ""
 "    * Säga \"./%s\" om du menar en fil; eller\n"
 "    * Ange flaggan --format-patch om du menar ett intervall.\n"
 
-#: git-send-email.perl:732
+#: git-send-email.perl:768
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr "Misslyckades utföra opendir %s: %s"
 
-#: git-send-email.perl:767
+#: git-send-email.perl:803
 msgid ""
 "\n"
 "No patch files specified!\n"
@@ -25998,17 +26005,17 @@ msgstr ""
 "Inga patchfiler angavs!\n"
 "\n"
 
-#: git-send-email.perl:780
+#: git-send-email.perl:816
 #, perl-format
 msgid "No subject line in %s?"
 msgstr "Ingen ärenderad i %s?"
 
-#: git-send-email.perl:791
+#: git-send-email.perl:827
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr "Kunde inte öppna för skrivning %s: %s"
 
-#: git-send-email.perl:802
+#: git-send-email.perl:838
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -26022,38 +26029,38 @@ msgstr ""
 "\n"
 "Rensa brevkroppen om du inte vill sända någon sammanfattning.\n"
 
-#: git-send-email.perl:826
+#: git-send-email.perl:862
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr "Misslyckades öppna %s: %s"
 
-#: git-send-email.perl:843
+#: git-send-email.perl:879
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr "Misslyckades öppna %s.final: %s"
 
-#: git-send-email.perl:886
+#: git-send-email.perl:922
 msgid "Summary email is empty, skipping it\n"
 msgstr "Sammanfattande brev tomt, hoppar över\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:935
+#: git-send-email.perl:971
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr "Är du säker på att du vill använda <%s> [Y=ja, N=nej]? "
 
-#: git-send-email.perl:990
+#: git-send-email.perl:1026
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
 msgstr ""
 "Följande filer är åttabitars, men anger inte en Content-Transfer-Encoding.\n"
 
-#: git-send-email.perl:995
+#: git-send-email.perl:1031
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr "Vilken åttabitarsteckenkodning ska jag ange [UTF-8]? "
 
-#: git-send-email.perl:1003
+#: git-send-email.perl:1039
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -26066,21 +26073,21 @@ msgstr ""
 "har mallärendet \"*** SUBJECT HERE ***\". Använd --force om du verkligen "
 "vill sända.\n"
 
-#: git-send-email.perl:1022
+#: git-send-email.perl:1058
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr "Till vem ska breven sändas (om någon)?"
 
-#: git-send-email.perl:1040
+#: git-send-email.perl:1076
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr "ödesdigert: aliaset \"%s\" expanderar till sig själv\n"
 
-#: git-send-email.perl:1052
+#: git-send-email.perl:1088
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
 "Message-ID att använda som In-Reply-To för det första brevet (om något)? "
 
-#: git-send-email.perl:1114 git-send-email.perl:1122
+#: git-send-email.perl:1150 git-send-email.perl:1158
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr "fel: kunde inte få fram en giltig adress från: %s\n"
@@ -26088,16 +26095,16 @@ msgstr "fel: kunde inte få fram en giltig adress från: %s\n"
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1126
+#: git-send-email.perl:1162
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr "Vad vill du göra med adressen? (q=avsluta, d=kasta, e=redigera): "
 
-#: git-send-email.perl:1446
+#: git-send-email.perl:1482
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr "CA-sökvägen \"%s\" finns inte"
 
-#: git-send-email.perl:1529
+#: git-send-email.perl:1565
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -26124,114 +26131,114 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1544
+#: git-send-email.perl:1580
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr "Sända brevet? (y=ja, n=nej, e=redigera, q=avsluta, a=alla): "
 
-#: git-send-email.perl:1547
+#: git-send-email.perl:1583
 msgid "Send this email reply required"
 msgstr "Svar krävs på frågan \"Sända brevet?\""
 
-#: git-send-email.perl:1581
+#: git-send-email.perl:1617
 msgid "The required SMTP server is not properly defined."
 msgstr "Nödvändig SMTP-server har inte angivits korrekt."
 
-#: git-send-email.perl:1628
+#: git-send-email.perl:1664
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr "Servern stöder inte SMARTTLS! %s"
 
-#: git-send-email.perl:1633 git-send-email.perl:1637
+#: git-send-email.perl:1669 git-send-email.perl:1673
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr "STARTTLS misslyckades! %s"
 
-#: git-send-email.perl:1646
+#: git-send-email.perl:1682
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 "Kan inte initiera SMTP korrekt. Kontrollera inställningarna och använd --"
 "smtp-debug."
 
-#: git-send-email.perl:1664
+#: git-send-email.perl:1700
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr "Misslyckades sända %s\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr "Test-Sände %s\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Sent %s\n"
 msgstr "Sände %s\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "Dry-OK. Log says:\n"
 msgstr "Test-OK. Loggen säger:\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "OK. Log says:\n"
 msgstr "OK. Loggen säger:\n"
 
-#: git-send-email.perl:1688
+#: git-send-email.perl:1724
 msgid "Result: "
 msgstr "Resultat: "
 
-#: git-send-email.perl:1691
+#: git-send-email.perl:1727
 msgid "Result: OK\n"
 msgstr "Resultat: OK\n"
 
-#: git-send-email.perl:1708
+#: git-send-email.perl:1744
 #, perl-format
 msgid "can't open file %s"
 msgstr "kan inte öppna filen %s"
 
-#: git-send-email.perl:1756 git-send-email.perl:1776
+#: git-send-email.perl:1792 git-send-email.perl:1812
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr "(mbox) Lägger till cc: %s från raden \"%s\"\n"
 
-#: git-send-email.perl:1762
+#: git-send-email.perl:1798
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr "(mbox) Lägger till to: %s från raden \"%s\"\n"
 
-#: git-send-email.perl:1819
+#: git-send-email.perl:1855
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr "(icke-mbox) Lägger till cc: %s från raden \"%s\"\n"
 
-#: git-send-email.perl:1854
+#: git-send-email.perl:1890
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(kropp) Lägger till cc: %s från raden \"%s\"\n"
 
-#: git-send-email.perl:1973
+#: git-send-email.perl:2009
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Kunde inte köra \"%s\""
 
-#: git-send-email.perl:1980
+#: git-send-email.perl:2016
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Lägger till %s: %s från: \"%s\"\n"
 
-#: git-send-email.perl:1984
+#: git-send-email.perl:2020
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) misslyckades stänga röret till \"%s\""
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2050
 msgid "cannot send message as 7bit"
 msgstr "kan inte sända brev som sjubitars"
 
-#: git-send-email.perl:2022
+#: git-send-email.perl:2058
 msgid "invalid transfer encoding"
 msgstr "ogiltig överföringskondning"
 
-#: git-send-email.perl:2059
+#: git-send-email.perl:2095
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
@@ -26242,12 +26249,12 @@ msgstr ""
 "%s\n"
 "varning: inga patchar har sänts\n"
 
-#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
+#: git-send-email.perl:2105 git-send-email.perl:2158 git-send-email.perl:2168
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "kunde inte öppna %s: %s\n"
 
-#: git-send-email.perl:2072
+#: git-send-email.perl:2108
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -26256,7 +26263,7 @@ msgstr ""
 "ödesdigert: %s:%d är längre än 998 tecken\n"
 "varning: inga patchar har sänts\n"
 
-#: git-send-email.perl:2090
+#: git-send-email.perl:2126
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr ""
@@ -26264,10 +26271,381 @@ msgstr ""
 "säkerhetskopior.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2094
+#: git-send-email.perl:2130
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
+
+#~ msgid "--index outside a repository"
+#~ msgstr "--index utanför arkiv"
+
+#~ msgid "--cached outside a repository"
+#~ msgstr "--cached utanför arkiv"
+
+#~ msgid "unrecognized input"
+#~ msgstr "indata känns inte igen"
+
+#, c-format
+#~ msgid "cannot read %s"
+#~ msgstr "kan inte läsa %s"
+
+#~ msgid "Option --exec can only be used together with --remote"
+#~ msgstr "Flaggan --exec kan endast användas tillsammans med --remote"
+
+#, c-format
+#~ msgid ""
+#~ "Branch '%s' set up to track remote branch '%s' from '%s' by rebasing."
+#~ msgstr ""
+#~ "Grenen %s ställdes in att spåra fjärrgrenen \"%s\" från \"%s\" genom "
+#~ "ombasering."
+
+#, c-format
+#~ msgid "Branch '%s' set up to track remote branch '%s' from '%s'."
+#~ msgstr "Grenen %s ställdes in att spåra fjärrgrenen \"%s\" från \"%s\"."
+
+#, c-format
+#~ msgid "Branch '%s' set up to track local branch '%s' by rebasing."
+#~ msgstr ""
+#~ "Grenen \"%s\" ställdes in att spåra den lokala grenen \"%s\"  genom "
+#~ "ombasering."
+
+#, c-format
+#~ msgid "Branch '%s' set up to track local branch '%s'."
+#~ msgstr "Grenen \"%s\" ställdes in att spåra den lokala grenen \"%s\"."
+
+#, c-format
+#~ msgid "Branch '%s' set up to track remote ref '%s' by rebasing."
+#~ msgstr ""
+#~ "Grenen \"%s\" ställdes in att spåra fjärreferensen \"%s\" genom "
+#~ "ombasering."
+
+#, c-format
+#~ msgid "Branch '%s' set up to track remote ref '%s'."
+#~ msgstr "Grenen \"%s\" ställdes in att spåra fjärreferensen \"%s\"."
+
+#~ msgid "Cannot force update the current branch."
+#~ msgstr "Kan inte tvinga uppdatering av aktuell gren."
+
+#, c-format
+#~ msgid "Not a valid object name: '%s'."
+#~ msgstr "Objektnamnet är inte giltigt: \"%s\"."
+
+#~ msgid "--name-only, --name-status, --check and -s are mutually exclusive"
+#~ msgstr ""
+#~ "--name-only, --name-status, --check och -s är ömsesidigt uteslutande"
+
+#~ msgid "-G, -S and --find-object are mutually exclusive"
+#~ msgstr "-G, -S och --find-object är ömsesidigt uteslutande"
+
+#~ msgid ""
+#~ "-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
+#~ msgstr ""
+#~ "-G och --pickaxe-regex är ömsesidigt uteslutande, använd --pickaxe-regex "
+#~ "med -S"
+
+#~ msgid ""
+#~ "--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
+#~ "with -G and -S"
+#~ msgstr ""
+#~ "--pickaxe-all och --find-object är ömsesidigt uteslutande, använd --"
+#~ "pickaxe-all med -G och -S"
+
+#~ msgid "--stateless-rpc requires multi_ack_detailed"
+#~ msgstr "--stateless-rpc kräver \"multi_ack_detailed\""
+
+#~ msgid "--left-only and --right-only are mutually exclusive"
+#~ msgstr "--left-only och --right-only är ömsesidigt uteslutande"
+
+#, c-format
+#~ msgid "unrecognized %%(objectsize) argument: %s"
+#~ msgstr "okänt %%(objectsize)-argument: %s"
+
+#, c-format
+#~ msgid "unrecognized %%(subject) argument: %s"
+#~ msgstr "okänt %%(subject)-argument: %s"
+
+#, c-format
+#~ msgid "unrecognized %%(contents) argument: %s"
+#~ msgstr "okänt %%(contents)-argument: %s"
+
+#, c-format
+#~ msgid "unrecognized %%(raw) argument: %s"
+#~ msgstr "okänt %%(raw)-argument: %s"
+
+#, c-format
+#~ msgid "unrecognized argument '%s' in %%(%s)"
+#~ msgstr "okänt argument \"%s\" i %%(%s)"
+
+#, c-format
+#~ msgid "unrecognized %%(align) argument: %s"
+#~ msgstr "okänt %%(align)-argument: %s"
+
+#, c-format
+#~ msgid "unrecognized %%(if) argument: %s"
+#~ msgstr "okänt %%(if)-argument: %s"
+
+#, c-format
+#~ msgid "format: %%(if) atom used without a %%(then) atom"
+#~ msgstr "format: atomen %%(if) använd utan en %%(then)-atom"
+
+#, c-format
+#~ msgid "format: %%(then) atom used without an %%(if) atom"
+#~ msgstr "format: atomen %%(then) använd utan en %%(if)-atom"
+
+#, c-format
+#~ msgid "format: %%(else) atom used without a %%(then) atom"
+#~ msgstr "format: atomen %%(else) använd utan en %%(then)-atom"
+
+#~ msgid "--unsorted-input is incompatible with --no-walk"
+#~ msgstr "--unsorted-input är inkompatibelt med --no-walk"
+
+#~ msgid "--no-walk is incompatible with --unsorted-input"
+#~ msgstr "--no-walk är inkompatibelt med --unsorted-input"
+
+#~ msgid "--dry-run is incompatible with --interactive/--patch"
+#~ msgstr "--dry-run är inkompatibelt med --interactive/--patch"
+
+#~ msgid "--pathspec-from-file is incompatible with --interactive/--patch"
+#~ msgstr "--pathspec-from-file är inkompatibelt med --interactive/--patch"
+
+#~ msgid "--pathspec-from-file is incompatible with --edit"
+#~ msgstr "--pathspec-from-file är inkompatibelt med --edit"
+
+#~ msgid "-A and -u are mutually incompatible"
+#~ msgstr "-A och -u är ömsesidigt inkompatibla"
+
+#~ msgid "Option --ignore-missing can only be used together with --dry-run"
+#~ msgstr ""
+#~ "Flaggan --ignore-missing kan endast användas tillsammans med --dry-run"
+
+#~ msgid "--pathspec-from-file is incompatible with pathspec arguments"
+#~ msgstr ""
+#~ "--pathspec-from-file är inkompatibelt med sökvägsangivelsesparametrar"
+
+#~ msgid "--pathspec-file-nul requires --pathspec-from-file"
+#~ msgstr "--pathspec-file-nul kräver --pathspec-from-file"
+
+#, c-format
+#~ msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
+#~ msgstr ""
+#~ "--show-current-patch=%s är inkompatibelt med --show-current-patch=%s"
+
+#~ msgid "--column and --verbose are incompatible"
+#~ msgstr "--column och --verbose är inkompatibla"
+
+#, c-format
+#~ msgid "'%s' cannot be used with %s"
+#~ msgstr "\"%s\" kan inte användas med %s"
+
+#~ msgid "set upstream info for new branch"
+#~ msgstr "sätt uppströmsinformation för ny gren"
+
+#, c-format
+#~ msgid "-%c, -%c and --orphan are mutually exclusive"
+#~ msgstr "-%c, -%c och --orphan är ömsesidigt uteslutande"
+
+#~ msgid "-p and --overlay are mutually exclusive"
+#~ msgstr "-p och --overlay är ömsesidigt uteslutande"
+
+#~ msgid "--pathspec-from-file is incompatible with --detach"
+#~ msgstr "--pathspec-from-file är inkompatibelt med --detach"
+
+#~ msgid "--pathspec-from-file is incompatible with --patch"
+#~ msgstr "--pathspec-from-file är inkompatibelt med --patch"
+
+#, c-format
+#~ msgid "--bare and --origin %s options are incompatible."
+#~ msgstr "flaggorna --bare och --origin %s är inkompatibla."
+
+#~ msgid "--bare and --separate-git-dir are incompatible."
+#~ msgstr "flaggorna --bare och --separate-git-dir är inkompatibla."
+
+#~ msgid "--pathspec-from-file with -a does not make sense"
+#~ msgstr "--pathspec-from-file med -a ger ingen mening"
+
+#, c-format
+#~ msgid "cannot combine -m with --fixup:%s"
+#~ msgstr "kan inte kombinera -m med --fixup:%s"
+
+#~ msgid "--long and -z are incompatible"
+#~ msgstr "--long och -z är inkompatibla"
+
+#, c-format
+#~ msgid "cannot combine reword option of --fixup with path '%s'"
+#~ msgstr ""
+#~ "kan inte kombinera omformuleringsflaggor för --fixup med sökvägen \"%s\""
+
+#~ msgid ""
+#~ "reword option of --fixup is mutually exclusive with --patch/--"
+#~ "interactive/--all/--include/--only"
+#~ msgstr ""
+#~ "omformuleringsflaggan i --fixup är ömsesidigt uteslutande med --patch/--"
+#~ "interactive/--all/--include/--only"
+
+#~ msgid "--long is incompatible with --abbrev=0"
+#~ msgstr "--long är inkompatibel med --abbrev=0"
+
+#~ msgid "--dirty is incompatible with commit-ishes"
+#~ msgstr "--dirty är inkompatibelt med \"commit-ish\"-värden"
+
+#~ msgid "--broken is incompatible with commit-ishes"
+#~ msgstr "--broken är inkompatibelt med \"commit-ish\"-värden"
+
+#~ msgid "--stdin and --merge-base are mutually exclusive"
+#~ msgstr "--stdin och --merge-base är ömsesidigt uteslutande"
+
+#~ msgid "--dir-diff is incompatible with --no-index"
+#~ msgstr "--dir-diff är inkompatibelt med --no-index"
+
+#~ msgid "--gui, --tool and --extcmd are mutually exclusive"
+#~ msgstr "--gui, --tool och --extcmd är ömsesidigt uteslutande"
+
+#~ msgid "--anonymize-map without --anonymize does not make sense"
+#~ msgstr "--anonymize-map utan --anonymize ger ingen mening"
+
+#~ msgid "Cannot pass both --import-marks and --import-marks-if-exists"
+#~ msgstr "Kan inte ange både --import-marks och --import-marks-if-exists"
+
+#, c-format
+#~ msgid "Refusing to fetch into current branch %s of non-bare repository"
+#~ msgstr "Vägrar hämta till aktuell gren %s i ett icke-naket arkiv"
+
+#~ msgid "--deepen and --depth are mutually exclusive"
+#~ msgstr "--deepen och --depth är ömsesidigt uteslutande"
+
+#~ msgid "--depth and --unshallow cannot be used together"
+#~ msgstr "--depth och --unshallow kan inte användas samtidigt"
+
+#~ msgid "--fix-thin cannot be used without --stdin"
+#~ msgstr "--fix-thin kan inte användas med --stdin"
+
+#~ msgid "--object-format cannot be used with --stdin"
+#~ msgstr "--object-format kan inte användas med --stdin"
+
+#~ msgid "--separate-git-dir and --bare are mutually exclusive"
+#~ msgstr "--separate-git-dir och --bare är ömsesidigt uteslutande"
+
+#~ msgid "-n and -k are mutually exclusive"
+#~ msgstr "-n och -k kan inte användas samtidigt"
+
+#~ msgid "--subject-prefix/--rfc and -k are mutually exclusive"
+#~ msgstr "--subject-prefix/--rfc och -k kan inte användas samtidigt"
+
+#~ msgid "--stdout, --output, and --output-directory are mutually exclusive"
+#~ msgstr ""
+#~ "--stdout, --output, och --output-directory är ömsesidigt uteslutande"
+
+#~ msgid "--creation-factor requires --range-diff"
+#~ msgstr "--creation-factor kräver --range-diff"
+
+#~ msgid "You cannot combine --squash with --no-ff."
+#~ msgstr "Du kan inte kombinera --squash med --no-ff."
+
+#~ msgid "You cannot combine --squash with --commit."
+#~ msgstr "Du kan inte kombinera --squash med --commit."
+
+#~ msgid "--keep-unreachable and --unpack-unreachable are incompatible"
+#~ msgstr ""
+#~ "--keep-unreachable och --unpack-unreachable kan inte användas samtidigt"
+
+#~ msgid "--delete is incompatible with --all, --mirror and --tags"
+#~ msgstr "--delete är inkompatibel med --all, --mirror och --tags"
+
+#~ msgid "--all and --tags are incompatible"
+#~ msgstr "--all och --tags är inkompatibla"
+
+#~ msgid "--mirror and --tags are incompatible"
+#~ msgstr "--mirror och --tags är inkompatibla"
+
+#~ msgid "--all and --mirror are incompatible"
+#~ msgstr "--all och --mirror är inkompatibla"
+
+#~ msgid "cannot combine '--keep-base' with '--onto'"
+#~ msgstr "kan inte kombinera \"--keep-base\" med \"--onto\""
+
+#~ msgid "cannot combine '--keep-base' with '--root'"
+#~ msgstr "kan inte kombinera \"--keep-base\" med \"--root\""
+
+#~ msgid "cannot combine '--root' with '--fork-point'"
+#~ msgstr "kan inte kombinera \"--root\" med \"--fork-point\""
+
+#~ msgid "cannot combine apply options with merge options"
+#~ msgstr "kan inte kombinera apply-flaggor med merge-flaggor"
+
+#~ msgid "--keep-unreachable and -A are incompatible"
+#~ msgstr "--keep-unreachable och -A kan inte användas samtidigt"
+
+#~ msgid "--geometric is incompatible with -A, -a"
+#~ msgstr "--geometric är inkompatibel med -A, -a"
+
+#~ msgid "--patch is incompatible with --{hard,mixed,soft}"
+#~ msgstr "--patch är inkompatibel med --{hard,mixed,soft}"
+
+#~ msgid "-N can only be used with --mixed"
+#~ msgstr "-N kan endast användas med --mixed"
+
+#~ msgid "cannot combine --exclude-promisor-objects and --missing"
+#~ msgstr "kan inte kombinera --exclude-promisor-objects och --missing"
+
+#~ msgid "marked counting is incompatible with --objects"
+#~ msgstr "markerad räkning är inkompatibelt med --objects"
+
+#~ msgid ""
+#~ "--reflog is incompatible with --all, --remotes, --independent or --merge-"
+#~ "base"
+#~ msgstr ""
+#~ "--reflog är inkompatibel med --all, --remotes, --independent eller --"
+#~ "merge-base"
+
+#~ msgid "git sparse-checkout reapply"
+#~ msgstr "git sparse-checkout reapply"
+
+#~ msgid "--cached and --files are mutually exclusive"
+#~ msgstr "--cached och --files är ömsesidigt uteslutande"
+
+#~ msgid "--branch and --default are mutually exclusive"
+#~ msgstr "--branch och --default är ömsesidigt uteslutande"
+
+#~ msgid "--column and -n are incompatible"
+#~ msgstr "--column och -n är inkompatibla"
+
+#~ msgid "--contains option is only allowed in list mode"
+#~ msgstr "Flaggan --contains är endast tillåten i listläge"
+
+#~ msgid "--no-contains option is only allowed in list mode"
+#~ msgstr "Flaggan --no-contains är endast tillåten i listläge"
+
+#~ msgid "--points-at option is only allowed in list mode"
+#~ msgstr "Flaggan --points-at är endast tillåten i listläge"
+
+#~ msgid "--merged and --no-merged options are only allowed in list mode"
+#~ msgstr "Flaggorna --merged och --no-merged är endast tillåtna i listläge"
+
+#~ msgid "only one -F or -m option is allowed."
+#~ msgstr "endast en av flaggorna -F eller -m tillåts."
+
+#~ msgid "-b, -B, and --detach are mutually exclusive"
+#~ msgstr "-b, -B och --detach är ömsesidigt uteslutande"
+
+#~ msgid "--reason requires --lock"
+#~ msgstr "--reason kräver --lock"
+
+#~ msgid "--verbose and --porcelain are mutually exclusive"
+#~ msgstr "--verbose och --porcelain är ömsesidigt uteslutande"
+
+#, c-format
+#~ msgid "no directory given for --git-dir\n"
+#~ msgstr "ingen katalog angavs för --git-dir\n"
+
+#, c-format
+#~ msgid "no directory given for --work-tree\n"
+#~ msgstr "ingen katalog angavs för --work-tree\n"
+
+#~ msgid "--packfile requires --index-pack-args"
+#~ msgstr "--packfile kräver --index-pack-args"
+
+#~ msgid "--index-pack-args can only be used with --packfile"
+#~ msgstr "--index-pack-args kan endast användas med --packfile"
 
 #~ msgid "gpg.ssh.defaultKeycommand succeeded but returned no keys: %s %s"
 #~ msgstr "gpg.ssh.defaultKeycommand lyckades men gav inga nycklar: %s %s"
@@ -26385,9 +26763,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 
 #~ msgid "edit the todo list"
 #~ msgstr "redigera attgöra-listan"
-
-#~ msgid "show the current patch"
-#~ msgstr "visa nuvarande patch"
 
 #~ msgid "shorten commit ids in the todo list"
 #~ msgstr "förkorta inchecknings-id i todo-listan"
@@ -27176,9 +27551,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 #~ msgid "Cannot store %s"
 #~ msgstr "Kan inte spara %s"
 
-#~ msgid "set sparse-checkout patterns"
-#~ msgstr "ställ in filter för gles utcheckning"
-
 #~ msgid "disable sparse-checkout"
 #~ msgstr "inaktivera gles utcheckning"
 
@@ -27452,9 +27824,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 #~ msgid "unrecognized verb: %s"
 #~ msgstr "okänt verb: %s"
 
-#~ msgid "option '%s' requires a value"
-#~ msgstr "flaggan \"%s\" behöver ett värde"
-
 #~ msgid "could not transform the todo list"
 #~ msgstr "kunde inte transformera att göra-listan"
 
@@ -27712,9 +28081,6 @@ msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
 
 #~ msgid "could not truncate '%s'"
 #~ msgstr "kunde inte trunkera \"%s\""
-
-#~ msgid "could not close %s"
-#~ msgstr "kunde inte stänga %s"
 
 #~ msgid "Copied a misnamed branch '%s' away"
 #~ msgstr "Kopierade bort en felaktigt namngiven gren \"%s\""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,14 +1,14 @@
 # Swedish translations for Git.
-# Copyright (C) 2010-2021 Peter Krefting <peter@softwolves.pp.se>
+# Copyright (C) 2010-2022 Peter Krefting <peter@softwolves.pp.se>
 # This file is distributed under the same license as the Git package.
-# Peter Krefting <peter@softwolves.pp.se>, 2010-2021.
+# Peter Krefting <peter@softwolves.pp.se>, 2010-2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: git 2.34.0\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2021-11-10 08:55+0800\n"
-"PO-Revision-Date: 2021-11-11 23:20+0100\n"
+"PO-Revision-Date: 2022-01-08 21:11+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -13212,9 +13212,7 @@ msgstr "serverspecifik"
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
 #: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
-msgstr ""
-"inget att checka in\n"
-"flagga att sända"
+msgstr "flagga att sända"
 
 #: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576


### PR DESCRIPTION
Includes extra translation for branch.c:313 which has an upstream whitespace error that should be patched:

>        die(_("cannot force update the branch '%s'"
>              "checked out at '%s'"),

missing space between first and second line.