### PR TITLE
l10n: recover negotiate-only error translations

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -15995,9 +15995,9 @@ msgid "you need to specify a tag name"
 msgstr "трябва да укажете име на етикет"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
 msgstr ""
-"Опцията „--negotiate-only“ изисква една или повече опции „--negotiate-tip=*“"
+"Опцията „--negotiate-only“ изисква една или повече опции „--negotiation-tip=*“"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/ca.po
+++ b/po/ca.po
@@ -15608,8 +15608,8 @@ msgid "you need to specify a tag name"
 msgstr "necessiteu especificar un nom d'etiqueta"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only necessita un o més --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only necessita un o més --negotiation-tip=*"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/de.po
+++ b/po/de.po
@@ -15761,8 +15761,8 @@ msgid "you need to specify a tag name"
 msgstr "Sie müssen den Namen des Tags angeben"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only benötigt einen oder mehrere --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only benötigt einen oder mehrere --negotiation-tip=*"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/es.po
+++ b/po/es.po
@@ -15568,8 +15568,8 @@ msgid "You need to specify a tag name."
 msgstr "Tienes que especificar un nombre de tag."
 
 #: builtin/fetch.c:2009
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only necesita uno o más --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only necesita uno o más --negotiation-tip=*"
 
 #: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15744,8 +15744,8 @@ msgid "you need to specify a tag name"
 msgstr "Vous devez spécifier un nom d'étiquette"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only nécessite au moins un --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only nécessite au moins un --negotiation-tip=*"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/id.po
+++ b/po/id.po
@@ -15052,8 +15052,8 @@ msgid "you need to specify a tag name"
 msgstr "Anda perlu sebutkan sebuah nama tag"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only perlu satu atau lebih --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only perlu satu atau lebih --negotiation-tip=*"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/pl.po
+++ b/po/pl.po
@@ -15548,8 +15548,8 @@ msgid "You need to specify a tag name."
 msgstr "Musisz określić nazwę tagu."
 
 #: builtin/fetch.c:2009
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only wymaga jednego lub wielu --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only wymaga jednego lub wielu --negotiation-tip=*"
 
 #: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -15335,8 +15335,8 @@ msgid "You need to specify a tag name."
 msgstr "Deve especificar um nome para a tag."
 
 #: builtin/fetch.c:2009
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only precisa de um ou mais --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only precisa de um ou mais --negotiation-tip=*"
 
 #: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"

--- a/po/sv.po
+++ b/po/sv.po
@@ -15388,8 +15388,8 @@ msgid "you need to specify a tag name"
 msgstr "du måste ange namnet på en tagg"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only behöver en eller flera --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only behöver en eller flera --negotiation-tip=*"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/tr.po
+++ b/po/tr.po
@@ -15465,9 +15465,9 @@ msgid "you need to specify a tag name"
 msgstr "bir etiket adı belirtmeniz gerekiyor"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
 msgstr ""
-"--negotiate-only'nin bir veya daha çok --negotiate-tip=* gereksinimi var"
+"--negotiate-only'nin bir veya daha çok --negotiation-tip=* gereksinimi var"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/vi.po
+++ b/po/vi.po
@@ -15492,8 +15492,8 @@ msgid "you need to specify a tag name"
 msgstr "bạn cần chỉ định một tên thẻ"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only cần một tham số hay nhiều --negotiate-tip=* hơn"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only cần một tham số hay nhiều --negotiation-tip=* hơn"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -15242,8 +15242,8 @@ msgid "you need to specify a tag name"
 msgstr "您需要指定一个标签名称"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only 需要一个或多个 --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only 需要一个或多个 --negotiation-tip=*"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -15103,8 +15103,8 @@ msgid "you need to specify a tag name"
 msgstr "您需要指定標籤名稱"
 
 #: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only 需要一或多個 --negotiate-tip=*"
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only 需要一或多個 --negotiation-tip=*"
 
 #: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"


### PR DESCRIPTION
In [1] the error message for a missing --negotiation-tip argument was
changed. This caused the translations to get unlinked from the original
error message.

This change reconnects them by using the correct source translation and
changes the translations to contain the correct argument.

1. 2826ffad8c (fetch: fix negotiate-only error message, 2022-01-28)
