### PR TITLE
l10n: po-id for 2.36 (round 1)

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-17 08:34+0800\n"
+"POT-Creation-Date: 2022-04-06 14:40+0800\n"
 "PO-Revision-Date: 2021-08-14 09:35+0700\n"
 "Last-Translator: Bagas Sanjaya <bagasdotme@gmail.com>\n"
 "Language-Team: Indonesian\n"
@@ -17,213 +17,212 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: add-interactive.c:380
+#: add-interactive.c:382
 #, c-format
 msgid "Huh (%s)?"
-msgstr "Huh (%s)"
+msgstr "Huh (%s)?"
 
-#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3509
-#: sequencer.c:3974 sequencer.c:4136 builtin/rebase.c:1233
-#: builtin/rebase.c:1642
+#: add-interactive.c:535 add-interactive.c:836 reset.c:136 sequencer.c:3505
+#: sequencer.c:3970 sequencer.c:4127 builtin/rebase.c:1261
+#: builtin/rebase.c:1671
 msgid "could not read index"
 msgstr "tidak dapat membaca indeks"
 
-#: add-interactive.c:588 git-add--interactive.perl:269
+#: add-interactive.c:590 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "biner"
 
-#: add-interactive.c:646 git-add--interactive.perl:278
+#: add-interactive.c:648 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "tidak ada"
 
-#: add-interactive.c:647 git-add--interactive.perl:314
+#: add-interactive.c:649 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "tak berubah"
 
-#: add-interactive.c:684 git-add--interactive.perl:641
+#: add-interactive.c:686 git-add--interactive.perl:641
 msgid "Update"
 msgstr "Perbarui"
 
-#: add-interactive.c:701 add-interactive.c:889
+#: add-interactive.c:703 add-interactive.c:891
 #, c-format
 msgid "could not stage '%s'"
 msgstr "tidak dapat menggelar '%s'"
 
-#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3713
+#: add-interactive.c:709 add-interactive.c:898 reset.c:160 sequencer.c:3709
 msgid "could not write index"
 msgstr "tidak dapat menulis indeks"
 
-#: add-interactive.c:710 git-add--interactive.perl:626
+#: add-interactive.c:712 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "%d jalur diperbarui\n"
 msgstr[1] "%d jalur diperbarui\n"
 
-#: add-interactive.c:728 git-add--interactive.perl:676
+#: add-interactive.c:730 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "catatan: %s sekarang tak terlacak.\n"
 
-#: add-interactive.c:733 apply.c:4151 builtin/checkout.c:306
+#: add-interactive.c:735 apply.c:4133 builtin/checkout.c:311
 #: builtin/reset.c:167
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry gagal untuk jalur '%s'"
 
-#: add-interactive.c:763 git-add--interactive.perl:653
+#: add-interactive.c:765 git-add--interactive.perl:653
 msgid "Revert"
 msgstr "Kembalikan"
 
-#: add-interactive.c:779
+#: add-interactive.c:781
 msgid "Could not parse HEAD^{tree}"
 msgstr "Tidak dapat menguraikan HEAD^{tree}"
 
-#: add-interactive.c:817 git-add--interactive.perl:629
+#: add-interactive.c:819 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "%d jalur dikembalikan\n"
 msgstr[1] "%d jalur dikembalikan\n"
 
-#: add-interactive.c:868 git-add--interactive.perl:693
+#: add-interactive.c:870 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
 msgstr "Tidak ada berkas tak terlacak.\n"
 
-#: add-interactive.c:872 git-add--interactive.perl:687
+#: add-interactive.c:874 git-add--interactive.perl:687
 msgid "Add untracked"
 msgstr "Tambahkan tak terlacak"
 
-#: add-interactive.c:899 git-add--interactive.perl:623
+#: add-interactive.c:901 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "%d jalur ditambahkan\n"
 msgstr[1] "%d jalur ditambahkan\n"
 
-#: add-interactive.c:929
+#: add-interactive.c:931
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "mengabaikan tak tergabung: %s"
 
-#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1758 git-add--interactive.perl:1371
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Hanya berkas biner yang berubah.\n"
 
-#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1373
+#: add-interactive.c:945 add-patch.c:1756 git-add--interactive.perl:1373
 #, c-format
 msgid "No changes.\n"
 msgstr "Tidak ada perubahan.\n"
 
-#: add-interactive.c:947 git-add--interactive.perl:1381
+#: add-interactive.c:949 git-add--interactive.perl:1381
 msgid "Patch update"
 msgstr "Pembaruan tambalan"
 
-#: add-interactive.c:986 git-add--interactive.perl:1794
+#: add-interactive.c:988 git-add--interactive.perl:1794
 msgid "Review diff"
 msgstr "Tinjau diff"
 
-#: add-interactive.c:1014
+#: add-interactive.c:1016
 msgid "show paths with changes"
 msgstr "perlihatkan jalur dengan perubahan"
 
-#: add-interactive.c:1016
+#: add-interactive.c:1018
 msgid "add working tree state to the staged set of changes"
 msgstr "tambahkan keadaan pohon kerja ke set perubahan yang tergelar"
 
-#: add-interactive.c:1018
+#: add-interactive.c:1020
 msgid "revert staged set of changes back to the HEAD version"
 msgstr "kembalikan set perubahan yang tergelar kembali ke versi HEAD"
 
-#: add-interactive.c:1020
+#: add-interactive.c:1022
 msgid "pick hunks and update selectively"
 msgstr "ambil bingkah dan perbarui secara selektif"
 
-#: add-interactive.c:1022
+#: add-interactive.c:1024
 msgid "view diff between HEAD and index"
 msgstr "lihat diff antara HEAD dan indeks"
 
-#: add-interactive.c:1024
+#: add-interactive.c:1026
 msgid "add contents of untracked files to the staged set of changes"
 msgstr "tambahkan isi berkas tak terlacak ke set perubahan yang tergelar"
 
-#: add-interactive.c:1032 add-interactive.c:1081
+#: add-interactive.c:1034 add-interactive.c:1083
 msgid "Prompt help:"
 msgstr "Permintaan bantuan:"
 
-#: add-interactive.c:1034
+#: add-interactive.c:1036
 msgid "select a single item"
 msgstr "pilih satu item"
 
-#: add-interactive.c:1036
+#: add-interactive.c:1038
 msgid "select a range of items"
 msgstr "pilih kisaran item"
 
-#: add-interactive.c:1038
+#: add-interactive.c:1040
 msgid "select multiple ranges"
 msgstr "pilih banyak kisaran"
 
-#: add-interactive.c:1040 add-interactive.c:1085
+#: add-interactive.c:1042 add-interactive.c:1087
 msgid "select item based on unique prefix"
 msgstr "pilih item berdasarkan prefiks unik"
 
-#: add-interactive.c:1042
+#: add-interactive.c:1044
 msgid "unselect specified items"
 msgstr "batal pilih item yang disebutkan"
 
-#: add-interactive.c:1044
+#: add-interactive.c:1046
 msgid "choose all items"
 msgstr "pilih semua item"
 
-#: add-interactive.c:1046
+#: add-interactive.c:1048
 msgid "(empty) finish selecting"
 msgstr "(kosong) sudah memilih"
 
-#: add-interactive.c:1083
+#: add-interactive.c:1085
 msgid "select a numbered item"
 msgstr "pilih item bernomor"
 
-#: add-interactive.c:1087
+#: add-interactive.c:1089
 msgid "(empty) select nothing"
 msgstr "(empty) tidak pilih apapun"
 
-#: add-interactive.c:1095 builtin/clean.c:839 git-add--interactive.perl:1898
+#: add-interactive.c:1097 builtin/clean.c:839 git-add--interactive.perl:1898
 msgid "*** Commands ***"
 msgstr "*** Perintah ***"
 
-#: add-interactive.c:1096 builtin/clean.c:840 git-add--interactive.perl:1895
+#: add-interactive.c:1098 builtin/clean.c:840 git-add--interactive.perl:1895
 msgid "What now"
 msgstr "Apa sekarang"
 
-#: add-interactive.c:1148 git-add--interactive.perl:213
+#: add-interactive.c:1150 git-add--interactive.perl:213
 msgid "staged"
 msgstr "tergelar"
 
-#: add-interactive.c:1148 git-add--interactive.perl:213
+#: add-interactive.c:1150 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "tak tergelar"
 
-#: add-interactive.c:1148 apply.c:5020 apply.c:5023 builtin/am.c:2367
-#: builtin/am.c:2370 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:153 builtin/merge.c:287 builtin/pull.c:194
-#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1858
-#: builtin/submodule--helper.c:1861 builtin/submodule--helper.c:2504
-#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2574
-#: builtin/submodule--helper.c:2579 builtin/submodule--helper.c:2812
+#: add-interactive.c:1150 apply.c:5002 apply.c:5005 builtin/am.c:2370
+#: builtin/am.c:2373 builtin/bugreport.c:107 builtin/clone.c:132
+#: builtin/fetch.c:154 builtin/merge.c:287 builtin/pull.c:194
+#: builtin/submodule--helper.c:412 builtin/submodule--helper.c:1872
+#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:2709
+#: builtin/submodule--helper.c:2712 builtin/submodule--helper.c:2891
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "jalur"
 
-#: add-interactive.c:1155
+#: add-interactive.c:1157
 msgid "could not refresh index"
 msgstr "tidak dapat menyegarkan indeks"
 
-#: add-interactive.c:1169 builtin/clean.c:804 git-add--interactive.perl:1805
+#: add-interactive.c:1171 builtin/clean.c:804 git-add--interactive.perl:1805
 #, c-format
 msgid "Bye.\n"
 msgstr "Sampai jumpa.\n"
@@ -534,24 +533,24 @@ msgstr "tidak dapat menguraikan kepala bingkah '%.*s'"
 msgid "could not parse colored hunk header '%.*s'"
 msgstr "tidak dapat menguraikan kepala bingkah berwarna '%.*s'"
 
-#: add-patch.c:420
+#: add-patch.c:431
 msgid "could not parse diff"
 msgstr "tidak dapat menguraikan diff"
 
-#: add-patch.c:439
+#: add-patch.c:450
 msgid "could not parse colored diff"
 msgstr "tidak dapat menguraikan diff berwarna"
 
-#: add-patch.c:453
+#: add-patch.c:464
 #, c-format
 msgid "failed to run '%s'"
 msgstr "gagal menjalankan '%s'"
 
-#: add-patch.c:612
+#: add-patch.c:618
 msgid "mismatched output from interactive.diffFilter"
 msgstr "keluaran tak cocok dari interactive.diffFilter"
 
-#: add-patch.c:613
+#: add-patch.c:619
 msgid ""
 "Your filter must maintain a one-to-one correspondence\n"
 "between its input and output lines."
@@ -559,7 +558,7 @@ msgstr ""
 "Saringan Anda haru menjaga korespondensi satu-satu antara masukannya\n"
 "dan baris keluaran."
 
-#: add-patch.c:791
+#: add-patch.c:797
 #, c-format
 msgid ""
 "expected context line #%d in\n"
@@ -568,7 +567,7 @@ msgstr ""
 "baris konteks #%d diharapkan dalam\n"
 "%.*s"
 
-#: add-patch.c:806
+#: add-patch.c:812
 #, c-format
 msgid ""
 "hunks do not overlap:\n"
@@ -581,11 +580,11 @@ msgstr ""
 "tidak berakhir dengan:\n"
 "%.*s"
 
-#: add-patch.c:1082 git-add--interactive.perl:1115
+#: add-patch.c:1088 git-add--interactive.perl:1115
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
 msgstr "Mode sunting bingkah manual -- lihat dibawah untuk panduan cepat.\n"
 
-#: add-patch.c:1086
+#: add-patch.c:1092
 #, c-format
 msgid ""
 "---\n"
@@ -599,7 +598,7 @@ msgstr ""
 "Baris yang diawali dengan %c akan dihapus.\n"
 
 #. TRANSLATORS: 'it' refers to the patch mentioned in the previous messages.
-#: add-patch.c:1100 git-add--interactive.perl:1129
+#: add-patch.c:1106 git-add--interactive.perl:1129
 msgid ""
 "If it does not apply cleanly, you will be given an opportunity to\n"
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
@@ -609,11 +608,11 @@ msgstr ""
 "untuk menyunting lagi. Jika semua baris dalam bingkah dihapus, suntingan\n"
 "dibatalkan dan bingkah tetap tidak berubah.\n"
 
-#: add-patch.c:1133
+#: add-patch.c:1139
 msgid "could not parse hunk header"
 msgstr "tidak dapat menguraikan kepala bingkah"
 
-#: add-patch.c:1178
+#: add-patch.c:1184
 msgid "'git apply --cached' failed"
 msgstr "'git apply --cached' gagal"
 
@@ -629,26 +628,26 @@ msgstr "'git apply --cached' gagal"
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1247 git-add--interactive.perl:1244
+#: add-patch.c:1253 git-add--interactive.perl:1244
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
 "Bingkah Anda tak diterapkan. Sunting lagi (bilang \"n\" untuk \"tidak\" "
 "buang!) [y/n]?"
 
-#: add-patch.c:1290
+#: add-patch.c:1296
 msgid "The selected hunks do not apply to the index!"
 msgstr "Bingkah yang dipilih tidak diterapkan ke indeks!"
 
-#: add-patch.c:1291 git-add--interactive.perl:1348
+#: add-patch.c:1297 git-add--interactive.perl:1348
 msgid "Apply them to the worktree anyway? "
 msgstr "Tetap terapkan itu ke pohon kerja? "
 
-#: add-patch.c:1298 git-add--interactive.perl:1351
+#: add-patch.c:1304 git-add--interactive.perl:1351
 msgid "Nothing was applied.\n"
 msgstr "Tidak ada yang diterapkan.\n"
 
-#: add-patch.c:1355
+#: add-patch.c:1361
 msgid ""
 "j - leave this hunk undecided, see next undecided hunk\n"
 "J - leave this hunk undecided, see next hunk\n"
@@ -670,73 +669,73 @@ msgstr ""
 "e - sunting bingkah saat ini secara manual\n"
 "? - cetak bantuan\n"
 
-#: add-patch.c:1517 add-patch.c:1527
+#: add-patch.c:1523 add-patch.c:1533
 msgid "No previous hunk"
 msgstr "Tidak ada bingkah sebelumnya"
 
-#: add-patch.c:1522 add-patch.c:1532
+#: add-patch.c:1528 add-patch.c:1538
 msgid "No next hunk"
 msgstr "Tidak ada bingkah selanjutnya"
 
-#: add-patch.c:1538
+#: add-patch.c:1544
 msgid "No other hunks to goto"
 msgstr "Tidak ada bingkah lainnya untuk dikunjungi"
 
-#: add-patch.c:1549 git-add--interactive.perl:1608
+#: add-patch.c:1555 git-add--interactive.perl:1608
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "pergi ke bingkah yang mana (<ret> untuk lihat lebih)? "
 
-#: add-patch.c:1550 git-add--interactive.perl:1610
+#: add-patch.c:1556 git-add--interactive.perl:1610
 msgid "go to which hunk? "
 msgstr "pergi ke bingkah yang mana?"
 
-#: add-patch.c:1561
+#: add-patch.c:1567
 #, c-format
 msgid "Invalid number: '%s'"
 msgstr "Angka tidak valid: '%s'"
 
-#: add-patch.c:1566
+#: add-patch.c:1572
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
 msgstr[0] "Maaf, hanya %d bingkah yang tersedia."
 msgstr[1] "Maaf, hanya %d bingkah yang tersedia."
 
-#: add-patch.c:1575
+#: add-patch.c:1581
 msgid "No other hunks to search"
 msgstr "Tidak ada bingkah lainnya untuk dicari"
 
-#: add-patch.c:1581 git-add--interactive.perl:1663
+#: add-patch.c:1587 git-add--interactive.perl:1663
 msgid "search for regex? "
 msgstr "cari untuk regex? "
 
-#: add-patch.c:1596
+#: add-patch.c:1602
 #, c-format
 msgid "Malformed search regexp %s: %s"
 msgstr "regexp pencarian %s cacat: %s"
 
-#: add-patch.c:1613
+#: add-patch.c:1619
 msgid "No hunk matches the given pattern"
 msgstr "Tidak ada bingkah yang cocok dengan pola yang diberikan"
 
-#: add-patch.c:1620
+#: add-patch.c:1626
 msgid "Sorry, cannot split this hunk"
 msgstr "Maaf, tidak dapat membelah bingkah ini"
 
-#: add-patch.c:1624
+#: add-patch.c:1630
 #, c-format
 msgid "Split into %d hunks."
 msgstr "Terbelah ke dalam %d bingkah."
 
-#: add-patch.c:1628
+#: add-patch.c:1634
 msgid "Sorry, cannot edit this hunk"
 msgstr "Maaf, tidak dapat menyunting bingkah ini"
 
-#: add-patch.c:1680
+#: add-patch.c:1686
 msgid "'git apply' failed"
 msgstr "'git apply' gagal"
 
-#: advice.c:78
+#: advice.c:81
 #, c-format
 msgid ""
 "\n"
@@ -745,37 +744,37 @@ msgstr ""
 "\n"
 "Nonaktifkan pesan ini dengan \"git config advice.%s false\""
 
-#: advice.c:94
+#: advice.c:97
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%shint: %.*s%s\n"
 
-#: advice.c:178
+#: advice.c:181
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr "Pemetikan ceri tidak mungkin sebab Anda punya berkas tak tergabung."
 
-#: advice.c:180
+#: advice.c:183
 msgid "Committing is not possible because you have unmerged files."
 msgstr "Pengkomitan tidak mungkin sebab Anda punya berkas tak tergabung."
 
-#: advice.c:182
+#: advice.c:185
 msgid "Merging is not possible because you have unmerged files."
 msgstr "Penggabungan tidak mungkin sebab Anda punya berkas tak tergabung."
 
-#: advice.c:184
+#: advice.c:187
 msgid "Pulling is not possible because you have unmerged files."
 msgstr "Penarikan tidak mungkin sebab Anda punya berkas tak tergabung."
 
-#: advice.c:186
+#: advice.c:189
 msgid "Reverting is not possible because you have unmerged files."
 msgstr "Pembalikkan tidak mungkin sebab Anda punya berkas tak tergabung."
 
-#: advice.c:188
+#: advice.c:191
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr "Tidak mungkin untuk %s sebab Anda punya berkas tak tergabung."
 
-#: advice.c:196
+#: advice.c:199
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -783,27 +782,27 @@ msgstr ""
 "Perbaiki di dalam pohon kerja, lalu gunakan 'git add/rm <berkas>'\n"
 "sebagaimana mestinya untuk menandai resolusi dan membuat sebuah komit."
 
-#: advice.c:204
+#: advice.c:207
 msgid "Exiting because of an unresolved conflict."
 msgstr "Keluar karena sebuah konflik tak terselesaikan."
 
-#: advice.c:209 builtin/merge.c:1382
+#: advice.c:212 builtin/merge.c:1388
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Anda belum mengakhiri penggabungan Anda (MERGE_HEAD ada)."
 
-#: advice.c:211
+#: advice.c:214
 msgid "Please, commit your changes before merging."
 msgstr "Mohon komit perubahan Anda sebelum menggabungkan."
 
-#: advice.c:212
+#: advice.c:215
 msgid "Exiting because of unfinished merge."
 msgstr "Keluar karena penggabungan belum selesai."
 
-#: advice.c:217
+#: advice.c:220
 msgid "Not possible to fast-forward, aborting."
 msgstr "Tidak mungkin untuk maju cepat, batalkan."
 
-#: advice.c:227
+#: advice.c:230
 #, c-format
 msgid ""
 "The following paths and/or pathspecs matched paths that exist\n"
@@ -814,7 +813,7 @@ msgstr ""
 "di luar definisi checkout tipis Anda, jadi tidak akan diperbarui\n"
 "di dalam indeks:\n"
 
-#: advice.c:234
+#: advice.c:237
 msgid ""
 "If you intend to update such entries, try one of the following:\n"
 "* Use the --sparse option.\n"
@@ -824,7 +823,7 @@ msgstr ""
 "* Gunakan opsi --sparse\n"
 "* Nonaktifkan atau modifikasi aturan kejarangan."
 
-#: advice.c:242
+#: advice.c:245
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -848,12 +847,15 @@ msgid ""
 msgstr ""
 "Catatan: berganti ke '%s'.\n"
 "\n"
-"Anda berada dalam keadaan 'HEAD terpisah'. Anda dapat melihat-lihat, membuat\n"
-"perubahan eksperimental and komit, dan Anda dapat membuang komit apa saja yang\n"
-"Anda buat di dalam keadaan ini tanpa mempengaruhi cabang apapun dengan bergantin"
-"kembali ke sebuah cabang.\n"
+"Anda berada dalam keadaan 'HEAD terpisah'. Anda dapat melihat-lihat, "
+"membuat\n"
+"perubahan eksperimental and komit, dan Anda dapat membuang komit apa saja "
+"yang\n"
+"Anda buat di dalam keadaan ini tanpa mempengaruhi cabang apapun dengan "
+"bergantinkembali ke sebuah cabang.\n"
 "\n"
-"Jika Anda ingin membuat cabang baru untuk menyimpan komit yang Anda buat, Anda\n"
+"Jika Anda ingin membuat cabang baru untuk menyimpan komit yang Anda buat, "
+"Anda\n"
 "dapat melakukannya (sekarang atau nanti) dengan:\n"
 "\n"
 "  git switch -c <nama cabang baru>\n"
@@ -862,8 +864,8 @@ msgstr ""
 "\n"
 "  git switch -\n"
 "\n"
-"Matikan saran ini dengan menyetel variabel konfigurasi advice.detachedHead ke "
-"false\n"
+"Matikan saran ini dengan menyetel variabel konfigurasi advice.detachedHead "
+"ke false\n"
 "\n"
 
 #: alias.c:50
@@ -884,82 +886,85 @@ msgstr "opsi spasi putih tidak dikenal '%s'"
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr "opsi abai spasi putih tidak dikenal '%s'"
 
-#: apply.c:136 archive.c:584 range-diff.c:559 revision.c:2303 revision.c:2307
-#: revision.c:2316 revision.c:2321 revision.c:2527 revision.c:2870
-#: revision.c:2874 revision.c:2880 revision.c:2883 revision.c:2885
-#: builtin/add.c:510 builtin/add.c:512 builtin/add.c:529 builtin/add.c:541
-#: builtin/branch.c:727 builtin/checkout.c:467 builtin/checkout.c:470
-#: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
-#: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
-#: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
-#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
-#: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
-#: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
-#: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
-#: builtin/rebase.c:1193 builtin/rebase.c:1195 builtin/rebase.c:1199
-#: builtin/repack.c:684 builtin/repack.c:715 builtin/reset.c:426
-#: builtin/reset.c:462 builtin/rev-list.c:541 builtin/show-branch.c:710
-#: builtin/stash.c:1707 builtin/stash.c:1710 builtin/submodule--helper.c:1316
-#: builtin/submodule--helper.c:2975 builtin/tag.c:526 builtin/tag.c:572
-#: builtin/worktree.c:702
+#: apply.c:138 archive.c:584 parse-options.c:1122 range-diff.c:555
+#: revision.c:2314 revision.c:2318 revision.c:2327 revision.c:2332
+#: revision.c:2560 revision.c:2895 revision.c:2899 revision.c:2907
+#: revision.c:2910 revision.c:2912 builtin/add.c:507 builtin/add.c:509
+#: builtin/add.c:515 builtin/add.c:527 builtin/branch.c:755
+#: builtin/checkout.c:472 builtin/checkout.c:475 builtin/checkout.c:1663
+#: builtin/checkout.c:1773 builtin/checkout.c:1776 builtin/clone.c:921
+#: builtin/commit.c:359 builtin/commit.c:362 builtin/commit.c:1200
+#: builtin/commit.c:1256 builtin/commit.c:1273 builtin/describe.c:593
+#: builtin/diff-tree.c:155 builtin/difftool.c:733 builtin/fast-export.c:1245
+#: builtin/fetch.c:2141 builtin/fetch.c:2162 builtin/fetch.c:2167
+#: builtin/help.c:602 builtin/index-pack.c:1858 builtin/init-db.c:560
+#: builtin/log.c:1968 builtin/log.c:1970 builtin/ls-files.c:778
+#: builtin/merge-base.c:163 builtin/merge-base.c:169 builtin/merge.c:1409
+#: builtin/merge.c:1411 builtin/pack-objects.c:4098 builtin/push.c:592
+#: builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
+#: builtin/rebase.c:1221 builtin/rebase.c:1223 builtin/rebase.c:1227
+#: builtin/repack.c:688 builtin/repack.c:719 builtin/reset.c:433
+#: builtin/reset.c:469 builtin/rev-list.c:537 builtin/show-branch.c:711
+#: builtin/stash.c:1696 builtin/stash.c:1699 builtin/submodule--helper.c:1328
+#: builtin/submodule--helper.c:3054 builtin/tag.c:527 builtin/tag.c:573
+#: builtin/worktree.c:779
 #, c-format
 msgid "options '%s' and '%s' cannot be used together"
 msgstr "Opsi '%s' dan '%s' tidak dapat digunakan bersamaan"
 
-#: apply.c:139 apply.c:150 apply.c:153
+#: apply.c:141 apply.c:152 apply.c:155
 #, c-format
 msgid "'%s' outside a repository"
 msgstr "'%s' di luar repositori"
 
-#: apply.c:800
+#: apply.c:807
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
 msgstr "Tidak dapat menyiapkan ekspresi reguler stempel waktu %s"
 
-#: apply.c:809
+#: apply.c:816
 #, c-format
 msgid "regexec returned %d for input: %s"
 msgstr "regexec kembalikan %d untuk input: %s"
 
-#: apply.c:883
+#: apply.c:890
 #, c-format
 msgid "unable to find filename in patch at line %d"
 msgstr "tidak dapat menemukan nama berkas dalam tambalan pada baris %d"
 
-#: apply.c:921
+#: apply.c:928
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
 msgstr "git apply: git-diff jelek - berharap /dev/null, dapat %s pada baris %d"
 
-#: apply.c:927
+#: apply.c:934
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
 "git apply: git-diff jelek - nama berkas baru tidak konsisten pada baris %d"
 
-#: apply.c:928
+#: apply.c:935
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr ""
 "git apply: git-diff jelek - nama berkas lama tidak konsisten pada baris %d"
 
-#: apply.c:933
+#: apply.c:940
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null on line %d"
 msgstr "git apply: git-diff jelek - berharap /dev/null pada baris %d"
 
-#: apply.c:962
+#: apply.c:969
 #, c-format
 msgid "invalid mode on line %d: %s"
 msgstr "mode tidak valid pada baris %d: %s"
 
-#: apply.c:1281
+#: apply.c:1288
 #, c-format
 msgid "inconsistent header lines %d and %d"
 msgstr "kepala baris %d dan %d tidak konsisten"
 
-#: apply.c:1371
+#: apply.c:1378
 #, c-format
 msgid ""
 "git diff header lacks filename information when removing %d leading pathname "
@@ -974,92 +979,92 @@ msgstr[1] ""
 "kepala git diff kekurangan informasi nama berkas ketika menghapus %d "
 "komponen nama jalur terkemuka (baris %d)"
 
-#: apply.c:1384
+#: apply.c:1391
 #, c-format
 msgid "git diff header lacks filename information (line %d)"
 msgstr "kepala git diff kekurangan informasi nama berkas (baris %d)"
 
-#: apply.c:1480
+#: apply.c:1487
 #, c-format
 msgid "recount: unexpected line: %.*s"
 msgstr "recount: baris tidak diharapkan: %.*s"
 
-#: apply.c:1549
+#: apply.c:1556
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
 msgstr "pecahan tambalan tanpa kepala pada baris %d: %.*s"
 
-#: apply.c:1752
+#: apply.c:1759
 msgid "new file depends on old contents"
 msgstr "berkas baru bergantung pada konten yang lama"
 
-#: apply.c:1754
+#: apply.c:1761
 msgid "deleted file still has contents"
 msgstr "berkas terhapus masih ada konten"
 
-#: apply.c:1788
+#: apply.c:1795
 #, c-format
 msgid "corrupt patch at line %d"
 msgstr "tambalan rusak pada baris %d"
 
-#: apply.c:1825
+#: apply.c:1832
 #, c-format
 msgid "new file %s depends on old contents"
 msgstr "berkas baru %s bergantung pada konten yang lama"
 
-#: apply.c:1827
+#: apply.c:1834
 #, c-format
 msgid "deleted file %s still has contents"
 msgstr "berkas yang dihapus %s masih ada konten"
 
-#: apply.c:1830
+#: apply.c:1837
 #, c-format
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "** peringatan: berkas %s menjadi kosong tetapi tidak dihapus"
 
-#: apply.c:1978
+#: apply.c:1985
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "tambalan biner rusak pada baris %d: %.*s"
 
-#: apply.c:2015
+#: apply.c:2022
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "tambalan biner tidak dikenal pada baris %d"
 
-#: apply.c:2177
+#: apply.c:2184
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "tambal dengan hanya sampah pada baris %d"
 
-#: apply.c:2263
+#: apply.c:2270
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "tidak dapat membaca tautan simbolik %s"
 
-#: apply.c:2267
+#: apply.c:2274
 #, c-format
 msgid "unable to open or read %s"
 msgstr "tidak dapat membuka atau membaca %s"
 
-#: apply.c:2936
+#: apply.c:2943
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "awal baris tidak valid: '%c'"
 
-#: apply.c:3057
+#: apply.c:3064
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
 msgstr[0] "Bingkah #%d berhasil pada %d (ganti %d baris)."
 msgstr[1] "Bingkah #%d berhasil pada %d (ganti %d baris)."
 
-#: apply.c:3069
+#: apply.c:3076
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr "Konteks dikurangi menjadi (%ld/%ld) untuk terapkan pecahan pada %d"
 
-#: apply.c:3075
+#: apply.c:3082
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -1068,453 +1073,453 @@ msgstr ""
 "ketika mencari:\n"
 "%.*s"
 
-#: apply.c:3097
+#: apply.c:3104
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr "data tambalan biner hilang untuk '%s'"
 
-#: apply.c:3105
+#: apply.c:3112
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
 "tidak dapat menerapkan balik tambalan biner tanpa membalikkan bingkah ke '%s'"
 
-#: apply.c:3152
+#: apply.c:3159
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr "tidak dapat menerapkan tambalan biner ke '%s' tanpa baris indeks penuh"
 
-#: apply.c:3163
+#: apply.c:3170
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
 msgstr ""
 "tambalan diterapkan ke '%s' (%s), yang tidak cocok dengan konten saat ini."
 
-#: apply.c:3171
+#: apply.c:3178
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "tambalan diterapkan ke '%s' kosong tapi tidak kosong"
 
-#: apply.c:3189
+#: apply.c:3196
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr "pascacitra %s yang diperlukan untuk '%s' tidak dapat dibaca"
 
-#: apply.c:3202
+#: apply.c:3209
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "tambalan biner tidak dapat diterapkan ke '%s'"
 
-#: apply.c:3209
+#: apply.c:3216
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "tambalan biner ke '%s' membuat hasil yang salah (diharapkan %s, dapat %s)"
 
-#: apply.c:3230
+#: apply.c:3237
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "tambalan gagal: %s:%ld"
 
-#: apply.c:3353
+#: apply.c:3360
 #, c-format
 msgid "cannot checkout %s"
 msgstr "tidak dapat men-checkout %s"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:104 pack-revindex.c:214
+#: apply.c:3412 apply.c:3423 apply.c:3469 midx.c:105 pack-revindex.c:214
 #: setup.c:309
 #, c-format
 msgid "failed to read %s"
 msgstr "gagal membaca %s"
 
-#: apply.c:3413
+#: apply.c:3420
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "membaca dari '%s' diluar tautan simbolik"
 
-#: apply.c:3442 apply.c:3711
+#: apply.c:3449 apply.c:3721
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "jalus %s sudah dinamai ulang/dihapus"
 
-#: apply.c:3549 apply.c:3726
+#: apply.c:3559 apply.c:3736
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: tidak ada di indeks"
 
-#: apply.c:3558 apply.c:3734 apply.c:3978
+#: apply.c:3568 apply.c:3744 apply.c:3960
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: tidak cocok dengan indeks"
 
-#: apply.c:3595
+#: apply.c:3605
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
 "repositori kekurangan blob yang diperlukan untuk melakukan penggabungan 3 "
 "arah."
 
-#: apply.c:3598
+#: apply.c:3608
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Melakukan penggabungan 3 arah...\n"
 
-#: apply.c:3614 apply.c:3618
+#: apply.c:3624 apply.c:3628
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "tidak dapat membaca konten saat ini dari '%s'"
 
-#: apply.c:3630
+#: apply.c:3640
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Gagal melakukan penggabungan 3 arah...\n"
 
-#: apply.c:3644
+#: apply.c:3654
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Tambalan diterapkan ke '%s' dengan konflik.\n"
 
-#: apply.c:3649
+#: apply.c:3659
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Tambalan diterapkan ke '%s' dengan rapi.\n"
 
-#: apply.c:3666
+#: apply.c:3676
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Mundur ke penerapan langsung...\n"
 
-#: apply.c:3678
+#: apply.c:3688
 msgid "removal patch leaves file contents"
 msgstr "tambalan penghapusan meninggalkan isi berkas"
 
-#: apply.c:3751
+#: apply.c:3761
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: salah tipe"
 
-#: apply.c:3753
+#: apply.c:3763
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s bertipe %o, diharapkan %o"
 
-#: apply.c:3918 apply.c:3920 read-cache.c:889 read-cache.c:918
-#: read-cache.c:1381
+#: apply.c:3900 apply.c:3902 read-cache.c:903 read-cache.c:932
+#: read-cache.c:1399
 #, c-format
 msgid "invalid path '%s'"
 msgstr "jalur tidak valid '%s'"
 
-#: apply.c:3976
+#: apply.c:3958
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: sudah ada di indeks"
 
-#: apply.c:3980
+#: apply.c:3962
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: sudah ada di direktori kerja"
 
-#: apply.c:4000
+#: apply.c:3982
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "mode baru (%o) dari %s tidak cocok dengan mode lama (%o)"
 
-#: apply.c:4005
+#: apply.c:3987
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "mode baru (%o) dari %s tidak cocok dengan mode lama (%o) dari %s"
 
-#: apply.c:4025
+#: apply.c:4007
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "berkas yang terpengaruh '%s' diluar tautan simbolik"
 
-#: apply.c:4029
+#: apply.c:4011
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: tambalan tak diterapkan"
 
-#: apply.c:4044
+#: apply.c:4026
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Memeriksa tambalan %s..."
 
-#: apply.c:4136
+#: apply.c:4118
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "informasi sha1 kurang atau tidak berguna untuk submodul %s"
 
-#: apply.c:4143
+#: apply.c:4125
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "perubahan mode untuk %s, yang bukan dalam HEAD saat ini"
 
-#: apply.c:4146
+#: apply.c:4128
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "informasi sha1 kurang atau tidak berguna (%s)"
 
-#: apply.c:4155
+#: apply.c:4137
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "tidak dapat menambahkan %s ke indeks sementara"
 
-#: apply.c:4165
+#: apply.c:4147
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "tidak dapat menulis indeks sementara ke %s"
 
-#: apply.c:4303
+#: apply.c:4285
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "tidak dapat menghapus %s dari indeks"
 
-#: apply.c:4337
+#: apply.c:4319
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "tambalan rusak untuk submodul %s"
 
-#: apply.c:4343
+#: apply.c:4325
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "tidak dapat men-stat berkas yang baru dibuat '%s'"
 
-#: apply.c:4351
+#: apply.c:4333
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
 "tidak dapat membuat simpanan pendukung untuk berkas yang baru dibuat %s"
 
-#: apply.c:4357 apply.c:4502
+#: apply.c:4339 apply.c:4484
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "tidak dapat menambahkan entri tembolok untuk %s"
 
-#: apply.c:4400 builtin/bisect--helper.c:540 builtin/gc.c:2258
+#: apply.c:4382 builtin/bisect--helper.c:540 builtin/gc.c:2258
 #: builtin/gc.c:2293
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "gagal menulis ke '%s'"
 
-#: apply.c:4404
+#: apply.c:4386
 #, c-format
 msgid "closing file '%s'"
 msgstr "menutup berkas '%s'"
 
-#: apply.c:4474
+#: apply.c:4456
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "tidak dapat menulis berkas '%s' mode %o"
 
-#: apply.c:4572
+#: apply.c:4554
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Tambalan %s diterapkan dengan rapi."
 
-#: apply.c:4580
+#: apply.c:4562
 msgid "internal error"
 msgstr "kesalahan internal"
 
-#: apply.c:4583
+#: apply.c:4565
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Menerapkan tambalan %%s dengan %d penolakan..."
 msgstr[1] "Menerapkan tambalan %%s dengan %d penolakan..."
 
-#: apply.c:4594
+#: apply.c:4576
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "memotong nama berkas .rej ke %.*s.rej"
 
-#: apply.c:4602
+#: apply.c:4584
 #, c-format
 msgid "cannot open %s"
 msgstr "tidak dapat membuka %s"
 
-#: apply.c:4616
+#: apply.c:4598
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Bingkah #%d diterapkan dengan rapi."
 
-#: apply.c:4620
+#: apply.c:4602
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Bingkah #%d ditolak."
 
-#: apply.c:4749
+#: apply.c:4731
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Tambalan '%s' dilewatkan."
 
-#: apply.c:4758
+#: apply.c:4740
 msgid "No valid patches in input (allow with \"--allow-empty\")"
 msgstr ""
 
-#: apply.c:4779
+#: apply.c:4761
 msgid "unable to read index file"
 msgstr "tidak dapa membaca berkas indeks"
 
-#: apply.c:4936
+#: apply.c:4918
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "tidak dapat membuka tambalan '%s': %s"
 
-#: apply.c:4963
+#: apply.c:4945
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "%d kesalahan spasi putih dipadamkan"
 msgstr[1] "%d kesalahan spasi putih dipadamkan"
 
-#: apply.c:4969 apply.c:4984
+#: apply.c:4951 apply.c:4966
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d baris menambahkan kesalahan spasi putih."
 msgstr[1] "%d baris menambahkan kesalahan spasi putih."
 
-#: apply.c:4977
+#: apply.c:4959
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d baris diterapkan setelah memperbaiki kesalahan spasi putih."
 msgstr[1] "%d baris diterapkan setelah memperbaiki kesalahan spasi putih."
 
-#: apply.c:4993 builtin/add.c:704 builtin/mv.c:338 builtin/rm.c:430
+#: apply.c:4975 builtin/add.c:690 builtin/mv.c:338 builtin/rm.c:430
 msgid "Unable to write new index file"
 msgstr "Tidak dapat menulis berkas indeks baru"
 
-#: apply.c:5021
+#: apply.c:5003
 msgid "don't apply changes matching the given path"
 msgstr "jangan terapkan perubahan yang cocok dengan jalur yang diberikan"
 
-#: apply.c:5024
+#: apply.c:5006
 msgid "apply changes matching the given path"
 msgstr "terapkan perubahan yang cocok dengan jalur yang diberikan"
 
-#: apply.c:5026 builtin/am.c:2376
+#: apply.c:5008 builtin/am.c:2379
 msgid "num"
 msgstr "jumlah"
 
-#: apply.c:5027
+#: apply.c:5009
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "hapus <jumlah> garis miring terkemuka dari jalur diff tradisional"
 
-#: apply.c:5030
+#: apply.c:5012
 msgid "ignore additions made by the patch"
 msgstr "abaikan penambahan yang dibuat oleh tambalan"
 
-#: apply.c:5032
+#: apply.c:5014
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr "daripada menerapkan tambalan, keluarkan diffstat untuk masukan"
 
-#: apply.c:5036
+#: apply.c:5018
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "perlihatkan jumlah baris yang ditambahkan dan dihapuskan dalam notasi desimal"
 
-#: apply.c:5038
+#: apply.c:5020
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "daripada menerapkan tambalan, keluarkan ringkasan untuk masukan"
 
-#: apply.c:5040
+#: apply.c:5022
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "daripada menerapkan tambalan, lihat jika tambalan bisa diterapkan"
 
-#: apply.c:5042
+#: apply.c:5024
 msgid "make sure the patch is applicable to the current index"
 msgstr "pastikan tambalan bisa diterapkan ke indeks saat ini"
 
-#: apply.c:5044
+#: apply.c:5026
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "tandai berkas baru dengan `git add --intent-to-add`"
 
-#: apply.c:5046
+#: apply.c:5028
 msgid "apply a patch without touching the working tree"
 msgstr "terapkan sebuah tambalan tanpa menyentuh pohon kerja"
 
-#: apply.c:5048
+#: apply.c:5030
 msgid "accept a patch that touches outside the working area"
 msgstr "terima sebuah tambalan yang menyentuh di luar area kerja"
 
-#: apply.c:5051
+#: apply.c:5033
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "juga terapkan tambalan (gunakan dengan --stat/--summary/--check)"
 
-#: apply.c:5053
+#: apply.c:5035
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr "coba penggabungan tiga arah, mundur ke penambalan normal jika gagal"
 
-#: apply.c:5055
+#: apply.c:5037
 msgid "build a temporary index based on embedded index information"
 msgstr "bangun sebuah indeks sementara berdasarkan informasi indeks tertanam"
 
-#: apply.c:5058 builtin/checkout-index.c:196
+#: apply.c:5040 builtin/checkout-index.c:230
 msgid "paths are separated with NUL character"
 msgstr "jalur dipisahkan dengan karakter NUL"
 
-#: apply.c:5060
+#: apply.c:5042
 msgid "ensure at least <n> lines of context match"
 msgstr "pastikan setidaknya <n> baris dari konteks cocokan"
 
-#: apply.c:5061 builtin/am.c:2352 builtin/am.c:2355
+#: apply.c:5043 builtin/am.c:2355 builtin/am.c:2358
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
-#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
-#: builtin/rebase.c:1051
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3983
+#: builtin/rebase.c:1079
 msgid "action"
 msgstr "aksi"
 
-#: apply.c:5062
+#: apply.c:5044
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "deteksi baris baru atau yang diubah yang ada kesalahan spasi putih"
 
-#: apply.c:5065 apply.c:5068
+#: apply.c:5047 apply.c:5050
 msgid "ignore changes in whitespace when finding context"
 msgstr "abaikan perubahan spasi putih ketika menemukan konteks"
 
-#: apply.c:5071
+#: apply.c:5053
 msgid "apply the patch in reverse"
 msgstr "terapkan tambalan terbalik"
 
-#: apply.c:5073
+#: apply.c:5055
 msgid "don't expect at least one line of context"
 msgstr "jangan harap setidaknya satu baris konteks"
 
-#: apply.c:5075
+#: apply.c:5057
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "tinggalkan bingkah yang ditolak pada berkas *.rej yang bersesuaian"
 
-#: apply.c:5077
+#: apply.c:5059
 msgid "allow overlapping hunks"
 msgstr "perbolehkan bingkah yang tumpang tindih"
 
-#: apply.c:5080
+#: apply.c:5062
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "tolerir baris baru hilang yang salah dideteksi pada akhir berkas"
 
-#: apply.c:5083
+#: apply.c:5065
 msgid "do not trust the line counts in the hunk headers"
 msgstr "jangan percaya hitungan baris pada kepala bingkah"
 
-#: apply.c:5085 builtin/am.c:2364
+#: apply.c:5067 builtin/am.c:2367
 msgid "root"
 msgstr "akar"
 
-#: apply.c:5086
+#: apply.c:5068
 msgid "prepend <root> to all filenames"
 msgstr "tambahkan <akar> di depan semua nama berkas"
 
-#: apply.c:5089
+#: apply.c:5071
 msgid "don't return error for empty patches"
 msgstr "jangan kembalikan kesalahan untuk tambalan kosong"
 
-#: archive-tar.c:125 archive-zip.c:345
+#: archive-tar.c:125 archive-zip.c:346
 #, c-format
 msgid "cannot stream blob %s"
 msgstr "tidak dapat mengaruskan blob %s"
 
-#: archive-tar.c:265 archive-zip.c:358
+#: archive-tar.c:265 archive-zip.c:359
 #, c-format
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "mode berkas tidak didukung: 0%o (SHA1: %s)"
@@ -1533,22 +1538,22 @@ msgstr "tidak dapat mengalihkan pendeskripsi"
 msgid "'%s' filter reported error"
 msgstr "saringan '%s' melaporkan kesalahan"
 
-#: archive-zip.c:318
+#: archive-zip.c:319
 #, c-format
 msgid "path is not valid UTF-8: %s"
 msgstr "jalur bukan UTF-8 valid: %s"
 
-#: archive-zip.c:322
+#: archive-zip.c:323
 #, c-format
 msgid "path too long (%d chars, SHA1: %s): %s"
 msgstr "jalur terlalu panjang (%d karakter, SHA1: %s): %s"
 
-#: archive-zip.c:469 builtin/pack-objects.c:365 builtin/pack-objects.c:368
+#: archive-zip.c:470 builtin/pack-objects.c:363 builtin/pack-objects.c:366
 #, c-format
 msgid "deflate error (%d)"
 msgstr "kesalahan deflasi (%d)"
 
-#: archive-zip.c:603
+#: archive-zip.c:604
 #, c-format
 msgid "timestamp too large for this system: %<PRIuMAX>"
 msgstr "stempel waktu terlalu besar untuk sistem ini: %<PRIuMAX>"
@@ -1556,10 +1561,6 @@ msgstr "stempel waktu terlalu besar untuk sistem ini: %<PRIuMAX>"
 #: archive.c:14
 msgid "git archive [<options>] <tree-ish> [<path>...]"
 msgstr "git archive [<opsi>] <mirip pohon> [<jalur>...]"
-
-#: archive.c:15
-msgid "git archive --list"
-msgstr "git archive --list"
 
 #: archive.c:16
 msgid ""
@@ -1573,12 +1574,12 @@ msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <repo> [--exec <perintah>] --list"
 
 #: archive.c:188 archive.c:341 builtin/gc.c:497 builtin/notes.c:238
-#: builtin/tag.c:578
+#: builtin/tag.c:579
 #, c-format
 msgid "cannot read '%s'"
 msgstr "tidak dapat membaca '%s'"
 
-#: archive.c:426 builtin/add.c:215 builtin/add.c:671 builtin/rm.c:334
+#: archive.c:426 builtin/add.c:214 builtin/add.c:657 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "spek jalur '%s' tidak cocok dengan berkas apapun"
@@ -1620,7 +1621,7 @@ msgstr "fmt"
 msgid "archive format"
 msgstr "format arsip"
 
-#: archive.c:552 builtin/log.c:1790
+#: archive.c:552 builtin/log.c:1809
 msgid "prefix"
 msgstr "prefiks"
 
@@ -1628,12 +1629,12 @@ msgstr "prefiks"
 msgid "prepend prefix to each pathname in the archive"
 msgstr "tambahkan prefiks di depan setiap nama jalur dalam arsip"
 
-#: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
-#: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
+#: archive.c:554 archive.c:557 builtin/blame.c:881 builtin/blame.c:885
+#: builtin/blame.c:886 builtin/commit-tree.c:115 builtin/config.c:135
 #: builtin/fast-export.c:1181 builtin/fast-export.c:1183
-#: builtin/fast-export.c:1187 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/fast-export.c:1187 builtin/grep.c:936 builtin/hash-object.c:104
 #: builtin/ls-files.c:654 builtin/ls-files.c:657 builtin/notes.c:410
-#: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
+#: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:195
 msgid "file"
 msgstr "berkas"
 
@@ -1661,8 +1662,8 @@ msgstr "setel level kompresi"
 msgid "list supported archive formats"
 msgstr "daftar format arsip yang didukung"
 
-#: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1870 builtin/submodule--helper.c:2513
+#: archive.c:568 builtin/archive.c:89 builtin/clone.c:122 builtin/clone.c:125
+#: builtin/submodule--helper.c:1884 builtin/submodule--helper.c:2718
 msgid "repo"
 msgstr "repositori"
 
@@ -1683,11 +1684,12 @@ msgstr "jalur ke perintah git-upload-archive remote"
 msgid "Unexpected option --remote"
 msgstr "Opsi --remote tak diharapkan"
 
-#: archive.c:580 fetch-pack.c:300 revision.c:2887 builtin/add.c:544
-#: builtin/add.c:576 builtin/checkout.c:1763 builtin/commit.c:370
-#: builtin/fast-export.c:1230 builtin/index-pack.c:1848 builtin/log.c:2115
-#: builtin/reset.c:435 builtin/reset.c:493 builtin/rm.c:281
-#: builtin/stash.c:1719 builtin/worktree.c:508 http-fetch.c:144
+#: archive.c:580 fetch-pack.c:300 revision.c:2914 builtin/add.c:530
+#: builtin/add.c:562 builtin/checkout.c:1782 builtin/clone.c:1099
+#: builtin/clone.c:1102 builtin/commit.c:371 builtin/fast-export.c:1230
+#: builtin/index-pack.c:1854 builtin/log.c:2140 builtin/reset.c:442
+#: builtin/reset.c:500 builtin/rm.c:281 builtin/stash.c:1708
+#: builtin/worktree.c:580 builtin/worktree.c:781 http-fetch.c:144
 #: http-fetch.c:153
 #, c-format
 msgid "the option '%s' requires '%s'"
@@ -1707,17 +1709,17 @@ msgstr "Format arsip tidak dikenal '%s'"
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argumen tidak didukung untuk format '%s': -%d"
 
-#: attr.c:203
+#: attr.c:202
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr ""
 
-#: attr.c:364
+#: attr.c:363
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr ""
 
-#: attr.c:404
+#: attr.c:403
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1733,12 +1735,12 @@ msgstr "Kontent terkutip jelek dalam berkas '%s': %s"
 msgid "We cannot bisect more!\n"
 msgstr "Kami tidak dapat membagi dua lagi!\n"
 
-#: bisect.c:764
+#: bisect.c:765
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "Bukan sebuah nama komit yang valid %s"
 
-#: bisect.c:789
+#: bisect.c:790
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1747,7 +1749,7 @@ msgstr ""
 "Dasar penggabungan %s jelek.\n"
 "Ini berarti bug telah diperbaiki antara %s dan [%s].\n"
 
-#: bisect.c:794
+#: bisect.c:795
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1756,7 +1758,7 @@ msgstr ""
 "Dasar penggabungan %s baru.\n"
 "Properti telah berubah antara %s dan [%s].\n"
 
-#: bisect.c:799
+#: bisect.c:800
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1765,7 +1767,7 @@ msgstr ""
 "Dasar penggabungan %s adalah %s.\n"
 "Ini berarti komit '%s' pertama adalah di antara %s dan [%s].\n"
 
-#: bisect.c:807
+#: bisect.c:808
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1776,7 +1778,7 @@ msgstr ""
 "git bisect tidak dapat bekerja dengan benar pada kasus ini.\n"
 "Mungkin Anda salah mengira revisi %s dan %s?\n"
 
-#: bisect.c:820
+#: bisect.c:821
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1787,36 +1789,36 @@ msgstr ""
 "Jadi kami tidak dapat yakin komit %s pertama di antara %s dan %s.\n"
 "Kami tetap lanjutkan."
 
-#: bisect.c:859
+#: bisect.c:860
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Membagi dua: dasar penggabungan harus diuji\n"
 
-#: bisect.c:909
+#: bisect.c:910
 #, c-format
 msgid "a %s revision is needed"
 msgstr "sebuah revisi %s diperlukan"
 
-#: bisect.c:939
+#: bisect.c:940
 #, c-format
 msgid "could not create file '%s'"
 msgstr "tidak dapat membuat berkas '%s'"
 
-#: bisect.c:985 builtin/merge.c:155
+#: bisect.c:986 builtin/merge.c:155
 #, c-format
 msgid "could not read file '%s'"
 msgstr "tidak dapat membaca berkas '%s'"
 
-#: bisect.c:1025
+#: bisect.c:1026
 msgid "reading bisect refs failed"
 msgstr "gagal membaca berkas referensi bagi dua"
 
-#: bisect.c:1055
+#: bisect.c:1056
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s sama-sama %s dan %s\n"
 
-#: bisect.c:1064
+#: bisect.c:1065
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1825,7 +1827,7 @@ msgstr ""
 "Tidak ada komit yang bisa diuji ditemukan.\n"
 "Mungkin Anda mulai dengan argumen jalur jelek?\n"
 
-#: bisect.c:1093
+#: bisect.c:1094
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1835,53 +1837,53 @@ msgstr[1] "(kira-kira %d langkah)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1099
+#: bisect.c:1100
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
 msgstr[0] "Membagi dua: %d revisi tersisa untuk diuji setelah ini %s\n"
 msgstr[1] "Membagi dua: %d revisi tersisa untuk diuji setelah ini %s\n"
 
-#: blame.c:2776
+#: blame.c:2773
 msgid "--contents and --reverse do not blend well."
 msgstr "--contents dan --reverse tidak dapat dipadu dengan baik."
 
-#: blame.c:2790
+#: blame.c:2787
 msgid "cannot use --contents with final commit object name"
 msgstr "tidak dapat menggunakan --contents dengan nama objek komit final"
 
-#: blame.c:2811
+#: blame.c:2808
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "--reverse dan --first-parent bersama-sama butuh komit terbaru yang disebutkan"
 
-#: blame.c:2820 bundle.c:224 midx.c:1042 ref-filter.c:2370 remote.c:2158
-#: sequencer.c:2352 sequencer.c:4899 submodule.c:883 builtin/commit.c:1114
-#: builtin/log.c:429 builtin/log.c:1036 builtin/log.c:1644 builtin/log.c:2071
-#: builtin/log.c:2362 builtin/merge.c:431 builtin/pack-objects.c:3373
-#: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
+#: blame.c:2817 bundle.c:231 midx.c:1058 ref-filter.c:2371 remote.c:2157
+#: sequencer.c:2348 sequencer.c:4872 submodule.c:913 builtin/commit.c:1118
+#: builtin/log.c:437 builtin/log.c:1055 builtin/log.c:1663 builtin/log.c:2096
+#: builtin/log.c:2387 builtin/merge.c:431 builtin/pack-objects.c:3381
+#: builtin/pack-objects.c:3781 builtin/pack-objects.c:3796
 #: builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "persiapan jalan revisi gagal"
 
-#: blame.c:2838
+#: blame.c:2835
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
 "--reverse --first-parent bersama-sama butuh rentang bersama rantai induk "
 "pertama"
 
-#: blame.c:2849
+#: blame.c:2846
 #, c-format
 msgid "no such path %s in %s"
 msgstr "tidak ada jalur seperti %s di %s"
 
-#: blame.c:2860
+#: blame.c:2857
 #, c-format
 msgid "cannot read blob %s for path %s"
 msgstr "tidak dapat membaca blob %s untuk jalur %s"
 
-#: branch.c:77
+#: branch.c:93
 msgid ""
 "cannot inherit upstream tracking configuration of multiple refs when "
 "rebasing is requested"
@@ -1889,31 +1891,31 @@ msgstr ""
 "tidak dapat mewariskan konfigurasi pelacakan hulu banyak referensi ketika "
 "pendasaran ulang diminta"
 
-#: branch.c:88
+#: branch.c:104
 #, c-format
 msgid "not setting branch '%s' as its own upstream"
 msgstr "tidak menyetel '%s' sebagai hulunya"
 
-#: branch.c:144
+#: branch.c:160
 #, c-format
 msgid "branch '%s' set up to track '%s' by rebasing."
 msgstr "cabang '%s' disiapkan untuk melacak '%s' oleh pendasaran ulang."
 
-#: branch.c:145
+#: branch.c:161
 #, c-format
 msgid "branch '%s' set up to track '%s'."
 msgstr "cabang '%s' disiapkan untuk melacak '%s'."
 
-#: branch.c:148
+#: branch.c:164
 #, c-format
 msgid "branch '%s' set up to track:"
 msgstr "cabang '%s' disiapkan untuk melacak:"
 
-#: branch.c:160
+#: branch.c:176
 msgid "unable to write upstream branch configuration"
 msgstr "tidak dapat menulis konfigurasi cabang hulu"
 
-#: branch.c:162
+#: branch.c:178
 msgid ""
 "\n"
 "After fixing the error cause you may try to fix up\n"
@@ -1923,52 +1925,82 @@ msgstr ""
 "Setelah memperbaiki penyebab kesalahan Anda dapat mencoba memperbaiki\n"
 "informasi pelacakan remote dengan menjalankan:"
 
-#: branch.c:203
+#: branch.c:219
 #, c-format
 msgid "asked to inherit tracking from '%s', but no remote is set"
 msgstr ""
 "diminta mewariskan pelacakan dari '%s', tetapi tidak ada remote yang disetel"
 
-#: branch.c:209
+#: branch.c:225
 #, c-format
 msgid "asked to inherit tracking from '%s', but no merge configuration is set"
 msgstr ""
 "diminta mewariskan pelacakan dari '%s', tetapi tidak ada konfigurasi "
 "penggabungan yang disetel"
 
-#: branch.c:252
+#: branch.c:277
 #, c-format
-msgid "not tracking: ambiguous information for ref %s"
-msgstr "tak melacak: informasi ambigu untuk referensi %s"
+msgid "not tracking: ambiguous information for ref '%s'"
+msgstr "tak melacak: informasi ambigu untuk referensi '%s'"
 
-#: branch.c:287
+#. TRANSLATORS: This is a line listing a remote with duplicate
+#. refspecs in the advice message below. For RTL languages you'll
+#. probably want to swap the "%s" and leading "  " space around.
+#.
+#. TRANSLATORS: This is line item of ambiguous object output
+#. from describe_ambiguous_object() above. For RTL languages
+#. you'll probably want to swap the "%s" and leading " " space
+#. around.
+#.
+#: branch.c:289 object-name.c:464
+#, c-format
+msgid "  %s\n"
+msgstr ""
+
+#. TRANSLATORS: The second argument is a \n-delimited list of
+#. duplicate refspecs, composed above.
+#.
+#: branch.c:295
+#, c-format
+msgid ""
+"There are multiple remotes whose fetch refspecs map to the remote\n"
+"tracking ref '%s':\n"
+"%s\n"
+"This is typically a configuration error.\n"
+"\n"
+"To support setting up tracking branches, ensure that\n"
+"different remotes' fetch refspecs map into different\n"
+"tracking namespaces."
+msgstr ""
+
+#: branch.c:344
 #, c-format
 msgid "'%s' is not a valid branch name"
 msgstr "'%s' bukan nama cabang valid"
 
-#: branch.c:307
+#: branch.c:364
 #, c-format
 msgid "a branch named '%s' already exists"
 msgstr "sebuah cabang bernama '%s' sudah ada"
 
-#: branch.c:313
+#: branch.c:370
 #, c-format
 msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr "tidak dapat memperbarui paksa cabang '%s' yang ter-check out pada '%s'"
 
-#: branch.c:336
+#: branch.c:393
 #, c-format
 msgid "cannot set up tracking information; starting point '%s' is not a branch"
 msgstr ""
 "tidak dapat menyiapkan informasi pelacakan; titik awal '%s' bukan sebuah "
 "cabang"
 
-#: branch.c:338
+#: branch.c:395
 #, c-format
 msgid "the requested upstream branch '%s' does not exist"
 msgstr "cabang hulu yang diminta '%s' tidak ada"
 
-#: branch.c:340
+#: branch.c:397
 msgid ""
 "\n"
 "If you are planning on basing your work on an upstream\n"
@@ -1980,126 +2012,145 @@ msgid ""
 "\"git push -u\" to set the upstream config as you push."
 msgstr ""
 
-#: branch.c:384 builtin/replace.c:321 builtin/replace.c:377
+#: branch.c:445 builtin/replace.c:321 builtin/replace.c:377
 #: builtin/replace.c:423 builtin/replace.c:453
 #, c-format
 msgid "not a valid object name: '%s'"
 msgstr "bukan nama objek valid: '%s'"
 
-#: branch.c:404
+#: branch.c:465
 #, c-format
 msgid "ambiguous object name: '%s'"
 msgstr "nama objek ambigu: '%s'"
 
-#: branch.c:409
+#: branch.c:470
 #, c-format
 msgid "not a valid branch point: '%s'"
 msgstr "bukan sebuah titik cabang valid: '%s'"
 
-#: branch.c:469
+#: branch.c:658
+#, c-format
+msgid "submodule '%s': unable to find submodule"
+msgstr "submodul '%s': tidak dapat menemukan submodul"
+
+#: branch.c:661
+#, c-format
+msgid ""
+"You may try updating the submodules using 'git checkout %s && git submodule "
+"update --init'"
+msgstr ""
+"Anda dapat mencoba memperbarui submodul dengan 'git checkout %s && git "
+"submodule update --init'"
+
+#: branch.c:672 branch.c:698
+#, c-format
+msgid "submodule '%s': cannot create branch '%s'"
+msgstr "submodul '%s': tidak dapat membuat cabang '%s'"
+
+#: branch.c:730
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr "'%s' sudah di-checkout pada '%s'"
 
-#: branch.c:494
+#: branch.c:755
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD dari pohon kerja %s tidak diperbarui"
 
-#: bundle.c:44
+#: bundle.c:45
 #, c-format
 msgid "unrecognized bundle hash algorithm: %s"
 msgstr "algoritma hash bundel tidak dikenal: %s"
 
-#: bundle.c:48
+#: bundle.c:53
 #, c-format
 msgid "unknown capability '%s'"
 msgstr "kapabilitas '%s' tidak dikenal"
 
-#: bundle.c:74
+#: bundle.c:79
 #, c-format
 msgid "'%s' does not look like a v2 or v3 bundle file"
 msgstr "'%s' tidak terlihat seperti berkas bundel v2 atau v3"
 
-#: bundle.c:113
+#: bundle.c:118
 #, c-format
 msgid "unrecognized header: %s%s (%d)"
 msgstr "kepala tidak dikenal: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2620 sequencer.c:3406
-#: builtin/commit.c:862
+#: bundle.c:145 rerere.c:464 rerere.c:675 sequencer.c:2616 sequencer.c:3402
+#: builtin/commit.c:865
 #, c-format
 msgid "could not open '%s'"
 msgstr "tidak dapat membuka '%s'"
 
-#: bundle.c:198
+#: bundle.c:203
 msgid "Repository lacks these prerequisite commits:"
 msgstr "Repositori kekurangan komit prasyarat berikut:"
 
-#: bundle.c:201
+#: bundle.c:206
 msgid "need a repository to verify a bundle"
 msgstr "perlu sebuah repositori untuk verifikasi bundel"
 
-#: bundle.c:257
+#: bundle.c:264
 #, c-format
 msgid "The bundle contains this ref:"
-msgid_plural "The bundle contains these %d refs:"
+msgid_plural "The bundle contains these %<PRIuMAX> refs:"
 msgstr[0] "Bundel berisi referensi ini:"
-msgstr[1] "Bundel berisi %d referensi berikut:"
+msgstr[1] "Bundel berisi %<PRIuMAX> referensi berikut:"
 
-#: bundle.c:264
+#: bundle.c:272
 msgid "The bundle records a complete history."
 msgstr "Bundel merekam riwayat penuh."
 
-#: bundle.c:266
+#: bundle.c:274
 #, c-format
 msgid "The bundle requires this ref:"
-msgid_plural "The bundle requires these %d refs:"
+msgid_plural "The bundle requires these %<PRIuMAX> refs:"
 msgstr[0] "Bundel membutuhkan referensi ini:"
-msgstr[1] "Bundel membutuhkan %d referensi berikut:"
+msgstr[1] "Bundel membutuhkan %<PRIuMAX> referensi berikut:"
 
-#: bundle.c:333
+#: bundle.c:350
 msgid "unable to dup bundle descriptor"
 msgstr "tidak dapat men-dup pendeskripsi bundel"
 
-#: bundle.c:340
+#: bundle.c:357
 msgid "Could not spawn pack-objects"
 msgstr "Tidak dapat menghidupkan pack-objects"
 
-#: bundle.c:351
+#: bundle.c:368
 msgid "pack-objects died"
 msgstr "pack-objects mati"
 
-#: bundle.c:400
+#: bundle.c:417
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
 msgstr "referensi '%s' dikecualikan oleh opsi rev-list"
 
-#: bundle.c:504
-#, c-format
-msgid "unsupported bundle version %d"
-msgstr "versi bundle %d tidak didukung"
-
-#: bundle.c:506
-#, c-format
-msgid "cannot write bundle version %d with algorithm %s"
-msgstr "tidak dapat menulis versi bundel %d dengan algoritma %s"
-
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1953 builtin/shortlog.c:399
+#: bundle.c:533 builtin/log.c:211 builtin/log.c:1975 builtin/shortlog.c:400
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "argumen tidak dikenal: %s"
 
-#: bundle.c:553
+#: bundle.c:548
+#, c-format
+msgid "unsupported bundle version %d"
+msgstr "versi bundle %d tidak didukung"
+
+#: bundle.c:550
+#, c-format
+msgid "cannot write bundle version %d with algorithm %s"
+msgstr "tidak dapat menulis versi bundel %d dengan algoritma %s"
+
+#: bundle.c:600
 msgid "Refusing to create empty bundle."
 msgstr "Menolak memuat bundel kosong."
 
-#: bundle.c:563
+#: bundle.c:610
 #, c-format
 msgid "cannot create '%s'"
 msgstr "tidak dapat membuat '%s'"
 
-#: bundle.c:588
+#: bundle.c:639
 msgid "index-pack died"
 msgstr "index-pack mati"
 
@@ -2127,7 +2178,7 @@ msgstr ""
 msgid "invalid color value: %.*s"
 msgstr ""
 
-#: commit-graph.c:204 midx.c:51
+#: commit-graph.c:204 midx.c:52
 msgid "invalid hash version"
 msgstr ""
 
@@ -2155,234 +2206,235 @@ msgstr ""
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr ""
 
-#: commit-graph.c:482
+#: commit-graph.c:485
 msgid "commit-graph has no base graphs chunk"
 msgstr ""
 
-#: commit-graph.c:492
+#: commit-graph.c:495
 msgid "commit-graph chain does not match"
 msgstr ""
 
-#: commit-graph.c:540
+#: commit-graph.c:543
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr ""
 
-#: commit-graph.c:564
+#: commit-graph.c:567
 msgid "unable to find all commit-graph files"
 msgstr ""
 
-#: commit-graph.c:749 commit-graph.c:786
+#: commit-graph.c:752 commit-graph.c:789
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:770
+#: commit-graph.c:773
 #, c-format
 msgid "could not find commit %s"
 msgstr ""
 
-#: commit-graph.c:803
+#: commit-graph.c:806
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 
-#: commit-graph.c:1108 builtin/am.c:1369
+#: commit-graph.c:1111 builtin/am.c:1370 builtin/checkout.c:775
+#: builtin/clone.c:705
 #, c-format
 msgid "unable to parse commit %s"
 msgstr ""
 
-#: commit-graph.c:1370 builtin/pack-objects.c:3070
+#: commit-graph.c:1373 builtin/pack-objects.c:3078
 #, c-format
 msgid "unable to get type of object %s"
 msgstr ""
 
-#: commit-graph.c:1401
+#: commit-graph.c:1404
 msgid "Loading known commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1418
+#: commit-graph.c:1421
 msgid "Expanding reachable commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1438
+#: commit-graph.c:1441
 msgid "Clearing commit marks in commit graph"
 msgstr ""
 
-#: commit-graph.c:1457
+#: commit-graph.c:1460
 msgid "Computing commit graph topological levels"
 msgstr ""
 
-#: commit-graph.c:1510
+#: commit-graph.c:1513
 msgid "Computing commit graph generation numbers"
 msgstr ""
 
-#: commit-graph.c:1591
+#: commit-graph.c:1598
 msgid "Computing commit changed paths Bloom filters"
 msgstr ""
 
-#: commit-graph.c:1668
+#: commit-graph.c:1675
 msgid "Collecting referenced commits"
 msgstr ""
 
-#: commit-graph.c:1693
+#: commit-graph.c:1701
 #, c-format
-msgid "Finding commits for commit graph in %d pack"
-msgid_plural "Finding commits for commit graph in %d packs"
+msgid "Finding commits for commit graph in %<PRIuMAX> pack"
+msgid_plural "Finding commits for commit graph in %<PRIuMAX> packs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:1706
+#: commit-graph.c:1714
 #, c-format
 msgid "error adding pack %s"
 msgstr ""
 
-#: commit-graph.c:1710
+#: commit-graph.c:1718
 #, c-format
 msgid "error opening index for %s"
 msgstr ""
 
-#: commit-graph.c:1747
+#: commit-graph.c:1756
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 
-#: commit-graph.c:1765
+#: commit-graph.c:1774
 msgid "Finding extra edges in commit graph"
 msgstr ""
 
-#: commit-graph.c:1814
+#: commit-graph.c:1823
 msgid "failed to write correct number of base graph ids"
 msgstr ""
 
-#: commit-graph.c:1845 midx.c:1149
+#: commit-graph.c:1854 midx.c:1168 builtin/sparse-checkout.c:475
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr ""
 
-#: commit-graph.c:1858
+#: commit-graph.c:1868
 msgid "unable to create temporary graph layer"
 msgstr ""
 
-#: commit-graph.c:1863
+#: commit-graph.c:1873
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr ""
 
-#: commit-graph.c:1920
+#: commit-graph.c:1930
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:1956
+#: commit-graph.c:1967
 msgid "unable to open commit-graph chain file"
 msgstr ""
 
-#: commit-graph.c:1972
+#: commit-graph.c:1983
 msgid "failed to rename base commit-graph file"
 msgstr ""
 
-#: commit-graph.c:1992
+#: commit-graph.c:2004
 msgid "failed to rename temporary commit-graph file"
 msgstr ""
 
-#: commit-graph.c:2125
+#: commit-graph.c:2137
 msgid "Scanning merged commits"
 msgstr ""
 
-#: commit-graph.c:2169
+#: commit-graph.c:2181
 msgid "Merging commit-graph"
 msgstr ""
 
-#: commit-graph.c:2277
+#: commit-graph.c:2289
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 
-#: commit-graph.c:2384
+#: commit-graph.c:2396
 msgid "too many commits to write graph"
 msgstr ""
 
-#: commit-graph.c:2482
+#: commit-graph.c:2494
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:2492
+#: commit-graph.c:2504
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr ""
 
-#: commit-graph.c:2502 commit-graph.c:2517
+#: commit-graph.c:2514 commit-graph.c:2529
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 
-#: commit-graph.c:2509
+#: commit-graph.c:2521
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr ""
 
-#: commit-graph.c:2527
+#: commit-graph.c:2539
 msgid "Verifying commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:2542
+#: commit-graph.c:2554
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 
-#: commit-graph.c:2549
+#: commit-graph.c:2561
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2559
+#: commit-graph.c:2571
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 
-#: commit-graph.c:2568
+#: commit-graph.c:2580
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2582
+#: commit-graph.c:2594
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 
-#: commit-graph.c:2587
+#: commit-graph.c:2599
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2591
+#: commit-graph.c:2603
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2608
+#: commit-graph.c:2620
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 
-#: commit-graph.c:2614
+#: commit-graph.c:2626
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 
-#: commit.c:53 sequencer.c:3109 builtin/am.c:399 builtin/am.c:444
-#: builtin/am.c:449 builtin/am.c:1448 builtin/am.c:2123 builtin/replace.c:456
+#: commit.c:54 sequencer.c:3105 builtin/am.c:400 builtin/am.c:445
+#: builtin/am.c:450 builtin/am.c:1449 builtin/am.c:2124 builtin/replace.c:456
 #, c-format
 msgid "could not parse %s"
 msgstr ""
 
-#: commit.c:55
+#: commit.c:56
 #, c-format
 msgid "%s %s is not a commit!"
 msgstr ""
 
-#: commit.c:196
+#: commit.c:197
 msgid ""
 "Support for <GIT_DIR>/info/grafts is deprecated\n"
 "and will be removed in a future Git version.\n"
@@ -2394,27 +2446,27 @@ msgid ""
 "\"git config advice.graftFileDeprecated false\""
 msgstr ""
 
-#: commit.c:1241
+#: commit.c:1252
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 
-#: commit.c:1245
+#: commit.c:1256
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr ""
 
-#: commit.c:1248
+#: commit.c:1259
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr ""
 
-#: commit.c:1251
+#: commit.c:1262
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr ""
 
-#: commit.c:1505
+#: commit.c:1516
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2425,7 +2477,15 @@ msgstr ""
 msgid "memory exhausted"
 msgstr ""
 
-#: config.c:125
+#: compat/terminal.c:167
+msgid "cannot resume in the background, please use 'fg' to resume"
+msgstr ""
+
+#: compat/terminal.c:168
+msgid "cannot restore terminal settings"
+msgstr ""
+
+#: config.c:143
 #, c-format
 msgid ""
 "exceeded maximum include depth (%d) while including\n"
@@ -2440,343 +2500,370 @@ msgstr ""
 "\t%s\n"
 "Ini mungkin disebabkan oleh include sirkular."
 
-#: config.c:141
+#: config.c:159
 #, c-format
 msgid "could not expand include path '%s'"
 msgstr "tidak dapat menjabarkan jalur include '%s'"
 
-#: config.c:152
+#: config.c:170
 msgid "relative config includes must come from files"
 msgstr "include konfigurasi relatif harus dari berkas"
 
-#: config.c:201
+#: config.c:219
 msgid "relative config include conditionals must come from files"
 msgstr "kondisional include konfigurasi relative harus dari berkas"
 
-#: config.c:398
+#: config.c:364
+msgid ""
+"remote URLs cannot be configured in file directly or indirectly included by "
+"includeIf.hasconfig:remote.*.url"
+msgstr ""
+"URL remote tidak dapat dikonfigurasikan langsung di dalam berkas maupun "
+"dimasukkan secara tidak langsung oleh includeIf.hasconfig:remote.*.url"
+
+#: config.c:508
 #, c-format
 msgid "invalid config format: %s"
 msgstr "format konfigurasi tidak valid: %s"
 
-#: config.c:402
+#: config.c:512
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
 msgstr "nama variabel lingkungan untuk konfigurasi hilang '%.*s'"
 
-#: config.c:407
+#: config.c:517
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
 msgstr "variabel lingkungan '%s' untuk konfigurasi '%.*s'"
 
-#: config.c:443
+#: config.c:553
 #, c-format
 msgid "key does not contain a section: %s"
 msgstr "kunci tidak berisi bagian: %s"
 
-#: config.c:448
+#: config.c:558
 #, c-format
 msgid "key does not contain variable name: %s"
 msgstr "kunci tidak berisi nama variabel: %s"
 
-#: config.c:470 sequencer.c:2806
+#: config.c:580 sequencer.c:2802
 #, c-format
 msgid "invalid key: %s"
 msgstr "kunci tidak valid: %s"
 
-#: config.c:475
+#: config.c:585
 #, c-format
 msgid "invalid key (newline): %s"
 msgstr "kunci tidak valid (barisbaru): %s"
 
-#: config.c:495
+#: config.c:605
 msgid "empty config key"
 msgstr "kunci konfigurasi kosong"
 
-#: config.c:513 config.c:525
+#: config.c:623 config.c:635
 #, c-format
 msgid "bogus config parameter: %s"
 msgstr "parameter konfigurasi gadungan: %s"
 
-#: config.c:539 config.c:556 config.c:563 config.c:572
+#: config.c:649 config.c:666 config.c:673 config.c:682
 #, c-format
 msgid "bogus format in %s"
 msgstr "format gadungan dalam %s"
 
-#: config.c:606
+#: config.c:716
 #, c-format
 msgid "bogus count in %s"
 msgstr "hitungan gadungan dalam %s"
 
-#: config.c:610
+#: config.c:720
 #, c-format
 msgid "too many entries in %s"
 msgstr "terlalu banyak entri di %s"
 
-#: config.c:620
+#: config.c:730
 #, c-format
 msgid "missing config key %s"
 msgstr "kunci konfigurasi %s hilang"
 
-#: config.c:628
+#: config.c:738
 #, c-format
 msgid "missing config value %s"
 msgstr "nilai konfigurasi %s hilang"
 
-#: config.c:979
+#: config.c:1089
 #, c-format
 msgid "bad config line %d in blob %s"
 msgstr "baris konfigurasi %d jelek dalam blob %s"
 
-#: config.c:983
+#: config.c:1093
 #, c-format
 msgid "bad config line %d in file %s"
 msgstr "baris konfigurasi %d jelek dalam berkas %s"
 
-#: config.c:987
+#: config.c:1097
 #, c-format
 msgid "bad config line %d in standard input"
 msgstr "baris konfigurasi %d jelek pada masukan standar"
 
-#: config.c:991
+#: config.c:1101
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
 msgstr "baris konfigurasi %d jelek dalam blob submodul %s"
 
-#: config.c:995
+#: config.c:1105
 #, c-format
 msgid "bad config line %d in command line %s"
 msgstr "baris konfigurasi %d jelek pada baris perintah %s"
 
-#: config.c:999
+#: config.c:1109
 #, c-format
 msgid "bad config line %d in %s"
 msgstr "baris konfigurasi %d jelek dalam %s"
 
-#: config.c:1136
+#: config.c:1246
 msgid "out of range"
 msgstr "di luar rentang"
 
-#: config.c:1136
+#: config.c:1246
 msgid "invalid unit"
 msgstr "satuan tidak valid"
 
-#: config.c:1137
+#: config.c:1247
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s': %s"
 
-#: config.c:1147
+#: config.c:1257
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam blob %s: %s"
 
-#: config.c:1150
+#: config.c:1260
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam berkas %s: %s"
 
-#: config.c:1153
+#: config.c:1263
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr ""
 "nilai konfigurasi numerik '%s' jelek untuk '%s' pada masukan standar: %s"
 
-#: config.c:1156
+#: config.c:1266
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr ""
 "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam blob submodul %s: %s"
 
-#: config.c:1159
+#: config.c:1269
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr ""
 "nilai konfigurasi numerik '%s' jelek untuk '%s' pada baris perintah %s: %s"
 
-#: config.c:1162
+#: config.c:1272
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "nilai konfigurasi numerik '%s' jelek untuk '%s' dalam %s: %s"
 
-#: config.c:1241
+#: config.c:1368
+#, c-format
+msgid "invalid value for variable %s"
+msgstr "nilai tidak valid untuk variabel %s"
+
+#: config.c:1389
+#, c-format
+msgid "ignoring unknown core.fsync component '%s'"
+msgstr "mengabaikan komponen core.fsync tidak dikenal '%s'"
+
+#: config.c:1425
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
 msgstr "nilai konfigurasi boolean '%s' jelek untuk '%s'"
 
-#: config.c:1259
+#: config.c:1443
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "gagal menjabarkan direktori pengguna di: '%s'"
 
-#: config.c:1268
+#: config.c:1452
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "'%s' untuk '%s' bukan stempel waktu valid"
 
-#: config.c:1361
+#: config.c:1545
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "panjang singkatan di luar rentang: %d"
 
-#: config.c:1375 config.c:1386
+#: config.c:1559 config.c:1570
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "level kompresi zlib jelek %d"
 
-#: config.c:1476
+#: config.c:1660
 msgid "core.commentChar should only be one character"
 msgstr "core.commentChar harusnya hanya satu karakter"
 
-#: config.c:1509
+#: config.c:1692
+#, c-format
+msgid "ignoring unknown core.fsyncMethod value '%s'"
+msgstr "mengabaikan nilai core.fsyncMethod tidak dikenal '%s'"
+
+#: config.c:1698
+msgid "core.fsyncObjectFiles is deprecated; use core.fsync instead"
+msgstr "core.fsyncObjectFiles usang; gunakan core.fsync sebagai gantinya"
+
+#: config.c:1714
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "mode tidak valid untuk pembuatan objek: %s"
 
-#: config.c:1584
+#: config.c:1800
 #, c-format
 msgid "malformed value for %s"
 msgstr "nilai rusak untuk %s"
 
-#: config.c:1610
+#: config.c:1826
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "nilai rusak untuk %s: %s"
 
-#: config.c:1611
+#: config.c:1827
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "harus salah satu dari nothing, matching, simple, upstream atau current"
 
-#: config.c:1672 builtin/pack-objects.c:4053
+#: config.c:1888 builtin/pack-objects.c:4078
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "level kompresi pak jelek %d"
 
-#: config.c:1795
+#: config.c:2014
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "tidak dapat memuat objek blob konfigurasi '%s'"
 
-#: config.c:1798
+#: config.c:2017
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "referensi '%s' tidak menunjuk pada sebuah blob"
 
-#: config.c:1816
+#: config.c:2035
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "tidak dapat menguraikan blob konfigurasi '%s'"
 
-#: config.c:1861
+#: config.c:2080
 #, c-format
 msgid "failed to parse %s"
 msgstr "gagal menguraikan %s"
 
-#: config.c:1917
+#: config.c:2136
 msgid "unable to parse command-line config"
 msgstr "gagal menguraikan konfigurasi baris perintah"
 
-#: config.c:2285
+#: config.c:2512
 msgid "unknown error occurred while reading the configuration files"
 msgstr "error tidak diketahui ketika membaca berkas konfigurasi"
 
-#: config.c:2459
+#: config.c:2686
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s tidak valid: '%s'"
 
-#: config.c:2504
+#: config.c:2731
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr "nilai splitIndex.maxPercentChange '%d' harusnya diantara 0 dan 100"
 
-#: config.c:2550
+#: config.c:2763
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "tidak dapat menguraikan '%s' dari konfigurasi baris perintah"
 
-#: config.c:2552
+#: config.c:2765
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "variabel konfigurasi '%s' jelek dalam berkas '%s' pada baris %d"
 
-#: config.c:2637
+#: config.c:2850
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "nama bagian '%s' tidak valid"
 
-#: config.c:2669
+#: config.c:2882
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s punya banyak nilai"
 
-#: config.c:2698
+#: config.c:2911
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "gagal menulis berkas konfigurasi baru %s"
 
-#: config.c:2950 config.c:3277
+#: config.c:3177 config.c:3518
 #, c-format
 msgid "could not lock config file %s"
 msgstr "tidak dapat mengunci berkas konfigurasi %s"
 
-#: config.c:2961
+#: config.c:3188
 #, c-format
 msgid "opening %s"
 msgstr "membuka %s"
 
-#: config.c:2998 builtin/config.c:361
+#: config.c:3225 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "pola tidak valid: %s"
 
-#: config.c:3023
+#: config.c:3250
 #, c-format
 msgid "invalid config file %s"
 msgstr "berkas konfigurasi %s tidak valid"
 
-#: config.c:3036 config.c:3290
+#: config.c:3263 config.c:3531
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat pada %s gagal"
 
-#: config.c:3047
+#: config.c:3274
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "tidak dapat me-mmap '%s'%s"
 
-#: config.c:3057 config.c:3295
+#: config.c:3284 config.c:3536
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod pada %s gagal"
 
-#: config.c:3142 config.c:3392
+#: config.c:3369 config.c:3633
 #, c-format
 msgid "could not write config file %s"
 msgstr "tidak dapat menulis berkas konfigurasi %s"
 
-#: config.c:3176
+#: config.c:3403
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "tidak dapat menyetel '%s' ke '%s'"
 
-#: config.c:3178 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
+#: config.c:3405 builtin/remote.c:666 builtin/remote.c:885 builtin/remote.c:893
 #, c-format
 msgid "could not unset '%s'"
 msgstr "tidak dapat mem-batal setel '%s'"
 
-#: config.c:3268
+#: config.c:3509
 #, c-format
 msgid "invalid section name: %s"
 msgstr "nama bagian tidak valid: %s"
 
-#: config.c:3435
+#: config.c:3676
 #, c-format
 msgid "missing value for '%s'"
 msgstr "nilai hilang untuk '%s'"
 
 #: connect.c:61
 msgid "the remote end hung up upon initial contact"
-msgstr ""
+msgstr "remote berakhir menggantung saat kontak pertama"
 
 #: connect.c:63
 msgid ""
@@ -2785,84 +2872,87 @@ msgid ""
 "Please make sure you have the correct access rights\n"
 "and the repository exists."
 msgstr ""
+"Tidak dapat membaca dari repositori remote.\n"
+"\n"
+"Mohon pastikan Anda punya hak akses yang benar dan repositori ada."
 
 #: connect.c:81
 #, c-format
 msgid "server doesn't support '%s'"
-msgstr ""
+msgstr "peladen tidak mendukung '%s'"
 
 #: connect.c:118
 #, c-format
 msgid "server doesn't support feature '%s'"
-msgstr ""
+msgstr "peladen tidak mendukung fitur '%s'"
 
 #: connect.c:129
 msgid "expected flush after capabilities"
-msgstr ""
+msgstr "bilasan diharapkan setelah kemampuan"
 
 #: connect.c:265
 #, c-format
 msgid "ignoring capabilities after first line '%s'"
-msgstr ""
+msgstr "mengabaikan kemampuan setelah baris pertama '%s'"
 
 #: connect.c:286
 msgid "protocol error: unexpected capabilities^{}"
-msgstr ""
+msgstr "kesalahan protokol: capabilities^{} tidak diharapkan"
 
 #: connect.c:308
 #, c-format
 msgid "protocol error: expected shallow sha-1, got '%s'"
-msgstr ""
+msgstr "kesalahan protokol: sha-1 dangkal diharapkan, dapat '%s'"
 
 #: connect.c:310
 msgid "repository on the other end cannot be shallow"
-msgstr ""
+msgstr "repositori pada ujung lainnya tidak boleh dangkal"
 
 #: connect.c:349
 msgid "invalid packet"
-msgstr ""
+msgstr "paket tidak valid"
 
 #: connect.c:369
 #, c-format
 msgid "protocol error: unexpected '%s'"
-msgstr ""
+msgstr "kesalahan protokol: '%s' tidak diharapkan"
 
 #: connect.c:499
 #, c-format
 msgid "unknown object format '%s' specified by server"
-msgstr ""
+msgstr "format objek tidak dikenal '%s' disebutkan oleh peladen"
 
 #: connect.c:528
 #, c-format
 msgid "invalid ls-refs response: %s"
-msgstr ""
+msgstr "jawaban ls-refs tidak valid: %s"
 
 #: connect.c:532
 msgid "expected flush after ref listing"
-msgstr ""
+msgstr "bilasan diharapkan setelah penyebutan referensi"
 
 #: connect.c:535
 msgid "expected response end packet after ref listing"
-msgstr ""
+msgstr "jawaban akhir paket diharapkan setelah penyebutan referensi"
 
 #: connect.c:670
 #, c-format
 msgid "protocol '%s' is not supported"
-msgstr ""
+msgstr "protokol '%s' tidak didukung"
 
 #: connect.c:721
 msgid "unable to set SO_KEEPALIVE on socket"
-msgstr ""
+msgstr "tidak dapat menyetel SO_KEEPALIVE pada soket"
 
 #: connect.c:761 connect.c:824
 #, c-format
 msgid "Looking up %s ... "
-msgstr ""
+msgstr "Mencari %s ... "
 
 #: connect.c:765
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
-msgstr ""
+msgstr "tidak dapat mencari %s (port %s) (%s)"
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
 #: connect.c:769 connect.c:840
@@ -2871,6 +2961,8 @@ msgid ""
 "done.\n"
 "Connecting to %s (port %s) ... "
 msgstr ""
+"selesai.\n"
+"Menghubungkan ke %s (port %s) ... "
 
 #: connect.c:791 connect.c:868
 #, c-format
@@ -2878,81 +2970,85 @@ msgid ""
 "unable to connect to %s:\n"
 "%s"
 msgstr ""
+"tidak dapat menghubungkan ke %s:\n"
+"%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
 #: connect.c:797 connect.c:874
 msgid "done."
-msgstr ""
+msgstr "selesai."
 
 #: connect.c:828
 #, c-format
 msgid "unable to look up %s (%s)"
-msgstr ""
+msgstr "tidak dapat mencari %s (%s)"
 
 #: connect.c:834
 #, c-format
 msgid "unknown port %s"
-msgstr ""
+msgstr "port tidak dikenal %s"
 
 #: connect.c:971 connect.c:1303
 #, c-format
 msgid "strange hostname '%s' blocked"
-msgstr ""
+msgstr "nama host aneh '%s' diblokir"
 
 #: connect.c:973
 #, c-format
 msgid "strange port '%s' blocked"
-msgstr ""
+msgstr "port aneh '%s' diblokir"
 
 #: connect.c:983
 #, c-format
 msgid "cannot start proxy %s"
-msgstr ""
+msgstr "tidak dapat memulai proksi %s"
 
 #: connect.c:1054
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr ""
+"tidak ada jalur yang disebutkan; lihat 'git help pull' untuk sintaks url "
+"yang valid"
 
 #: connect.c:1194
 msgid "newline is forbidden in git:// hosts and repo paths"
-msgstr ""
+msgstr "baris baru dilarang di host git:// dan jalur repositori"
 
 #: connect.c:1251
 msgid "ssh variant 'simple' does not support -4"
-msgstr ""
+msgstr "varian ssh 'simple' tidak mendukung -4"
 
 #: connect.c:1263
 msgid "ssh variant 'simple' does not support -6"
-msgstr ""
+msgstr "varian ssh 'simple' tidak mendukung -6"
 
 #: connect.c:1280
 msgid "ssh variant 'simple' does not support setting port"
-msgstr ""
+msgstr "varian ssh 'simple' tidak mendukung penyetelan port"
 
 #: connect.c:1392
 #, c-format
 msgid "strange pathname '%s' blocked"
-msgstr ""
+msgstr "nama jalur aneh '%s' diblokir"
 
 #: connect.c:1440
 msgid "unable to fork"
-msgstr ""
+msgstr "tidak dapat menggarpu"
 
 #: connected.c:109 builtin/fsck.c:189 builtin/prune.c:57
 msgid "Checking connectivity"
-msgstr ""
+msgstr "Memeriksa konektivitas"
 
 #: connected.c:122
 msgid "Could not run 'git rev-list'"
-msgstr ""
+msgstr "Tidak dapat menjalankan 'git rev-list'"
 
 #: connected.c:146
 msgid "failed write to rev-list"
-msgstr ""
+msgstr "gagal menulis ke rev-list"
 
 #: connected.c:151
 msgid "failed to close rev-list's stdin"
-msgstr ""
+msgstr "gagal menutup masukan standar rev-list"
 
 #: convert.c:183
 #, c-format
@@ -3084,88 +3180,88 @@ msgstr ""
 msgid "refusing to work with credential missing protocol field"
 msgstr ""
 
-#: credential.c:395
+#: credential.c:396
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr ""
 
-#: credential.c:439
+#: credential.c:440
 #, c-format
 msgid "url has no scheme: %s"
 msgstr ""
 
-#: credential.c:512
+#: credential.c:513
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr ""
 
-#: date.c:138
+#: date.c:139
 msgid "in the future"
-msgstr ""
+msgstr "di masa depan"
 
-#: date.c:144
+#: date.c:145
 #, c-format
 msgid "%<PRIuMAX> second ago"
 msgid_plural "%<PRIuMAX> seconds ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> detik yang lalu"
+msgstr[1] "%<PRIuMAX> detik yang lalu"
 
-#: date.c:151
+#: date.c:152
 #, c-format
 msgid "%<PRIuMAX> minute ago"
 msgid_plural "%<PRIuMAX> minutes ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> menit yang lalu"
+msgstr[1] "%<PRIuMAX> menit yang lalu"
 
-#: date.c:158
+#: date.c:159
 #, c-format
 msgid "%<PRIuMAX> hour ago"
 msgid_plural "%<PRIuMAX> hours ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> jam yang lalu"
+msgstr[1] "%<PRIuMAX> jam yang lalu"
 
-#: date.c:165
+#: date.c:166
 #, c-format
 msgid "%<PRIuMAX> day ago"
 msgid_plural "%<PRIuMAX> days ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> hari yang lalu"
+msgstr[1] "%<PRIuMAX> hari yang lalu"
 
-#: date.c:171
+#: date.c:172
 #, c-format
 msgid "%<PRIuMAX> week ago"
 msgid_plural "%<PRIuMAX> weeks ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> minggu yang lalu"
+msgstr[1] "%<PRIuMAX> minggu yang lalu"
 
-#: date.c:178
+#: date.c:179
 #, c-format
 msgid "%<PRIuMAX> month ago"
 msgid_plural "%<PRIuMAX> months ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> bulan yang lalu"
+msgstr[1] "%<PRIuMAX> bulan yang lalu"
 
-#: date.c:189
+#: date.c:190
 #, c-format
 msgid "%<PRIuMAX> year"
 msgid_plural "%<PRIuMAX> years"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> tahun"
+msgstr[1] "%<PRIuMAX> tahun"
 
 #. TRANSLATORS: "%s" is "<n> years"
-#: date.c:192
+#: date.c:193
 #, c-format
 msgid "%s, %<PRIuMAX> month ago"
 msgid_plural "%s, %<PRIuMAX> months ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s, %<PRIuMAX> bulan yang lalu"
+msgstr[1] "%s, %<PRIuMAX> bulan yang lalu"
 
-#: date.c:197 date.c:202
+#: date.c:198 date.c:203
 #, c-format
 msgid "%<PRIuMAX> year ago"
 msgid_plural "%<PRIuMAX> years ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%<PRIuMAX> tahun yang lalu"
+msgstr[1] "%<PRIuMAX> tahun yang lalu"
 
 #: delta-islands.c:272
 msgid "Propagating island marks"
@@ -3191,9 +3287,13 @@ msgstr ""
 msgid "Marked %d islands, done.\n"
 msgstr ""
 
-#: diff-merges.c:70
+#: diff-merges.c:81 gpg-interface.c:719 gpg-interface.c:734 ls-refs.c:37
+#: parallel-checkout.c:42 sequencer.c:2805 setup.c:562 builtin/am.c:203
+#: builtin/am.c:2243 builtin/am.c:2287 builtin/blame.c:724 builtin/blame.c:742
+#: builtin/fetch.c:792 builtin/pack-objects.c:3515 builtin/pull.c:45
+#: builtin/pull.c:47 builtin/pull.c:321
 #, c-format
-msgid "unknown value for --diff-merges: %s"
+msgid "invalid value for '%s': '%s'"
 msgstr ""
 
 #: diff-lib.c:561
@@ -3226,17 +3326,17 @@ msgid ""
 "tree"
 msgstr ""
 
-#: diff.c:158
+#: diff.c:159
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr "  Gagal mengurai persentase potongan dirstat '%s'\n"
 
-#: diff.c:163
+#: diff.c:164
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Parameter dirstat tidak ditketahui '%s'\n"
 
-#: diff.c:299
+#: diff.c:300
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3244,7 +3344,7 @@ msgstr ""
 "Setelan warna berpindah harus salah satu dari 'no', 'default', 'blocks', "
 "'dimmed-zebra', 'plain'"
 
-#: diff.c:327
+#: diff.c:328
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3254,7 +3354,7 @@ msgstr ""
 "space-change', 'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-"
 "change'"
 
-#: diff.c:335
+#: diff.c:336
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3262,12 +3362,12 @@ msgstr ""
 "color-moved-ws: allow-indentation-change tidak dapat digabungkan dengan mode "
 "spasi yang lainnya"
 
-#: diff.c:412
+#: diff.c:413
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Nilai tidak dikenal untuk variabel konfigurasi 'diff.submodule': '%s'"
 
-#: diff.c:472
+#: diff.c:473
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3276,28 +3376,28 @@ msgstr ""
 "Ditemukan error dalam variable konfigurasi 'diff.dirstat':\n"
 "%s"
 
-#: diff.c:4237
+#: diff.c:4282
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "diff eksternal mati, berhenti pada %s"
 
-#: diff.c:4589
+#: diff.c:4677 parse-options.c:1114
 #, c-format
 msgid "options '%s', '%s', '%s', and '%s' cannot be used together"
 msgstr "Opsi '%s', '%s', '%s', dan '%s' tidak dapat digunakan bersamaan"
 
-#: diff.c:4593 builtin/difftool.c:736 builtin/log.c:1982 builtin/worktree.c:506
+#: diff.c:4681 parse-options.c:1118 builtin/worktree.c:578
 #, c-format
 msgid "options '%s', '%s', and '%s' cannot be used together"
 msgstr "Opsi '%s', '%s', dan '%s' tidak dapat digunakan bersamaan"
 
-#: diff.c:4597
+#: diff.c:4685
 #, c-format
 msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
 msgstr ""
 "opsi '%s' dan '%s' tidak dapat digunakan bersamaan, gunakan '%s' dengan '%s'"
 
-#: diff.c:4601
+#: diff.c:4689
 #, c-format
 msgid ""
 "options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
@@ -3305,22 +3405,22 @@ msgstr ""
 "opsi '%s' dan '%s' tidak dapat digunakan bersamaan, gunakan '%s' dengan '%s' "
 "dan '%s'"
 
-#: diff.c:4681
+#: diff.c:4769
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow butuh tepatnya satu spek jalur"
 
-#: diff.c:4729
+#: diff.c:4823
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "nilai --stat tidak valid: %s"
 
-#: diff.c:4734 diff.c:4739 diff.c:4744 diff.c:4749 diff.c:5277
+#: diff.c:4828 diff.c:4833 diff.c:4838 diff.c:4843 diff.c:5319
 #: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s harap nilai numerik"
 
-#: diff.c:4766
+#: diff.c:4860
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3329,42 +3429,42 @@ msgstr ""
 "Gagal menguraikan parameter opsi --dirstat/-X:\n"
 "%s"
 
-#: diff.c:4851
+#: diff.c:4893
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "kelas perubahan '%c' tidak dikenal dalam --diff-filter=%s"
 
-#: diff.c:4875
+#: diff.c:4917
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "nilai tidak dikenal setelah ws-error-highlight=%.*s"
 
-#: diff.c:4889
+#: diff.c:4931
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "tidak dapat menguraikan '%s'"
 
-#: diff.c:4939 diff.c:4945
+#: diff.c:4981 diff.c:4987
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s butuh bentuk <n>/<m>"
 
-#: diff.c:4957
+#: diff.c:4999
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s butuh sebuah karakter, dapat '%s'"
 
-#: diff.c:4978
+#: diff.c:5020
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "argumen --color-moved jelek: %s"
 
-#: diff.c:4997
+#: diff.c:5039
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "mode tidak valid '%s' dalam --color-moved-ws"
 
-#: diff.c:5037
+#: diff.c:5079
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3372,162 +3472,162 @@ msgstr ""
 "opsi diff-algorithm terima \"myers\", \"minimal\", \"patience\" dan "
 "\"histogram\""
 
-#: diff.c:5073 diff.c:5093
+#: diff.c:5115 diff.c:5135
 #, c-format
 msgid "invalid argument to %s"
 msgstr "argumen tidak valid ke %s"
 
-#: diff.c:5197
+#: diff.c:5239
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "regex tidak valid diberikan ke -I: '%s'"
 
-#: diff.c:5246
+#: diff.c:5288
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "gagal menguraikan parameter opsi --submodule: '%s'"
 
-#: diff.c:5302
+#: diff.c:5344
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "argumen --word-diff jelek: %s"
 
-#: diff.c:5338
+#: diff.c:5380
 msgid "Diff output format options"
 msgstr "Opsi format keluaran diff"
 
-#: diff.c:5340 diff.c:5346
+#: diff.c:5382 diff.c:5388
 msgid "generate patch"
 msgstr "buat tambalan"
 
-#: diff.c:5343 builtin/log.c:179
+#: diff.c:5385 builtin/log.c:180
 msgid "suppress diff output"
 msgstr "sembunyikan keluaran diff"
 
-#: diff.c:5348 diff.c:5462 diff.c:5469
+#: diff.c:5390 diff.c:5504 diff.c:5511
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5349 diff.c:5352
+#: diff.c:5391 diff.c:5394
 msgid "generate diffs with <n> lines context"
 msgstr "buat diff dengan <n> baris konteks"
 
-#: diff.c:5354
+#: diff.c:5396
 msgid "generate the diff in raw format"
 msgstr "buat diff dalam format mentah"
 
-#: diff.c:5357
+#: diff.c:5399
 msgid "synonym for '-p --raw'"
 msgstr "sinonim untuk '-p --raw'"
 
-#: diff.c:5361
+#: diff.c:5403
 msgid "synonym for '-p --stat'"
 msgstr "sinonim untuk '-p --stat'"
 
-#: diff.c:5365
+#: diff.c:5407
 msgid "machine friendly --stat"
 msgstr "--stat yang ramah mesin"
 
-#: diff.c:5368
+#: diff.c:5410
 msgid "output only the last line of --stat"
 msgstr "keluarkan hanya baris terakhir --stat"
 
-#: diff.c:5370 diff.c:5378
+#: diff.c:5412 diff.c:5420
 msgid "<param1,param2>..."
 msgstr "<parameter 1,parameter 2>..."
 
-#: diff.c:5371
+#: diff.c:5413
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "keluarkan distribusi jumlah perubahan relatif untuk setiap subdirektori"
 
-#: diff.c:5375
+#: diff.c:5417
 msgid "synonym for --dirstat=cumulative"
 msgstr "sinonim untuk --dirstat=cumulative"
 
-#: diff.c:5379
+#: diff.c:5421
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "sinonim untuk --dirstat=files,param1,param2..."
 
-#: diff.c:5383
+#: diff.c:5425
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "peringatkan bila perubahan memasukkan penanda konflik atau kesalahan spasi"
 
-#: diff.c:5386
+#: diff.c:5428
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "ringkasan singkat seperti pembuatan, penggantian nama dan perubahan mode"
 
-#: diff.c:5389
+#: diff.c:5431
 msgid "show only names of changed files"
 msgstr "perlihatkan hanya nama berkas yang berubah"
 
-#: diff.c:5392
+#: diff.c:5434
 msgid "show only names and status of changed files"
 msgstr "perlihatkan hanya nama dan status berkas yang berubah"
 
-#: diff.c:5394
+#: diff.c:5436
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<lebar>[,<nama lebar>[,<hitungan>]]"
 
-#: diff.c:5395
+#: diff.c:5437
 msgid "generate diffstat"
 msgstr "buat diffstat"
 
-#: diff.c:5397 diff.c:5400 diff.c:5403
+#: diff.c:5439 diff.c:5442 diff.c:5445
 msgid "<width>"
 msgstr "<lebar>"
 
-#: diff.c:5398
+#: diff.c:5440
 msgid "generate diffstat with a given width"
 msgstr "buat diffstat dengan lebar yang diberikan"
 
-#: diff.c:5401
+#: diff.c:5443
 msgid "generate diffstat with a given name width"
 msgstr "buat diffstat dengan nama lebar yang diberikan"
 
-#: diff.c:5404
+#: diff.c:5446
 msgid "generate diffstat with a given graph width"
 msgstr "buat diffstat dengan lebar grafik yang diberikan"
 
-#: diff.c:5406
+#: diff.c:5448
 msgid "<count>"
 msgstr "<hitungan>"
 
-#: diff.c:5407
+#: diff.c:5449
 msgid "generate diffstat with limited lines"
 msgstr "buat diffstat dengan baris yang terbatas"
 
-#: diff.c:5410
+#: diff.c:5452
 msgid "generate compact summary in diffstat"
 msgstr "buat ringkasan singkat dalam diffstat"
 
-#: diff.c:5413
+#: diff.c:5455
 msgid "output a binary diff that can be applied"
 msgstr "keluarkan diff biner yang dapat diterapkan"
 
-#: diff.c:5416
+#: diff.c:5458
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "perlihatkan objek pra- dan pasca-citra penuh pada baris \"index\""
 
-#: diff.c:5418
+#: diff.c:5460
 msgid "show colored diff"
 msgstr "perlihatkan diff berwarna"
 
-#: diff.c:5419
+#: diff.c:5461
 msgid "<kind>"
 msgstr "<tipe>"
 
-#: diff.c:5420
+#: diff.c:5462
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
 msgstr ""
 "soroti kesalahan spasi dalam baris 'context', 'old' atau 'new' dalam diff"
 
-#: diff.c:5423
+#: diff.c:5465
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3535,91 +3635,91 @@ msgstr ""
 "jangan tengkar jalur nama dan gunakan NUL sebagai pembatas bidang keluaran "
 "pada --raw atau --numstat"
 
-#: diff.c:5426 diff.c:5429 diff.c:5432 diff.c:5541
+#: diff.c:5468 diff.c:5471 diff.c:5474 diff.c:5583
 msgid "<prefix>"
 msgstr "<prefiks>"
 
-#: diff.c:5427
+#: diff.c:5469
 msgid "show the given source prefix instead of \"a/\""
 msgstr "perlihatkan prefiks sumber yang diberikan daripada \"a/\""
 
-#: diff.c:5430
+#: diff.c:5472
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "perlihatkan prefiks tujuan daripada \"b/\""
 
-#: diff.c:5433
+#: diff.c:5475
 msgid "prepend an additional prefix to every line of output"
 msgstr "tambah depan prefiks tambahan pada setiap baris keluaran"
 
-#: diff.c:5436
+#: diff.c:5478
 msgid "do not show any source or destination prefix"
 msgstr "jangan perlihatkan prefiks sumber atau tujuan apapun"
 
-#: diff.c:5439
+#: diff.c:5481
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "perlihatkan konteks diantara bingkah diff hingga jumlah baris yang disebutkan"
 
-#: diff.c:5443 diff.c:5448 diff.c:5453
+#: diff.c:5485 diff.c:5490 diff.c:5495
 msgid "<char>"
 msgstr "<karakter>"
 
-#: diff.c:5444
+#: diff.c:5486
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "sebutkan karakter yang menandai baris baru daripada '+'"
 
-#: diff.c:5449
+#: diff.c:5491
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "sebutkan karakter yang menandai baris lama daripada '-'"
 
-#: diff.c:5454
+#: diff.c:5496
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "sebutkan karakter yang menandai konteks daripada ' '"
 
-#: diff.c:5457
+#: diff.c:5499
 msgid "Diff rename options"
 msgstr "Opsi penamaan ulang diff"
 
-#: diff.c:5458
+#: diff.c:5500
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5459
+#: diff.c:5501
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "pisahkan perubahan penulisan ulang penuh kedalam pasangan penghapusan dan "
 "pembuatan"
 
-#: diff.c:5463
+#: diff.c:5505
 msgid "detect renames"
 msgstr "deteksi penamaan ulang"
 
-#: diff.c:5467
+#: diff.c:5509
 msgid "omit the preimage for deletes"
 msgstr "lewati pracitra untuk penghapusan"
 
-#: diff.c:5470
+#: diff.c:5512
 msgid "detect copies"
 msgstr "deteksi penyalinan"
 
-#: diff.c:5474
+#: diff.c:5516
 msgid "use unmodified files as source to find copies"
 msgstr ""
 "gunakan berkas tak termodifikasi sebagai sumber untuk menemukan salinan"
 
-#: diff.c:5476
+#: diff.c:5518
 msgid "disable rename detection"
 msgstr "nonaktifkan deteksi penamaan ulang"
 
-#: diff.c:5479
+#: diff.c:5521
 msgid "use empty blobs as rename source"
 msgstr "gunakan blob kosong sebagai sumber penamaan ulang"
 
-#: diff.c:5481
+#: diff.c:5523
 msgid "continue listing the history of a file beyond renames"
 msgstr "lanjutkan daftarkan riwayat berkas di luar penamaan ulang"
 
-#: diff.c:5484
+#: diff.c:5526
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3627,232 +3727,232 @@ msgstr ""
 "cegah pendeteksian penamaan ulang/penyalinan jika jumlah target penamaan "
 "ulang/penyalinan melebihi batas yang diberikan"
 
-#: diff.c:5486
+#: diff.c:5528
 msgid "Diff algorithm options"
 msgstr "Opsi algoritma diff"
 
-#: diff.c:5488
+#: diff.c:5530
 msgid "produce the smallest possible diff"
 msgstr "hasilkan diff yang paling kecil yang dimungkinkan"
 
-#: diff.c:5491
+#: diff.c:5533
 msgid "ignore whitespace when comparing lines"
 msgstr "abaikan spasi saat membandingkan baris"
 
-#: diff.c:5494
+#: diff.c:5536
 msgid "ignore changes in amount of whitespace"
 msgstr "abaikan perubahan dalam jumlah spasi"
 
-#: diff.c:5497
+#: diff.c:5539
 msgid "ignore changes in whitespace at EOL"
 msgstr "abaikan perubahan spasi pada EOL"
 
-#: diff.c:5500
+#: diff.c:5542
 msgid "ignore carrier-return at the end of line"
 msgstr "abaikan kembalian-kurir pada akhir baris"
 
-#: diff.c:5503
+#: diff.c:5545
 msgid "ignore changes whose lines are all blank"
 msgstr "abaikan perubahan yang semua baris kosong"
 
-#: diff.c:5505 diff.c:5527 diff.c:5530 diff.c:5575
+#: diff.c:5547 diff.c:5569 diff.c:5572 diff.c:5617
 msgid "<regex>"
 msgstr "<regex>"
 
-#: diff.c:5506
+#: diff.c:5548
 msgid "ignore changes whose all lines match <regex>"
 msgstr "abaikan perubahan yang semua baris cocok dengan <regex>"
 
-#: diff.c:5509
+#: diff.c:5551
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "heuristik untuk geser perbatasan bingkah diff untuk pembacaan yang mudah"
 
-#: diff.c:5512
+#: diff.c:5554
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "buat diff menggunakan algoritma \"diff sabar\""
 
-#: diff.c:5516
+#: diff.c:5558
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "buat diff menggunakan algoritma \"diff histogram\""
 
-#: diff.c:5518
+#: diff.c:5560
 msgid "<algorithm>"
 msgstr "<algoritma>"
 
-#: diff.c:5519
+#: diff.c:5561
 msgid "choose a diff algorithm"
 msgstr "pilih algoritma diff"
 
-#: diff.c:5521
+#: diff.c:5563
 msgid "<text>"
 msgstr "<teks>"
 
-#: diff.c:5522
+#: diff.c:5564
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "buat diff menggunakan algoritma \"diff terlabuh\""
 
-#: diff.c:5524 diff.c:5533 diff.c:5536
+#: diff.c:5566 diff.c:5575 diff.c:5578
 msgid "<mode>"
 msgstr "<mode>"
 
-#: diff.c:5525
+#: diff.c:5567
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "perlihatkan diff kata, menggunakan <mode> untuk batasi kata yang berubah"
 
-#: diff.c:5528
+#: diff.c:5570
 msgid "use <regex> to decide what a word is"
 msgstr "gunakan <regex> untuk menentukan apa itu kata"
 
-#: diff.c:5531
+#: diff.c:5573
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "sama dengan --word-diff=color --word-diff-regex=<regex>"
 
-#: diff.c:5534
+#: diff.c:5576
 msgid "moved lines of code are colored differently"
 msgstr "baris kode yang berpindah diwarnai berbeda"
 
-#: diff.c:5537
+#: diff.c:5579
 msgid "how white spaces are ignored in --color-moved"
 msgstr "bagaimana spasi diabaikan di --color-moved"
 
-#: diff.c:5540
+#: diff.c:5582
 msgid "Other diff options"
 msgstr "Opsi diff yang lainnya"
 
-#: diff.c:5542
+#: diff.c:5584
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "ketika dijalankan dari subdirektori, kecualikan perubahan diluar dan "
 "perlihatkan jalur relatif"
 
-#: diff.c:5546
+#: diff.c:5588
 msgid "treat all files as text"
 msgstr "perlakukan semua berkas sebagai teks"
 
-#: diff.c:5548
+#: diff.c:5590
 msgid "swap two inputs, reverse the diff"
 msgstr "tukar dua masukkan, balikkan diff"
 
-#: diff.c:5550
+#: diff.c:5592
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr "keluar dengan 1 jika ada perbedaan, selain itu 0"
 
-#: diff.c:5552
+#: diff.c:5594
 msgid "disable all output of the program"
 msgstr "nonaktifkan semua keluaran program"
 
-#: diff.c:5554
+#: diff.c:5596
 msgid "allow an external diff helper to be executed"
 msgstr "perbolehkan pembantu diff eksternal untuk dieksekusi"
 
-#: diff.c:5556
+#: diff.c:5598
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "jalankan saringan konversi teks eksternal ketika membandingkan berkas biner"
 
-#: diff.c:5558
+#: diff.c:5600
 msgid "<when>"
 msgstr "<kapan>"
 
-#: diff.c:5559
+#: diff.c:5601
 msgid "ignore changes to submodules in the diff generation"
 msgstr "abaikan perubahan submodul dalam pembuatan diff"
 
-#: diff.c:5562
+#: diff.c:5604
 msgid "<format>"
 msgstr "<format>"
 
-#: diff.c:5563
+#: diff.c:5605
 msgid "specify how differences in submodules are shown"
 msgstr "sebutkan bagaimana perbedaan dalam submodul diperlihatkan"
 
-#: diff.c:5567
+#: diff.c:5609
 msgid "hide 'git add -N' entries from the index"
 msgstr "sembunyikan entri 'git add -N' dari indeks"
 
-#: diff.c:5570
+#: diff.c:5612
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "perlakukan entri 'git add -N' sebagai nyata dalam indeks"
 
-#: diff.c:5572
+#: diff.c:5614
 msgid "<string>"
 msgstr "<untai>"
 
-#: diff.c:5573
+#: diff.c:5615
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr "cari perbedaan yang mengubah jumlah kemunculan untai yang disebutkan"
 
-#: diff.c:5576
+#: diff.c:5618
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
 msgstr "cari perbedaan yang mengubah jumlah kemunculan regex yang disebutkan"
 
-#: diff.c:5579
+#: diff.c:5621
 msgid "show all changes in the changeset with -S or -G"
 msgstr "perlihatkan semua perubahan dalam set perubahan dengan -S atau -G"
 
-#: diff.c:5582
+#: diff.c:5624
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "perlakukan <string> di -S sebagai ekspresi reguler POSIX yang diperluas"
 
-#: diff.c:5585
+#: diff.c:5627
 msgid "control the order in which files appear in the output"
 msgstr "kontrol urutan berkas yang muncul dalam keluaran"
 
-#: diff.c:5586 diff.c:5589
+#: diff.c:5628 diff.c:5631
 msgid "<path>"
 msgstr "<jalur>"
 
-#: diff.c:5587
+#: diff.c:5629
 msgid "show the change in the specified path first"
 msgstr "perlihatkan perubahan dalam jalur yang disebutkan terlebih dahulu"
 
-#: diff.c:5590
+#: diff.c:5632
 msgid "skip the output to the specified path"
 msgstr "lewati keluaran ke jalur yang disebutkan"
 
-#: diff.c:5592
+#: diff.c:5634
 msgid "<object-id>"
 msgstr "<id objek>"
 
-#: diff.c:5593
+#: diff.c:5635
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
 msgstr "cari perubahan yang mengubah jumlah kemunculan objek yang disebutkan"
 
-#: diff.c:5595
+#: diff.c:5637
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5596
+#: diff.c:5638
 msgid "select files by diff type"
 msgstr "pilih berkas oleh tipe diff"
 
-#: diff.c:5598
+#: diff.c:5640
 msgid "<file>"
 msgstr "<berkas>"
 
-#: diff.c:5599
-msgid "Output to a specific file"
-msgstr "Keluarkan ke berkas yang disebutkan"
+#: diff.c:5641
+msgid "output to a specific file"
+msgstr "keluarkan ke berkas yang disebutkan"
 
-#: diff.c:6257
+#: diff.c:6321
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr "deteksi penamaan ulang lengkap dilewati karena terlalu banyak berkas."
 
-#: diff.c:6260
+#: diff.c:6324
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "hanya ditemukan salinan dari jalur yang berubah karena terlalu banyak berkas."
 
-#: diff.c:6263
+#: diff.c:6327
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3903,20 +4003,20 @@ msgstr ""
 msgid "cannot use %s as an exclude file"
 msgstr ""
 
-#: dir.c:2418
+#: dir.c:2419
 #, c-format
 msgid "could not open directory '%s'"
 msgstr ""
 
-#: dir.c:2720
+#: dir.c:2721
 msgid "failed to get kernel name and information"
 msgstr ""
 
-#: dir.c:2844
+#: dir.c:2846
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 
-#: dir.c:3112
+#: dir.c:3119
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -3924,17 +4024,17 @@ msgstr ""
 "Nama direktori tidak dapat ditebak.\n"
 "Mohon sebutkan direktori pada baris perintah"
 
-#: dir.c:3800
+#: dir.c:3807
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr ""
 
-#: dir.c:3847 dir.c:3852
+#: dir.c:3854 dir.c:3859
 #, c-format
 msgid "could not create directories for %s"
 msgstr ""
 
-#: dir.c:3881
+#: dir.c:3888
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr ""
@@ -3953,7 +4053,7 @@ msgstr ""
 msgid "could not stat file '%s'"
 msgstr ""
 
-#: environment.c:145
+#: environment.c:147
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr ""
@@ -3984,248 +4084,275 @@ msgstr "git fetch-pack: ACK/NAK diharapkan, dapat '%s'"
 msgid "unable to write to remote"
 msgstr "tidak dapat menulis ke remote"
 
-#: fetch-pack.c:395 fetch-pack.c:1439
+#: fetch-pack.c:397 fetch-pack.c:1460
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "baris dangkal tidak valid: %s"
 
-#: fetch-pack.c:401 fetch-pack.c:1445
+#: fetch-pack.c:403 fetch-pack.c:1466
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "baris dangkal-balik tidak valid: %s"
 
-#: fetch-pack.c:403 fetch-pack.c:1447
+#: fetch-pack.c:405 fetch-pack.c:1468
 #, c-format
 msgid "object not found: %s"
 msgstr "object tidak ditemukan: %s"
 
-#: fetch-pack.c:406 fetch-pack.c:1450
+#: fetch-pack.c:408 fetch-pack.c:1471
 #, c-format
 msgid "error in object: %s"
 msgstr "kesalahan dalam objek: %s"
 
-#: fetch-pack.c:408 fetch-pack.c:1452
+#: fetch-pack.c:410 fetch-pack.c:1473
 #, c-format
 msgid "no shallow found: %s"
 msgstr "tidak ada dangkal yang ditemukan: %s"
 
-#: fetch-pack.c:411 fetch-pack.c:1456
+#: fetch-pack.c:413 fetch-pack.c:1477
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "dangkal/dangkal-balik diharapkan, dapat %s"
 
-#: fetch-pack.c:451
+#: fetch-pack.c:453
 #, c-format
 msgid "got %s %d %s"
 msgstr "dapat %s %d %s"
 
-#: fetch-pack.c:468
+#: fetch-pack.c:470
 #, c-format
 msgid "invalid commit %s"
 msgstr "komit tidak valid %s"
 
-#: fetch-pack.c:499
+#: fetch-pack.c:501
 msgid "giving up"
 msgstr "menyerah"
 
-#: fetch-pack.c:512 progress.c:339
+#: fetch-pack.c:514 progress.h:25
 msgid "done"
 msgstr "selesai"
 
-#: fetch-pack.c:524
+#: fetch-pack.c:526
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "dapat %s (%d) %s"
 
-#: fetch-pack.c:560
+#: fetch-pack.c:562
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Menandai %s sebagai lengkap"
 
-#: fetch-pack.c:775
+#: fetch-pack.c:784
 #, c-format
 msgid "already have %s (%s)"
 msgstr "sudah punya %s (%s)"
 
-#: fetch-pack.c:861
+#: fetch-pack.c:870
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: tidak dapat menggarpu pemultipleks-balik pita samping"
 
-#: fetch-pack.c:869
+#: fetch-pack.c:878
 msgid "protocol error: bad pack header"
 msgstr "kesalahan protokol: kepala pak jelek"
 
-#: fetch-pack.c:965
+#: fetch-pack.c:974
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: tidak dapat menggarpu %s"
 
-#: fetch-pack.c:971
+#: fetch-pack.c:980
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: keluaran index-pack tidak valid"
 
-#: fetch-pack.c:988
+#: fetch-pack.c:997
 #, c-format
 msgid "%s failed"
 msgstr "%s gagal"
 
-#: fetch-pack.c:990
+#: fetch-pack.c:999
 msgid "error in sideband demultiplexer"
 msgstr "kesalahan dalam pemultipleks-balik pita samping"
 
-#: fetch-pack.c:1035
+#: fetch-pack.c:1048
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Versi peladen %.*s"
 
-#: fetch-pack.c:1043 fetch-pack.c:1049 fetch-pack.c:1052 fetch-pack.c:1058
-#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
-#: fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086 fetch-pack.c:1090
-#: fetch-pack.c:1096 fetch-pack.c:1102 fetch-pack.c:1107 fetch-pack.c:1112
+#: fetch-pack.c:1056 fetch-pack.c:1062 fetch-pack.c:1065 fetch-pack.c:1071
+#: fetch-pack.c:1075 fetch-pack.c:1079 fetch-pack.c:1083 fetch-pack.c:1087
+#: fetch-pack.c:1091 fetch-pack.c:1095 fetch-pack.c:1099 fetch-pack.c:1103
+#: fetch-pack.c:1109 fetch-pack.c:1115 fetch-pack.c:1120 fetch-pack.c:1125
 #, c-format
 msgid "Server supports %s"
 msgstr "Peladen mendukung %s"
 
-#: fetch-pack.c:1045
+#: fetch-pack.c:1058
 msgid "Server does not support shallow clients"
 msgstr "Peladen tidak mendukung klien dangkal"
 
-#: fetch-pack.c:1105
+#: fetch-pack.c:1118
 msgid "Server does not support --shallow-since"
 msgstr "Peladen tidak mendukung --shallow-since"
 
-#: fetch-pack.c:1110
+#: fetch-pack.c:1123
 msgid "Server does not support --shallow-exclude"
 msgstr "Peladen tidak mendukung --shallow-exclude"
 
-#: fetch-pack.c:1114
+#: fetch-pack.c:1127
 msgid "Server does not support --deepen"
 msgstr "Peladen tidak mendukung --deepen"
 
-#: fetch-pack.c:1116
+#: fetch-pack.c:1129
 msgid "Server does not support this repository's object format"
 msgstr "Peladen tidak mendukung objek format repositori ini"
 
-#: fetch-pack.c:1129
+#: fetch-pack.c:1142
 msgid "no common commits"
 msgstr "tidak ada komit umum"
 
-#: fetch-pack.c:1138 fetch-pack.c:1485 builtin/clone.c:1130
+#: fetch-pack.c:1151 fetch-pack.c:1506 builtin/clone.c:1166
 msgid "source repository is shallow, reject to clone."
 msgstr "repositori sumber dangkal, menolak mengkloning."
 
-#: fetch-pack.c:1144 fetch-pack.c:1681
+#: fetch-pack.c:1157 fetch-pack.c:1705
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: pengambilan gagal."
 
-#: fetch-pack.c:1258
+#: fetch-pack.c:1271
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "algoritma tidak cocok: klien %s; peladen %s"
 
-#: fetch-pack.c:1262
+#: fetch-pack.c:1275
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "peladen tidak mendukung algoritma '%s'"
 
-#: fetch-pack.c:1295
+#: fetch-pack.c:1308
 msgid "Server does not support shallow requests"
 msgstr "Peladen tidak mendukung permintaan dangkal"
 
-#: fetch-pack.c:1302
+#: fetch-pack.c:1315
 msgid "Server supports filter"
 msgstr "Peladen mendukung saringan"
 
-#: fetch-pack.c:1345 fetch-pack.c:2063
+#: fetch-pack.c:1358 fetch-pack.c:2087
 msgid "unable to write request to remote"
 msgstr "tidak dapat menulis permintaan kepada remote"
 
-#: fetch-pack.c:1363
+#: fetch-pack.c:1376
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "kesalahan membaca kepala seksi '%s'"
 
-#: fetch-pack.c:1369
+#: fetch-pack.c:1382
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "diharapkan '%s', diterima '%s'"
 
-#: fetch-pack.c:1403
+#: fetch-pack.c:1416
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "baris pengakuan tidak diharapkan: %s"
 
-#: fetch-pack.c:1408
+#: fetch-pack.c:1421
 #, c-format
 msgid "error processing acks: %d"
 msgstr "kesalahan memproses ack: %d"
 
-#: fetch-pack.c:1418
-msgid "expected packfile to be sent after 'ready'"
-msgstr "berkas pak diharapkan dikirim setelah 'ready'"
+#. TRANSLATORS: The parameter will be 'ready', a protocol
+#. keyword.
+#.
+#: fetch-pack.c:1435
+#, c-format
+msgid "expected packfile to be sent after '%s'"
+msgstr "berkas pak diharapkan dikirim setelah '%s'"
 
-#: fetch-pack.c:1420
-msgid "expected no other sections to be sent after no 'ready'"
+#. TRANSLATORS: The parameter will be 'ready', a protocol
+#. keyword.
+#.
+#: fetch-pack.c:1441
+#, c-format
+msgid "expected no other sections to be sent after no '%s'"
 msgstr ""
-"tidak ada seksi lainnya yang diharapkan dikirim setelah tidak ada 'ready'"
+"tidak ada bagian lainnya yang diharapkan dikirim setelah tidak ada '%s'"
 
-#: fetch-pack.c:1461
+#: fetch-pack.c:1482
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "gagal memproses info dangkal: %d"
 
-#: fetch-pack.c:1510
+#: fetch-pack.c:1531
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref diharapkan, dapat '%s'"
 
-#: fetch-pack.c:1515
+#: fetch-pack.c:1536
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "wanted-ref tidak diharapkan: '%s'"
 
-#: fetch-pack.c:1520
+#: fetch-pack.c:1541
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "kesalahan memproses referensi yang diminta: %d"
 
-#: fetch-pack.c:1550
+#: fetch-pack.c:1571
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: paket jawaban akhir diharapkan"
 
-#: fetch-pack.c:1959
+#: fetch-pack.c:1983
 msgid "no matching remote head"
 msgstr "tidak ada kepala remote yang cocok"
 
-#: fetch-pack.c:1982 builtin/clone.c:581
+#: fetch-pack.c:2006 builtin/clone.c:587
 msgid "remote did not send all necessary objects"
 msgstr "remote tidak mengirim semua objek yang dibutuhkan"
 
-#: fetch-pack.c:2085
+#: fetch-pack.c:2109
 msgid "unexpected 'ready' from remote"
 msgstr "'ready' tidak diharapkan dari remote"
 
-#: fetch-pack.c:2108
+#: fetch-pack.c:2132
 #, c-format
 msgid "no such remote ref %s"
 msgstr "tidak ada referensi remote seperti %s"
 
-#: fetch-pack.c:2111
+#: fetch-pack.c:2135
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Peladen tidak memperbolehkan permintaan untuk objek tak diiklankan %s"
 
-#: gpg-interface.c:329 gpg-interface.c:457 gpg-interface.c:974
-#: gpg-interface.c:990
+#: fsmonitor-ipc.c:119
+#, c-format
+msgid "fsmonitor_ipc__send_query: invalid path '%s'"
+msgstr ""
+
+#: fsmonitor-ipc.c:125
+#, c-format
+msgid "fsmonitor_ipc__send_query: unspecified error on '%s'"
+msgstr ""
+
+#: fsmonitor-ipc.c:155
+msgid "fsmonitor--daemon is not running"
+msgstr ""
+
+#: fsmonitor-ipc.c:164
+#, c-format
+msgid "could not send '%s' command to fsmonitor--daemon"
+msgstr ""
+
+#: gpg-interface.c:329 gpg-interface.c:456 gpg-interface.c:995
+#: gpg-interface.c:1011
 msgid "could not create temporary file"
 msgstr "tidak dapat membuat berkas sementara"
 
-#: gpg-interface.c:332 gpg-interface.c:460
+#: gpg-interface.c:332 gpg-interface.c:459
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "gagal menulis tandatangan terlepas ke '%s'"
 
-#: gpg-interface.c:451
+#: gpg-interface.c:450
 msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
@@ -4233,7 +4360,7 @@ msgstr ""
 "gpg.ssh.allowedSignersFile perlu dikonfigurasi dan ada untuk verifikasi "
 "tandatangan ssh"
 
-#: gpg-interface.c:480
+#: gpg-interface.c:479
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
@@ -4241,57 +4368,57 @@ msgstr ""
 "ssh-keygen -Y find-principals/verify diperlukan untuk verifikasi tandatangan "
 "ssh (tersedia di openssh versi 8.2p1+)"
 
-#: gpg-interface.c:536
+#: gpg-interface.c:550
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
 msgstr ""
 "berkas pencabutan penandatanganan ssh terkonfigurasi tapi tidak ada: %s"
 
-#: gpg-interface.c:624
+#: gpg-interface.c:638
 #, c-format
 msgid "bad/incompatible signature '%s'"
 msgstr "tanda tangan '%s' jelek/tidak kompatibel"
 
-#: gpg-interface.c:801 gpg-interface.c:806
+#: gpg-interface.c:815 gpg-interface.c:820
 #, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
 msgstr "gagal mendapatkan sidik jari ssh untuk kunci '%s'"
 
-#: gpg-interface.c:829
+#: gpg-interface.c:843
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
 msgstr ""
 "baik user.signingkey atau gpg.ssh.defaultKeyCommand perlu dikonfigurasi"
 
-#: gpg-interface.c:851
+#: gpg-interface.c:865
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
 msgstr "gpg.ssh.defaultKeyCommand sukses tapi tidak mengembalikan kunci: %s %s"
 
-#: gpg-interface.c:857
+#: gpg-interface.c:871
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
 msgstr "gpg.ssh.defaultKeyCommand gagal: %s %s"
 
-#: gpg-interface.c:945
+#: gpg-interface.c:966
 msgid "gpg failed to sign the data"
 msgstr "gpg gagal menandatangani data"
 
-#: gpg-interface.c:967
+#: gpg-interface.c:988
 msgid "user.signingkey needs to be set for ssh signing"
 msgstr "user.signingkey perlu disetel untuk penandatanganan ssh"
 
-#: gpg-interface.c:978
+#: gpg-interface.c:999
 #, c-format
 msgid "failed writing ssh signing key to '%s'"
 msgstr "gagal menulis kunci penandatanganan ssh ke '%s'"
 
-#: gpg-interface.c:996
+#: gpg-interface.c:1017
 #, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
 msgstr "gagal menulis penyangga kunci penandatanganan ssh ke '%s'"
 
-#: gpg-interface.c:1014
+#: gpg-interface.c:1035
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
@@ -4299,7 +4426,7 @@ msgstr ""
 "ssh-keygen -Y sign diperlukan untuk penandatanganan ssh (tersedia di "
 "openssh  versi 8.2p1+)"
 
-#: gpg-interface.c:1026
+#: gpg-interface.c:1047
 #, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
 msgstr "gagal membaca penyangga data penandatanganan ssh dari '%s'"
@@ -4309,7 +4436,7 @@ msgstr "gagal membaca penyangga data penandatanganan ssh dari '%s'"
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "warna tidak valid '%.*s' diabaikan di log.graphColors"
 
-#: grep.c:531
+#: grep.c:446
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4317,109 +4444,109 @@ msgstr ""
 "pola yang diberikan berisi bita NULL (via -f <berkas>). Hal ini hanya "
 "didukung dengan -P di bawah PCRE v2"
 
-#: grep.c:1942
+#: grep.c:1859
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': tidak dapat membaca %s"
 
-#: grep.c:1959 setup.c:177 builtin/clone.c:302 builtin/diff.c:90
+#: grep.c:1876 setup.c:177 builtin/clone.c:308 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "gagal men-stat '%s'"
 
-#: grep.c:1970
+#: grep.c:1887
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': baca pendek"
 
-#: help.c:24
+#: help.c:25
 msgid "start a working area (see also: git help tutorial)"
 msgstr "mulai area kerja (lihat pula: git help tutorial)"
 
-#: help.c:25
+#: help.c:26
 msgid "work on the current change (see also: git help everyday)"
 msgstr "bekerja pada perubahan saat ini (lihat pula: git help everyday)"
 
-#: help.c:26
+#: help.c:27
 msgid "examine the history and state (see also: git help revisions)"
 msgstr "periksa riwayat dan keadaan (lihat pula: git help revisions)"
 
-#: help.c:27
+#: help.c:28
 msgid "grow, mark and tweak your common history"
 msgstr "tumbuhkan, tandai, dan cubit riwayat umum Anda"
 
-#: help.c:28
+#: help.c:29
 msgid "collaborate (see also: git help workflows)"
 msgstr "kolaborasi (lihat pula: git help workflows)"
 
-#: help.c:32
+#: help.c:33
 msgid "Main Porcelain Commands"
 msgstr "Perintah Porselen Utama"
 
-#: help.c:33
+#: help.c:34
 msgid "Ancillary Commands / Manipulators"
 msgstr "Perintah Tambahan / Peubah"
 
-#: help.c:34
+#: help.c:35
 msgid "Ancillary Commands / Interrogators"
 msgstr "Perintah Tambahan / Pemeriksa"
 
-#: help.c:35
+#: help.c:36
 msgid "Interacting with Others"
 msgstr "Berinteraksi dengan yang Lain"
 
-#: help.c:36
+#: help.c:37
 msgid "Low-level Commands / Manipulators"
 msgstr "Perintah Tingkat Rendah / Peubah"
 
-#: help.c:37
+#: help.c:38
 msgid "Low-level Commands / Interrogators"
 msgstr "Perintah Tingkat Rendah / Pemeriksa"
 
-#: help.c:38
+#: help.c:39
 msgid "Low-level Commands / Syncing Repositories"
 msgstr "Perintah Tingkat Rendah / Sinkronisasi Repositori"
 
-#: help.c:39
+#: help.c:40
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Perintah Tingak Rendah / Pembantu Internal"
 
-#: help.c:313
+#: help.c:316
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "perintah git yang tersedia di '%s'"
 
-#: help.c:320
+#: help.c:323
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "perintah git yang tersedia dari tempat lain pada $PATH Anda"
 
-#: help.c:329
+#: help.c:332
 msgid "These are common Git commands used in various situations:"
 msgstr "Berikut ini perintah Git umum yang digunakan dalam beragam situasi:"
 
-#: help.c:378 git.c:100
+#: help.c:382 git.c:100
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "tipe daftar perintah '%s' tidak didukung"
 
-#: help.c:418
+#: help.c:422
 msgid "The Git concept guides are:"
 msgstr "Panduan konsep Git adalah:"
 
-#: help.c:442
-msgid "See 'git help <command>' to read about a specific subcommand"
-msgstr "Lihat 'git help <perintah>' untuk baca tentang subperintah spesifik"
-
-#: help.c:447
+#: help.c:446
 msgid "External commands"
 msgstr "Perintah eksternal"
 
-#: help.c:462
+#: help.c:468
 msgid "Command aliases"
 msgstr "Alias perintah"
 
-#: help.c:543
+#: help.c:486
+msgid "See 'git help <command>' to read about a specific subcommand"
+msgstr "Lihat 'git help <perintah>' untuk baca tentang subperintah spesifik"
+
+#: help.c:563
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4428,36 +4555,36 @@ msgstr ""
 "'%s' sepertinya perintah git, tetapi kami tidak dapat\n"
 "menjalankannya. Mungkin git-%s rusak?"
 
-#: help.c:565 help.c:662
+#: help.c:585 help.c:682
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: '%s' bukan perintah git. Lihat 'git --help'."
 
-#: help.c:613
+#: help.c:633
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Eh oh. Sistem Anda melaporkan tidak ada perintah Git sama sekali."
 
-#: help.c:635
+#: help.c:655
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr "PERINGATAN: Anda memanggil perintah Git bernama '%s' yang tidak ada."
 
-#: help.c:640
+#: help.c:660
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Melanjutkan di bawah asumsi bahwa maksud Anda '%s'."
 
-#: help.c:646
+#: help.c:666
 #, c-format
 msgid "Run '%s' instead [y/N]? "
-msgstr ""
+msgstr "Jalankan '%s' sebagai gantinya [y/N]?"
 
-#: help.c:654
+#: help.c:674
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Melanjutkan dalam %0.1f detik, mengasumsikan bahwa maksud Anda '%s'."
 
-#: help.c:666
+#: help.c:686
 msgid ""
 "\n"
 "The most similar command is"
@@ -4471,16 +4598,16 @@ msgstr[1] ""
 "\n"
 "Perintah paling mirip adalah"
 
-#: help.c:706
+#: help.c:729
 msgid "git version [<options>]"
 msgstr "git version [<opsi>]"
 
-#: help.c:761
+#: help.c:784
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:765
+#: help.c:788
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4494,22 +4621,30 @@ msgstr[1] ""
 "\n"
 "Mungkin maksud Anda salah satu dari yang ini?"
 
-#: hook.c:27
+#: hook.c:28
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
 "You can disable this warning with `git config advice.ignoredHook false`."
 msgstr ""
+"Kait '%s' diabaikan karena tidak disetel sebagai dapat dieksekusi.\n"
+"Anda dapat menonaktifkan peringatan ini dengan `git config advice."
+"ignoredHook false`."
 
-#: ident.c:353
+#: hook.c:87
+#, c-format
+msgid "Couldn't start hook '%s'\n"
+msgstr "Tidak dapat memulai kait '%s'\n"
+
+#: ident.c:354
 msgid "Author identity unknown\n"
-msgstr ""
+msgstr "Identitas pengarang tidak dikenal\n"
 
-#: ident.c:356
+#: ident.c:357
 msgid "Committer identity unknown\n"
-msgstr ""
+msgstr "Identitas pengkomit tidak dikenal\n"
 
-#: ident.c:362
+#: ident.c:363
 msgid ""
 "\n"
 "*** Please tell me who you are.\n"
@@ -4523,72 +4658,83 @@ msgid ""
 "Omit --global to set the identity only in this repository.\n"
 "\n"
 msgstr ""
+"\n"
+"*** Mohon beri tahu saya siapa Anda.\n"
+"\n"
+"Jalankan\n"
+"\n"
+"  git config --global user.email \"anda@example.com\"\n"
+"  git config --global user.name \"Nama Anda\"\n"
+"\n"
+"untuk menyetel identitas asali akun Anda.\n"
+"Abaikan --global untuk menyetel identitas hanya di dalam repositori ini.\n"
+"\n"
 
-#: ident.c:397
+#: ident.c:398
 msgid "no email was given and auto-detection is disabled"
-msgstr ""
+msgstr "tidak ada email yang diberikan dan deteksi otomatis dimatikan"
 
-#: ident.c:402
+#: ident.c:403
 #, c-format
 msgid "unable to auto-detect email address (got '%s')"
-msgstr ""
+msgstr "tidak dapat mendeteksi otomatis alamat email (dapat '%s')"
 
-#: ident.c:419
+#: ident.c:420
 msgid "no name was given and auto-detection is disabled"
-msgstr ""
+msgstr "tidak ada nama yang diberikan dan deteksi otomatis dimatikan"
 
-#: ident.c:425
+#: ident.c:426
 #, c-format
 msgid "unable to auto-detect name (got '%s')"
-msgstr ""
+msgstr "tidak dapat mendeteksi otomatis nama (dapat '%s')"
 
-#: ident.c:433
+#: ident.c:434
 #, c-format
 msgid "empty ident name (for <%s>) not allowed"
-msgstr ""
+msgstr "nama identitas kosong (untuk <%s>) tidak diperbolehkan"
 
-#: ident.c:439
+#: ident.c:440
 #, c-format
 msgid "name consists only of disallowed characters: %s"
-msgstr ""
+msgstr "nama hanya terdiri dari karakter yang tidak diperbolehkan: %s"
 
-#: ident.c:454 builtin/commit.c:648
+#: ident.c:455 builtin/commit.c:649
 #, c-format
 msgid "invalid date format: %s"
-msgstr ""
+msgstr "format tanggal tidak valid: %s"
 
-#: list-objects-filter-options.c:83
+#: list-objects-filter-options.c:68
 msgid "expected 'tree:<depth>'"
 msgstr ""
 
-#: list-objects-filter-options.c:98
+#: list-objects-filter-options.c:83
 msgid "sparse:path filters support has been dropped"
 msgstr ""
 
-#: list-objects-filter-options.c:105
+#: list-objects-filter-options.c:90
 #, c-format
 msgid "'%s' for 'object:type=<type>' is not a valid object type"
 msgstr ""
 
-#: list-objects-filter-options.c:124
+#: list-objects-filter-options.c:109
 #, c-format
 msgid "invalid filter-spec '%s'"
 msgstr ""
 
-#: list-objects-filter-options.c:140
+#: list-objects-filter-options.c:125
 #, c-format
 msgid "must escape char in sub-filter-spec: '%c'"
 msgstr ""
 
-#: list-objects-filter-options.c:182
+#: list-objects-filter-options.c:167
 msgid "expected something after combine:"
 msgstr ""
 
-#: list-objects-filter-options.c:264
+#: list-objects-filter-options.c:249
 msgid "multiple filter-specs cannot be combined"
 msgstr ""
 
-#: list-objects-filter-options.c:376
+#: list-objects-filter-options.c:365
 msgid "unable to upgrade repository format to support partial clone"
 msgstr ""
 
@@ -4602,17 +4748,17 @@ msgstr ""
 msgid "unable to parse sparse filter data in %s"
 msgstr ""
 
-#: list-objects.c:127
+#: list-objects.c:144
 #, c-format
 msgid "entry '%s' in tree %s has tree mode, but is not a tree"
 msgstr ""
 
-#: list-objects.c:140
+#: list-objects.c:157
 #, c-format
 msgid "entry '%s' in tree %s has blob mode, but is not a blob"
 msgstr ""
 
-#: list-objects.c:398
+#: list-objects.c:415
 #, c-format
 msgid "unable to load root tree for commit %s"
 msgstr ""
@@ -4634,17 +4780,12 @@ msgstr ""
 msgid "Unable to create '%s.lock': %s"
 msgstr ""
 
-#: ls-refs.c:37
-#, c-format
-msgid "invalid value '%s' for lsrefs.unborn"
-msgstr ""
-
-#: ls-refs.c:174
+#: ls-refs.c:175
 #, c-format
 msgid "unexpected line: '%s'"
 msgstr ""
 
-#: ls-refs.c:178
+#: ls-refs.c:179
 msgid "expected flush after ls-refs arguments"
 msgstr ""
 
@@ -4652,44 +4793,48 @@ msgstr ""
 msgid "quoted CRLF detected"
 msgstr ""
 
-#: mailinfo.c:1254 builtin/am.c:184 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:185 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr ""
 
-#: merge-ort.c:1584 merge-recursive.c:1211
+#: merge-ort.c:1630 merge-recursive.c:1214
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
-msgstr ""
+msgstr "Gagal menggabungkan submodul %s (tidak di-checkout)"
 
-#: merge-ort.c:1593 merge-recursive.c:1218
+#: merge-ort.c:1639 merge-recursive.c:1221
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
-msgstr ""
+msgstr "Gagal menggabungkan submodul %s (komit tidak ada)"
 
-#: merge-ort.c:1602 merge-recursive.c:1225
+#: merge-ort.c:1648 merge-recursive.c:1228
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
+"Gagal menggabungkan submodul %s (komit tidak mengikuti dasar penggabungan)"
 
-#: merge-ort.c:1612 merge-ort.c:1620
+#: merge-ort.c:1658 merge-ort.c:1666
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
-msgstr ""
+msgstr "Catatan: Memaju-cepat submodul %s ke %s"
 
-#: merge-ort.c:1642
+#: merge-ort.c:1688
 #, c-format
 msgid "Failed to merge submodule %s"
-msgstr ""
+msgstr "Gagal menggabungkan submodul %s"
 
-#: merge-ort.c:1649
+#: merge-ort.c:1695
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
 "%s\n"
 msgstr ""
+"Gagal menggabungkan submodul %s, tetapi sebuah penyelesaian penggabungan "
+"yang mungkin ada:\n"
+"%s\n"
 
-#: merge-ort.c:1653 merge-recursive.c:1281
+#: merge-ort.c:1699 merge-recursive.c:1284
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4699,610 +4844,689 @@ msgid ""
 "\n"
 "which will accept this suggestion.\n"
 msgstr ""
+"Jika benar, cukup misalkan tambahkan ke indeks dengan menggunakan:\n"
+"\n"
+"  git update-index --cacheinfo 160000 %s \"%s\"\n"
+"\n"
+"yang akan menerima saran ini.\n"
 
-#: merge-ort.c:1666
+#: merge-ort.c:1712
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
+"Gagal menggabungkan submodul %s, tetapi ada banyak penggabungan yang "
+"mungkin:\n"
+"%s"
 
-#: merge-ort.c:1887 merge-recursive.c:1372
+#: merge-ort.c:1937 merge-recursive.c:1375
 msgid "Failed to execute internal merge"
-msgstr ""
+msgstr "Gagal menjalankan penggabungan internal"
 
-#: merge-ort.c:1892 merge-recursive.c:1377
+#: merge-ort.c:1942 merge-recursive.c:1380
 #, c-format
 msgid "Unable to add %s to database"
-msgstr ""
+msgstr "Tidak dapat menambahkan %s ke basis data"
 
-#: merge-ort.c:1899 merge-recursive.c:1410
+#: merge-ort.c:1949 merge-recursive.c:1413
 #, c-format
 msgid "Auto-merging %s"
-msgstr ""
+msgstr "Menggabungkan otomatis %s"
 
-#: merge-ort.c:2038 merge-recursive.c:2132
+#: merge-ort.c:2088 merge-recursive.c:2135
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
 "implicit directory rename(s) putting the following path(s) there: %s."
 msgstr ""
+"KONFLIK (penamaan ulang direktori implisit): Berkas/direktori yang sudah ada "
+"pada %s saat penamaan ulang direktori menempatkan jalur berikut di sana: %s."
 
-#: merge-ort.c:2048 merge-recursive.c:2142
+#: merge-ort.c:2098 merge-recursive.c:2145
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
 "implicit directory renames tried to put these paths there: %s"
 msgstr ""
+"KONFLIK (penamaan ulang direktori implisit): Tidak dapat memetakan lebih "
+"dari satu jalur ke %s; penamaan ulang direktori implisit mencoba menempatkan "
+"jalur tersebut di sana: %s"
 
-#: merge-ort.c:2106
+#: merge-ort.c:2156
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
 "renamed to multiple other directories, with no destination getting a "
 "majority of the files."
 msgstr ""
+"KONFLIK (pemecahan penamaan ulang direktori): Tidak jelas kemana menamakan "
+"ulang %s; itu dinamai ulang ke banyak direktori lainnya, dengan tiada tujuan "
+"mendapatkan mayoritas berkas."
 
-#: merge-ort.c:2260 merge-recursive.c:2478
+#: merge-ort.c:2310 merge-recursive.c:2481
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
 "renamed."
 msgstr ""
+"PERINGATAN: Menghindari menerapkan penamaan ulang %s -> %s ke %s, karena %s-"
+"nya sendiri dinamai ulang."
 
-#: merge-ort.c:2400 merge-recursive.c:3261
+#: merge-ort.c:2450 merge-recursive.c:3264
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
 "moving it to %s."
 msgstr ""
+"Jalur diperbarui: %s menambahkan %s di dalam sebuah direktori yang dinamai "
+"ulang di %s; memindahkan ke %s."
 
-#: merge-ort.c:2407 merge-recursive.c:3268
+#: merge-ort.c:2457 merge-recursive.c:3271
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
 "%s; moving it to %s."
 msgstr ""
+"Jalur diperbarui: %s dinamai ulang ke %s di %s, di dalam sebuah direktori "
+"yang dinamai ulang di %s; memindahkan ke %s."
 
-#: merge-ort.c:2420 merge-recursive.c:3264
+#: merge-ort.c:2470 merge-recursive.c:3267
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
 "in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
+"KONFLIK (lokasi berkas): %s menambahkan %s di dalam sebuah direktori yang "
+"dinamai ulang di %s, menyarankan mungkin dipindahkan ke %s."
 
-#: merge-ort.c:2428 merge-recursive.c:3271
+#: merge-ort.c:2478 merge-recursive.c:3274
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
 "was renamed in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
+"KONFLIK (lokasi berkas): %s dinamai ulang ke %s di %s, di dalam sebuah "
+"direktori yang dinamai ulang di %s, menyarankan mungkin dipindahkan ke %s. "
 
-#: merge-ort.c:2584
+#: merge-ort.c:2634
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
+"KONFLIK (penamaan ulang/penamaan ulang): %s dinamai ulang ke %s di %s dan ke "
+"%s di %s."
 
-#: merge-ort.c:2679
+#: merge-ort.c:2729
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
 "conflicts AND collides with another path; this may result in nested conflict "
 "markers."
 msgstr ""
+"KONFLIK (penamaan ulang terlibat di dalam tabrakan): penamaan ulang %s -> %s "
+"punya konflik konten DAN bertabrakan dengan jalur yang lain; ini mungkin "
+"menghasilkan penanda konflik bersarang."
 
-#: merge-ort.c:2698 merge-ort.c:2722
+#: merge-ort.c:2748 merge-ort.c:2772
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
+"KONFLIK (penamaan ulang/penghapusan): %s dinamai ulang ke %s di %s, tetapi "
+"dihapus di %s."
 
-#: merge-ort.c:3212 merge-recursive.c:3022
+#: merge-ort.c:3261 merge-recursive.c:3025
 #, c-format
 msgid "cannot read object %s"
-msgstr ""
+msgstr "tidak dapat membaca objek %s"
 
-#: merge-ort.c:3215 merge-recursive.c:3025
+#: merge-ort.c:3264 merge-recursive.c:3028
 #, c-format
 msgid "object %s is not a blob"
-msgstr ""
+msgstr "objek %s bukanlah sebuah blob"
 
-#: merge-ort.c:3644
+#: merge-ort.c:3693
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
 msgstr ""
+"KONFLIK (berkas/direktori): direktori di jalan %s dari %s; memindahkan ke %s "
+"sebagai gantinya."
 
-#: merge-ort.c:3721
+#: merge-ort.c:3770
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
 "of them so each can be recorded somewhere."
 msgstr ""
+"KONFLIK (tipe berbeda): %s punya tipe berbeda pada setiap sisi; kedua-duanya "
+"dinamai ulang sehingga masing-masing dapat direkam di suatu tempat."
 
-#: merge-ort.c:3728
+#: merge-ort.c:3777
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
 "of them so each can be recorded somewhere."
 msgstr ""
+"KONFLIK (tipe berbeda): %s punya tipe berbeda pada setiap sisi; salah "
+"satunya dinamai ulang sehingga masing-masing dapat direkam di suatu tempat."
 
-#: merge-ort.c:3819 merge-recursive.c:3101
+#: merge-ort.c:3866 merge-recursive.c:3104
 msgid "content"
-msgstr ""
+msgstr "konten"
 
-#: merge-ort.c:3821 merge-recursive.c:3105
+#: merge-ort.c:3868 merge-recursive.c:3108
 msgid "add/add"
-msgstr ""
+msgstr "penambahan/penambahan"
 
-#: merge-ort.c:3823 merge-recursive.c:3150
+#: merge-ort.c:3870 merge-recursive.c:3153
 msgid "submodule"
-msgstr ""
+msgstr "submodul"
 
-#: merge-ort.c:3825 merge-recursive.c:3151
+#: merge-ort.c:3872 merge-recursive.c:3154
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
-msgstr ""
+msgstr "KONFLIK (%s): Konflik penggabungan di %s"
 
-#: merge-ort.c:3869
+#: merge-ort.c:3916
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
 "of %s left in tree."
 msgstr ""
+"KONFLIK (pengubahan/penghapusan): %s dihapus di %s dan diubah di %s. Versi "
+"%s dari %s ditinggalkan di dalam pohon."
 
-#: merge-ort.c:4165
+#: merge-ort.c:4212
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
 "copy renamed to %s"
 msgstr ""
+"Catatan: %s tidak terbaru dan dalam men-checkout versi berkonflik; salinan "
+"lama dinamai ulang ke %s"
 
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4534
+#: merge-ort.c:4586
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
-msgstr ""
+msgstr "pengumpulan info penggabungan gagal untuk pohon %s, %s, dan %s"
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3716
+#: merge-ort-wrappers.c:13 merge-recursive.c:3723
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "  %s"
 msgstr ""
+"Perubahan lokal Anda terhadap berkas berikut akan ditimpa oleh "
+"penggabungan:\n"
+"  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:405
+#: merge-ort-wrappers.c:33 merge-recursive.c:3485 builtin/merge.c:405
 msgid "Already up to date."
 msgstr "Sudah terbaru."
 
 #: merge-recursive.c:353
 msgid "(bad commit)\n"
-msgstr ""
+msgstr "(komit jelek)\n"
 
 #: merge-recursive.c:381
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
-msgstr ""
+msgstr "add_cacheinfo gagal untuk jalur '%s'; penggabungan dibatalkan."
 
 #: merge-recursive.c:390
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
+"add_cacheinfo gagal menyegarkan untuk jalur '%s'; penggabungan dibatalkan."
 
 #: merge-recursive.c:881
 #, c-format
 msgid "failed to create path '%s'%s"
-msgstr ""
+msgstr "gagal membuat jalur '%s'%s"
 
 #: merge-recursive.c:892
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
-msgstr ""
+msgstr "Menghapus %s untuk membuat ruang untuk subdirektori\n"
 
 #: merge-recursive.c:906 merge-recursive.c:925
 msgid ": perhaps a D/F conflict?"
-msgstr ""
+msgstr ": mungkin konflik direktori/berkas?"
 
 #: merge-recursive.c:915
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
-msgstr ""
+msgstr "menolak menghilangkan berkas tak terlacak pada '%s'"
 
-#: merge-recursive.c:956 builtin/cat-file.c:41
+#: merge-recursive.c:956 builtin/cat-file.c:47
 #, c-format
 msgid "cannot read object %s '%s'"
-msgstr ""
+msgstr "tidak dapat membaca objek %s '%s'"
 
 #: merge-recursive.c:961
 #, c-format
 msgid "blob expected for %s '%s'"
-msgstr ""
+msgstr "blob diharapkan untuk %s '%s'"
 
 #: merge-recursive.c:986
 #, c-format
 msgid "failed to open '%s': %s"
-msgstr ""
+msgstr "gagal membuka '%s': %s"
 
 #: merge-recursive.c:997
 #, c-format
 msgid "failed to symlink '%s': %s"
-msgstr ""
+msgstr "gagal menautkan simbolik '%s': %s"
 
 #: merge-recursive.c:1002
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
-msgstr ""
-
-#: merge-recursive.c:1233 merge-recursive.c:1246
-#, c-format
-msgid "Fast-forwarding submodule %s to the following commit:"
-msgstr ""
+msgstr "tidak tahu apa yang dilakukan dengan %06o %s '%s'"
 
 #: merge-recursive.c:1236 merge-recursive.c:1249
 #, c-format
-msgid "Fast-forwarding submodule %s"
-msgstr ""
+msgid "Fast-forwarding submodule %s to the following commit:"
+msgstr "Memaju-cepat submodul %s ke komit berikut:"
 
-#: merge-recursive.c:1273
+#: merge-recursive.c:1239 merge-recursive.c:1252
+#, c-format
+msgid "Fast-forwarding submodule %s"
+msgstr "Memaju-cepat submodul %s"
+
+#: merge-recursive.c:1276
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
+"Gagal menggabungkan submodul %s (penggabungan komit berikutnya tidak "
+"ditemukan)"
 
-#: merge-recursive.c:1277
+#: merge-recursive.c:1280
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
-msgstr ""
+msgstr "Gagal menggabungkan submodul %s (bukan maju-cepat)"
 
-#: merge-recursive.c:1278
+#: merge-recursive.c:1281
 msgid "Found a possible merge resolution for the submodule:\n"
-msgstr ""
+msgstr "Sebuah resolusi penggabungan yang mungkin ditemukan untuk submodul:\n"
 
-#: merge-recursive.c:1290
+#: merge-recursive.c:1293
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
-msgstr ""
+msgstr "Gagal menggabungkan submodul %s (banyak penggabungan ditemukan)"
 
-#: merge-recursive.c:1434
+#: merge-recursive.c:1437
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
+"Kesalahan: Menolak menghilangkan berkas tak terlacak pada %s; menulis ke %s "
+"sebagai gantinya."
 
-#: merge-recursive.c:1506
+#: merge-recursive.c:1509
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
 "in tree."
 msgstr ""
+"KONFLIK (%s/penghapusan): %s dihapus di %s dan %s di %s. Versi %s dari %s "
+"ditinggalkan di dalam pohon."
 
-#: merge-recursive.c:1511
+#: merge-recursive.c:1514
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
 "left in tree."
 msgstr ""
+"KONFLIK (%s/penghapusan): %s dihapus di %s dan %s ke %s di %s. Versi %s dari "
+"%s ditinggalkan di dalam pohon."
 
-#: merge-recursive.c:1518
+#: merge-recursive.c:1521
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
 "in tree at %s."
 msgstr ""
+"KONFLIK (%s/penghapusan): %s dihapus di %s dan %s di %s. Versi %s dari %s "
+"ditinggalkan di dalam pohon pada %s."
 
-#: merge-recursive.c:1523
+#: merge-recursive.c:1526
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
 "left in tree at %s."
 msgstr ""
+"KONFLIK (%s/penghapusan): %s dihapus di %s dan %s ke %s di %s. Versi %s dari "
+"%s ditinggalkan di dalam pohon pada %s."
 
-#: merge-recursive.c:1558
+#: merge-recursive.c:1561
 msgid "rename"
-msgstr ""
+msgstr "penamaan ulang"
 
-#: merge-recursive.c:1558
+#: merge-recursive.c:1561
 msgid "renamed"
-msgstr ""
+msgstr "dinamai ulang"
 
-#: merge-recursive.c:1609 merge-recursive.c:2515 merge-recursive.c:3178
+#: merge-recursive.c:1612 merge-recursive.c:2518 merge-recursive.c:3181
 #, c-format
 msgid "Refusing to lose dirty file at %s"
-msgstr ""
+msgstr "Menolak menghilangkan berkas kotor pada %s"
 
-#: merge-recursive.c:1619
+#: merge-recursive.c:1622
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
+"Menolak menghilangkan berkas tak terlacak pada %s, bahkan jika itu berjalan."
 
-#: merge-recursive.c:1677
+#: merge-recursive.c:1680
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
+"KONFLIK (penamaan ulang/penambahan): Penamaan ulang %s-%s di %s. %s "
+"ditambahkan di %s"
 
-#: merge-recursive.c:1708
+#: merge-recursive.c:1711
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr ""
+"%s adalah sebuah direktori dalam %s menambahkan sebagai %s sebagai gantinya"
 
-#: merge-recursive.c:1713
+#: merge-recursive.c:1716
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
+"Menolak menghilangkan berkas tak terlacak pada %s; menambahkan sebagai %s "
+"sebagai gantinya"
 
-#: merge-recursive.c:1740
+#: merge-recursive.c:1743
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
 "\"->\"%s\" in \"%s\"%s"
 msgstr ""
+"KONFLIK (penamaan ulang/penamaan ulang): Penamaan ulang \"%s\"->\"%s\" di "
+"dalam cabang \"%s\" penamaan ulang \"%s\"->\"%s\" di \"%s\"%s"
 
-#: merge-recursive.c:1745
+#: merge-recursive.c:1748
 msgid " (left unresolved)"
-msgstr ""
+msgstr " dibiarkan tak diselesaikan"
 
-#: merge-recursive.c:1837
+#: merge-recursive.c:1840
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
+"KONFLIK (penamaan ulang/penamaan ulang): Penamaan ulang %s->%s di %s. "
+"Penamaan ulang %s->%s di %s"
 
-#: merge-recursive.c:2100
+#: merge-recursive.c:2103
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
 "directory %s was renamed to multiple other directories, with no destination "
 "getting a majority of the files."
 msgstr ""
+"KONFLIK (pemecahan penamaan ulang direktori): Tidak jelas dimana untuk "
+"menempatkan %s karena direktori %s dinamai ulang ke banyak direktori "
+"lainnya, dengan tidak ada tujuan yang mendapatkan mayoritas berkas."
 
-#: merge-recursive.c:2234
+#: merge-recursive.c:2237
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
 ">%s in %s"
 msgstr ""
+"KONFLIK (penamaan ulang/penamaan ulang): Penamaan ulang direktori %s->%s di "
+"%s. Penamaan ulang %s->%s di %s"
 
-#: merge-recursive.c:3089
+#: merge-recursive.c:3092
 msgid "modify"
-msgstr ""
+msgstr "ubah"
 
-#: merge-recursive.c:3089
+#: merge-recursive.c:3092
 msgid "modified"
-msgstr ""
+msgstr "diubah"
 
-#: merge-recursive.c:3128
+#: merge-recursive.c:3131
 #, c-format
 msgid "Skipped %s (merged same as existing)"
-msgstr ""
+msgstr "%s dilewatkan (digabungkan sama seperti yang ada)"
 
-#: merge-recursive.c:3181
+#: merge-recursive.c:3184
 #, c-format
 msgid "Adding as %s instead"
-msgstr ""
+msgstr "Menambahkan sebagai %s sebagai gantinya"
 
-#: merge-recursive.c:3385
+#: merge-recursive.c:3388
 #, c-format
 msgid "Removing %s"
-msgstr ""
+msgstr "Menghapus %s"
 
-#: merge-recursive.c:3408
+#: merge-recursive.c:3411
 msgid "file/directory"
-msgstr ""
+msgstr "berkas/direktori"
 
-#: merge-recursive.c:3413
+#: merge-recursive.c:3416
 msgid "directory/file"
-msgstr ""
+msgstr "direktori/berkas"
 
-#: merge-recursive.c:3420
+#: merge-recursive.c:3423
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
+"KONFLIK (%s): Ada direktori dengan nama %s di %s. Menambahakn %s sebagai %s"
 
-#: merge-recursive.c:3429
+#: merge-recursive.c:3432
 #, c-format
 msgid "Adding %s"
-msgstr ""
+msgstr "Menambahkan %s"
 
-#: merge-recursive.c:3438
+#: merge-recursive.c:3441
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
-msgstr ""
+msgstr "KONFLIK (penambahan/penambahan): Konflik penggabungan di %s"
 
-#: merge-recursive.c:3491
+#: merge-recursive.c:3494
 #, c-format
 msgid "merging of trees %s and %s failed"
-msgstr ""
+msgstr "penggabungan pohon %s dan %s gagal"
 
-#: merge-recursive.c:3585
+#: merge-recursive.c:3588
 msgid "Merging:"
-msgstr ""
+msgstr "Menggabungkan:"
 
-#: merge-recursive.c:3598
+#: merge-recursive.c:3601
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%u leluhur umum ditemukan:"
+msgstr[1] "%u leluhur umum ditemukan:"
 
-#: merge-recursive.c:3648
+#: merge-recursive.c:3651
 msgid "merge returned no commit"
-msgstr ""
+msgstr "penggabungan tidak mengembalikan komit"
 
-#: merge-recursive.c:3816
+#: merge-recursive.c:3823
 #, c-format
 msgid "Could not parse object '%s'"
-msgstr ""
+msgstr "Tidak dapat menguraikan objek '%s'"
 
-#: merge-recursive.c:3834 builtin/merge.c:720 builtin/merge.c:906
+#: merge-recursive.c:3841 builtin/merge.c:720 builtin/merge.c:912
 #: builtin/stash.c:489
 msgid "Unable to write index."
-msgstr ""
+msgstr "Tidak dapat menulis indeks."
 
 #: merge.c:41
 msgid "failed to read the cache"
 msgstr "gagal membaca tembolok"
 
-#: merge.c:102 rerere.c:704 builtin/am.c:1988 builtin/am.c:2022
-#: builtin/checkout.c:598 builtin/checkout.c:853 builtin/clone.c:706
+#: merge.c:102 rerere.c:705 builtin/am.c:1989 builtin/am.c:2023
+#: builtin/checkout.c:603 builtin/checkout.c:865 builtin/clone.c:714
 #: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "gagal menulis berkas indeks baru"
 
-#: midx.c:78
+#: midx.c:79
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "OID kipas-keluar indeks multipak salah ukuran"
 
-#: midx.c:111
+#: midx.c:112
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "berkas indeks multipak %s terlalu kecil"
 
-#: midx.c:127
+#: midx.c:128
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "tanda tangan indeks multipak 0x%08x tidak cocok dengan tanda tangan 0x%08x"
 
-#: midx.c:132
+#: midx.c:133
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "versi indeks multipak %d tidak dikenal"
 
-#: midx.c:137
+#: midx.c:138
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "versi hash indeks multipak %u tidak cocok dengan versi %u"
 
-#: midx.c:154
+#: midx.c:155
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "indeks multipak kehilangan bingkah pack-name yang diperlukan"
 
-#: midx.c:156
+#: midx.c:157
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "indeks multipak kehilangan bingkah OID kipas keluar yang diperlukan"
 
-#: midx.c:158
+#: midx.c:159
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "indeks multipak kehilangan bingkah pencarian OID yang diperlukan"
 
-#: midx.c:160
+#: midx.c:161
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "indeks multipak kehilangan bingkah offset objek yang diperlukan"
 
-#: midx.c:176
+#: midx.c:180
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "nama pak indeks multipak tidak berurutan: '%s' sebelum '%s'"
 
-#: midx.c:224
+#: midx.c:228
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "pack-int-id jelek: %u (total pak %u)"
 
-#: midx.c:274
+#: midx.c:278
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr "indeks multipak simpan offset 64-bit, tapi off_t terlalu kecil"
 
-#: midx.c:505
+#: midx.c:509
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "gagal menambah berkas pak '%s'"
 
-#: midx.c:511
+#: midx.c:515
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "gagal membuka indeks pak '%s'"
 
-#: midx.c:579
+#: midx.c:583
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "gagal melokasi objek %d di dalam berkas pak"
 
-#: midx.c:895
+#: midx.c:911
 msgid "cannot store reverse index file"
 msgstr "tidak dapat menyimpan berkas indeks balik"
 
-#: midx.c:993
+#: midx.c:1009
 #, c-format
 msgid "could not parse line: %s"
 msgstr "tidak dapat menguraikan baris: %s"
 
-#: midx.c:995
+#: midx.c:1011
 #, c-format
 msgid "malformed line: %s"
 msgstr "baris jelek '%s'."
 
-#: midx.c:1162
+#: midx.c:1181
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr "abaikan indeks multipak yang sudah ada; checksum tidak cocok"
 
-#: midx.c:1187
+#: midx.c:1206
 msgid "could not load pack"
 msgstr "tidak dapat memuat pak"
 
-#: midx.c:1193
+#: midx.c:1212
 #, c-format
 msgid "could not open index for %s"
 msgstr "tidak dapat membuka indeks untuk %s"
 
-#: midx.c:1204
+#: midx.c:1223
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Menambahkan berkas pak ke indeks multipak"
 
-#: midx.c:1247
+#: midx.c:1266
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "pak yang disukai tidak dikenal: '%s'"
 
-#: midx.c:1292
+#: midx.c:1311
 #, c-format
 msgid "cannot select preferred pack %s with no objects"
 msgstr "tidak dapat memilih pak yang disukai %s tanpa objek"
 
-#: midx.c:1324
+#: midx.c:1343
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "tidak melihat berkas pak %s untuk dijeblokkan"
 
-#: midx.c:1370
+#: midx.c:1389
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "pak yang disukai '%s' kadaluarsa"
 
-#: midx.c:1383
+#: midx.c:1402
 msgid "no pack files to index."
 msgstr "tidak ada berkas pak untuk diindeks."
 
-#: midx.c:1420
+#: midx.c:1409
+msgid "refusing to write multi-pack .bitmap without any objects"
+msgstr "menolak menulis .bitmap multipak tanpa objek apapun"
+
+#: midx.c:1451
 msgid "could not write multi-pack bitmap"
 msgstr "tidak dapat menulis bitmap multipak"
 
-#: midx.c:1430
+#: midx.c:1461
 msgid "could not write multi-pack-index"
 msgstr "gagal menulis indeks multipak"
 
-#: midx.c:1489 builtin/clean.c:37
+#: midx.c:1520 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "gagal menghapus %s"
 
-#: midx.c:1522
+#: midx.c:1553
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "gagal membersihkan indeks multipak pada %s"
 
-#: midx.c:1585
+#: midx.c:1616
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "berkas indeks multipak ada, tetapi gagal diurai"
 
-#: midx.c:1593
+#: midx.c:1624
 msgid "incorrect checksum"
 msgstr "checksum salah"
 
-#: midx.c:1596
+#: midx.c:1627
 msgid "Looking for referenced packfiles"
 msgstr "Mencari berkas pak yang direferensikan"
 
-#: midx.c:1611
+#: midx.c:1642
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5310,55 +5534,55 @@ msgstr ""
 "kipas-keluar oid tidak berurutan: fanout[%d] =%<PRIx32> > %<PRIx32> = "
 "fanout[%d]"
 
-#: midx.c:1616
+#: midx.c:1647
 msgid "the midx contains no oid"
 msgstr "midx tidak berisi oid"
 
-#: midx.c:1625
+#: midx.c:1656
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Memverifikasi urutan OID di dalam indeks multipak"
 
-#: midx.c:1634
+#: midx.c:1665
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "urutan pencarian oid tidak berurutan: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1654
+#: midx.c:1685
 msgid "Sorting objects by packfile"
 msgstr "Mengurutkan objek oleh berkas pak"
 
-#: midx.c:1661
+#: midx.c:1692
 msgid "Verifying object offsets"
 msgstr "Memverifikasi offset objek"
 
-#: midx.c:1677
+#: midx.c:1708
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "gagal memuat entri pak untuk oid[%d] = %s"
 
-#: midx.c:1683
+#: midx.c:1714
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "gagal memuat indeks pak untuk berkas pak %s"
 
-#: midx.c:1692
+#: midx.c:1723
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "offset objek salah untuk oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1719
+#: midx.c:1750
 msgid "Counting referenced objects"
 msgstr "Menghitung objek tereferensi"
 
-#: midx.c:1729
+#: midx.c:1760
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Mencari dan menghapus berkas pak tak tereferensi"
 
-#: midx.c:1921
+#: midx.c:1952
 msgid "could not start pack-objects"
 msgstr "tidak dapat memulai pack-objects"
 
-#: midx.c:1941
+#: midx.c:1972
 msgid "could not finish pack-objects"
 msgstr "tidak dapat menyelesaikan pack-objects"
 
@@ -5377,7 +5601,7 @@ msgstr ""
 msgid "unable to join lazy_name thread: %s"
 msgstr ""
 
-#: notes-merge.c:277
+#: notes-merge.c:276
 #, c-format
 msgid ""
 "You have not concluded your previous notes merge (%s exists).\n"
@@ -5385,7 +5609,7 @@ msgid ""
 "commit/abort the previous merge before you start a new notes merge."
 msgstr ""
 
-#: notes-merge.c:284
+#: notes-merge.c:283
 #, c-format
 msgid "You have not concluded your notes merge (%s exists)."
 msgstr ""
@@ -5413,271 +5637,340 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr ""
 
-#: object-file.c:456
+#: object-file.c:457
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 
-#: object-file.c:514
+#: object-file.c:515
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr ""
 
-#: object-file.c:588
+#: object-file.c:589
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr ""
 
-#: object-file.c:595
+#: object-file.c:596
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr ""
 
-#: object-file.c:638
+#: object-file.c:639
 msgid "unable to fdopen alternates lockfile"
 msgstr ""
 
-#: object-file.c:656
+#: object-file.c:657
 msgid "unable to read alternates file"
 msgstr ""
 
-#: object-file.c:663
+#: object-file.c:664
 msgid "unable to move new alternates file into place"
 msgstr ""
 
-#: object-file.c:741
+#: object-file.c:742
 #, c-format
 msgid "path '%s' does not exist"
 msgstr ""
 
-#: object-file.c:762
+#: object-file.c:763
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 
-#: object-file.c:768
+#: object-file.c:769
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr ""
 
-#: object-file.c:774
+#: object-file.c:775
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr ""
 
-#: object-file.c:782
+#: object-file.c:783
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr ""
 
-#: object-file.c:813
+#: object-file.c:814
 #, c-format
 msgid "could not find object directory matching %s"
 msgstr ""
 
-#: object-file.c:863
+#: object-file.c:864
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr ""
 
-#: object-file.c:1013
+#: object-file.c:1014
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr ""
 
-#: object-file.c:1048
+#: object-file.c:1049
 #, c-format
 msgid "mmap failed%s"
 msgstr ""
 
-#: object-file.c:1214
+#: object-file.c:1230
 #, c-format
 msgid "object file %s is empty"
 msgstr ""
 
-#: object-file.c:1333 object-file.c:2542
+#: object-file.c:1349 object-file.c:2588
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr ""
 
-#: object-file.c:1335 object-file.c:2546
+#: object-file.c:1351 object-file.c:2592
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr ""
 
-#: object-file.c:1457
+#: object-file.c:1473
 #, c-format
 msgid "unable to parse %s header"
 msgstr ""
 
-#: object-file.c:1459
+#: object-file.c:1475
 msgid "invalid object type"
 msgstr ""
 
-#: object-file.c:1470
+#: object-file.c:1486
 #, c-format
 msgid "unable to unpack %s header"
 msgstr ""
 
-#: object-file.c:1474
+#: object-file.c:1490
 #, c-format
 msgid "header for %s too long, exceeds %d bytes"
 msgstr ""
 
-#: object-file.c:1704
+#: object-file.c:1720
 #, c-format
 msgid "failed to read object %s"
 msgstr ""
 
-#: object-file.c:1708
+#: object-file.c:1724
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr ""
 
-#: object-file.c:1712
+#: object-file.c:1728
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr ""
 
-#: object-file.c:1716
+#: object-file.c:1732
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr ""
 
-#: object-file.c:1821
+#: object-file.c:1855
 #, c-format
 msgid "unable to write file %s"
 msgstr ""
 
-#: object-file.c:1828
+#: object-file.c:1862
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr ""
 
-#: object-file.c:1835
+#: object-file.c:1869
 msgid "file write error"
 msgstr ""
 
-#: object-file.c:1858
+#: object-file.c:1904
 msgid "error when closing loose object file"
 msgstr ""
 
-#: object-file.c:1925
+#: object-file.c:1971
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 
-#: object-file.c:1927
+#: object-file.c:1973
 msgid "unable to create temporary file"
 msgstr ""
 
-#: object-file.c:1951
+#: object-file.c:1997
 msgid "unable to write loose object file"
 msgstr ""
 
-#: object-file.c:1957
+#: object-file.c:2003
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr ""
 
-#: object-file.c:1961
+#: object-file.c:2007
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr ""
 
-#: object-file.c:1965
+#: object-file.c:2011
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr ""
 
-#: object-file.c:1976 builtin/pack-objects.c:1243
+#: object-file.c:2022 builtin/pack-objects.c:1251
 #, c-format
 msgid "failed utime() on %s"
 msgstr ""
 
-#: object-file.c:2054
+#: object-file.c:2100
 #, c-format
 msgid "cannot read object for %s"
 msgstr ""
 
-#: object-file.c:2105
+#: object-file.c:2151
 msgid "corrupt commit"
 msgstr ""
 
-#: object-file.c:2113
+#: object-file.c:2159
 msgid "corrupt tag"
 msgstr ""
 
-#: object-file.c:2213
+#: object-file.c:2259
 #, c-format
 msgid "read error while indexing %s"
 msgstr ""
 
-#: object-file.c:2216
+#: object-file.c:2262
 #, c-format
 msgid "short read while indexing %s"
 msgstr ""
 
-#: object-file.c:2289 object-file.c:2299
+#: object-file.c:2335 object-file.c:2345
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr ""
 
-#: object-file.c:2305
+#: object-file.c:2351
 #, c-format
 msgid "%s: unsupported file type"
 msgstr ""
 
-#: object-file.c:2329 builtin/fetch.c:1453
+#: object-file.c:2375 builtin/fetch.c:1494
 #, c-format
 msgid "%s is not a valid object"
 msgstr ""
 
-#: object-file.c:2331
+#: object-file.c:2377
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr ""
 
-#: object-file.c:2358
+#: object-file.c:2404
 #, c-format
 msgid "unable to open %s"
 msgstr "tidak dapat membuka %s"
 
-#: object-file.c:2553
+#: object-file.c:2599
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr ""
 
-#: object-file.c:2576
+#: object-file.c:2622
 #, c-format
 msgid "unable to mmap %s"
 msgstr ""
 
-#: object-file.c:2582
+#: object-file.c:2628
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr ""
 
-#: object-file.c:2587
+#: object-file.c:2633
 #, c-format
 msgid "unable to parse header of %s"
 msgstr ""
 
-#: object-file.c:2598
+#: object-file.c:2644
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr ""
 
-#: object-name.c:480
+#. TRANSLATORS: This is a line of ambiguous object
+#. output shown when we cannot look up or parse the
+#. object in question. E.g. "deadbeef [bad object]".
+#.
+#: object-name.c:382
+#, c-format
+msgid "%s [bad object]"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous commit
+#. object output. E.g.:
+#. *
+#.    "deadbeef commit 2021-01-01 - Some Commit Message"
+#.
+#: object-name.c:407
+#, c-format
+msgid "%s commit %s - %s"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous
+#. tag object output. E.g.:
+#. *
+#.    "deadbeef tag 2022-01-01 - Some Tag Message"
+#. *
+#. The second argument is the YYYY-MM-DD found
+#. in the tag.
+#. *
+#. The third argument is the "tag" string
+#. from object.c.
+#.
+#: object-name.c:428
+#, c-format
+msgid "%s tag %s - %s"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous
+#. tag object output where we couldn't parse
+#. the tag itself. E.g.:
+#. *
+#.    "deadbeef [bad tag, could not parse it]"
+#.
+#: object-name.c:439
+#, c-format
+msgid "%s [bad tag, could not parse it]"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous <type>
+#. object output. E.g. "deadbeef tree".
+#.
+#: object-name.c:447
+#, c-format
+msgid "%s tree"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous <type>
+#. object output. E.g. "deadbeef blob".
+#.
+#: object-name.c:453
+#, c-format
+msgid "%s blob"
+msgstr ""
+
+#: object-name.c:569
 #, c-format
 msgid "short object ID %s is ambiguous"
 msgstr ""
 
-#: object-name.c:491
-msgid "The candidates are:"
+#. TRANSLATORS: The argument is the list of ambiguous
+#. objects composed in show_ambiguous_object(). See
+#. its "TRANSLATORS" comments for details.
+#.
+#: object-name.c:591
+#, c-format
+msgid ""
+"The candidates are:\n"
+"%s"
 msgstr ""
 
-#: object-name.c:790
+#: object-name.c:888
 msgid ""
 "Git normally never creates a ref that ends with 40 hex characters\n"
 "because it will be ignored when you just specify 40-hex. These refs\n"
@@ -5690,62 +5983,67 @@ msgid ""
 "running \"git config advice.objectNameWarning false\""
 msgstr ""
 
-#: object-name.c:910
+#: object-name.c:1008
 #, c-format
 msgid "log for '%.*s' only goes back to %s"
 msgstr ""
 
-#: object-name.c:918
+#: object-name.c:1016
 #, c-format
 msgid "log for '%.*s' only has %d entries"
 msgstr ""
 
-#: object-name.c:1696
+#: object-name.c:1794
 #, c-format
 msgid "path '%s' exists on disk, but not in '%.*s'"
 msgstr ""
 
-#: object-name.c:1702
+#: object-name.c:1800
 #, c-format
 msgid ""
 "path '%s' exists, but not '%s'\n"
 "hint: Did you mean '%.*s:%s' aka '%.*s:./%s'?"
 msgstr ""
 
-#: object-name.c:1711
+#: object-name.c:1809
 #, c-format
 msgid "path '%s' does not exist in '%.*s'"
 msgstr ""
 
-#: object-name.c:1739
+#: object-name.c:1837
 #, c-format
 msgid ""
 "path '%s' is in the index, but not at stage %d\n"
 "hint: Did you mean ':%d:%s'?"
 msgstr ""
 
-#: object-name.c:1755
+#: object-name.c:1853
 #, c-format
 msgid ""
 "path '%s' is in the index, but not '%s'\n"
 "hint: Did you mean ':%d:%s' aka ':%d:./%s'?"
 msgstr ""
 
-#: object-name.c:1763
+#: object-name.c:1861
 #, c-format
 msgid "path '%s' exists on disk, but not in the index"
 msgstr ""
 
-#: object-name.c:1765
+#: object-name.c:1863
 #, c-format
 msgid "path '%s' does not exist (neither on disk nor in the index)"
 msgstr ""
 
-#: object-name.c:1778
+#: object-name.c:1876
 msgid "relative path syntax can't be used outside working tree"
 msgstr ""
 
-#: object-name.c:1916
+#: object-name.c:1901
+#, c-format
+msgid "<object>:<path> required, only <object> '%s' given"
+msgstr ""
+
+#: object-name.c:2014
 #, c-format
 msgid "invalid object name '%.*s'."
 msgstr ""
@@ -5770,7 +6068,7 @@ msgstr ""
 msgid "unable to parse object: %s"
 msgstr ""
 
-#: object.c:283 object.c:295
+#: object.c:283 object.c:294
 #, c-format
 msgid "hash mismatch %s"
 msgstr ""
@@ -5779,21 +6077,21 @@ msgstr ""
 msgid "multi-pack bitmap is missing required reverse index"
 msgstr ""
 
-#: pack-bitmap.c:429
+#: pack-bitmap.c:433
 msgid "load_reverse_index: could not open pack"
 msgstr ""
 
-#: pack-bitmap.c:1069 pack-bitmap.c:1075 builtin/pack-objects.c:2424
+#: pack-bitmap.c:1072 pack-bitmap.c:1078 builtin/pack-objects.c:2432
 #, c-format
 msgid "unable to get size of %s"
 msgstr ""
 
-#: pack-bitmap.c:1935
+#: pack-bitmap.c:1937
 #, c-format
 msgid "could not find %s in pack %s at offset %<PRIuMAX>"
 msgstr ""
 
-#: pack-bitmap.c:1971 builtin/rev-list.c:92
+#: pack-bitmap.c:1973 builtin/rev-list.c:91
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr ""
@@ -5837,7 +6135,7 @@ msgstr ""
 msgid "failed to make %s readable"
 msgstr ""
 
-#: pack-write.c:520
+#: pack-write.c:521
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr ""
@@ -6171,234 +6469,238 @@ msgstr ""
 msgid "Removing duplicate objects"
 msgstr ""
 
-#: range-diff.c:67
+#: range-diff.c:68
 msgid "could not start `log`"
 msgstr ""
 
-#: range-diff.c:69
+#: range-diff.c:70
 msgid "could not read `log` output"
 msgstr ""
 
-#: range-diff.c:97 sequencer.c:5602
+#: range-diff.c:98 sequencer.c:5575
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr ""
 
-#: range-diff.c:111
+#: range-diff.c:109
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
 "'%s'"
 msgstr ""
 
-#: range-diff.c:137
+#: range-diff.c:132
 #, c-format
 msgid "could not parse git header '%.*s'"
 msgstr ""
 
-#: range-diff.c:304
+#: range-diff.c:300
 msgid "failed to generate diff"
 msgstr ""
 
-#: range-diff.c:562 range-diff.c:564
+#: range-diff.c:558 range-diff.c:560
 #, c-format
 msgid "could not parse log for '%s'"
 msgstr ""
 
-#: read-cache.c:723
+#: read-cache.c:737
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr ""
 
-#: read-cache.c:739
+#: read-cache.c:753
 msgid "cannot create an empty blob in the object database"
 msgstr ""
 
-#: read-cache.c:761
+#: read-cache.c:775
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 
-#: read-cache.c:766 builtin/submodule--helper.c:3242
+#: read-cache.c:780 builtin/submodule--helper.c:3359
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr ""
 
-#: read-cache.c:818
+#: read-cache.c:832
 #, c-format
 msgid "unable to index file '%s'"
 msgstr ""
 
-#: read-cache.c:837
+#: read-cache.c:851
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr ""
 
-#: read-cache.c:848
+#: read-cache.c:862
 #, c-format
 msgid "unable to stat '%s'"
 msgstr ""
 
-#: read-cache.c:1386
+#: read-cache.c:1404
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr ""
 
-#: read-cache.c:1601
+#: read-cache.c:1619
 msgid "Refresh index"
 msgstr ""
 
-#: read-cache.c:1733
+#: read-cache.c:1751
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1743
+#: read-cache.c:1761
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1799
+#: read-cache.c:1817
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr ""
 
-#: read-cache.c:1802
+#: read-cache.c:1820
 #, c-format
 msgid "bad index version %d"
 msgstr ""
 
-#: read-cache.c:1811
+#: read-cache.c:1829
 msgid "bad index file sha1 signature"
 msgstr ""
 
-#: read-cache.c:1845
+#: read-cache.c:1863
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr ""
 
-#: read-cache.c:1847
+#: read-cache.c:1865
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr ""
 
-#: read-cache.c:1884
+#: read-cache.c:1902
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr ""
 
-#: read-cache.c:1900
+#: read-cache.c:1918
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr ""
 
-#: read-cache.c:1957
+#: read-cache.c:1975
 msgid "unordered stage entries in index"
 msgstr ""
 
-#: read-cache.c:1960
+#: read-cache.c:1978
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr ""
 
-#: read-cache.c:1963
+#: read-cache.c:1981
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr ""
 
-#: read-cache.c:2078 read-cache.c:2384 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1662 builtin/add.c:600 builtin/check-ignore.c:183
-#: builtin/checkout.c:527 builtin/checkout.c:719 builtin/clean.c:1013
-#: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
-#: builtin/mv.c:148 builtin/reset.c:499 builtin/rm.c:293
-#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3202
+#: read-cache.c:2096 read-cache.c:2402 rerere.c:549 rerere.c:583 rerere.c:1096
+#: submodule.c:1831 builtin/add.c:586 builtin/check-ignore.c:183
+#: builtin/checkout.c:532 builtin/checkout.c:724 builtin/clean.c:1016
+#: builtin/commit.c:379 builtin/diff-tree.c:122 builtin/grep.c:521
+#: builtin/mv.c:148 builtin/reset.c:506 builtin/rm.c:293
+#: builtin/submodule--helper.c:335 builtin/submodule--helper.c:3319
 msgid "index file corrupt"
 msgstr ""
 
-#: read-cache.c:2222
+#: read-cache.c:2240
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2235
+#: read-cache.c:2253
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2268
+#: read-cache.c:2286
 #, c-format
 msgid "%s: index file open failed"
 msgstr ""
 
-#: read-cache.c:2272
+#: read-cache.c:2290
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr ""
 
-#: read-cache.c:2276
+#: read-cache.c:2294
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr ""
 
-#: read-cache.c:2280
+#: read-cache.c:2298
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr ""
 
-#: read-cache.c:2323
+#: read-cache.c:2341
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2350
+#: read-cache.c:2368
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2396
+#: read-cache.c:2414
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr ""
 
-#: read-cache.c:2455
+#: read-cache.c:2473
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr ""
 
-#: read-cache.c:3086 strbuf.c:1191 wrapper.c:641 builtin/merge.c:1150
+#: read-cache.c:3032
+msgid "cannot write split index for a sparse index"
+msgstr ""
+
+#: read-cache.c:3114 strbuf.c:1192 wrapper.c:717 builtin/merge.c:1156
 #, c-format
 msgid "could not close '%s'"
 msgstr ""
 
-#: read-cache.c:3129
+#: read-cache.c:3157
 msgid "failed to convert to a sparse-index"
 msgstr ""
 
-#: read-cache.c:3200
+#: read-cache.c:3228
 #, c-format
 msgid "could not stat '%s'"
 msgstr ""
 
-#: read-cache.c:3213
+#: read-cache.c:3241
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr ""
 
-#: read-cache.c:3225
+#: read-cache.c:3253
 #, c-format
 msgid "unable to unlink: %s"
 msgstr ""
 
-#: read-cache.c:3254
+#: read-cache.c:3282
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr ""
 
-#: read-cache.c:3411
+#: read-cache.c:3439
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr ""
@@ -6518,9 +6820,9 @@ msgstr ""
 "dibatalkan.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3883
-#: sequencer.c:3909 sequencer.c:5708 builtin/fsck.c:328 builtin/gc.c:1791
-#: builtin/rebase.c:190
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:677 sequencer.c:3879
+#: sequencer.c:3905 sequencer.c:5681 builtin/fsck.c:328 builtin/gc.c:1791
+#: builtin/rebase.c:191
 #, c-format
 msgid "could not write '%s'"
 msgstr "tidak dapat menulis '%s'"
@@ -6561,7 +6863,7 @@ msgstr ""
 msgid "%s: 'preserve' superseded by 'merges'"
 msgstr "%s: 'preserve' digantikan oleh 'merges'"
 
-#: ref-filter.c:42 wt-status.c:2048
+#: ref-filter.c:42 wt-status.c:2057
 msgid "gone"
 msgstr ""
 
@@ -6727,81 +7029,91 @@ msgstr ""
 msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
 msgstr ""
 
-#: ref-filter.c:1706
+#: ref-filter.c:1707
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr ""
 
-#: ref-filter.c:1709
+#: ref-filter.c:1710
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr ""
 
-#: ref-filter.c:1712
+#: ref-filter.c:1713
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr ""
 
-#: ref-filter.c:1716
+#: ref-filter.c:1717
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr ""
 
-#: ref-filter.c:1719
+#: ref-filter.c:1720
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr ""
 
-#: ref-filter.c:1722
+#: ref-filter.c:1723
 msgid "(no branch)"
 msgstr ""
 
-#: ref-filter.c:1754 ref-filter.c:1972
+#: ref-filter.c:1755 ref-filter.c:1973
 #, c-format
 msgid "missing object %s for %s"
 msgstr ""
 
-#: ref-filter.c:1764
+#: ref-filter.c:1765
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr ""
 
-#: ref-filter.c:2155
+#: ref-filter.c:2156
 #, c-format
 msgid "malformed object at '%s'"
 msgstr ""
 
-#: ref-filter.c:2245
+#: ref-filter.c:2246
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr ""
 
-#: ref-filter.c:2250 refs.c:676
+#: ref-filter.c:2251 refs.c:672
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr ""
 
-#: ref-filter.c:2629
+#: ref-filter.c:2630
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr ""
 
-#: ref-filter.c:2740
+#: ref-filter.c:2741
 #, c-format
 msgid "malformed object name %s"
 msgstr ""
 
-#: ref-filter.c:2745
+#: ref-filter.c:2746
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr ""
 
-#: refs.c:261
+#: reflog.c:407
+#, c-format
+msgid "not a reflog: %s"
+msgstr "bukan sebuah log referensi: %s"
+
+#: reflog.c:410
+#, c-format
+msgid "no reflog for '%s'"
+msgstr "tidak ada log referensi untuk '%s'"
+
+#: refs.c:262
 #, c-format
 msgid "%s does not point to a valid object!"
-msgstr ""
+msgstr "%s tidak menunjuk ke sebuah objek valid!"
 
-#: refs.c:563
+#: refs.c:561
 #, c-format
 msgid ""
 "Using '%s' as the name for the initial branch. This default branch name\n"
@@ -6815,90 +7127,102 @@ msgid ""
 "\n"
 "\tgit branch -m <name>\n"
 msgstr ""
+"Menggunakan '%s' sebagai nama cabang awal. Nama cabang asali ini dapat\n"
+"berubah. Untuk menyetel nama cabang awal untuk digunakan pada semua\n"
+"repositori baru Anda, dimana akan mematikan peringatan ini, panggil:\n"
+"\n"
+"\tgit config --global init.defaultBranch <nama>\n"
+"\n"
+"Nama-nama yang umumnya dipilih selain 'master' adalah 'main', 'trunk' dan\n"
+"'development'. Cabang yang baru saja dibuat bisa dinamai ulang lewat "
+"perintah\n"
+"ini:\n"
+"\n"
+"\tgit branch -m <nama>\n"
 
-#: refs.c:585
+#: refs.c:583
 #, c-format
 msgid "could not retrieve `%s`"
-msgstr ""
+msgstr "tidak dapat mengambil `%s`"
 
-#: refs.c:595
+#: refs.c:593
 #, c-format
 msgid "invalid branch name: %s = %s"
-msgstr ""
+msgstr "nama cabang tidak valid: %s = %s"
 
-#: refs.c:674
+#: refs.c:670
 #, c-format
 msgid "ignoring dangling symref %s"
-msgstr ""
+msgstr "abaikan referensi simbolik teruntai %s"
 
-#: refs.c:925
+#: refs.c:919
 #, c-format
 msgid "log for ref %s has gap after %s"
-msgstr ""
+msgstr "log untuk referensi %s ada celah setelah %s"
 
-#: refs.c:932
+#: refs.c:926
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
-msgstr ""
+msgstr "log untuk referensi %s sayangnya berakhir pada %s"
 
-#: refs.c:997
+#: refs.c:991
 #, c-format
 msgid "log for %s is empty"
-msgstr ""
+msgstr "log untuk %s kosong"
 
-#: refs.c:1090
+#: refs.c:1086
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
-msgstr ""
+msgstr "menolak memperbarui referensi dengan nama jelek '%s'"
 
-#: refs.c:1168
+#: refs.c:1164
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
-msgstr ""
+msgstr "update_ref gagal untuk referensi '%s': %s"
 
-#: refs.c:2067
+#: refs.c:2059
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
-msgstr ""
+msgstr "pembaruan berlipat untuk referensi '%s' tidak diperbolehkan"
 
-#: refs.c:2150
+#: refs.c:2145
 msgid "ref updates forbidden inside quarantine environment"
-msgstr ""
+msgstr "pembaruan referensi tidak diperbolehkan di dalam lingkungan karantina"
 
-#: refs.c:2161
+#: refs.c:2156
 msgid "ref updates aborted by hook"
-msgstr ""
+msgstr "pembaruan referensi dihentikan oleh kait"
 
-#: refs.c:2269 refs.c:2299
+#: refs.c:2264 refs.c:2294
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
-msgstr ""
+msgstr "'%s' ada; tidak dapat membuat '%s'"
 
-#: refs.c:2275 refs.c:2310
+#: refs.c:2270 refs.c:2305
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
-msgstr ""
+msgstr "tidak dapat memproses '%s' dan '%s' pada waktu yang bersamaan"
 
-#: refs/files-backend.c:1267
+#: refs/files-backend.c:1295
 #, c-format
 msgid "could not remove reference %s"
-msgstr ""
+msgstr "tidak dapat menghapus referensi %s"
 
-#: refs/files-backend.c:1281 refs/packed-backend.c:1549
-#: refs/packed-backend.c:1559
+#: refs/files-backend.c:1310 refs/packed-backend.c:1565
+#: refs/packed-backend.c:1575
 #, c-format
 msgid "could not delete reference %s: %s"
-msgstr ""
+msgstr "tidak dapat menghapus referensi %s: %s"
 
-#: refs/files-backend.c:1284 refs/packed-backend.c:1562
+#: refs/files-backend.c:1313 refs/packed-backend.c:1578
 #, c-format
 msgid "could not delete references: %s"
-msgstr ""
+msgstr "tidak dapat menghapus referensi: %s"
 
 #: refspec.c:170
 #, c-format
 msgid "invalid refspec '%s'"
-msgstr ""
+msgstr "spek referensi tidak valid '%s'"
 
 #: remote.c:402
 #, c-format
@@ -6913,37 +7237,37 @@ msgstr "lebih dari satu paket terima diberikan, gunakan yang pertama"
 msgid "more than one uploadpack given, using the first"
 msgstr "lebih dari satu paket unggah diberikan, gunakan yang pertama"
 
-#: remote.c:699
+#: remote.c:698
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "tidak dapat mengambil baik %s dan %s ke %s"
 
-#: remote.c:703
+#: remote.c:702
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s biasanya melacak %s, bukan %s"
 
-#: remote.c:707
+#: remote.c:706
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s melacak baik %s dan %s"
 
-#: remote.c:775
+#: remote.c:774
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "kunci '%s' dari pola tidak ada '*'"
 
-#: remote.c:785
+#: remote.c:784
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "nilai '%s' dari pola tidak ada '*'"
 
-#: remote.c:1192
+#: remote.c:1191
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "spek referensi sumber %s tidak cocok dengan apapun"
 
-#: remote.c:1197
+#: remote.c:1196
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr "spek referensi sumber %s cocok dengan lebih dari satu"
@@ -6952,7 +7276,7 @@ msgstr "spek referensi sumber %s cocok dengan lebih dari satu"
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1212
+#: remote.c:1211
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -6976,7 +7300,7 @@ msgstr ""
 "Kedua-duanya tidak bekerja, jadi kami menyerah. Anda harus kualifikasi\n"
 "penuh referensi."
 
-#: remote.c:1232
+#: remote.c:1231
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -6987,7 +7311,7 @@ msgstr ""
 "Apakah maksud Anda buat cabang baru dengan mendorong ke\n"
 "'%s:refs/heads/%s'?"
 
-#: remote.c:1237
+#: remote.c:1236
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -6998,7 +7322,7 @@ msgstr ""
 "Apakah maksud Anda buat tag baru dengan mendorong ke\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1242
+#: remote.c:1241
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -7009,7 +7333,7 @@ msgstr ""
 "Apakah maksud Anda tag pohon dengan mendorong ke\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1247
+#: remote.c:1246
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -7020,114 +7344,114 @@ msgstr ""
 "Apakah maksud Anda tag blob baru dengan mendorong ke\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1283
+#: remote.c:1282
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "%s tidak dapat diselesaikan ke cabang"
 
-#: remote.c:1294
+#: remote.c:1293
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "tidak dapat menghapus '%s': referensi remote tidak ada"
 
-#: remote.c:1306
+#: remote.c:1305
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr "spek referensi tujuan %s cocok dengan lebih dari satu"
 
-#: remote.c:1313
+#: remote.c:1312
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr "referensi tujuan %s menerima dari lebih dari satu sumber"
 
-#: remote.c:1834 remote.c:1941
+#: remote.c:1833 remote.c:1940
 msgid "HEAD does not point to a branch"
 msgstr "HEAD tidak menunjuk ke cabang"
 
-#: remote.c:1843
+#: remote.c:1842
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "tidak ada cabang seperti: '%s'"
 
-#: remote.c:1846
+#: remote.c:1845
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "tidak ada hulu yang terkonfigurasi untuk cabang '%s'"
 
-#: remote.c:1852
+#: remote.c:1851
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "cabang hulu '%s' tidak disimpan sebagai cabang pelacak remote"
 
-#: remote.c:1867
+#: remote.c:1866
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr "tujuan dorong '%s' pada remote '%s' tidak ada cabang pelacak lokal"
 
-#: remote.c:1882
+#: remote.c:1881
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "cabang '%s' tidak ada remote untuk didorong"
 
-#: remote.c:1892
+#: remote.c:1891
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "spek referensi dorong untuk '%s' tidak termasuk '%s'"
 
-#: remote.c:1905
+#: remote.c:1904
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "dorong tidak ada tujuan (push.default yaitu 'nothing')"
 
-#: remote.c:1927
+#: remote.c:1926
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "tidak dapat menyelesaikan dorongan 'sederhana' ke satu tujuan"
 
-#: remote.c:2060
+#: remote.c:2059
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "tidak dapat menemukan referensi remote %s"
 
-#: remote.c:2073
+#: remote.c:2072
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Abaikan referensi lucu '%s' secara lokal"
 
-#: remote.c:2236
+#: remote.c:2235
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Cabang Anda didasarkan pada '%s', tapi hulu sudah tiada.\n"
 
-#: remote.c:2240
+#: remote.c:2239
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (gunakan \"git branch --unset-upstream\" untuk perbaiki)\n"
 
-#: remote.c:2243
+#: remote.c:2242
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Cabang Anda mutakhir dengan '%s'.\n"
 
-#: remote.c:2247
+#: remote.c:2246
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Cabang Anda dan '%s' merujuk pada komit yang berbeda.\n"
 
-#: remote.c:2250
+#: remote.c:2249
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (gunakan \"%s\" untuk selengkapnya)\n"
 
-#: remote.c:2254
+#: remote.c:2253
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] ""
 msgstr[1] ""
 
-#: remote.c:2260
+#: remote.c:2259
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (gunakan \"git push\" untuk terbitkan komit lokal Anda)\n"
 
-#: remote.c:2263
+#: remote.c:2262
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -7135,11 +7459,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: remote.c:2271
+#: remote.c:2270
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (gunakan \"git pull\" untuk perbarui cabang lokal Anda)\n"
 
-#: remote.c:2274
+#: remote.c:2273
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -7150,11 +7474,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: remote.c:2284
+#: remote.c:2283
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr "  (gunakan \"git pull\" untuk gabungkan cabang remote ke milik Anda)\n"
 
-#: remote.c:2476
+#: remote.c:2475
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "tidak dapat mengurai nama object yang diharapkan '%s'"
@@ -7192,106 +7516,110 @@ msgstr "ada kesalahan saat menulis '%s' (%s)"
 msgid "failed to flush '%s'"
 msgstr "gagal membilas '%s'"
 
-#: rerere.c:487 rerere.c:1023
+#: rerere.c:487 rerere.c:1024
 #, c-format
 msgid "could not parse conflict hunks in '%s'"
 msgstr "tidak dapat mengurai bingkah konflik di '%s'"
 
-#: rerere.c:668
+#: rerere.c:669
 #, c-format
 msgid "failed utime() on '%s'"
 msgstr "utime() gagal pada '%s'"
 
-#: rerere.c:678
+#: rerere.c:679
 #, c-format
 msgid "writing '%s' failed"
 msgstr "gagal menulis '%s'"
 
-#: rerere.c:698
+#: rerere.c:699
 #, c-format
 msgid "Staged '%s' using previous resolution."
 msgstr "'%s' digelarkan menggunakan resolusi sebelumnya."
 
-#: rerere.c:737
+#: rerere.c:738
 #, c-format
 msgid "Recorded resolution for '%s'."
 msgstr "Resolusi direkam untuk '%s'."
 
-#: rerere.c:772
+#: rerere.c:773
 #, c-format
 msgid "Resolved '%s' using previous resolution."
 msgstr "'%s' diselesaikan menggunakan resolusi sebelumnya."
 
-#: rerere.c:787
+#: rerere.c:788
 #, c-format
 msgid "cannot unlink stray '%s'"
 msgstr "tidak dapat batal taut simpangan '%s'"
 
-#: rerere.c:791
+#: rerere.c:792
 #, c-format
 msgid "Recorded preimage for '%s'"
 msgstr "Pracitra direkam untuk '%s'"
 
-#: rerere.c:865 submodule.c:2121 builtin/log.c:2017
-#: builtin/submodule--helper.c:1777 builtin/submodule--helper.c:1820
+#: rerere.c:866 submodule.c:2290 builtin/log.c:2042
+#: builtin/submodule--helper.c:1786 builtin/submodule--helper.c:1833
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "tidak dapat membuat direktori '%s'"
 
-#: rerere.c:1041
+#: rerere.c:1042
 #, c-format
 msgid "failed to update conflicted state in '%s'"
 msgstr "gagal memperbarui keadaan konflik di '%s'"
 
-#: rerere.c:1052 rerere.c:1059
+#: rerere.c:1053 rerere.c:1060
 #, c-format
 msgid "no remembered resolution for '%s'"
 msgstr "tidak ada resolusi yang diingat untuk '%s'"
 
-#: rerere.c:1061
+#: rerere.c:1062
 #, c-format
 msgid "cannot unlink '%s'"
 msgstr "tidak dapat batal taut '%s'"
 
-#: rerere.c:1071
+#: rerere.c:1072
 #, c-format
 msgid "Updated preimage for '%s'"
 msgstr "Pracitra diperbarui untuk '%s'"
 
-#: rerere.c:1080
+#: rerere.c:1081
 #, c-format
 msgid "Forgot resolution for '%s'\n"
 msgstr "Resolusi dilupakan untuk '%s'\n"
 
-#: rerere.c:1191
+#: rerere.c:1192
 msgid "unable to open rr-cache directory"
 msgstr "tidak dapat membuka direktori rr-cache"
 
-#: reset.c:42
+#: reset.c:112
 msgid "could not determine HEAD revision"
 msgstr "tidak dapat menentukan revisi HEAD"
 
-#: reset.c:70 reset.c:76 sequencer.c:3700
+#: reset.c:141 reset.c:147 sequencer.c:3696
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "gagal menemukan pohon %s"
 
-#: revision.c:2347
+#: revision.c:2358
 msgid "--unpacked=<packfile> no longer supported"
-msgstr ""
+msgstr "--unpacked=<berkas pak> tidak didukung lagi"
 
-#: revision.c:2686
+#: revision.c:2712
 msgid "your current branch appears to be broken"
-msgstr ""
+msgstr "sepertinya cabang Anda saat ini rusak"
 
-#: revision.c:2689
+#: revision.c:2715
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
-msgstr ""
+msgstr "cabang Anda saat ini '%s' belum memiliki komit apapun"
 
-#: revision.c:2891
+#: revision.c:2901
+msgid "object filtering requires --objects"
+msgstr "penyaringan objek memerlukan --objects"
+
+#: revision.c:2918
 msgid "-L does not yet support diff formats besides -p and -s"
-msgstr ""
+msgstr "-L belum mendukung format diff selain -p dan -s"
 
 #: run-command.c:1262
 #, c-format
@@ -7358,7 +7686,7 @@ msgstr "mode pembersihan pesan komit tidak valid '%s'"
 msgid "could not delete '%s'"
 msgstr "tidak dapat menghapus '%s'"
 
-#: sequencer.c:345 sequencer.c:4751 builtin/rebase.c:563 builtin/rebase.c:1297
+#: sequencer.c:345 sequencer.c:4724 builtin/rebase.c:564 builtin/rebase.c:1326
 #: builtin/rm.c:409
 #, c-format
 msgid "could not remove '%s'"
@@ -7421,13 +7749,13 @@ msgstr ""
 "Untuk membatalkan dan kembali ke keadaan sebelum \"git revert\",\n"
 "jalankan \"git revert --abort\"."
 
-#: sequencer.c:448 sequencer.c:3292
+#: sequencer.c:448 sequencer.c:3288
 #, c-format
 msgid "could not lock '%s'"
 msgstr "tidak dapat mengunci '%s'"
 
-#: sequencer.c:450 sequencer.c:3091 sequencer.c:3296 sequencer.c:3310
-#: sequencer.c:3561 sequencer.c:5618 strbuf.c:1188 wrapper.c:639
+#: sequencer.c:450 sequencer.c:3087 sequencer.c:3292 sequencer.c:3306
+#: sequencer.c:3557 sequencer.c:5591 strbuf.c:1189 wrapper.c:715
 #, c-format
 msgid "could not write to '%s'"
 msgstr "tidak dapat menulis ke '%s'"
@@ -7437,14 +7765,14 @@ msgstr "tidak dapat menulis ke '%s'"
 msgid "could not write eol to '%s'"
 msgstr "tidak dapat menulis akhir baris ke '%s'"
 
-#: sequencer.c:460 sequencer.c:3096 sequencer.c:3298 sequencer.c:3312
-#: sequencer.c:3569
+#: sequencer.c:460 sequencer.c:3092 sequencer.c:3294 sequencer.c:3308
+#: sequencer.c:3565
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "gagal mengakhiri '%s'"
 
-#: sequencer.c:473 sequencer.c:1934 sequencer.c:3116 sequencer.c:3551
-#: sequencer.c:3679 builtin/am.c:289 builtin/commit.c:834 builtin/merge.c:1148
+#: sequencer.c:473 sequencer.c:1930 sequencer.c:3112 sequencer.c:3547
+#: sequencer.c:3675 builtin/am.c:290 builtin/commit.c:837 builtin/merge.c:1154
 #, c-format
 msgid "could not read '%s'"
 msgstr "tidak dapat membaca '%s'"
@@ -7463,7 +7791,7 @@ msgstr "komit perubahan Anda atau stase untuk melanjutkan."
 msgid "%s: fast-forward"
 msgstr "%s: maju-cepat"
 
-#: sequencer.c:574 builtin/tag.c:614
+#: sequencer.c:574 builtin/tag.c:615
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Mode pembersihan tidak valid %s"
@@ -7494,8 +7822,8 @@ msgstr "tidak ada kunci yang ada di pada '%.*s'"
 msgid "unable to dequote value of '%s'"
 msgstr "tidak dapat membatal-kutip nilai dari '%s'"
 
-#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:756
-#: builtin/am.c:848 builtin/rebase.c:694
+#: sequencer.c:841 wrapper.c:219 wrapper.c:389 builtin/am.c:757
+#: builtin/am.c:849 builtin/rebase.c:699
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "tidak dapat membuka '%s' untuk dibaca"
@@ -7546,7 +7874,8 @@ msgid ""
 "  git rebase --continue\n"
 msgstr ""
 "Anda punya perubahan tergelar di dalam pohon kerja Anda.\n"
-"Apabila perubahan tersebut dimaksudkan untuk dilumat ke komit sebelumnya, jalankan:\n"
+"Apabila perubahan tersebut dimaksudkan untuk dilumat ke komit sebelumnya, "
+"jalankan:\n"
 "\n"
 "  git commit --amend %s\n"
 "\n"
@@ -7612,349 +7941,346 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1288
+#: sequencer.c:1287
 msgid "couldn't look up newly created commit"
 msgstr "tidak dapat mencari komit yang baru saja dibuat"
 
-#: sequencer.c:1290
+#: sequencer.c:1289
 msgid "could not parse newly created commit"
 msgstr "tidak dapat menguraikan komit yang baru saja dibuat"
 
-#: sequencer.c:1339
+#: sequencer.c:1336
 msgid "unable to resolve HEAD after creating commit"
 msgstr "tidak dapat menguraikan HEAD setelah membuat komit"
 
-#: sequencer.c:1342
+#: sequencer.c:1338
 msgid "detached HEAD"
 msgstr "HEAD terpisah"
 
-#: sequencer.c:1346
+#: sequencer.c:1342
 msgid " (root-commit)"
 msgstr " (komit-akar)"
 
-#: sequencer.c:1367
+#: sequencer.c:1363
 msgid "could not parse HEAD"
 msgstr "tidak dapat menguraikan HEAD"
 
-#: sequencer.c:1369
+#: sequencer.c:1365
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s bukan sebuah komit!"
 
-#: sequencer.c:1373 sequencer.c:1451 builtin/commit.c:1708
+#: sequencer.c:1369 sequencer.c:1447 builtin/commit.c:1707
 msgid "could not parse HEAD commit"
 msgstr "tidak dapat menguraikan komit HEAD"
 
-#: sequencer.c:1429 sequencer.c:2314
+#: sequencer.c:1425 sequencer.c:2310
 msgid "unable to parse commit author"
 msgstr "tidak dapat menguraikan pengarang komit"
 
-#: sequencer.c:1440 builtin/am.c:1643 builtin/merge.c:710
+#: sequencer.c:1436 builtin/am.c:1644 builtin/merge.c:710
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree gagal menulis sebuah pohon"
 
-#: sequencer.c:1473 sequencer.c:1593
+#: sequencer.c:1469 sequencer.c:1589
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "tidak dapat membaca pesan komit dari '%s'"
 
-#: sequencer.c:1504 sequencer.c:1536
+#: sequencer.c:1500 sequencer.c:1532
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "identitas pengarang tidak valid '%s'"
 
-#: sequencer.c:1510
+#: sequencer.c:1506
 msgid "corrupt author: missing date information"
 msgstr "pengarang rusak: informasi tanggal hilang"
 
-#: sequencer.c:1549 builtin/am.c:1670 builtin/commit.c:1822 builtin/merge.c:915
-#: builtin/merge.c:940 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1545 builtin/am.c:1671 builtin/commit.c:1821 builtin/merge.c:921
+#: builtin/merge.c:946 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "gagal menulis objek komit"
 
-#: sequencer.c:1576 sequencer.c:4523 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1572 sequencer.c:4496 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "tidak dapat memperbarui %s"
 
-#: sequencer.c:1625
+#: sequencer.c:1621
 #, c-format
 msgid "could not parse commit %s"
 msgstr "tidak dapat menguraikan komit %s"
 
-#: sequencer.c:1630
+#: sequencer.c:1626
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "tidak dapat menguraikan komit induk %s"
 
-#: sequencer.c:1713 sequencer.c:1994
+#: sequencer.c:1709 sequencer.c:1990
 #, c-format
 msgid "unknown command: %d"
 msgstr "perintah tidak dikenal: %d"
 
-#: sequencer.c:1755
+#: sequencer.c:1751
 msgid "This is the 1st commit message:"
 msgstr "Ini komit pertama:"
 
-#: sequencer.c:1756
+#: sequencer.c:1752
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Ini komit ke-%d:"
 
-#: sequencer.c:1757
+#: sequencer.c:1753
 msgid "The 1st commit message will be skipped:"
 msgstr "Pesan komit pertama akan dilewati:"
 
-#: sequencer.c:1758
+#: sequencer.c:1754
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Pesan komit ke-%d akan dilewati"
 
-#: sequencer.c:1759
+#: sequencer.c:1755
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Ini kombinasi dari %d komit."
 
-#: sequencer.c:1906 sequencer.c:1963
+#: sequencer.c:1902 sequencer.c:1959
 #, c-format
 msgid "cannot write '%s'"
 msgstr "tidak dapat menulis '%s'"
 
-#: sequencer.c:1953
+#: sequencer.c:1949
 msgid "need a HEAD to fixup"
 msgstr "butuh sebuah HEAD untuk memperbaiki"
 
-#: sequencer.c:1955 sequencer.c:3596
+#: sequencer.c:1951 sequencer.c:3592
 msgid "could not read HEAD"
 msgstr "tidak dapat membaca HEAD"
 
-#: sequencer.c:1957
+#: sequencer.c:1953
 msgid "could not read HEAD's commit message"
 msgstr "tidak dapat membaca pesan komit HEAD"
 
-#: sequencer.c:1981
+#: sequencer.c:1977
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "tidak dapat membaca pesan komit %s"
 
-#: sequencer.c:2091
+#: sequencer.c:2087
 msgid "your index file is unmerged."
 msgstr "berkas indeks Anda tak tergabung."
 
-#: sequencer.c:2098
+#: sequencer.c:2094
 msgid "cannot fixup root commit"
 msgstr "tidak dapat memperbaiki komit akar"
 
-#: sequencer.c:2117
+#: sequencer.c:2113
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "komit %s adalah penggabungan tetapi opsi -m tidak diberikan."
 
-#: sequencer.c:2125 sequencer.c:2133
+#: sequencer.c:2121 sequencer.c:2129
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "komit %s tidak punya induk %d"
 
-#: sequencer.c:2139
+#: sequencer.c:2135
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "tidak dapat mendapatkan pesan komit untuk %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2158
+#: sequencer.c:2154
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: tidak dapat menguraikan komit induk %s"
 
-#: sequencer.c:2224
+#: sequencer.c:2220
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "tidak dapat menamai ulang '%s' ke '%s'"
 
-#: sequencer.c:2284
+#: sequencer.c:2280
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "tidak dapat membalikkan %s... %s"
 
-#: sequencer.c:2285
+#: sequencer.c:2281
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "tidak dapat menerapkan %s... %s"
 
-#: sequencer.c:2306
+#: sequencer.c:2302
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "menjatuhkan %s %s -- isi tambalan sudah di hulu\n"
 
-#: sequencer.c:2364
+#: sequencer.c:2360
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: gagal membaca indeks"
 
-#: sequencer.c:2372
+#: sequencer.c:2368
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: gagal menyegarkan indeks"
 
-#: sequencer.c:2452
+#: sequencer.c:2448
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s tidak menerima argumen: '%s'"
 
-#: sequencer.c:2461
+#: sequencer.c:2457
 #, c-format
 msgid "missing arguments for %s"
 msgstr "argumen hilang untuk %s"
 
-#: sequencer.c:2504
+#: sequencer.c:2500
 #, c-format
 msgid "could not parse '%s'"
 msgstr "tidak dapat menguraikan '%s'"
 
-#: sequencer.c:2565
+#: sequencer.c:2561
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "baris %d tidak valid: %.*s"
 
-#: sequencer.c:2576
+#: sequencer.c:2572
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "tidak dapat '%s' tanpa komit sebelumnya"
 
-#: sequencer.c:2624 builtin/rebase.c:184
+#: sequencer.c:2620 builtin/rebase.c:185
 #, c-format
 msgid "could not read '%s'."
 msgstr "tidak dapat membaca '%s'."
 
-#: sequencer.c:2662
+#: sequencer.c:2658
 msgid "cancelling a cherry picking in progress"
 msgstr "membatalkan pemetikan ceri yang sedang berlangsung"
 
-#: sequencer.c:2671
+#: sequencer.c:2667
 msgid "cancelling a revert in progress"
 msgstr "membatalkan pembalikkan yang sedang berlangsung"
 
-#: sequencer.c:2711
+#: sequencer.c:2707
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "mohon perbaiki menggunakan 'git rebase --edit-todo'."
 
-#: sequencer.c:2713
+#: sequencer.c:2709
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "lembar perintah tidak dapat digunakan: '%s'"
 
-#: sequencer.c:2718
+#: sequencer.c:2714
 msgid "no commits parsed."
 msgstr "tidak ada komit yang diuraikan."
 
-#: sequencer.c:2729
+#: sequencer.c:2725
 msgid "cannot cherry-pick during a revert."
 msgstr "tidak dapat memetik ceri selama pembalikkan."
 
-#: sequencer.c:2731
+#: sequencer.c:2727
 msgid "cannot revert during a cherry-pick."
 msgstr "tidak dapat membalikkan selama petik ceri."
 
-#: sequencer.c:2809
-#, c-format
-msgid "invalid value for %s: %s"
-msgstr "nilai tidak valid untuk %s: %s"
-
-#: sequencer.c:2918
+#: sequencer.c:2914
 msgid "unusable squash-onto"
 msgstr "squash-onto tidak dapat digunakan"
 
-#: sequencer.c:2938
+#: sequencer.c:2934
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "lembar opsi jelek: '%s'"
 
-#: sequencer.c:3033 sequencer.c:4902
+#: sequencer.c:3029 sequencer.c:4875
 msgid "empty commit set passed"
 msgstr "himpunan komit kosong dilewatkan"
 
-#: sequencer.c:3050
+#: sequencer.c:3046
 msgid "revert is already in progress"
 msgstr "pembalikkan sudah berjalan"
 
-#: sequencer.c:3052
+#: sequencer.c:3048
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "coba \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3055
+#: sequencer.c:3051
 msgid "cherry-pick is already in progress"
 msgstr "pemetikan ceri sudah berjalan"
 
-#: sequencer.c:3057
+#: sequencer.c:3053
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "coba \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3071
+#: sequencer.c:3067
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "tidak dapat membuat direktori pembaris '%s'"
 
-#: sequencer.c:3086
+#: sequencer.c:3082
 msgid "could not lock HEAD"
 msgstr "tidak dapat mengunci HEAD"
 
-#: sequencer.c:3146 sequencer.c:4612
+#: sequencer.c:3142 sequencer.c:4585
 msgid "no cherry-pick or revert in progress"
 msgstr "tidak ada pemetikan ceri atau pembalikkan yang sedang berjalan"
 
-#: sequencer.c:3148 sequencer.c:3159
+#: sequencer.c:3144 sequencer.c:3155
 msgid "cannot resolve HEAD"
 msgstr "tidak dapat menguraikan HEAD"
 
-#: sequencer.c:3150 sequencer.c:3194
+#: sequencer.c:3146 sequencer.c:3190
 msgid "cannot abort from a branch yet to be born"
 msgstr "tidak dapat membatalkan dari cabang yang belum lahir"
 
-#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
-#: builtin/grep.c:772
+#: sequencer.c:3176 builtin/fetch.c:1030 builtin/fetch.c:1457
+#: builtin/grep.c:774
 #, c-format
 msgid "cannot open '%s'"
 msgstr "tidak dapat membuka '%s'"
 
-#: sequencer.c:3182
+#: sequencer.c:3178
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "tidak dapat membaca '%s': %s"
 
-#: sequencer.c:3183
+#: sequencer.c:3179
 msgid "unexpected end of file"
 msgstr "akhir berkas tidak diharapkan"
 
-#: sequencer.c:3189
+#: sequencer.c:3185
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "berkas HEAD pra-petik-ceri yang tersimpan '%s' rusak"
 
-#: sequencer.c:3200
+#: sequencer.c:3196
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
-msgstr "Sepertinya Anda sudah memindahkan HEAD. Tidak memutar ulang, periksa HEAD Anda!"
+msgstr ""
+"Sepertinya Anda sudah memindahkan HEAD. Tidak memutar ulang, periksa HEAD "
+"Anda!"
 
-#: sequencer.c:3241
+#: sequencer.c:3237
 msgid "no revert in progress"
 msgstr "tidak ada pembalikkan yang sedang berjalan"
 
-#: sequencer.c:3250
+#: sequencer.c:3246
 msgid "no cherry-pick in progress"
 msgstr "tidak ada pemetikan ceri yang sedang berjalan"
 
-#: sequencer.c:3260
+#: sequencer.c:3256
 msgid "failed to skip the commit"
 msgstr "gagal melewati komit"
 
-#: sequencer.c:3267
+#: sequencer.c:3263
 msgid "there is nothing to skip"
 msgstr "tidak ada yang dilewati"
 
-#: sequencer.c:3270
+#: sequencer.c:3266
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -7963,16 +8289,16 @@ msgstr ""
 "sudahkah Anda komit?\n"
 "coba \"git %s --continue\""
 
-#: sequencer.c:3432 sequencer.c:4503
+#: sequencer.c:3428 sequencer.c:4476
 msgid "cannot read HEAD"
 msgstr "tidak dapat membaca HEAD"
 
-#: sequencer.c:3449
+#: sequencer.c:3445
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "tidak dapat menyalin '%s' ke '%s'"
 
-#: sequencer.c:3457
+#: sequencer.c:3453
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -7991,27 +8317,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3467
+#: sequencer.c:3463
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Tidak dapat menerapkan %s... %.*s"
 
-#: sequencer.c:3474
+#: sequencer.c:3470
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Tidak dapat menggabungkan %.*s"
 
-#: sequencer.c:3488 sequencer.c:3492 builtin/difftool.c:633
+#: sequencer.c:3484 sequencer.c:3488 builtin/difftool.c:633
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "tidak dapat menyalin '%s' ke '%s'"
 
-#: sequencer.c:3503
+#: sequencer.c:3499
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Mengeksekusi: %s\n"
 
-#: sequencer.c:3514
+#: sequencer.c:3510
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8026,11 +8352,11 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3520
+#: sequencer.c:3516
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "dan buat perubahan ke indeks dan/atau pohon kerja\n"
 
-#: sequencer.c:3526
+#: sequencer.c:3522
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8047,90 +8373,90 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3586
+#: sequencer.c:3582
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "nama label ilegal: '%.*s'"
 
-#: sequencer.c:3659
+#: sequencer.c:3655
 msgid "writing fake root commit"
 msgstr "menulis komit akar palsu"
 
-#: sequencer.c:3664
+#: sequencer.c:3660
 msgid "writing squash-onto"
 msgstr "menulis squash-onto"
 
-#: sequencer.c:3743
+#: sequencer.c:3739
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "tidak dapat menguraikan '%s'"
 
-#: sequencer.c:3775
+#: sequencer.c:3771
 msgid "cannot merge without a current revision"
 msgstr "tidak dapat menggabungkan tanpa revisi saat ini"
 
-#: sequencer.c:3797
+#: sequencer.c:3793
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "tidak dapat menguraikan '%.*s'"
 
-#: sequencer.c:3806
+#: sequencer.c:3802
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "tidak ada yang digabungkan: '%.*s'"
 
-#: sequencer.c:3818
+#: sequencer.c:3814
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "penggabungan gurita tidak dapat dieksekusi di atas sebuah [akar baru]"
 
-#: sequencer.c:3873
+#: sequencer.c:3869
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "tidak dapat mendapatkan pesan komit dari '%s'"
 
-#: sequencer.c:4019
+#: sequencer.c:4013
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "bahkan tidak dapat mencoba menggabungkan '%.*s'"
 
-#: sequencer.c:4035
+#: sequencer.c:4029
 msgid "merge: Unable to write new index file"
 msgstr "merge: Tidak dapat menulis berkas indeks baru"
 
-#: sequencer.c:4116
+#: sequencer.c:4110
 msgid "Cannot autostash"
 msgstr "Tidak dapat menstase otomatis"
 
-#: sequencer.c:4119
+#: sequencer.c:4113
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Respons stase tidak diharapkan: '%s'"
 
-#: sequencer.c:4125
+#: sequencer.c:4119
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Tidak dapat membuat direktori untuk '%s'"
 
-#: sequencer.c:4128
+#: sequencer.c:4122
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Stase otomatis dibuat: %s\n"
 
-#: sequencer.c:4132
+#: sequencer.c:4124
 msgid "could not reset --hard"
 msgstr "tidak dapat reset --hard"
 
-#: sequencer.c:4157
+#: sequencer.c:4148
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Stase otomatis diterapkan.\n"
 
-#: sequencer.c:4169
+#: sequencer.c:4160
 #, c-format
 msgid "cannot store %s"
 msgstr "tidak dapat menyimpan %s"
 
-#: sequencer.c:4172
+#: sequencer.c:4163
 #, c-format
 msgid ""
 "%s\n"
@@ -8141,29 +8467,29 @@ msgstr ""
 "Perubahan Anda aman di dalam stase.\n"
 "Anda dapat menjalankan \"git stash pop\" atau \"git stash drop\" kapanpun.\n"
 
-#: sequencer.c:4177
+#: sequencer.c:4168
 msgid "Applying autostash resulted in conflicts."
 msgstr "Menerapkan stase otomatis menghasilkan konflik."
 
-#: sequencer.c:4178
+#: sequencer.c:4169
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Stase otomatis sudah ada; membuat entri stase baru."
 
-#: sequencer.c:4252
+#: sequencer.c:4225
 msgid "could not detach HEAD"
 msgstr "tidak dapat melepas HEAD"
 
-#: sequencer.c:4267
+#: sequencer.c:4240
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Berhenti pada HEAD\n"
 
-#: sequencer.c:4269
+#: sequencer.c:4242
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Berhenti pada %s\n"
 
-#: sequencer.c:4301
+#: sequencer.c:4274
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8184,58 +8510,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4347
+#: sequencer.c:4320
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Mendasarkan ulang (%d/%d)%s"
 
-#: sequencer.c:4393
+#: sequencer.c:4366
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Berhenti pada %s... %.*s\n"
 
-#: sequencer.c:4463
+#: sequencer.c:4436
 #, c-format
 msgid "unknown command %d"
 msgstr "perintah tidak dikenal %d"
 
-#: sequencer.c:4511
+#: sequencer.c:4484
 msgid "could not read orig-head"
 msgstr "tidak dapat membaca orig-head"
 
-#: sequencer.c:4516
+#: sequencer.c:4489
 msgid "could not read 'onto'"
 msgstr "tidak dapat membaca 'onto'"
 
-#: sequencer.c:4530
+#: sequencer.c:4503
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "tidak dapat memperbarui HEAD ke %s"
 
-#: sequencer.c:4590
+#: sequencer.c:4563
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "%s didasarkan ulang dan diperbarui dengan sukses.\n"
 
-#: sequencer.c:4642
+#: sequencer.c:4615
 msgid "cannot rebase: You have unstaged changes."
 msgstr "tidak dapat mendasarkan ulang: Anda punya perubahan tak tergelar."
 
-#: sequencer.c:4651
+#: sequencer.c:4624
 msgid "cannot amend non-existing commit"
 msgstr "tidak dapat mengubah komit yang tidak ada"
 
-#: sequencer.c:4653
+#: sequencer.c:4626
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "berkas tidak valid: '%s'"
 
-#: sequencer.c:4655
+#: sequencer.c:4628
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "konten tidak valid: '%s'"
 
-#: sequencer.c:4658
+#: sequencer.c:4631
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8245,59 +8571,59 @@ msgstr ""
 "Anda punya perubahan tak tergelar di dalam pohon kerja Anda. Mohon komit\n"
 "terlebih dahulu dan jalankan 'git rebase --continue' lagi."
 
-#: sequencer.c:4694 sequencer.c:4733
+#: sequencer.c:4667 sequencer.c:4706
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "tidak dapat menulis berkas: '%s'"
 
-#: sequencer.c:4749
+#: sequencer.c:4722
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "tidak dapat menghapus CHERRY_PICK_HEAD"
 
-#: sequencer.c:4759
+#: sequencer.c:4732
 msgid "could not commit staged changes."
 msgstr "tidak dapat mengkomit perubahan tergelar."
 
-#: sequencer.c:4879
+#: sequencer.c:4852
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: tidak dapat memetik ceri sebuah %s"
 
-#: sequencer.c:4883
+#: sequencer.c:4856
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: revisi jelek"
 
-#: sequencer.c:4918
+#: sequencer.c:4891
 msgid "can't revert as initial commit"
 msgstr "tidak dapat membalikkan sebagai komit awal"
 
-#: sequencer.c:5189 sequencer.c:5418
+#: sequencer.c:5162 sequencer.c:5391
 #, c-format
 msgid "skipped previously applied commit %s"
 msgstr "melewatkan komit yang sudah diterapkan sebelumnya %s"
 
-#: sequencer.c:5259 sequencer.c:5434
+#: sequencer.c:5232 sequencer.c:5407
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr "gunakan --reapply-cherry-picks untuk memasukkan komit yang terlewat"
 
-#: sequencer.c:5405
+#: sequencer.c:5378
 msgid "make_script: unhandled options"
 msgstr "make_script: opsi tak ditangani"
 
-#: sequencer.c:5408
+#: sequencer.c:5381
 msgid "make_script: error preparing revisions"
 msgstr "make_script: kesalahan membuat revisi"
 
-#: sequencer.c:5666 sequencer.c:5683
+#: sequencer.c:5639 sequencer.c:5656
 msgid "nothing to do"
 msgstr "tidak ada yang dilakukan"
 
-#: sequencer.c:5702
+#: sequencer.c:5675
 msgid "could not skip unnecessary pick commands"
 msgstr "tidak dapat melewatkan perintah pick yang tidak perlu"
 
-#: sequencer.c:5802
+#: sequencer.c:5775
 msgid "the script was already rearranged."
 msgstr "skrip sudah ditata ulang."
 
@@ -8342,156 +8668,160 @@ msgstr ""
 msgid "this operation must be run in a work tree"
 msgstr ""
 
-#: setup.c:722
+#: setup.c:723
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr ""
 
-#: setup.c:730
+#: setup.c:731
 msgid "unknown repository extension found:"
 msgid_plural "unknown repository extensions found:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: setup.c:744
+#: setup.c:745
 msgid "repo version is 0, but v1-only extension found:"
 msgid_plural "repo version is 0, but v1-only extensions found:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: setup.c:765
+#: setup.c:766
 #, c-format
 msgid "error opening '%s'"
 msgstr ""
 
-#: setup.c:767
+#: setup.c:768
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr ""
 
-#: setup.c:769
+#: setup.c:770
 #, c-format
 msgid "error reading %s"
 msgstr ""
 
-#: setup.c:771
+#: setup.c:772
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr ""
 
-#: setup.c:773
+#: setup.c:774
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr ""
 
-#: setup.c:775
+#: setup.c:776
 #, c-format
 msgid "not a git repository: %s"
 msgstr ""
 
-#: setup.c:877
+#: setup.c:878
 #, c-format
 msgid "'$%s' too big"
 msgstr ""
 
-#: setup.c:891
+#: setup.c:892
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr ""
 
-#: setup.c:920 setup.c:922 setup.c:953
+#: setup.c:921 setup.c:923 setup.c:954
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr ""
 
-#: setup.c:925 setup.c:981 setup.c:991 setup.c:1030 setup.c:1038
+#: setup.c:926 setup.c:982 setup.c:992 setup.c:1031 setup.c:1039
 msgid "cannot come back to cwd"
 msgstr ""
 
-#: setup.c:1052
+#: setup.c:1053
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr ""
 
-#: setup.c:1295
+#: setup.c:1296
 msgid "Unable to read current working directory"
 msgstr ""
 
-#: setup.c:1304 setup.c:1310
+#: setup.c:1305 setup.c:1311
 #, c-format
 msgid "cannot change to '%s'"
 msgstr ""
 
-#: setup.c:1315
+#: setup.c:1316
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr ""
 
-#: setup.c:1321
+#: setup.c:1322
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
 "Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)."
 msgstr ""
 
-#: setup.c:1446
+#: setup.c:1447
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
 "The owner of files must always have read and write permissions."
 msgstr ""
 
-#: setup.c:1508
+#: setup.c:1509
 msgid "fork failed"
 msgstr ""
 
-#: setup.c:1513
+#: setup.c:1514
 msgid "setsid failed"
 msgstr ""
 
-#: sparse-index.c:289
+#: sparse-index.c:285
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "entri indeks adalah direktori, tapi bukan tipis (%08x)"
 
+#: split-index.c:9
+msgid "cannot use split index with a sparse index"
+msgstr ""
+
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
-#: strbuf.c:850
+#: strbuf.c:851
 #, c-format
 msgid "%u.%2.2u GiB"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte/second
-#: strbuf.c:852
+#: strbuf.c:853
 #, c-format
 msgid "%u.%2.2u GiB/s"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte
-#: strbuf.c:860
+#: strbuf.c:861
 #, c-format
 msgid "%u.%2.2u MiB"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte/second
-#: strbuf.c:862
+#: strbuf.c:863
 #, c-format
 msgid "%u.%2.2u MiB/s"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte
-#: strbuf.c:869
+#: strbuf.c:870
 #, c-format
 msgid "%u.%2.2u KiB"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte/second
-#: strbuf.c:871
+#: strbuf.c:872
 #, c-format
 msgid "%u.%2.2u KiB/s"
 msgstr ""
 
 #. TRANSLATORS: IEC 80000-13:2008 byte
-#: strbuf.c:877
+#: strbuf.c:878
 #, c-format
 msgid "%u byte"
 msgid_plural "%u bytes"
@@ -8499,84 +8829,84 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. TRANSLATORS: IEC 80000-13:2008 byte/second
-#: strbuf.c:879
+#: strbuf.c:880
 #, c-format
 msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: strbuf.c:1186 wrapper.c:207 wrapper.c:377 builtin/am.c:765
-#: builtin/rebase.c:650
+#: strbuf.c:1187 wrapper.c:217 wrapper.c:387 builtin/am.c:766
+#: builtin/rebase.c:653
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr ""
 
-#: strbuf.c:1195
+#: strbuf.c:1196
 #, c-format
 msgid "could not edit '%s'"
 msgstr ""
 
-#: submodule-config.c:237
+#: submodule-config.c:238
 #, c-format
 msgid "ignoring suspicious submodule name: %s"
 msgstr "abaikan nama submodul dicurigai: %s"
 
-#: submodule-config.c:304
+#: submodule-config.c:305
 msgid "negative values not allowed for submodule.fetchjobs"
 msgstr "nilai negatif tidak diperbolehkan untuk submodule.fetchjobs"
 
-#: submodule-config.c:402
+#: submodule-config.c:403
 #, c-format
 msgid "ignoring '%s' which may be interpreted as a command-line option: %s"
 msgstr "abaikan '%s' yang mungkin ditafsirkan sebagai opsi baris perintah: %s"
 
-#: submodule-config.c:499
+#: submodule-config.c:500 builtin/push.c:489 builtin/send-pack.c:148
 #, c-format
-msgid "invalid value for %s"
-msgstr "nilai tidak valid untuk %s"
+msgid "invalid value for '%s'"
+msgstr "nilai tidak valid untuk '%s'"
 
-#: submodule-config.c:767
+#: submodule-config.c:828
 #, c-format
 msgid "Could not update .gitmodules entry %s"
 msgstr "Tidak dapat memperbarui entri .gitmodules %s"
 
-#: submodule.c:114 submodule.c:143
+#: submodule.c:115 submodule.c:144
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
 msgstr ""
 "Tidak dapat mengubah .gitmodules yang tak tergabung, selesaikan konflik "
 "penggabungan terlebih dahulu"
 
-#: submodule.c:118 submodule.c:147
+#: submodule.c:119 submodule.c:148
 #, c-format
 msgid "Could not find section in .gitmodules where path=%s"
 msgstr "Tidak dapat menemukan bagian .gitmodules dimana path=%s"
 
-#: submodule.c:154
+#: submodule.c:155
 #, c-format
 msgid "Could not remove .gitmodules entry for %s"
 msgstr "Tidak dapat menghapus entri .gitmodules untuk %s"
 
-#: submodule.c:165
+#: submodule.c:166
 msgid "staging updated .gitmodules failed"
 msgstr "gagal menggelar .gitmodules terbarui"
 
-#: submodule.c:358
+#: submodule.c:346
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "dalam submodul tak terisi '%s'"
 
-#: submodule.c:389
+#: submodule.c:377
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Spek jalur '%s' di dalam submodul '%.*s'"
 
-#: submodule.c:466
+#: submodule.c:454
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "argumen --ignore-submodules jelek: %s"
 
-#: submodule.c:844
+#: submodule.c:866
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8585,12 +8915,12 @@ msgstr ""
 "Submodul dalam komit %s pada jalur '%s' bertabrakan dengan submodul yang "
 "bernama sama. Melewati itu."
 
-#: submodule.c:954
+#: submodule.c:987
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "entri submodul '%s' (%s) adalah %s, bukan komit"
 
-#: submodule.c:1042
+#: submodule.c:1069
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8599,36 +8929,46 @@ msgstr ""
 "Tidak dapat menjalankan perintah 'git rev-list <komit> --not --remotes -n 1' "
 "dalam submodul %s"
 
-#: submodule.c:1165
+#: submodule.c:1192
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "proses untuk submodul '%s' gagal"
 
-#: submodule.c:1194 builtin/branch.c:699 builtin/submodule--helper.c:2714
+#: submodule.c:1221 builtin/branch.c:714 builtin/submodule--helper.c:2827
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Gagal menguraikan HEAD sebagai referensi valid."
 
-#: submodule.c:1205
+#: submodule.c:1232
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Mendorong submodul '%s'\n"
 
-#: submodule.c:1208
+#: submodule.c:1235
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Tidak dapat mendorong submodul '%s'\n"
 
-#: submodule.c:1491
+#: submodule.c:1567
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Mengambil submodul %s%s\n"
 
-#: submodule.c:1525
+#: submodule.c:1589
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Tidak dapat mengakses submodul '%s'\n"
 
-#: submodule.c:1680
+#: submodule.c:1618
+#, c-format
+msgid "Could not access submodule '%s' at commit %s\n"
+msgstr "Tidak dapat mengakses submodul '%s' pada komit %s\n"
+
+#: submodule.c:1629
+#, c-format
+msgid "Fetching submodule %s%s at commit %s\n"
+msgstr "Mengambil submodul %s%s pada komit %s\n"
+
+#: submodule.c:1849
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8637,61 +8977,61 @@ msgstr ""
 "Kesalahan saat pengambilan submodul:\n"
 "%s"
 
-#: submodule.c:1705
+#: submodule.c:1874
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' tak dikenal sebagai repositori git"
 
-#: submodule.c:1722
+#: submodule.c:1891
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Tidak dapat menjalankan 'git status --porcelain=2' dalam submodul %s"
 
-#: submodule.c:1763
+#: submodule.c:1932
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "'git status --porcelain=2' gagal dalam submodul %s"
 
-#: submodule.c:1838
+#: submodule.c:2007
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "Tidak dalat memulai 'git status' dalam submodul '%s'"
 
-#: submodule.c:1851
+#: submodule.c:2020
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "tidak dapat menjalankan 'git status' dalam submodul '%s'"
 
-#: submodule.c:1868
+#: submodule.c:2037
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Tidak dapat batal setel setelan core.worktree dalam submodul '%s'"
 
-#: submodule.c:1895 submodule.c:2210
+#: submodule.c:2064 submodule.c:2379
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "tidak dapat rekursi ke dalam submodul '%s'"
 
-#: submodule.c:1917
+#: submodule.c:2086
 msgid "could not reset submodule index"
 msgstr "tidak dapat reset indeks submodul"
 
-#: submodule.c:1959
+#: submodule.c:2128
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "submodul '%s' punya indeks kotor"
 
-#: submodule.c:2013
+#: submodule.c:2182
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Submodul '%s' tidak dapat diperbarui."
 
-#: submodule.c:2081
+#: submodule.c:2250
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr "direktori submodul git '%s' di dalam direktori git '%.*s'"
 
-#: submodule.c:2102
+#: submodule.c:2271
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8699,17 +9039,17 @@ msgstr ""
 "relocate_gitdir untuk submodul '%s' dengan lebih dari satu pohon kerja tidak "
 "didukung"
 
-#: submodule.c:2114 submodule.c:2174
+#: submodule.c:2283 submodule.c:2343
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "tidak dapat mencari nama untuk submodul '%s'"
 
-#: submodule.c:2118
+#: submodule.c:2287
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "menolak memindahkan '%s' ke dalam direktori git yang ada"
 
-#: submodule.c:2124
+#: submodule.c:2293
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8720,11 +9060,11 @@ msgstr ""
 "'%s' ke\n"
 "'%s'\n"
 
-#: submodule.c:2255
+#: submodule.c:2424
 msgid "could not start ls-files in .."
 msgstr "tidak dapat memulai ls-files dalam .."
 
-#: submodule.c:2295
+#: submodule.c:2464
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree kembalikan kode kembali %d yang tak diharapkan"
@@ -8732,7 +9072,7 @@ msgstr "ls-tree kembalikan kode kembali %d yang tak diharapkan"
 #: symlinks.c:244
 #, c-format
 msgid "failed to lstat '%s'"
-msgstr ""
+msgstr "gagal men-lstat '%s'"
 
 #: trailer.c:244
 #, c-format
@@ -8745,8 +9085,8 @@ msgstr ""
 msgid "unknown value '%s' for key '%s'"
 msgstr ""
 
-#: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
-#: builtin/remote.c:327
+#: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:300
+#: builtin/remote.c:328
 #, c-format
 msgid "more than one %s"
 msgstr ""
@@ -8761,11 +9101,11 @@ msgstr ""
 msgid "could not read input file '%s'"
 msgstr ""
 
-#: trailer.c:766 builtin/mktag.c:89 imap-send.c:1573
+#: trailer.c:766 builtin/mktag.c:88 imap-send.c:1563
 msgid "could not read from stdin"
 msgstr ""
 
-#: trailer.c:1024 wrapper.c:684
+#: trailer.c:1024 wrapper.c:760
 #, c-format
 msgid "could not stat %s"
 msgstr ""
@@ -8831,7 +9171,7 @@ msgstr ""
 msgid "error while running fast-import"
 msgstr ""
 
-#: transport-helper.c:549 transport-helper.c:1251
+#: transport-helper.c:549 transport-helper.c:1254
 #, c-format
 msgid "could not read ref %s"
 msgstr ""
@@ -8849,7 +9189,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr ""
 
-#: transport-helper.c:661 transport.c:1479
+#: transport-helper.c:661 transport.c:1496
 msgid "operation not supported by protocol"
 msgstr ""
 
@@ -8858,124 +9198,124 @@ msgstr ""
 msgid "can't connect to subservice %s"
 msgstr ""
 
-#: transport-helper.c:693 transport.c:404
+#: transport-helper.c:693 transport.c:415
 msgid "--negotiate-only requires protocol v2"
 msgstr ""
 
-#: transport-helper.c:755
+#: transport-helper.c:758
 msgid "'option' without a matching 'ok/error' directive"
 msgstr ""
 
-#: transport-helper.c:798
+#: transport-helper.c:801
 #, c-format
 msgid "expected ok/error, helper said '%s'"
 msgstr ""
 
-#: transport-helper.c:859
+#: transport-helper.c:862
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr ""
 
-#: transport-helper.c:942
+#: transport-helper.c:945
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr ""
 
-#: transport-helper.c:945
+#: transport-helper.c:948
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr ""
 
-#: transport-helper.c:948
+#: transport-helper.c:951
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr ""
 
-#: transport-helper.c:953
+#: transport-helper.c:956
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr ""
 
-#: transport-helper.c:957
+#: transport-helper.c:960
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr ""
 
-#: transport-helper.c:964
+#: transport-helper.c:967
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr ""
 
-#: transport-helper.c:1064
+#: transport-helper.c:1067
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr ""
 
-#: transport-helper.c:1069
+#: transport-helper.c:1072
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr ""
 
-#: transport-helper.c:1116
+#: transport-helper.c:1119
 msgid "couldn't run fast-export"
 msgstr ""
 
-#: transport-helper.c:1121
+#: transport-helper.c:1124
 msgid "error while running fast-export"
 msgstr ""
 
-#: transport-helper.c:1146
+#: transport-helper.c:1149
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
 "Perhaps you should specify a branch.\n"
 msgstr ""
 
-#: transport-helper.c:1228
+#: transport-helper.c:1231
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr ""
 
-#: transport-helper.c:1237
+#: transport-helper.c:1240
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr ""
 
-#: transport-helper.c:1389
+#: transport-helper.c:1392
 #, c-format
 msgid "read(%s) failed"
 msgstr ""
 
-#: transport-helper.c:1416
+#: transport-helper.c:1419
 #, c-format
 msgid "write(%s) failed"
 msgstr ""
 
-#: transport-helper.c:1465
+#: transport-helper.c:1468
 #, c-format
 msgid "%s thread failed"
 msgstr ""
 
-#: transport-helper.c:1469
+#: transport-helper.c:1472
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr ""
 
-#: transport-helper.c:1488 transport-helper.c:1492
+#: transport-helper.c:1491 transport-helper.c:1495
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr ""
 
-#: transport-helper.c:1529
+#: transport-helper.c:1532
 #, c-format
 msgid "%s process failed to wait"
 msgstr ""
 
-#: transport-helper.c:1533
+#: transport-helper.c:1536
 #, c-format
 msgid "%s process failed"
 msgstr ""
 
-#: transport-helper.c:1551 transport-helper.c:1560
+#: transport-helper.c:1554 transport-helper.c:1563
 msgid "can't start thread for copying data"
 msgstr ""
 
@@ -8984,58 +9324,58 @@ msgstr ""
 msgid "Would set upstream of '%s' to '%s' of '%s'\n"
 msgstr ""
 
-#: transport.c:145
+#: transport.c:138
 #, c-format
 msgid "could not read bundle '%s'"
 msgstr ""
 
-#: transport.c:227
+#: transport.c:234
 #, c-format
 msgid "transport: invalid depth option '%s'"
 msgstr ""
 
-#: transport.c:279
+#: transport.c:289
 msgid "see protocol.version in 'git help config' for more details"
 msgstr ""
 
-#: transport.c:280
+#: transport.c:290
 msgid "server options require protocol version 2 or later"
 msgstr ""
 
-#: transport.c:407
+#: transport.c:418
 msgid "server does not support wait-for-done"
 msgstr ""
 
-#: transport.c:759
+#: transport.c:770
 msgid "could not parse transport.color.* config"
 msgstr ""
 
-#: transport.c:834
+#: transport.c:845
 msgid "support for protocol v2 not implemented yet"
 msgstr ""
 
-#: transport.c:967
+#: transport.c:978
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr ""
 
-#: transport.c:1033
+#: transport.c:1044
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr ""
 
-#: transport.c:1082
+#: transport.c:1093
 msgid "git-over-rsync is no longer supported"
 msgstr ""
 
-#: transport.c:1185
+#: transport.c:1196
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
 "not be found on any remote:\n"
 msgstr ""
 
-#: transport.c:1189
+#: transport.c:1200
 #, c-format
 msgid ""
 "\n"
@@ -9051,11 +9391,11 @@ msgid ""
 "\n"
 msgstr ""
 
-#: transport.c:1197
+#: transport.c:1208
 msgid "Aborting."
 msgstr ""
 
-#: transport.c:1343
+#: transport.c:1354
 msgid "failed to push all needed submodules"
 msgstr ""
 
@@ -9275,16 +9615,16 @@ msgid ""
 "colliding group is in the working tree:\n"
 msgstr ""
 
-#: unpack-trees.c:1636
+#: unpack-trees.c:1664
 msgid "Updating index flags"
 msgstr ""
 
-#: unpack-trees.c:2803
+#: unpack-trees.c:2925
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 
-#: upload-pack.c:1565
+#: upload-pack.c:1579
 msgid "expected flush after fetch arguments"
 msgstr "bilasan diharapkan setelah argumen pengambilan"
 
@@ -9321,124 +9661,138 @@ msgstr ""
 msgid "Fetching objects"
 msgstr ""
 
-#: worktree.c:238 builtin/am.c:2209 builtin/bisect--helper.c:156
+#: worktree.c:237 builtin/am.c:2210 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "gagal membaca '%s'"
 
-#: worktree.c:305
+#: worktree.c:304
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr "'%s' pada pohon kerja utama bukan direktori repositori"
 
-#: worktree.c:316
+#: worktree.c:315
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr "berkas '%s' tidak berisi jalur absolut ke lokasi pohon kerja"
 
-#: worktree.c:328
+#: worktree.c:327
 #, c-format
 msgid "'%s' does not exist"
 msgstr "'%s' tidak ada"
 
-#: worktree.c:334
+#: worktree.c:333
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "'%s' bukan berkas .git, kode error %d"
 
-#: worktree.c:343
+#: worktree.c:342
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "'%s' tidak menunjuk kembali ke '%s'"
 
-#: worktree.c:604
+#: worktree.c:600
 msgid "not a directory"
 msgstr "bukan direktori"
 
-#: worktree.c:613
+#: worktree.c:609
 msgid ".git is not a file"
 msgstr ".git bukan berkas"
 
-#: worktree.c:615
+#: worktree.c:611
 msgid ".git file broken"
 msgstr "berkas .git rusak"
 
-#: worktree.c:617
+#: worktree.c:613
 msgid ".git file incorrect"
 msgstr "berkas .git salah"
 
-#: worktree.c:723
+#: worktree.c:719
 msgid "not a valid path"
 msgstr "bukan jalur valid"
 
-#: worktree.c:729
+#: worktree.c:725
 msgid "unable to locate repository; .git is not a file"
 msgstr "tidak dapat menempatkan repositori; .git bukan berkas"
 
-#: worktree.c:733
+#: worktree.c:729
 msgid "unable to locate repository; .git file does not reference a repository"
 msgstr ""
 "tidak dapat menempatkan repositori; berkas .git tidak merujuk repositori"
 
-#: worktree.c:737
+#: worktree.c:733
 msgid "unable to locate repository; .git file broken"
 msgstr "tidak dapat menempatkan repositori; berkas .git rusak"
 
-#: worktree.c:743
+#: worktree.c:739
 msgid "gitdir unreadable"
 msgstr "gitdir tidak dapat dibaca"
 
-#: worktree.c:747
+#: worktree.c:743
 msgid "gitdir incorrect"
 msgstr "gitdir salah"
 
-#: worktree.c:772
+#: worktree.c:768
 msgid "not a valid directory"
 msgstr "bukan direktori valid"
 
-#: worktree.c:778
+#: worktree.c:774
 msgid "gitdir file does not exist"
 msgstr "berkas gitdir tidak ada"
 
-#: worktree.c:783 worktree.c:792
+#: worktree.c:779 worktree.c:788
 #, c-format
 msgid "unable to read gitdir file (%s)"
 msgstr "tidak dapat membaca berkas gitdir (%s)"
 
-#: worktree.c:802
+#: worktree.c:798
 #, c-format
 msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
 msgstr "baca singkat (diharapkan %<PRIuMAX> bita, terbaca %<PRIuMAX>)"
 
-#: worktree.c:810
+#: worktree.c:806
 msgid "invalid gitdir file"
 msgstr "berkas gitdir tidak valid"
 
-#: worktree.c:818
+#: worktree.c:814
 msgid "gitdir file points to non-existent location"
 msgstr "berkas gitdir menunjuk ke lokasi yang tidak ada"
 
-#: wrapper.c:151
+#: worktree.c:830
+#, c-format
+msgid "unable to set %s in '%s'"
+msgstr "tidak dapat menyetel %s di '%s'"
+
+#: worktree.c:832
+#, c-format
+msgid "unable to unset %s in '%s'"
+msgstr "tidak dapat menyetel balik %s di '%s'"
+
+#: worktree.c:852
+msgid "failed to set extensions.worktreeConfig setting"
+msgstr "gagal menyetel setelan extensions.worktreeConfig"
+
+#: wrapper.c:161
 #, c-format
 msgid "could not setenv '%s'"
 msgstr ""
 
-#: wrapper.c:203
+#: wrapper.c:213
 #, c-format
 msgid "unable to create '%s'"
 msgstr "tidak dapat membuat '%s'"
 
-#: wrapper.c:205 wrapper.c:375
+#: wrapper.c:215 wrapper.c:385
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr ""
 
-#: wrapper.c:406 wrapper.c:607
+#: wrapper.c:416 wrapper.c:683
 #, c-format
 msgid "unable to access '%s'"
 msgstr ""
 
-#: wrapper.c:615
+#: wrapper.c:691
 msgid "unable to get current working directory"
 msgstr ""
 
@@ -9475,11 +9829,11 @@ msgstr ""
 msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr "  (gunakan \"git rm <berkas>\" untuk menandai penyelesaian)"
 
-#: wt-status.c:211 wt-status.c:1131
+#: wt-status.c:211 wt-status.c:1140
 msgid "Changes to be committed:"
 msgstr "Perubahan yang akan dikomit:"
 
-#: wt-status.c:234 wt-status.c:1140
+#: wt-status.c:234 wt-status.c:1149
 msgid "Changes not staged for commit:"
 msgstr "Perubahan yang tidak digelar untuk komit:"
 
@@ -9583,22 +9937,22 @@ msgstr "konten yang dimodifikasi, "
 msgid "untracked content, "
 msgstr "konten yang tak dilacak, "
 
-#: wt-status.c:964
+#: wt-status.c:973
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Simpanan Anda saat ini ada %d entri"
 msgstr[1] "Simpanan Anda saat ini ada %d entri"
 
-#: wt-status.c:995
+#: wt-status.c:1004
 msgid "Submodules changed but not updated:"
 msgstr "Submodul berubah tapi tak diperbarui:"
 
-#: wt-status.c:997
+#: wt-status.c:1006
 msgid "Submodule changes to be committed:"
 msgstr "Perubahan submodul yang akan dikomit:"
 
-#: wt-status.c:1079
+#: wt-status.c:1088
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -9606,7 +9960,7 @@ msgstr ""
 "Jangan ubah atau hapus baris diatas.\n"
 "Semua dibawahnya akan diabaikan."
 
-#: wt-status.c:1171
+#: wt-status.c:1180
 #, c-format
 msgid ""
 "\n"
@@ -9617,273 +9971,273 @@ msgstr ""
 "Butuh %.2f detik untuk menghitung cabang di depan/di belakang nilai.\n"
 "Anda bisa gunakan '--no-ahead-behind' untuk menghindari hal tersebut.\n"
 
-#: wt-status.c:1201
+#: wt-status.c:1210
 msgid "You have unmerged paths."
 msgstr "Anda punya jalur yang tak tergabung."
 
-#: wt-status.c:1204
+#: wt-status.c:1213
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (selesaikan konflik dan jalankan \"git commit\")"
 
-#: wt-status.c:1206
+#: wt-status.c:1215
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (gunakan \"git merge --abort\" untuk membatalkan penggabungan)"
 
-#: wt-status.c:1210
+#: wt-status.c:1219
 msgid "All conflicts fixed but you are still merging."
 msgstr "Semua konflik sudah selesai tapi Anda masih menggabungkan."
 
-#: wt-status.c:1213
+#: wt-status.c:1222
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (gunakan \"git commit\" untuk mengakhiri penggabungan)"
 
-#: wt-status.c:1224
+#: wt-status.c:1233
 msgid "You are in the middle of an am session."
 msgstr "Anda berada ditengah-tengah sesi am."
 
-#: wt-status.c:1227
+#: wt-status.c:1236
 msgid "The current patch is empty."
 msgstr "Jalur saat ini kosong"
 
-#: wt-status.c:1232
+#: wt-status.c:1241
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (selesaikan konflik lalu jalankan \"git am --continue\")"
 
-#: wt-status.c:1234
+#: wt-status.c:1243
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (gunakan \"git am --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1237
+#: wt-status.c:1246
 msgid ""
 "  (use \"git am --allow-empty\" to record this patch as an empty commit)"
 msgstr ""
 "  (gunakan \"git am --allow-empty\" untuk merekam tambalan ini sebagai komit "
 "kosong)"
 
-#: wt-status.c:1239
+#: wt-status.c:1248
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr "  (gunakan \"git am --abort\" untuk mengembalikan cabang asal)"
 
-#: wt-status.c:1372
+#: wt-status.c:1381
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo hilang."
 
-#: wt-status.c:1374
+#: wt-status.c:1383
 msgid "No commands done."
 msgstr "Tidak ada perintah selesai."
 
-#: wt-status.c:1377
+#: wt-status.c:1386
 #, c-format
-msgid "Last command done (%d command done):"
-msgid_plural "Last commands done (%d commands done):"
-msgstr[0] "Perintah yang selesai (%d perintah):"
-msgstr[1] "Perintah yang selesai (%d perintah):"
+msgid "Last command done (%<PRIuMAX> command done):"
+msgid_plural "Last commands done (%<PRIuMAX> commands done):"
+msgstr[0] "Perintah yang selesai (%<PRIuMAX> perintah):"
+msgstr[1] "Perintah yang selesai (%<PRIuMAX> perintah):"
 
-#: wt-status.c:1388
+#: wt-status.c:1397
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (lihat lebih lanjut di berkas %s)"
 
-#: wt-status.c:1393
+#: wt-status.c:1402
 msgid "No commands remaining."
 msgstr "Tidak ada perintah yang tersisa."
 
-#: wt-status.c:1396
+#: wt-status.c:1405
 #, c-format
-msgid "Next command to do (%d remaining command):"
-msgid_plural "Next commands to do (%d remaining commands):"
-msgstr[0] "Perintah berikutnya (%d perintah tersisa):"
-msgstr[1] "Perintah berikutnya (%d perintah tersisa):"
+msgid "Next command to do (%<PRIuMAX> remaining command):"
+msgid_plural "Next commands to do (%<PRIuMAX> remaining commands):"
+msgstr[0] "Perintah berikutnya (%<PRIuMAX> perintah tersisa):"
+msgstr[1] "Perintah berikutnya (%<PRIuMAX> perintah tersisa):"
 
-#: wt-status.c:1404
+#: wt-status.c:1413
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (gunakan \"git rebase --edit-todo\" untuk lihat dan sunting)"
 
-#: wt-status.c:1416
+#: wt-status.c:1425
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Anda sedang mendasarkan ulang cabang '%s' pada '%s'."
 
-#: wt-status.c:1421
+#: wt-status.c:1430
 msgid "You are currently rebasing."
 msgstr "Anda sedang mendasarkan ulang."
 
-#: wt-status.c:1434
+#: wt-status.c:1443
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr "  (selesaikan konflik lalu jalankan \"git rebase --continue\")"
 
-#: wt-status.c:1436
+#: wt-status.c:1445
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (gunakan \"git rebase --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1438
+#: wt-status.c:1447
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr "  (gunakan \"git rebase --abort\" untuk check out cabang asal)"
 
-#: wt-status.c:1445
+#: wt-status.c:1454
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (semua konflik sudah selesai: jalankan \"git rebase --continue\")"
 
-#: wt-status.c:1449
+#: wt-status.c:1458
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Anda sedang membelah komit saat mendasarkan ulang cabang '%s' pada '%s'."
 
-#: wt-status.c:1454
+#: wt-status.c:1463
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Anda sedang membelah komit saat mendasarkan ulang."
 
-#: wt-status.c:1457
+#: wt-status.c:1466
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Setelah direktori kerja Anda bersih, jalankan \"git rebase --continue\")"
 
-#: wt-status.c:1461
+#: wt-status.c:1470
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Anda sedang menyunting komit saat mendasarkan ulang cabang '%s' pada '%s'."
 
-#: wt-status.c:1466
+#: wt-status.c:1475
 msgid "You are currently editing a commit during a rebase."
 msgstr "Anda sedang menyunting komit saat mendasarkan ulang."
 
-#: wt-status.c:1469
+#: wt-status.c:1478
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr "  (gunakan \"git commit --amend\" untuk mengubah komit saat ini)"
 
-#: wt-status.c:1471
+#: wt-status.c:1480
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (gunakan \"git rebase --continue\" begitu Anda puas dengan perubahan Anda)"
 
-#: wt-status.c:1482
+#: wt-status.c:1491
 msgid "Cherry-pick currently in progress."
 msgstr "Petik ceri sedang berjalan."
 
-#: wt-status.c:1485
+#: wt-status.c:1494
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Anda sedang memetik ceri komit %s."
 
-#: wt-status.c:1492
+#: wt-status.c:1501
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (selesaikan konflik dan jalankan \"git cherry-pick --continue\")"
 
-#: wt-status.c:1495
+#: wt-status.c:1504
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (jalankan \"git cherry-pick --continue\" untuk melanjutkan)"
 
-#: wt-status.c:1498
+#: wt-status.c:1507
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (semua konflik sudah selesai: jalankan \"git cherry-pick --continue\")"
 
-#: wt-status.c:1500
+#: wt-status.c:1509
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr "  (gunakan \"git cherry-pick --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1502
+#: wt-status.c:1511
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (gunakan \"git cherry-pick --abort\" untuk membatalkan operasi petik ceri)"
 
-#: wt-status.c:1512
+#: wt-status.c:1521
 msgid "Revert currently in progress."
 msgstr "Pengembalian sedang berjalang."
 
-#: wt-status.c:1515
+#: wt-status.c:1524
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Anda sedang mengembalikan komit %s."
 
-#: wt-status.c:1521
+#: wt-status.c:1530
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (selesaikan konflik dan jalankan \"git revert --continue\")"
 
-#: wt-status.c:1524
+#: wt-status.c:1533
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (jalankan \"git revert --continue\" untuk melanjutkan)"
 
-#: wt-status.c:1527
+#: wt-status.c:1536
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (semua konflik sudah selesai: jalankan \"git revert --continue\")"
 
-#: wt-status.c:1529
+#: wt-status.c:1538
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (gunakan \"git revert --skip\" untuk lewati tambalan ini)"
 
-#: wt-status.c:1531
+#: wt-status.c:1540
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr ""
 "  (gunakan \"git revert --abort\" untuk membatalkan operasi pengembalian)"
 
-#: wt-status.c:1541
+#: wt-status.c:1550
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Anda sedang membagi dua, dimulai dari cabang '%s'."
 
-#: wt-status.c:1545
+#: wt-status.c:1554
 msgid "You are currently bisecting."
 msgstr "Anda sedang membagi dua."
 
-#: wt-status.c:1548
+#: wt-status.c:1557
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr "  (gunakan \"git bisect reset\" untuk kembali ke cabang asal)"
 
-#: wt-status.c:1559
+#: wt-status.c:1568
 msgid "You are in a sparse checkout."
 msgstr "Anda berada dalam checkout tipis."
 
-#: wt-status.c:1562
+#: wt-status.c:1571
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr "Anda berada dalam checkout tipis dengan %d%% berkas terlacak ada."
 
-#: wt-status.c:1806
+#: wt-status.c:1815
 msgid "On branch "
 msgstr "Pada cabang "
 
-#: wt-status.c:1813
+#: wt-status.c:1822
 msgid "interactive rebase in progress; onto "
 msgstr "sedang mendasarkan ulang interaktif; ke "
 
-#: wt-status.c:1815
+#: wt-status.c:1824
 msgid "rebase in progress; onto "
 msgstr "sedang mendasarkan ulang; ke "
 
-#: wt-status.c:1820
+#: wt-status.c:1829
 msgid "HEAD detached at "
 msgstr ""
 
-#: wt-status.c:1822
+#: wt-status.c:1831
 msgid "HEAD detached from "
 msgstr ""
 
-#: wt-status.c:1825
+#: wt-status.c:1834
 msgid "Not currently on any branch."
 msgstr "Tidak sedang berada pada cabang apapun."
 
-#: wt-status.c:1842
+#: wt-status.c:1851
 msgid "Initial commit"
 msgstr "Komit awal"
 
-#: wt-status.c:1843
+#: wt-status.c:1852
 msgid "No commits yet"
 msgstr "Tidak ada komit"
 
-#: wt-status.c:1857
+#: wt-status.c:1866
 msgid "Untracked files"
 msgstr "Berkas tak terlacak"
 
-#: wt-status.c:1859
+#: wt-status.c:1868
 msgid "Ignored files"
 msgstr "Berkas yang diabaikan"
 
-#: wt-status.c:1863
+#: wt-status.c:1872
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -9894,32 +10248,32 @@ msgstr ""
 "mungkin bisa mempercepat, tapi Anda harus berhati-hati jangan sampai lupa\n"
 "untuk tambahkan berkas baru sendiri (lihat 'git help status')."
 
-#: wt-status.c:1869
+#: wt-status.c:1878
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Berkas tak terlacak yang tak disebutkan%s"
 
-#: wt-status.c:1871
+#: wt-status.c:1880
 msgid " (use -u option to show untracked files)"
 msgstr " (gunakan opsi -u untuk melihat berkas yang tak terlacak)"
 
-#: wt-status.c:1877
+#: wt-status.c:1886
 msgid "No changes"
 msgstr "Tidak ada perubahan"
 
-#: wt-status.c:1882
+#: wt-status.c:1891
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "tidak ada perubahan untuk dikomit (gunakan \"git add\" dan/atau \"git commit "
 "-a\")\n"
 
-#: wt-status.c:1886
+#: wt-status.c:1895
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "tidak ada perubahan untuk dikomit\n"
 
-#: wt-status.c:1890
+#: wt-status.c:1899
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -9928,64 +10282,64 @@ msgstr ""
 "tidak ada perubahan untuk dikomit tapi berkas yang tak terlacak ada(gunakan "
 "\"git add\" untuk lacak)\n"
 
-#: wt-status.c:1894
+#: wt-status.c:1903
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "tidak ada perubahan untuk dikomit tapi berkas yang tak terlacak ada\n"
 
-#: wt-status.c:1898
+#: wt-status.c:1907
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "tidak ada yang dikomit (buat/salin berkas dan gunakan \"git add\" untuk "
 "lacak)\n"
 
-#: wt-status.c:1902 wt-status.c:1908
+#: wt-status.c:1911 wt-status.c:1917
 #, c-format
 msgid "nothing to commit\n"
 msgstr "tidak ada yang dikomit\n"
 
-#: wt-status.c:1905
+#: wt-status.c:1914
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr "tidak ada yang dikomit (gunakan -u untuk lihat berkas tak terlacak)\n"
 
-#: wt-status.c:1910
+#: wt-status.c:1919
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "tidak ada yang dikomit, pohon kerja bersih\n"
 
-#: wt-status.c:2015
+#: wt-status.c:2024
 msgid "No commits yet on "
 msgstr "Tidak ada komit apapun pada "
 
-#: wt-status.c:2019
+#: wt-status.c:2028
 msgid "HEAD (no branch)"
 msgstr "HEAD (tanpa cabang)"
 
-#: wt-status.c:2050
+#: wt-status.c:2059
 msgid "different"
 msgstr "berbeda"
 
-#: wt-status.c:2052 wt-status.c:2060
+#: wt-status.c:2061 wt-status.c:2069
 msgid "behind "
 msgstr "di belakang "
 
-#: wt-status.c:2055 wt-status.c:2058
+#: wt-status.c:2064 wt-status.c:2067
 msgid "ahead "
 msgstr "di depan "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2596
+#: wt-status.c:2605
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "tidak dapat %s: Anda punya perubahan yang tidak digelar."
 
-#: wt-status.c:2602
+#: wt-status.c:2611
 msgid "additionally, your index contains uncommitted changes."
 msgstr "juga indeks Anda berisi perubahan yang belum dikomit."
 
-#: wt-status.c:2604
+#: wt-status.c:2613
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "tidak dapat %s: indeks Anda berisi perubahan yang belum dikomit."
@@ -10008,145 +10362,149 @@ msgstr ""
 msgid "could not start worker[0] for '%s'"
 msgstr ""
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:347
+#: compat/precompose_utf8.c:58 builtin/clone.c:353
 #, c-format
 msgid "failed to unlink '%s'"
+msgstr "gagal menghapus tautan '%s'"
+
+#: compat/fsmonitor/fsm-listen-darwin.c:355
+msgid "Unable to create FSEventStream."
+msgstr ""
+
+#: compat/fsmonitor/fsm-listen-darwin.c:403
+msgid "Failed to start the FSEventStream"
 msgstr ""
 
 #: builtin/add.c:26
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<opsi>] [--] <pathspec>..."
 
-#: builtin/add.c:64
+#: builtin/add.c:63
 #, c-format
 msgid "cannot chmod %cx '%s'"
 msgstr "tidak dapat chmod %cx '%s'"
 
-#: builtin/add.c:106
+#: builtin/add.c:105
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "status diff tak diharapkan %c"
 
-#: builtin/add.c:111 builtin/commit.c:298
+#: builtin/add.c:110 builtin/commit.c:299
 msgid "updating files failed"
 msgstr "gagal memperbarui berkas"
 
-#: builtin/add.c:121
+#: builtin/add.c:120
 #, c-format
 msgid "remove '%s'\n"
 msgstr "hapus '%s'\n"
 
-#: builtin/add.c:205
+#: builtin/add.c:204
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Perubahan tak tergelar setelah menyegarkan indeks:"
 
-#: builtin/add.c:313 builtin/rev-parse.c:993
+#: builtin/add.c:312 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Tidak dapat membaca indeks"
 
-#: builtin/add.c:326
+#: builtin/add.c:325
 msgid "Could not write patch"
 msgstr "Tidak dapat menulis tambalan"
 
-#: builtin/add.c:329
+#: builtin/add.c:328
 msgid "editing patch failed"
 msgstr "Gagal menyunting tambalan"
 
-#: builtin/add.c:332
+#: builtin/add.c:331
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Tidak dapat men-stat '%s'"
 
-#: builtin/add.c:334
+#: builtin/add.c:333
 msgid "Empty patch. Aborted."
 msgstr "Tambalan kosong. Dibatalkan."
 
-#: builtin/add.c:340
+#: builtin/add.c:339
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Tidak dapat terapkan '%s'"
 
-#: builtin/add.c:348
+#: builtin/add.c:347
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "Jalur berikut diabaikan oleh salah satu dari berkas .gitignore Anda:\n"
 
-#: builtin/add.c:368 builtin/clean.c:927 builtin/fetch.c:174 builtin/mv.c:124
+#: builtin/add.c:367 builtin/clean.c:927 builtin/fetch.c:175 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
-#: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
+#: builtin/remote.c:1454 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "latihan"
 
-#: builtin/add.c:369 builtin/check-ignore.c:22 builtin/commit.c:1484
-#: builtin/count-objects.c:98 builtin/fsck.c:789 builtin/log.c:2313
+#: builtin/add.c:368 builtin/check-ignore.c:22 builtin/commit.c:1483
+#: builtin/count-objects.c:98 builtin/fsck.c:789 builtin/log.c:2338
 #: builtin/mv.c:123 builtin/read-tree.c:120
 msgid "be verbose"
 msgstr "jadi berkata-kata"
 
-#: builtin/add.c:371
+#: builtin/add.c:370
 msgid "interactive picking"
 msgstr "pengambilan interaktif"
 
-#: builtin/add.c:372 builtin/checkout.c:1581 builtin/reset.c:409
+#: builtin/add.c:371 builtin/checkout.c:1599 builtin/reset.c:417
 msgid "select hunks interactively"
 msgstr "pilih bingkah secara interaktif"
 
-#: builtin/add.c:373
+#: builtin/add.c:372
 msgid "edit current diff and apply"
 msgstr "sunting diff saat ini dan terapkan"
 
-#: builtin/add.c:374
+#: builtin/add.c:373
 msgid "allow adding otherwise ignored files"
 msgstr "perbolehkan tambah berkas yang diabaikan"
 
-#: builtin/add.c:375
+#: builtin/add.c:374
 msgid "update tracked files"
 msgstr "perbarui berkas terlacak"
 
-#: builtin/add.c:376
+#: builtin/add.c:375
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "normalisasi ulang EOL berkas terlacak (menyiratkan -u)"
 
-#: builtin/add.c:377
+#: builtin/add.c:376
 msgid "record only the fact that the path will be added later"
 msgstr "rekam hanya fakta bahwa jalur akan ditambahkan nanti"
 
-#: builtin/add.c:378
+#: builtin/add.c:377
 msgid "add changes from all tracked and untracked files"
 msgstr "tambahkan perubahan dari semua berkas terlacak dan tak terlacak"
 
-#: builtin/add.c:381
+#: builtin/add.c:380
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "abaikan jalur yang terhapus dari pohon kerja (sama dengan --no-all)"
 
-#: builtin/add.c:383
+#: builtin/add.c:382
 msgid "don't add, only refresh the index"
 msgstr "jangan tambahkan, hanya segarkan indeks"
 
-#: builtin/add.c:384
+#: builtin/add.c:383
 msgid "just skip files which cannot be added because of errors"
 msgstr "hanya lewatkan berkas yang tidak dapat ditambah karena error"
 
-#: builtin/add.c:385
+#: builtin/add.c:384
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "periksa bahwa berkas yang - bahkan hilang - diabaikan dalam latihan"
 
-#: builtin/add.c:386 builtin/mv.c:128 builtin/rm.c:251
+#: builtin/add.c:385 builtin/mv.c:128 builtin/rm.c:251
 msgid "allow updating entries outside of the sparse-checkout cone"
 msgstr "perbolehkan perbarui entri di luar kerucut checkout tipis"
 
-#: builtin/add.c:388 builtin/update-index.c:1004
+#: builtin/add.c:387 builtin/update-index.c:1023
 msgid "override the executable bit of the listed files"
 msgstr "timpa bit yang dapat dieksekusi dari berkas terdaftar"
 
-#: builtin/add.c:390
+#: builtin/add.c:389
 msgid "warn when adding an embedded repository"
 msgstr "peringatkan ketika menambahkan repositori tertanam"
 
-#: builtin/add.c:392
-msgid "backend for `git stash -p`"
-msgstr "tulang belakang untuk `git stash -p`"
-
-#: builtin/add.c:410
+#: builtin/add.c:407
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10177,12 +10535,12 @@ msgstr ""
 "\n"
 "Lihat \"git help submodule\" untuk selengkapnya."
 
-#: builtin/add.c:439
+#: builtin/add.c:436
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "menambahkan repositori git tertanam: %s"
 
-#: builtin/add.c:459
+#: builtin/add.c:456
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10192,27 +10550,27 @@ msgstr ""
 "Matikan pesan ini dengan menjalankan\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:474
+#: builtin/add.c:471
 msgid "adding files failed"
 msgstr "gagal menambahkan berkas"
 
-#: builtin/add.c:548
+#: builtin/add.c:534
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod param '%s' harus berupa -x atau +x"
 
-#: builtin/add.c:569 builtin/checkout.c:1751 builtin/commit.c:364
-#: builtin/reset.c:429 builtin/rm.c:275 builtin/stash.c:1713
+#: builtin/add.c:555 builtin/checkout.c:1770 builtin/commit.c:365
+#: builtin/reset.c:436 builtin/rm.c:275 builtin/stash.c:1702
 #, c-format
 msgid "'%s' and pathspec arguments cannot be used together"
 msgstr "'%s' dan argumen spek jalur tidak dapat digunakan bersamaan"
 
-#: builtin/add.c:580
+#: builtin/add.c:566
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Tidak ada yang disebutkan, tidak ada yang ditambahkan.\n"
 
-#: builtin/add.c:582
+#: builtin/add.c:568
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10222,121 +10580,116 @@ msgstr ""
 "Matikan pesan ini dengan menjalankan\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:202
-#, c-format
-msgid "Invalid value for --empty: %s"
-msgstr "Nilai tidak valid untuk --empty: %s"
-
-#: builtin/am.c:392
+#: builtin/am.c:393
 msgid "could not parse author script"
 msgstr "tidak dapat mengurai skrip pengarang"
 
-#: builtin/am.c:482
+#: builtin/am.c:483
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' dihapus oleh kail applypatch-msg"
 
-#: builtin/am.c:524
+#: builtin/am.c:525
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Baris masukan salah format: '%s'."
 
-#: builtin/am.c:562
+#: builtin/am.c:563
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Gagal menyalin catatan dari '%s' ke '%s'"
 
-#: builtin/am.c:588
+#: builtin/am.c:589
 msgid "fseek failed"
 msgstr "fseek gagal"
 
-#: builtin/am.c:776
+#: builtin/am.c:777
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "tidak dapat mengurai tambalan '%s'"
 
-#: builtin/am.c:841
+#: builtin/am.c:842
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Hanya satu rangkaian tambalan StGIT yang bisa diterapkan sekaligus"
 
-#: builtin/am.c:889
+#: builtin/am.c:890
 msgid "invalid timestamp"
 msgstr "stempel waktu tidak valid"
 
-#: builtin/am.c:894 builtin/am.c:906
+#: builtin/am.c:895 builtin/am.c:907
 msgid "invalid Date line"
 msgstr "baris Date tidak valid"
 
-#: builtin/am.c:901
+#: builtin/am.c:902
 msgid "invalid timezone offset"
 msgstr "offset zona waktu tidak valid"
 
-#: builtin/am.c:994
+#: builtin/am.c:995
 msgid "Patch format detection failed."
 msgstr "Pendeteksian format tambalan gagal."
 
-#: builtin/am.c:999 builtin/clone.c:300
+#: builtin/am.c:1000 builtin/clone.c:306
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "gagal membuat direktori '%s'"
 
-#: builtin/am.c:1004
+#: builtin/am.c:1005
 msgid "Failed to split patches."
 msgstr "Gagal memecah tambalan."
 
-#: builtin/am.c:1153
+#: builtin/am.c:1154
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "Saat Anda sudah menyelesaikan masalah ini, jalankan \"%s --continue\"."
 
-#: builtin/am.c:1154
+#: builtin/am.c:1155
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 "Jika Anda lebih suka melewati tambalan ini, jalankan \"%s --skip\" sebagai "
 "gantinya."
 
-#: builtin/am.c:1159
+#: builtin/am.c:1160
 #, c-format
 msgid "To record the empty patch as an empty commit, run \"%s --allow-empty\"."
 msgstr ""
 "Untuk merekam tambalan kosong sebagai komit kosong, jalankan \"%s --allow-"
 "empty\"."
 
-#: builtin/am.c:1161
+#: builtin/am.c:1162
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Untuk mengembalikan cabang yang asli dan berhenti menambal, jalankan \"%s --"
 "abort\""
 
-#: builtin/am.c:1256
+#: builtin/am.c:1257
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Tambalan dikirimkan dengan format=flowed; spasi pada akhir baris mungkin "
 "hilang."
 
-#: builtin/am.c:1344
+#: builtin/am.c:1345
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "baris pengarang hilang dalam komit %s"
 
-#: builtin/am.c:1347
+#: builtin/am.c:1348
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "baris identitas tidak valid: %.*s"
 
-#: builtin/am.c:1566
+#: builtin/am.c:1567
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Repositori kekurangan blob yang diperlukan untuk mundur ke penggabungan 3 "
 "arah."
 
-#: builtin/am.c:1568
+#: builtin/am.c:1569
 msgid "Using index info to reconstruct a base tree..."
 msgstr "Menggunakan info indeks untuk membangun ulang sebuah pohon dasar..."
 
-#: builtin/am.c:1587
+#: builtin/am.c:1588
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10344,24 +10697,24 @@ msgstr ""
 "Apakah Anda menyunting tambalan Anda?\n"
 "Itu tidak diterapkan ke blob yang direkam dalam indeksnya."
 
-#: builtin/am.c:1593
+#: builtin/am.c:1594
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Mundur ke penambalan dasar dan penggabungan 3 arah..."
 
-#: builtin/am.c:1619
+#: builtin/am.c:1620
 msgid "Failed to merge in the changes."
 msgstr "Gagal menggabungkan perubahan."
 
-#: builtin/am.c:1651
+#: builtin/am.c:1652
 msgid "applying to an empty history"
 msgstr "menerapkan ke sebuah riwayat kosong"
 
-#: builtin/am.c:1703 builtin/am.c:1707
+#: builtin/am.c:1704 builtin/am.c:1708
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "tidak dapat melanjutkan: %s tidak ada."
 
-#: builtin/am.c:1725
+#: builtin/am.c:1726
 msgid "Commit Body is:"
 msgstr "Badan komit adalah:"
 
@@ -10369,59 +10722,59 @@ msgstr "Badan komit adalah:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1735
+#: builtin/am.c:1736
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Terapkan? [y]a/[n] tidak/[e] sunting/[v] lihat tambalan/terim[a] semua: "
 
-#: builtin/am.c:1781 builtin/commit.c:409
+#: builtin/am.c:1782 builtin/commit.c:410
 msgid "unable to write index file"
 msgstr "tidak dapat menulis berkas indeks"
 
-#: builtin/am.c:1785
+#: builtin/am.c:1786
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Indeks kotor: tidak dapat menerapkan tambalan (kotor: %s)"
 
-#: builtin/am.c:1827
+#: builtin/am.c:1828
 #, c-format
 msgid "Skipping: %.*s"
 msgstr "Melewatkan: %.*s"
 
-#: builtin/am.c:1832
+#: builtin/am.c:1833
 #, c-format
 msgid "Creating an empty commit: %.*s"
 msgstr "Membuat sebuah komit kosong: %.*s"
 
-#: builtin/am.c:1836
+#: builtin/am.c:1837
 msgid "Patch is empty."
 msgstr "Tambalan kosong."
 
-#: builtin/am.c:1847 builtin/am.c:1916
+#: builtin/am.c:1848 builtin/am.c:1917
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Menerapkan: %.*s"
 
-#: builtin/am.c:1864
+#: builtin/am.c:1865
 msgid "No changes -- Patch already applied."
 msgstr "Tidak ada perubahan -- tambalan sudah diterapkan"
 
-#: builtin/am.c:1870
+#: builtin/am.c:1871
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Penambalan gagal pada %s %.*s"
 
-#: builtin/am.c:1874
+#: builtin/am.c:1875
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "Gunakan 'git am --show-current-patch=diff' untuk melihat tambalan yang gagal"
 
-#: builtin/am.c:1920
+#: builtin/am.c:1921
 msgid "No changes - recorded it as an empty commit."
 msgstr "Tidak ada perubahan - direkam sebagai komit kosong."
 
-#: builtin/am.c:1922
+#: builtin/am.c:1923
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10431,7 +10784,7 @@ msgstr ""
 "Jika tidak ada lagi yang diterapkan, sepertinya sesuatu yang lain sudah \n"
 "memasukkan perubahan yang sama; mungkin Anda ingin melewatkan tambalan ini."
 
-#: builtin/am.c:1930
+#: builtin/am.c:1931
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -10444,17 +10797,17 @@ msgstr ""
 "Anda mungkin jalankan `git rm` pada berkas untuk menerima \"penghapusan oleh "
 "mereka\" untuk itu."
 
-#: builtin/am.c:2038 builtin/am.c:2042 builtin/am.c:2054 builtin/reset.c:448
-#: builtin/reset.c:456
+#: builtin/am.c:2039 builtin/am.c:2043 builtin/am.c:2055 builtin/reset.c:455
+#: builtin/reset.c:463
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Tidak dapat mengurai objek '%s'."
 
-#: builtin/am.c:2090 builtin/am.c:2166
+#: builtin/am.c:2091 builtin/am.c:2167
 msgid "failed to clean index"
 msgstr "gagal membersihkan indeks"
 
-#: builtin/am.c:2134
+#: builtin/am.c:2135
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10462,168 +10815,159 @@ msgstr ""
 "Sepertinya Anda telah memindahkan HEAD sejak kegagalan 'am' terakhir.\n"
 "Tidak memutar ulang ke ORIG_HEAD"
 
-#: builtin/am.c:2242
-#, c-format
-msgid "Invalid value for --patch-format: %s"
-msgstr "Nilai tidak valid untuk --patch-format: %s"
-
-#: builtin/am.c:2285
-#, c-format
-msgid "Invalid value for --show-current-patch: %s"
-msgstr "Nilai tidak valid untuk --show-current-patch: %s"
-
-#: builtin/am.c:2289
+#: builtin/am.c:2292
 #, c-format
 msgid "options '%s=%s' and '%s=%s' cannot be used together"
 msgstr "Opsi '%s=%s' dan '%s=%s' tidak dapat digunakan bersamaan"
 
-#: builtin/am.c:2320
+#: builtin/am.c:2323
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<opsi>] [(<mbox> | <Maildir>)...]"
 
-#: builtin/am.c:2321
+#: builtin/am.c:2324
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<opsi>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2327
+#: builtin/am.c:2330
 msgid "run interactively"
 msgstr "jalankan secara interaktif"
 
-#: builtin/am.c:2329
+#: builtin/am.c:2332
 msgid "historical option -- no-op"
 msgstr "opsi bersejarah -- no-op"
 
-#: builtin/am.c:2331
+#: builtin/am.c:2334
 msgid "allow fall back on 3way merging if needed"
 msgstr "perbolehkan mundur ke penggabungan 3 arah jika diperlukan"
 
-#: builtin/am.c:2332 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:642 builtin/stash.c:962
+#: builtin/am.c:2335 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:646 builtin/stash.c:946
 msgid "be quiet"
 msgstr "jadi senyap"
 
-#: builtin/am.c:2334
+#: builtin/am.c:2337
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "tambahkan trailer Signed-off-by kepada pesan komit"
 
-#: builtin/am.c:2337
+#: builtin/am.c:2340
 msgid "recode into utf8 (default)"
 msgstr "koding ulang ke dalam utf8 (asali)"
 
-#: builtin/am.c:2339
+#: builtin/am.c:2342
 msgid "pass -k flag to git-mailinfo"
 msgstr "lewatkan opsi -k ke git-mailinfo"
 
-#: builtin/am.c:2341
+#: builtin/am.c:2344
 msgid "pass -b flag to git-mailinfo"
 msgstr "lewatkan opsi -b ke git-mailinfo"
 
-#: builtin/am.c:2343
+#: builtin/am.c:2346
 msgid "pass -m flag to git-mailinfo"
 msgstr "lewatkan opsi -m ke git-mailinfo"
 
-#: builtin/am.c:2345
+#: builtin/am.c:2348
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "lewatkan opsi --keep-cr ke git-mailsplit untuk format mbox"
 
-#: builtin/am.c:2348
+#: builtin/am.c:2351
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "jangan lewatkan opsi --keep-cr ke git-mailsplit tak bergantung pada am.keepcr"
 
-#: builtin/am.c:2351
+#: builtin/am.c:2354
 msgid "strip everything before a scissors line"
 msgstr "copot semuanya sebelum garis gunting"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2356
 msgid "pass it through git-mailinfo"
 msgstr "lewatkannya melalui git-mailinfo"
 
-#: builtin/am.c:2356 builtin/am.c:2359 builtin/am.c:2362 builtin/am.c:2365
-#: builtin/am.c:2368 builtin/am.c:2371 builtin/am.c:2374 builtin/am.c:2377
-#: builtin/am.c:2383
+#: builtin/am.c:2359 builtin/am.c:2362 builtin/am.c:2365 builtin/am.c:2368
+#: builtin/am.c:2371 builtin/am.c:2374 builtin/am.c:2377 builtin/am.c:2380
+#: builtin/am.c:2386
 msgid "pass it through git-apply"
 msgstr "lewatkannya melalui git-apply"
 
-#: builtin/am.c:2373 builtin/commit.c:1515 builtin/fmt-merge-msg.c:18
-#: builtin/fmt-merge-msg.c:21 builtin/grep.c:919 builtin/merge.c:263
+#: builtin/am.c:2376 builtin/commit.c:1514 builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:21 builtin/grep.c:920 builtin/merge.c:263
 #: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
-#: builtin/rebase.c:1046 builtin/repack.c:653 builtin/repack.c:657
-#: builtin/repack.c:659 builtin/show-branch.c:649 builtin/show-ref.c:172
-#: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:317
+#: builtin/rebase.c:1074 builtin/repack.c:657 builtin/repack.c:661
+#: builtin/repack.c:663 builtin/show-branch.c:650 builtin/show-ref.c:172
+#: builtin/tag.c:446 parse-options.h:159 parse-options.h:180
+#: parse-options.h:348
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2379 builtin/branch.c:680 builtin/bugreport.c:109
-#: builtin/for-each-ref.c:41 builtin/replace.c:555 builtin/tag.c:479
-#: builtin/verify-tag.c:38
+#: builtin/am.c:2382 builtin/branch.c:695 builtin/bugreport.c:109
+#: builtin/cat-file.c:848 builtin/cat-file.c:852 builtin/cat-file.c:856
+#: builtin/for-each-ref.c:41 builtin/ls-tree.c:357 builtin/replace.c:555
+#: builtin/tag.c:480 builtin/verify-tag.c:38
 msgid "format"
 msgstr "format"
 
-#: builtin/am.c:2380
+#: builtin/am.c:2383
 msgid "format the patch(es) are in"
 msgstr "format tambalan yang ada di"
 
-#: builtin/am.c:2386
+#: builtin/am.c:2389
 msgid "override error message when patch failure occurs"
 msgstr "timpa pesan error ketika kegagalan penambalan terjadi"
 
-#: builtin/am.c:2388
+#: builtin/am.c:2391
 msgid "continue applying patches after resolving a conflict"
 msgstr "lanjutkan penerapan tambalan setelah menyelesaikan konflik"
 
-#: builtin/am.c:2391
+#: builtin/am.c:2394
 msgid "synonyms for --continue"
 msgstr "sinonim untuk --continue"
 
-#: builtin/am.c:2394
+#: builtin/am.c:2397
 msgid "skip the current patch"
 msgstr "lewati tambalan saat ini"
 
-#: builtin/am.c:2397
+#: builtin/am.c:2400
 msgid "restore the original branch and abort the patching operation"
 msgstr "kembalikan cabang asli dan batalkan operasi penambalan"
 
-#: builtin/am.c:2400
+#: builtin/am.c:2403
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "batalkan operasi penambalan tetapi simpan HEAD dimanapun itu"
 
-#: builtin/am.c:2404
+#: builtin/am.c:2407
 msgid "show the patch being applied"
 msgstr "perlihatkan tambalan yang diterapkan"
 
-#: builtin/am.c:2408
+#: builtin/am.c:2411
 msgid "record the empty patch as an empty commit"
 msgstr "rekam tambalan kosong sebagai komit kosong"
 
-#: builtin/am.c:2412
+#: builtin/am.c:2415
 msgid "lie about committer date"
 msgstr "berbohong soal tanggal pengkomit"
 
-#: builtin/am.c:2414
+#: builtin/am.c:2417
 msgid "use current timestamp for author date"
 msgstr "gunakan stempel waktu saat ini untuk tanggal pengarang"
 
-#: builtin/am.c:2416 builtin/commit-tree.c:118 builtin/commit.c:1643
-#: builtin/merge.c:302 builtin/pull.c:179 builtin/rebase.c:1099
-#: builtin/revert.c:117 builtin/tag.c:460
+#: builtin/am.c:2419 builtin/commit-tree.c:118 builtin/commit.c:1642
+#: builtin/merge.c:302 builtin/pull.c:179 builtin/rebase.c:1127
+#: builtin/revert.c:117 builtin/tag.c:461
 msgid "key-id"
 msgstr "key-id"
 
-#: builtin/am.c:2417 builtin/rebase.c:1100
+#: builtin/am.c:2420 builtin/rebase.c:1128
 msgid "GPG-sign commits"
 msgstr "tandatangani komit dengan GPG"
 
-#: builtin/am.c:2420
+#: builtin/am.c:2423
 msgid "how to handle empty patches"
 msgstr "bagaimana cara menangani tambalan kosong"
 
-#: builtin/am.c:2423
+#: builtin/am.c:2426
 msgid "(internal use for git-rebase)"
 msgstr "(penggunaan internal untuk git-rebase)"
 
-#: builtin/am.c:2441
+#: builtin/am.c:2444
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10631,17 +10975,17 @@ msgstr ""
 "Opsi -b/--binary telah menjadi no-op untuk waktu yang lama, dan\n"
 "itu akan dihapus. Mohon jangan gunakan itu lagi."
 
-#: builtin/am.c:2448
+#: builtin/am.c:2451
 msgid "failed to read the index"
 msgstr "gagal membaca indeks"
 
-#: builtin/am.c:2463
+#: builtin/am.c:2466
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
 "direktori pendasaran ulang sebelumnya %s masih ada tapi mbox diberikan."
 
-#: builtin/am.c:2487
+#: builtin/am.c:2490
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10650,11 +10994,11 @@ msgstr ""
 "Direktori menyimpang %s ditemukan.\n"
 "Gunakan \"git am --abort\" untuk menghapusnya."
 
-#: builtin/am.c:2493
+#: builtin/am.c:2496
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Operasi penguraian tidak berjalan, kami tidak melanjutkan."
 
-#: builtin/am.c:2503
+#: builtin/am.c:2506
 msgid "interactive mode requires patches on the command line"
 msgstr "mode interaktif butuh tambalan pada baris perintah"
 
@@ -10691,14 +11035,6 @@ msgstr "git archive: sebuah bilasan diharapkan"
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<komit>]"
 
-#: builtin/bisect--helper.c:25
-msgid ""
-"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
-"term-new]"
-msgstr ""
-"git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
-"term-new]"
-
 #: builtin/bisect--helper.c:26
 msgid ""
 "git bisect--helper --bisect-start [--term-{new,bad}=<term> --term-{old,good}"
@@ -10708,10 +11044,6 @@ msgstr ""
 "git bisect--helper --bisect-start [--term-{new,bad}=<istilah> --term-{old,"
 "good}=<istilah>] [--no-checkout] [--first-parent] [<jelek> [<bagus>...]] "
 "[--] [<jalur>...]"
-
-#: builtin/bisect--helper.c:28
-msgid "git bisect--helper --bisect-next"
-msgstr "git bisect--helper --bisect-next"
 
 #: builtin/bisect--helper.c:29
 msgid "git bisect--helper --bisect-state (bad|new) [<rev>]"
@@ -10728,10 +11060,6 @@ msgstr "git bisect--helper --bisect-replay <nama berkas>"
 #: builtin/bisect--helper.c:32
 msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
 msgstr "git bisect--helper --bisect-skip [(<revisi>|<rentang>)...]"
-
-#: builtin/bisect--helper.c:33
-msgid "git bisect--helper --bisect-visualize"
-msgstr "git bisect--helper --bisect-visualize"
 
 #: builtin/bisect--helper.c:34
 msgid "git bisect--helper --bisect-run <cmd>..."
@@ -10953,40 +11281,50 @@ msgstr "'%s'?? Anda bilang tentang apa?"
 msgid "cannot read file '%s' for replaying"
 msgstr "tidak dapat membuka berkas '%s' untuk memainkan ulang"
 
-#: builtin/bisect--helper.c:1107 builtin/bisect--helper.c:1274
-msgid "bisect run failed: no command provided."
-msgstr "bisect run gagal: tidak ada perintah yang diberikan"
-
-#: builtin/bisect--helper.c:1116
+#: builtin/bisect--helper.c:1120 builtin/bisect--helper.c:1152
 #, c-format
 msgid "running %s\n"
 msgstr "menjalankan %s\n"
 
-#: builtin/bisect--helper.c:1120
+#: builtin/bisect--helper.c:1145 builtin/bisect--helper.c:1335
+msgid "bisect run failed: no command provided."
+msgstr "bisect run gagal: tidak ada perintah yang diberikan"
+
+#: builtin/bisect--helper.c:1166
+#, c-format
+msgid "unable to verify '%s' on good revision"
+msgstr "tidak dapat memverifikasi '%s' pada revisi bagus"
+
+#: builtin/bisect--helper.c:1172
+#, c-format
+msgid "bogus exit code %d for good revision"
+msgstr "kode keluar gadungan %d untuk revisi bagu"
+
+#: builtin/bisect--helper.c:1180
 #, c-format
 msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
 msgstr "bisect run gagal: kode keluar %d dari '%s' < 0 atau >= 128"
 
-#: builtin/bisect--helper.c:1136
+#: builtin/bisect--helper.c:1195
 #, c-format
 msgid "cannot open file '%s' for writing"
 msgstr "tidak dapat membuka berkas '%s' untuk ditulis"
 
-#: builtin/bisect--helper.c:1152
+#: builtin/bisect--helper.c:1213
 msgid "bisect run cannot continue any more"
 msgstr "bisect run tidak dapat dilanjutkan lagi"
 
-#: builtin/bisect--helper.c:1154
+#: builtin/bisect--helper.c:1215
 #, c-format
 msgid "bisect run success"
 msgstr "bisect run sukses"
 
-#: builtin/bisect--helper.c:1157
+#: builtin/bisect--helper.c:1218
 #, c-format
 msgid "bisect found first bad commit"
 msgstr "pembagian dua menemukan komit jelek pertama"
 
-#: builtin/bisect--helper.c:1160
+#: builtin/bisect--helper.c:1221
 #, c-format
 msgid ""
 "bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
@@ -10995,71 +11333,71 @@ msgstr ""
 "bisect run gagal: 'git bisect--helper --bisect-state %s' keluar dengan kode "
 "keluar %d"
 
-#: builtin/bisect--helper.c:1192
+#: builtin/bisect--helper.c:1253
 msgid "reset the bisection state"
 msgstr "setel ulang keadaan pembagian dua"
 
-#: builtin/bisect--helper.c:1194
+#: builtin/bisect--helper.c:1255
 msgid "check whether bad or good terms exist"
 msgstr "periksa apakah ada istilah jelek atau bagus"
 
-#: builtin/bisect--helper.c:1196
+#: builtin/bisect--helper.c:1257
 msgid "print out the bisect terms"
 msgstr "cetak istilah pembagian dua"
 
-#: builtin/bisect--helper.c:1198
+#: builtin/bisect--helper.c:1259
 msgid "start the bisect session"
 msgstr "mulai sesi pembagian dua"
 
-#: builtin/bisect--helper.c:1200
+#: builtin/bisect--helper.c:1261
 msgid "find the next bisection commit"
 msgstr "temukan komit pembagian dua berikutnya"
 
-#: builtin/bisect--helper.c:1202
+#: builtin/bisect--helper.c:1263
 msgid "mark the state of ref (or refs)"
 msgstr "tandai keadaan referensi"
 
-#: builtin/bisect--helper.c:1204
+#: builtin/bisect--helper.c:1265
 msgid "list the bisection steps so far"
 msgstr "daftar langkah pembagian dua sejauh ini"
 
-#: builtin/bisect--helper.c:1206
+#: builtin/bisect--helper.c:1267
 msgid "replay the bisection process from the given file"
 msgstr "mainkan ulang proses pembagian dua dari berkas yang diberikan"
 
-#: builtin/bisect--helper.c:1208
+#: builtin/bisect--helper.c:1269
 msgid "skip some commits for checkout"
 msgstr "lewati beberapa komit untuk checkout"
 
-#: builtin/bisect--helper.c:1210
+#: builtin/bisect--helper.c:1271
 msgid "visualize the bisection"
 msgstr "visualisasikan pembagian dua"
 
-#: builtin/bisect--helper.c:1212
-msgid "use <cmd>... to automatically bisect."
+#: builtin/bisect--helper.c:1273
+msgid "use <cmd>... to automatically bisect"
 msgstr "gunakan <cmd>... untuk bagi dua otomatis."
 
-#: builtin/bisect--helper.c:1214
+#: builtin/bisect--helper.c:1275
 msgid "no log for BISECT_WRITE"
 msgstr "tidak ada log untuk BISECT_WRITE"
 
-#: builtin/bisect--helper.c:1229
+#: builtin/bisect--helper.c:1290
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset butuh baik tanpa argumen atau sebuah komit"
 
-#: builtin/bisect--helper.c:1234
+#: builtin/bisect--helper.c:1295
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms butuh 0 atau 1 argumen"
 
-#: builtin/bisect--helper.c:1243
+#: builtin/bisect--helper.c:1304
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next butuh 0 argumen"
 
-#: builtin/bisect--helper.c:1254
+#: builtin/bisect--helper.c:1315
 msgid "--bisect-log requires 0 arguments"
 msgstr "--bisect-log butuh 0 argumen"
 
-#: builtin/bisect--helper.c:1259
+#: builtin/bisect--helper.c:1320
 msgid "no logfile given"
 msgstr "tidak ada berkas log yang diberikan"
 
@@ -11080,142 +11418,133 @@ msgstr "mengharapkan warna: %s"
 msgid "must end with a color"
 msgstr "harus berakhir dengan warna"
 
-#: builtin/blame.c:724
-#, c-format
-msgid "invalid color '%s' in color.blame.repeatedLines"
-msgstr "warna tidak valid '%s' pada color.blame.repeatedLines"
-
-#: builtin/blame.c:742
-msgid "invalid value for blame.coloring"
-msgstr "nilai tidak valid untuk blame.coloring"
-
-#: builtin/blame.c:841
+#: builtin/blame.c:842
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "tidak dapat menemukan revisi %s untuk diabaikan"
 
-#: builtin/blame.c:863
+#: builtin/blame.c:864
 msgid "show blame entries as we find them, incrementally"
 msgstr "perlihatkan entri penyalahan seperti yang kami temukan secara bertahap"
 
-#: builtin/blame.c:864
+#: builtin/blame.c:865
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr "jangan perlihatkan nama objek dari komit perbatasan (asali: off)"
 
-#: builtin/blame.c:865
+#: builtin/blame.c:866
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr "jangan perlakukan komit akar sebagai perbatasan (asali: off)"
 
-#: builtin/blame.c:866
+#: builtin/blame.c:867
 msgid "show work cost statistics"
 msgstr "perlihatkan statistik biaya usaha"
 
-#: builtin/blame.c:867 builtin/checkout.c:1536 builtin/clone.c:94
-#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:180
+#: builtin/blame.c:868 builtin/checkout.c:1554 builtin/clone.c:98
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:181
 #: builtin/merge.c:301 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:180
 #: builtin/multi-pack-index.c:208 builtin/pull.c:120 builtin/push.c:566
-#: builtin/send-pack.c:202
+#: builtin/remote.c:683 builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "paksa laporkan perkembangan"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:869
 msgid "show output score for blame entries"
 msgstr "perlihatkan nilai keluaran untuk entri penyalahan"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:870
 msgid "show original filename (Default: auto)"
 msgstr "perlihatkan nama berkas asli (asali: auto)"
 
-#: builtin/blame.c:870
+#: builtin/blame.c:871
 msgid "show original linenumber (Default: off)"
 msgstr "perlihatkan nomor baris asli (asali: off)"
 
-#: builtin/blame.c:871
+#: builtin/blame.c:872
 msgid "show in a format designed for machine consumption"
 msgstr "perlihatkan dalam format yang didesain untuk konsumsi mesin"
 
-#: builtin/blame.c:872
+#: builtin/blame.c:873
 msgid "show porcelain format with per-line commit information"
 msgstr "perlihatkan format porselen dengan informasi komit per baris"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:874
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr "gunakan mode keluaran yang sama dengan git-annotate (asali: off)"
 
-#: builtin/blame.c:874
+#: builtin/blame.c:875
 msgid "show raw timestamp (Default: off)"
 msgstr "perlihatkan stempel waktu mentah (asali: off)"
 
-#: builtin/blame.c:875
+#: builtin/blame.c:876
 msgid "show long commit SHA1 (Default: off)"
 msgstr "perlihatkan SHA1 komit panjang (asali: off)"
 
-#: builtin/blame.c:876
+#: builtin/blame.c:877
 msgid "suppress author name and timestamp (Default: off)"
 msgstr "sembunyikan nama pengarang dan stempel waktu (asali: off)"
 
-#: builtin/blame.c:877
+#: builtin/blame.c:878
 msgid "show author email instead of name (Default: off)"
 msgstr "perlihatkan email pengarang daripada nama (asali: off)"
 
-#: builtin/blame.c:878
+#: builtin/blame.c:879
 msgid "ignore whitespace differences"
 msgstr "abaikan perbedaan spasi putih"
 
-#: builtin/blame.c:879 builtin/log.c:1838
+#: builtin/blame.c:880 builtin/log.c:1857
 msgid "rev"
 msgstr "revisi"
 
-#: builtin/blame.c:879
+#: builtin/blame.c:880
 msgid "ignore <rev> when blaming"
 msgstr "abaikan <revisi> ketika menyalahkan"
 
-#: builtin/blame.c:880
+#: builtin/blame.c:881
 msgid "ignore revisions from <file>"
 msgstr "abaikan revisi dari <berkas>"
 
-#: builtin/blame.c:881
+#: builtin/blame.c:882
 msgid "color redundant metadata from previous line differently"
 msgstr "metadata warna berlebihan dari baris sebelumnya secara berbeda"
 
-#: builtin/blame.c:882
+#: builtin/blame.c:883
 msgid "color lines by age"
 msgstr "warnai baris oleh umur"
 
-#: builtin/blame.c:883
+#: builtin/blame.c:884
 msgid "spend extra cycles to find better match"
 msgstr "perlihatkan siklus ekstra untuk menemukan cocokan yang lebih baik"
 
-#: builtin/blame.c:884
+#: builtin/blame.c:885
 msgid "use revisions from <file> instead of calling git-rev-list"
 msgstr "gunakan revisi dari <berkas> daripada memanggil git-rev-list"
 
-#: builtin/blame.c:885
+#: builtin/blame.c:886
 msgid "use <file>'s contents as the final image"
 msgstr "gunakan konten <berkas> sebagai citra final"
 
-#: builtin/blame.c:886 builtin/blame.c:887
+#: builtin/blame.c:887 builtin/blame.c:888
 msgid "score"
 msgstr "nilai"
 
-#: builtin/blame.c:886
+#: builtin/blame.c:887
 msgid "find line copies within and across files"
 msgstr "temukan salinan baris di dalam dan di seluruh berkas"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:888
 msgid "find line movements within and across files"
 msgstr "temukan gerakan baris di dalam dan di seluruh baris"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:889
 msgid "range"
 msgstr "rentang"
 
-#: builtin/blame.c:889
+#: builtin/blame.c:890
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr "hanya proses rentang baris <awal>,<akhir> atau fungsi :<nama fungsi>"
 
-#: builtin/blame.c:947
+#: builtin/blame.c:949
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress tidak dapat digunakan dengan --incremental atau format porselen"
@@ -11228,18 +11557,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:998
+#: builtin/blame.c:1000
 msgid "4 years, 11 months ago"
 msgstr "4 tahun, 11 bulan yang lalu"
 
-#: builtin/blame.c:1114
+#: builtin/blame.c:1116
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "berkas %s hanya punya %lu baris"
 msgstr[1] "berkas %s hanya punya %lu baris"
 
-#: builtin/blame.c:1159
+#: builtin/blame.c:1161
 msgid "Blaming lines"
 msgstr "Menyalahkan baris"
 
@@ -11248,30 +11577,37 @@ msgid "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
 msgstr "git branch [<opsi>] [-r | -a] [--merged] [--no-merged]"
 
 #: builtin/branch.c:30
-msgid "git branch [<options>] [-l] [-f] <branch-name> [<start-point>]"
-msgstr "git branch [<opsi>] [-l] [-f] <nama-cabang> [<titik-awal>]"
+msgid ""
+"git branch [<options>] [-f] [--recurse-submodules] <branch-name> [<start-"
+"point>]"
+msgstr ""
+"git branch [<opsi>] [-f] [--recurse-submodules] <nama-cabang> [<titik-awal>]"
 
 #: builtin/branch.c:31
+msgid "git branch [<options>] [-l] [<pattern>...]"
+msgstr "git branch [<opsi>] [-l] [<pola>...]"
+
+#: builtin/branch.c:32
 msgid "git branch [<options>] [-r] (-d | -D) <branch-name>..."
 msgstr "git branch [<opsi> [-r] (-d | -D) <nama-cabang>...]"
 
-#: builtin/branch.c:32
+#: builtin/branch.c:33
 msgid "git branch [<options>] (-m | -M) [<old-branch>] <new-branch>"
 msgstr "git branch [<opsi>] (-m | -M) [<cabang-lama>] <cabang-baru>"
 
-#: builtin/branch.c:33
+#: builtin/branch.c:34
 msgid "git branch [<options>] (-c | -C) [<old-branch>] <new-branch>"
 msgstr "git branch [<opsi>] (-c | -C) [<cabang-lama>] <cabang-baru>"
 
-#: builtin/branch.c:34
+#: builtin/branch.c:35
 msgid "git branch [<options>] [-r | -a] [--points-at]"
 msgstr "git branch [<opsi>] [-r | -a] [--points-at]"
 
-#: builtin/branch.c:35
+#: builtin/branch.c:36
 msgid "git branch [<options>] [-r | -a] [--format]"
 msgstr "git branch [<opsi>] [-r | -a] [--format]"
 
-#: builtin/branch.c:153
+#: builtin/branch.c:165
 #, c-format
 msgid ""
 "deleting branch '%s' that has been merged to\n"
@@ -11280,7 +11616,7 @@ msgstr ""
 "menghapus cabang '%s' yang sudah digabungkan ke\n"
 "         '%s', tapi belum digabungkan ke HEAD."
 
-#: builtin/branch.c:157
+#: builtin/branch.c:169
 #, c-format
 msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
@@ -11289,12 +11625,12 @@ msgstr ""
 "tidak menghapus cabang '%s' yang belum digabungkan ke\n"
 "         '%s', walaupun tergabung ke HEAD."
 
-#: builtin/branch.c:171
+#: builtin/branch.c:183
 #, c-format
 msgid "Couldn't look up commit object for '%s'"
 msgstr "Tidak dapat mencari objek komit untuk '%s'"
 
-#: builtin/branch.c:175
+#: builtin/branch.c:187
 #, c-format
 msgid ""
 "The branch '%s' is not fully merged.\n"
@@ -11303,111 +11639,111 @@ msgstr ""
 "Cabang '%s' belum sepenuhnya tergabung.\n"
 "Kalau Anda yakin ingin menghapus itu, jalankan 'git branch -D %s'."
 
-#: builtin/branch.c:188
+#: builtin/branch.c:200
 msgid "Update of config-file failed"
 msgstr "Pembaruan berkas konfigurasi gagal"
 
-#: builtin/branch.c:223
+#: builtin/branch.c:235
 msgid "cannot use -a with -d"
 msgstr "tidak dapat gunakan -a dengan -d"
 
-#: builtin/branch.c:230
+#: builtin/branch.c:242
 msgid "Couldn't look up commit object for HEAD"
 msgstr "Tidak dapat mencari objek komit untuk HEAD"
 
-#: builtin/branch.c:247
+#: builtin/branch.c:259
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
 msgstr "Tidak dapat menghapus cabang '%s' yang ter-checkout pada '%s'"
 
-#: builtin/branch.c:262
+#: builtin/branch.c:274
 #, c-format
 msgid "remote-tracking branch '%s' not found."
 msgstr "cabang pelacak remote '%s' tidak ditemukan."
 
-#: builtin/branch.c:263
+#: builtin/branch.c:275
 #, c-format
 msgid "branch '%s' not found."
 msgstr "cabang '%s' tidak ditemukan."
 
-#: builtin/branch.c:294
+#: builtin/branch.c:306
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
 msgstr "Cabang pelacak remote %s (yaitu %s) dihapus.\n"
 
-#: builtin/branch.c:295
+#: builtin/branch.c:307
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Cabang %s (yaitu %s) dihapus.\n"
 
-#: builtin/branch.c:445 builtin/tag.c:63
+#: builtin/branch.c:457 builtin/tag.c:64
 msgid "unable to parse format string"
 msgstr "tidak dapat menguraikan untai format"
 
-#: builtin/branch.c:476
+#: builtin/branch.c:488
 msgid "could not resolve HEAD"
 msgstr "tidak dapat menguraikan HEAD"
 
-#: builtin/branch.c:482
+#: builtin/branch.c:494
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) merujuk diluar refs/heads/"
 
-#: builtin/branch.c:497
+#: builtin/branch.c:509
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Cabang %s sedang didasarkan ulang pada %s"
 
-#: builtin/branch.c:501
+#: builtin/branch.c:513
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Cabang %s sedang dibagi dua pada %s"
 
-#: builtin/branch.c:518
+#: builtin/branch.c:530
 msgid "cannot copy the current branch while not on any."
 msgstr "tidak dapat menyalin cabang saat ini ketika tidak ada."
 
-#: builtin/branch.c:520
+#: builtin/branch.c:532
 msgid "cannot rename the current branch while not on any."
 msgstr "tidak dapat mengganti nama cabang saat ini ketika tidak ada."
 
-#: builtin/branch.c:531
+#: builtin/branch.c:543
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Nama cabang tidak valid: '%s'"
 
-#: builtin/branch.c:560
+#: builtin/branch.c:572
 msgid "Branch rename failed"
 msgstr "Penggantian nama cabang gagal"
 
-#: builtin/branch.c:562
+#: builtin/branch.c:574
 msgid "Branch copy failed"
 msgstr "Penyalinan cabang gagal"
 
-#: builtin/branch.c:566
+#: builtin/branch.c:578
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Salinan cabang salah nama '%s' dibuat"
 
-#: builtin/branch.c:569
+#: builtin/branch.c:581
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Cabang salah nama '%s' berganti nama"
 
-#: builtin/branch.c:575
+#: builtin/branch.c:587
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Cabang berganti nama ke %s, tapi HEAD tidak diperbarui!"
 
-#: builtin/branch.c:584
+#: builtin/branch.c:596
 msgid "Branch is renamed, but update of config-file failed"
 msgstr "Cabang berganti nama, tapi pembaruan berkas konfigurasi gagal"
 
-#: builtin/branch.c:586
+#: builtin/branch.c:598
 msgid "Branch is copied, but update of config-file failed"
 msgstr "Cabang disalin, tapi pembaruan berkas konfigurasi gagal"
 
-#: builtin/branch.c:602
+#: builtin/branch.c:614
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11418,176 +11754,193 @@ msgstr ""
 "  %s\n"
 "Baris yang diawali dengan '%c' akan dicopot.\n"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:651
 msgid "Generic options"
 msgstr "Opsi generik"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:653
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "perlihatkan hash dan subjek, berikan dua kali untuk cabang hulu"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:654
 msgid "suppress informational messages"
 msgstr "sembunyikan pesan informasi"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:656 builtin/checkout.c:1571
+#: builtin/submodule--helper.c:3077
 msgid "set branch tracking configuration"
 msgstr "setel konfigurasi pelacakan cabang"
 
-#: builtin/branch.c:645
+#: builtin/branch.c:659
 msgid "do not use"
 msgstr "jangan gunakan"
 
-#: builtin/branch.c:647
+#: builtin/branch.c:661
 msgid "upstream"
 msgstr "hulu"
 
-#: builtin/branch.c:647
+#: builtin/branch.c:661
 msgid "change the upstream info"
 msgstr "ubah info hulu"
 
-#: builtin/branch.c:648
+#: builtin/branch.c:662
 msgid "unset the upstream info"
 msgstr "batal-setel info hulu"
 
-#: builtin/branch.c:649
+#: builtin/branch.c:663
 msgid "use colored output"
 msgstr "gunakan keluaran berwarna"
 
-#: builtin/branch.c:650
+#: builtin/branch.c:664
 msgid "act on remote-tracking branches"
 msgstr "lakukan pada cabang pelacak remote"
 
-#: builtin/branch.c:652 builtin/branch.c:654
+#: builtin/branch.c:666 builtin/branch.c:668
 msgid "print only branches that contain the commit"
 msgstr "cetak hanya cabang yang berisi komit"
 
-#: builtin/branch.c:653 builtin/branch.c:655
+#: builtin/branch.c:667 builtin/branch.c:669
 msgid "print only branches that don't contain the commit"
 msgstr "cetak hanya cabang yang tak berisi komit"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:672
 msgid "Specific git-branch actions:"
 msgstr "Aksi git-branch spesifik:"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:673
 msgid "list both remote-tracking and local branches"
 msgstr "sebut baik cabang pelacak remote dan cabang lokal"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:675
 msgid "delete fully merged branch"
 msgstr "hapus cabang yang tergabung sepenuhnya"
 
-#: builtin/branch.c:662
+#: builtin/branch.c:676
 msgid "delete branch (even if not merged)"
 msgstr "hapus cabang (walaupun tak tergabung)"
 
-#: builtin/branch.c:663
+#: builtin/branch.c:677
 msgid "move/rename a branch and its reflog"
 msgstr "pindah/ganti nama cabang dan reflog-nya"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:678
 msgid "move/rename a branch, even if target exists"
 msgstr "pindah/ganti nama cabang, walaupun target ada"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:679
 msgid "copy a branch and its reflog"
 msgstr "salin cabang dan reflog-nya"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:680
 msgid "copy a branch, even if target exists"
 msgstr "salin cabang, walapun target ada"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:681
 msgid "list branch names"
 msgstr "sebut nama cabang"
 
-#: builtin/branch.c:668
+#: builtin/branch.c:682
 msgid "show current branch name"
 msgstr "perlihatkan nama cabang saat ini"
 
-#: builtin/branch.c:669
+#: builtin/branch.c:683 builtin/submodule--helper.c:3075
 msgid "create the branch's reflog"
 msgstr "buat reflog cabang"
 
-#: builtin/branch.c:671
+#: builtin/branch.c:685
 msgid "edit the description for the branch"
 msgstr "sunting deskripsi cabang"
 
-#: builtin/branch.c:672
+#: builtin/branch.c:686
 msgid "force creation, move/rename, deletion"
 msgstr "paksa buat, pindah/ganti nama, hapus"
 
-#: builtin/branch.c:673
+#: builtin/branch.c:687
 msgid "print only branches that are merged"
 msgstr "cetak hanya cabang yang tergabung"
 
-#: builtin/branch.c:674
+#: builtin/branch.c:688
 msgid "print only branches that are not merged"
 msgstr "cetak hanya cabang yang tak tergabung"
 
-#: builtin/branch.c:675
+#: builtin/branch.c:689
 msgid "list branches in columns"
 msgstr "sebut cabang dalam kolom"
 
-#: builtin/branch.c:677 builtin/for-each-ref.c:45 builtin/notes.c:413
+#: builtin/branch.c:691 builtin/for-each-ref.c:45 builtin/notes.c:413
 #: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
-#: builtin/tag.c:475
+#: builtin/tag.c:476
 msgid "object"
 msgstr "objek"
 
-#: builtin/branch.c:678
+#: builtin/branch.c:692
 msgid "print only branches of the object"
 msgstr "cetak hanya cabang objek"
 
-#: builtin/branch.c:679 builtin/for-each-ref.c:51 builtin/tag.c:482
+#: builtin/branch.c:693 builtin/for-each-ref.c:51 builtin/tag.c:483
 msgid "sorting and filtering are case insensitive"
 msgstr "pengurutan dan penyaringan tak peka kapital"
 
-#: builtin/branch.c:680 builtin/for-each-ref.c:41 builtin/tag.c:480
-#: builtin/verify-tag.c:38
+#: builtin/branch.c:694 builtin/ls-files.c:667
+msgid "recurse through submodules"
+msgstr "rekursi melalui submodul"
+
+#: builtin/branch.c:695 builtin/for-each-ref.c:41 builtin/ls-tree.c:358
+#: builtin/tag.c:481 builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "format yang digunakan untuk keluaran"
 
-#: builtin/branch.c:703 builtin/clone.c:678
+#: builtin/branch.c:718 builtin/clone.c:684
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD tidak ditemukan di bawah refs/heads!"
 
-#: builtin/branch.c:742 builtin/branch.c:798 builtin/branch.c:807
+#: builtin/branch.c:739
+msgid ""
+"branch with --recurse-submodules can only be used if submodule."
+"propagateBranches is enabled"
+msgstr ""
+"cabang dengan --recurse-submodules hanya dapat digunakan jika submodule."
+"propagateBranches diaktifkan"
+
+#: builtin/branch.c:741
+msgid "--recurse-submodules can only be used to create branches"
+msgstr "--recurse-submodules hanya dapat digunakan untuk membuat cabang"
+
+#: builtin/branch.c:770 builtin/branch.c:826 builtin/branch.c:835
 msgid "branch name required"
 msgstr "nama cabang diperlukan"
 
-#: builtin/branch.c:774
+#: builtin/branch.c:802
 msgid "Cannot give description to detached HEAD"
 msgstr "Tidak dapat memberikan deskripsi ke HEAD terpisah"
 
-#: builtin/branch.c:779
+#: builtin/branch.c:807
 msgid "cannot edit description of more than one branch"
 msgstr "tidak dapat menyunting deskripsi lebih dari satu cabang"
 
-#: builtin/branch.c:786
+#: builtin/branch.c:814
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Belum ada komit pada cabang '%s'."
 
-#: builtin/branch.c:789
+#: builtin/branch.c:817
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Tidak ada cabang bernama '%s'."
 
-#: builtin/branch.c:804
+#: builtin/branch.c:832
 msgid "too many branches for a copy operation"
 msgstr "terlalu banyak cabang untuk operasi penyalinan"
 
-#: builtin/branch.c:813
+#: builtin/branch.c:841
 msgid "too many arguments for a rename operation"
 msgstr "terlalu banyak argumen untuk operasi penggantian nama"
 
-#: builtin/branch.c:818
+#: builtin/branch.c:846
 msgid "too many arguments to set new upstream"
 msgstr "terlalu banyak argumen untuk menyetel hulu baru"
 
-#: builtin/branch.c:822
+#: builtin/branch.c:850
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11595,32 +11948,32 @@ msgstr ""
 "tidak dapat menyetel hulu HEAD ke %s ketika itu tak menunjuk pada cabang "
 "apapun."
 
-#: builtin/branch.c:825 builtin/branch.c:848
+#: builtin/branch.c:853 builtin/branch.c:873
 #, c-format
 msgid "no such branch '%s'"
 msgstr "tidak ada cabang '%s'"
 
-#: builtin/branch.c:829
+#: builtin/branch.c:857
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "cabang '%s' tidak ada"
 
-#: builtin/branch.c:842
+#: builtin/branch.c:867
 msgid "too many arguments to unset upstream"
 msgstr "terlalu banyak argumen untuk batal-setel hulu"
 
-#: builtin/branch.c:846
+#: builtin/branch.c:871
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "tidak dapat membatal-setel hulu HEAD ketika itu tak menunjuk pada cabang "
 "apapun."
 
-#: builtin/branch.c:852
+#: builtin/branch.c:877
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Cabang '%s' tidak ada informasi hulu"
 
-#: builtin/branch.c:862
+#: builtin/branch.c:890
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11628,7 +11981,7 @@ msgstr ""
 "Opsi -a dan -r tidak mengambil nama cabang.\n"
 "Mungkin maksud Anda gunakan: -a|-r --list <pola>?"
 
-#: builtin/branch.c:866
+#: builtin/branch.c:894
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -11727,19 +12080,19 @@ msgstr "git bundle list-heads <berkas> [<nama referensi>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <berkas> [<nama referensi>...]"
 
-#: builtin/bundle.c:65 builtin/pack-objects.c:3876
+#: builtin/bundle.c:65 builtin/pack-objects.c:3899
 msgid "do not show progress meter"
 msgstr "jangan perlihatkan meteran perkembangan"
 
-#: builtin/bundle.c:67 builtin/bundle.c:167 builtin/pack-objects.c:3878
+#: builtin/bundle.c:67 builtin/bundle.c:168 builtin/pack-objects.c:3901
 msgid "show progress meter"
 msgstr "perlihatkan meteran perkembangan"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3880
+#: builtin/bundle.c:69 builtin/pack-objects.c:3903
 msgid "show progress meter during object writing phase"
 msgstr "perlihatkan meteran perkembangan saat fase penulisan objek"
 
-#: builtin/bundle.c:72 builtin/pack-objects.c:3883
+#: builtin/bundle.c:72 builtin/pack-objects.c:3906
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "sama seperti --all-progress ketika meteran perkembangan diperlihatkan"
 
@@ -11751,113 +12104,229 @@ msgstr "sebutkan versi format bundel"
 msgid "Need a repository to create a bundle."
 msgstr "Perlu sebuah repositori untuk membuat bundel."
 
-#: builtin/bundle.c:107
+#: builtin/bundle.c:108
 msgid "do not show bundle details"
 msgstr "jangan perlihatkan detail bundel"
 
-#: builtin/bundle.c:126
+#: builtin/bundle.c:127
 #, c-format
 msgid "%s is okay\n"
 msgstr "%s oke \n"
 
-#: builtin/bundle.c:182
+#: builtin/bundle.c:183
 msgid "Need a repository to unbundle."
 msgstr "Perlu sebuah repositori untuk membongkar bundel."
 
-#: builtin/bundle.c:185
+#: builtin/bundle.c:186
 msgid "Unbundling objects"
 msgstr "Membongkar bundel objek"
 
-#: builtin/bundle.c:219 builtin/remote.c:1733
+#: builtin/bundle.c:220 builtin/remote.c:1758
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Subperintah tidak dikenal: %s"
 
-#: builtin/cat-file.c:622
-msgid ""
-"git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
-"p | <type> | --textconv | --filters) [--path=<path>] <object>"
-msgstr ""
-"git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
-"p | <tipe> | --textconv | --filters) [--path=<jalur>] <objek>"
+#: builtin/cat-file.c:568
+msgid "flush is only for --buffer mode"
+msgstr "bilas hanya untuk mode --buffer"
+
+#: builtin/cat-file.c:612
+msgid "empty command in input"
+msgstr "perintah kosong pada masukan"
+
+#: builtin/cat-file.c:614
+#, c-format
+msgid "whitespace before command: '%s'"
+msgstr "spasi sebelum perintah: '%s'"
 
 #: builtin/cat-file.c:623
-msgid ""
-"git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
-"symlinks] [--textconv | --filters]"
-msgstr ""
-"git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
-"symlinks] [--textconv | --filters]"
+#, c-format
+msgid "%s requires arguments"
+msgstr "%s butuh sebuah argumen"
 
-#: builtin/cat-file.c:644
+#: builtin/cat-file.c:628
+#, c-format
+msgid "%s takes no arguments"
+msgstr "%s tidak mengambil argumen"
+
+#: builtin/cat-file.c:636
+#, c-format
+msgid "unknown command: '%s'"
+msgstr "perintah tidak dikenal: '%s'"
+
+#: builtin/cat-file.c:795
 msgid "only one batch option may be specified"
 msgstr "hanya satu opsi setumpuk yang mungkin disebutkan"
 
-#: builtin/cat-file.c:662
-msgid "<type> can be one of: blob, tree, commit, tag"
-msgstr "<tipe> bisa salah satu dari: blob, tree, commit, tag"
+#: builtin/cat-file.c:824
+msgid "git cat-file <type> <object>"
+msgstr "git cat-file <tipe> <objek>"
 
-#: builtin/cat-file.c:663
-msgid "show object type"
-msgstr "perlihatkan tipe objek"
+#: builtin/cat-file.c:825
+msgid "git cat-file (-e | -p) <object>"
+msgstr "git cat-file (-e | -p) <objek>"
 
-#: builtin/cat-file.c:664
+#: builtin/cat-file.c:826
+msgid "git cat-file (-t | -s) [--allow-unknown-type] <object>"
+msgstr "git cat-file (-t | -s) [--allow-unknown-type] <objek>"
+
+#: builtin/cat-file.c:827
+msgid ""
+"git cat-file (--batch | --batch-check | --batch-command) [--batch-all-"
+"objects]\n"
+"             [--buffer] [--follow-symlinks] [--unordered]\n"
+"             [--textconv | --filters]"
+msgstr ""
+"git cat-file (--batch | --batch-check | --batch-command) [--batch-all-"
+"objects]\n"
+"             [--buffer] [--follow-symlinks] [--unordered]\n"
+"             [--textconv | --filters]"
+
+#: builtin/cat-file.c:830
+msgid ""
+"git cat-file (--textconv | --filters)\n"
+"             [<rev>:<path|tree-ish> | --path=<path|tree-ish> <rev>]"
+msgstr ""
+"git cat-file (--textconv | --filters)\n"
+"             [<revisi>:<jalur|mirip-pohon> | --path=<jalur|mirip-pohon>] "
+"<revisi>"
+
+#: builtin/cat-file.c:836
+msgid "Check object existence or emit object contents"
+msgstr "Periksa keberadaan objek atau keluarkan isi objek"
+
+#: builtin/cat-file.c:838
+msgid "check if <object> exists"
+msgstr "periksa jika <objek> ada"
+
+#: builtin/cat-file.c:839
+msgid "pretty-print <object> content"
+msgstr "cetak-cantik isi <objek>"
+
+#: builtin/cat-file.c:841
+msgid "Emit [broken] object attributes"
+msgstr "Keluarkan atribut objek [rusak]"
+
+#: builtin/cat-file.c:842
+msgid "show object type (one of 'blob', 'tree', 'commit', 'tag', ...)"
+msgstr "perlihatkan tipe objek (salah satu dari 'blob', 'commit', 'tag', ...)"
+
+#: builtin/cat-file.c:843
 msgid "show object size"
 msgstr "perlihatkan ukuran objek"
 
-#: builtin/cat-file.c:666
-msgid "exit with zero when there's no error"
-msgstr "keluar dengan nol ketika tidak ada kesalahan"
-
-#: builtin/cat-file.c:667
-msgid "pretty-print object's content"
-msgstr "cetak-cantik isi objek"
-
-#: builtin/cat-file.c:669
-msgid "for blob objects, run textconv on object's content"
-msgstr "untuk objek blob, jalankan textconv pada isi objek"
-
-#: builtin/cat-file.c:671
-msgid "for blob objects, run filters on object's content"
-msgstr "untuk objek blob, jalankan penyaring pada isi objek"
-
-#: builtin/cat-file.c:672
-msgid "blob"
-msgstr "blob"
-
-#: builtin/cat-file.c:673
-msgid "use a specific path for --textconv/--filters"
-msgstr "gunakan jalur spesifik untuk --textconv/--filters"
-
-#: builtin/cat-file.c:675
+#: builtin/cat-file.c:845
 msgid "allow -s and -t to work with broken/corrupt objects"
 msgstr "perbolehkan -s dan -t bekerja dengan objek rusak"
 
-#: builtin/cat-file.c:676
+#: builtin/cat-file.c:847
+msgid "Batch objects requested on stdin (or --batch-all-objects)"
+msgstr "Objek batch diminta pada masukan standar (atau --batch-all-objects)"
+
+#: builtin/cat-file.c:849
+msgid "show full <object> or <rev> contents"
+msgstr "perlihatkan isi <objek> atau <revisi> penuh"
+
+#: builtin/cat-file.c:853
+msgid "like --batch, but don't emit <contents>"
+msgstr "seperti --batch, tapi jangan keluarkan <isi>"
+
+#: builtin/cat-file.c:857
+msgid "read commands from stdin"
+msgstr "baca perintah dari masukan standar"
+
+#: builtin/cat-file.c:861
+msgid "with --batch[-check]: ignores stdin, batches all known objects"
+msgstr ""
+"dengan --batch[-check]: abaikan masukan standar, batch semua objek yang "
+"dikenal"
+
+#: builtin/cat-file.c:863
+msgid "Change or optimize batch output"
+msgstr "Ubah atau optimalkan keluaran batch"
+
+#: builtin/cat-file.c:864
 msgid "buffer --batch output"
 msgstr "sannga keluaran --batch"
 
-#: builtin/cat-file.c:678
-msgid "show info and content of objects fed from the standard input"
-msgstr "perlihatkan info dan isi objek yang disuap dari masukan standar"
+#: builtin/cat-file.c:866
+msgid "follow in-tree symlinks"
+msgstr "ikuti tautan simbolik dalam pohon"
 
-#: builtin/cat-file.c:682
-msgid "show info about objects fed from the standard input"
-msgstr "perlihatkan info tentang objek yang disuap dari masukan standar"
+#: builtin/cat-file.c:868
+msgid "do not order objects before emitting them"
+msgstr "jangan urutkan objek sebelum dikeluarkan"
 
-#: builtin/cat-file.c:686
-msgid "follow in-tree symlinks (used with --batch or --batch-check)"
+#: builtin/cat-file.c:870
+msgid ""
+"Emit object (blob or tree) with conversion or filter (stand-alone, or with "
+"batch)"
 msgstr ""
-"ikuti tautan simbolik dalam pohon (digunakan dengan --batch atau --batch-"
-"check)"
+"Keluarkan objek (blob atau pohon) dengan konversi atau saringan (berdiri "
+"sendiri atau dengan batch)"
 
-#: builtin/cat-file.c:688
-msgid "show all objects with --batch or --batch-check"
-msgstr "perlihatkan semua objek dengan --batch atau --batch-check"
+#: builtin/cat-file.c:872
+msgid "run textconv on object's content"
+msgstr "jalankan textconv pada isi objek"
 
-#: builtin/cat-file.c:690
-msgid "do not order --batch-all-objects output"
-msgstr "jangan urutkan keluaran --batch-all-objects"
+#: builtin/cat-file.c:874
+msgid "run filters on object's content"
+msgstr "jalankan penyaring pada isi objek"
+
+#: builtin/cat-file.c:875
+msgid "blob|tree"
+msgstr "blob|tree"
+
+#: builtin/cat-file.c:876
+msgid "use a <path> for (--textconv | --filters); Not with 'batch'"
+msgstr "gunakan <jalur> untuk (--textconv | --filters); tidak dengan 'batch'"
+
+#: builtin/cat-file.c:894
+#, c-format
+msgid "'%s=<%s>' needs '%s' or '%s'"
+msgstr "'%s=<%s>' butuh '%s' atau '%s'"
+
+#: builtin/cat-file.c:896
+msgid "path|tree-ish"
+msgstr "jalur|mirip-pohon"
+
+#: builtin/cat-file.c:903 builtin/cat-file.c:906 builtin/cat-file.c:909
+#, c-format
+msgid "'%s' requires a batch mode"
+msgstr "opsi '%s' butuh sebuah mode batch"
+
+#: builtin/cat-file.c:921
+#, c-format
+msgid "'-%c' is incompatible with batch mode"
+msgstr "'-%c' tidak kompatibel dengan mode batch"
+
+#: builtin/cat-file.c:924
+msgid "batch modes take no arguments"
+msgstr "mode batch tidak mengambil argumen"
+
+#: builtin/cat-file.c:932 builtin/cat-file.c:935
+#, c-format
+msgid "<rev> required with '%s'"
+msgstr "<revisi> diperlukan dengan '%s'"
+
+#: builtin/cat-file.c:938
+#, c-format
+msgid "<object> required with '-%c'"
+msgstr "<objek> diperlukan dengan '-%c'"
+
+#: builtin/cat-file.c:943 builtin/notes.c:374 builtin/notes.c:429
+#: builtin/notes.c:507 builtin/notes.c:519 builtin/notes.c:596
+#: builtin/notes.c:663 builtin/notes.c:813 builtin/notes.c:965
+#: builtin/notes.c:987 builtin/prune-packed.c:25 builtin/receive-pack.c:2489
+#: builtin/tag.c:592
+msgid "too many arguments"
+msgstr "terlalu banyak argumen"
+
+#: builtin/cat-file.c:947
+#, c-format
+msgid "only two arguments allowed in <type> <object> mode, not %d"
+msgstr ""
+"hanya dua argumen yang diperbolehkan di dalam mode <tipe> <objek>, bukan %d"
 
 #: builtin/check-attr.c:13
 msgid "git check-attr [-a | --all | <attr>...] [--] <pathname>..."
@@ -11875,7 +12344,7 @@ msgstr ""
 msgid "use .gitattributes only from the index"
 msgstr ""
 
-#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:100
+#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:101
 msgid "read file names from stdin"
 msgstr ""
 
@@ -11883,8 +12352,8 @@ msgstr ""
 msgid "terminate input and output records by a NUL character"
 msgstr ""
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1532 builtin/gc.c:550
-#: builtin/worktree.c:493
+#: builtin/check-ignore.c:21 builtin/checkout.c:1550 builtin/gc.c:550
+#: builtin/worktree.c:565
 msgid "suppress progress reporting"
 msgstr ""
 
@@ -11941,163 +12410,167 @@ msgstr ""
 msgid "git checkout--worker [<options>]"
 msgstr ""
 
-#: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1864
-#: builtin/submodule--helper.c:1867 builtin/submodule--helper.c:1875
-#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
-#: builtin/worktree.c:491 builtin/worktree.c:728
+#: builtin/checkout--worker.c:118 builtin/checkout-index.c:235
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1878
+#: builtin/submodule--helper.c:1881 builtin/submodule--helper.c:1889
+#: builtin/submodule--helper.c:2716 builtin/worktree.c:563
+#: builtin/worktree.c:808
 msgid "string"
 msgstr ""
 
-#: builtin/checkout--worker.c:119 builtin/checkout-index.c:202
+#: builtin/checkout--worker.c:119 builtin/checkout-index.c:236
 msgid "when creating files, prepend <string>"
 msgstr ""
 
-#: builtin/checkout-index.c:152
+#: builtin/checkout-index.c:184
 msgid "git checkout-index [<options>] [--] [<file>...]"
 msgstr ""
 
-#: builtin/checkout-index.c:169
+#: builtin/checkout-index.c:201
 msgid "stage should be between 1 and 3 or all"
 msgstr ""
 
-#: builtin/checkout-index.c:187
+#: builtin/checkout-index.c:219
 msgid "check out all files in the index"
 msgstr ""
 
-#: builtin/checkout-index.c:188
+#: builtin/checkout-index.c:221
+msgid "do not skip files with skip-worktree set"
+msgstr ""
+
+#: builtin/checkout-index.c:222
 msgid "force overwrite of existing files"
 msgstr ""
 
-#: builtin/checkout-index.c:190
+#: builtin/checkout-index.c:224
 msgid "no warning for existing files and files not in index"
 msgstr ""
 
-#: builtin/checkout-index.c:192
+#: builtin/checkout-index.c:226
 msgid "don't checkout new files"
 msgstr ""
 
-#: builtin/checkout-index.c:194
+#: builtin/checkout-index.c:228
 msgid "update stat information in the index file"
 msgstr ""
 
-#: builtin/checkout-index.c:198
+#: builtin/checkout-index.c:232
 msgid "read list of paths from the standard input"
 msgstr ""
 
-#: builtin/checkout-index.c:200
+#: builtin/checkout-index.c:234
 msgid "write the content to temporary files"
 msgstr ""
 
-#: builtin/checkout-index.c:204
+#: builtin/checkout-index.c:238
 msgid "copy out the files from named stage"
 msgstr ""
 
-#: builtin/checkout.c:33
+#: builtin/checkout.c:34
 msgid "git checkout [<options>] <branch>"
 msgstr "git checkout [<opsi>] <cabang>"
 
-#: builtin/checkout.c:34
+#: builtin/checkout.c:35
 msgid "git checkout [<options>] [<branch>] -- <file>..."
 msgstr "git checkout [<opsi>] [<cabang>] -- <berkas>..."
 
-#: builtin/checkout.c:39
+#: builtin/checkout.c:40
 msgid "git switch [<options>] [<branch>]"
 msgstr "git switch [<opsi>] [<cabang>]"
 
-#: builtin/checkout.c:44
+#: builtin/checkout.c:45
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [<opsi>] [--source=<cabang>] <berkas>..."
 
-#: builtin/checkout.c:198 builtin/checkout.c:237
+#: builtin/checkout.c:199 builtin/checkout.c:238
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "jalur '%s' tidak punya versi kami"
 
-#: builtin/checkout.c:200 builtin/checkout.c:239
+#: builtin/checkout.c:201 builtin/checkout.c:240
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "jalur '%s' tidak punya versi mereka"
 
-#: builtin/checkout.c:216
+#: builtin/checkout.c:217
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "jalur '%s' tidak punya semua versi yang diperlukan"
 
-#: builtin/checkout.c:269
+#: builtin/checkout.c:271
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "jalur '%s' tidak punya versi yang diperlukan"
 
-#: builtin/checkout.c:286
+#: builtin/checkout.c:291
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "jalur '%s': tidak dapat gabung"
 
-#: builtin/checkout.c:302
+#: builtin/checkout.c:307
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Tidak dapat menambahkan hasil penggabungan untuk '%s'"
 
-#: builtin/checkout.c:419
+#: builtin/checkout.c:424
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Konflik penggabungan %d dibuat ulang"
 msgstr[1] "Konflik penggabungan %d dibuat ulang"
 
-#: builtin/checkout.c:424
+#: builtin/checkout.c:429
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "%d jalur diperbarui dari %s"
 msgstr[1] "%d jalur diperbarui dari %s"
 
-#: builtin/checkout.c:431
+#: builtin/checkout.c:436
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "%d jalur diperbarui dari indeks"
 msgstr[1] "%d jalur diperbarui dari indeks"
 
-#: builtin/checkout.c:454 builtin/checkout.c:457 builtin/checkout.c:460
-#: builtin/checkout.c:464
+#: builtin/checkout.c:459 builtin/checkout.c:462 builtin/checkout.c:465
+#: builtin/checkout.c:469
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "'%s' tidak dapat digunakan untuk memperbarui jalur"
 
-#: builtin/checkout.c:474
+#: builtin/checkout.c:479
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Tidak dapat memperbarui jalur dan mengganti ke cabang '%s' dalam waktu yang "
 "bersamaan."
 
-#: builtin/checkout.c:478
+#: builtin/checkout.c:483
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "baik '%s' atau '%s' tidak disebutkan"
 
-#: builtin/checkout.c:482
+#: builtin/checkout.c:487
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "'%s' harus disebutkan ketika '%s' tidak disebutkan"
 
-#: builtin/checkout.c:487 builtin/checkout.c:492
+#: builtin/checkout.c:492 builtin/checkout.c:497
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "'%s' atau '%s' tidak dapat digunakan untuk %s"
 
-#: builtin/checkout.c:566 builtin/checkout.c:573
+#: builtin/checkout.c:571 builtin/checkout.c:578
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "jalur '%s' tak tergabung"
 
-#: builtin/checkout.c:747
+#: builtin/checkout.c:753
 msgid "you need to resolve your current index first"
 msgstr "Anda perlu selesaikan dulu indeks Anda saat ini"
 
-#: builtin/checkout.c:797
+#: builtin/checkout.c:809
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12107,50 +12580,50 @@ msgstr ""
 "berikut:\n"
 "%s"
 
-#: builtin/checkout.c:890
+#: builtin/checkout.c:902
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Tidak dapat melakukan reflog untuk '%s': %s\n"
 
-#: builtin/checkout.c:934
+#: builtin/checkout.c:947
 msgid "HEAD is now at"
 msgstr "HEAD sekarang berada di"
 
-#: builtin/checkout.c:938 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:951 builtin/clone.c:615 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "tidak dapat memperbarui HEAD"
 
-#: builtin/checkout.c:942
+#: builtin/checkout.c:955
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Ganti ulang cabang '%s'\n"
 
-#: builtin/checkout.c:945
+#: builtin/checkout.c:958
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Sudah berada pada '%s'\n"
 
-#: builtin/checkout.c:949
+#: builtin/checkout.c:962
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Ganti ke dan ganti cabang '%s'\n"
 
-#: builtin/checkout.c:951 builtin/checkout.c:1388
+#: builtin/checkout.c:964 builtin/checkout.c:1398
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Ganti ke cabang baru '%s'\n"
 
-#: builtin/checkout.c:953
+#: builtin/checkout.c:966
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Ganti ke cabang '%s'\n"
 
-#: builtin/checkout.c:1004
+#: builtin/checkout.c:1017
 #, c-format
 msgid " ... and %d more.\n"
 msgstr "... dan %d lainnya.\n"
 
-#: builtin/checkout.c:1010
+#: builtin/checkout.c:1023
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12173,7 +12646,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1029
+#: builtin/checkout.c:1042
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12196,19 +12669,19 @@ msgstr[1] ""
 "saat yang tepat untuk dilakukan dengan:\n"
 "git branch <nama-cabang-baru> %s\n"
 
-#: builtin/checkout.c:1064
+#: builtin/checkout.c:1077
 msgid "internal error in revision walk"
 msgstr "kesalahan internal dalam jalan revisi"
 
-#: builtin/checkout.c:1068
+#: builtin/checkout.c:1081
 msgid "Previous HEAD position was"
 msgstr "Posisi HEAD sebelumnya adalah"
 
-#: builtin/checkout.c:1114 builtin/checkout.c:1383
+#: builtin/checkout.c:1124 builtin/checkout.c:1393
 msgid "You are on a branch yet to be born"
 msgstr "Anda berada pada cabang yang belum lahir"
 
-#: builtin/checkout.c:1196
+#: builtin/checkout.c:1206
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12217,7 +12690,7 @@ msgstr ""
 "'%s' bisa jadi berkas lokal dan cabang pelacak.\n"
 "Mohon gunakan -- (dan secara opsional --no-guess) untuk disambiguasi"
 
-#: builtin/checkout.c:1203
+#: builtin/checkout.c:1213
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12237,51 +12710,56 @@ msgstr ""
 "seperti remote 'origin', pertimbangkan untuk menyetel\n"
 "checkout.defaultRemote=origin di konfigurasi Anda"
 
-#: builtin/checkout.c:1213
+#: builtin/checkout.c:1223
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' cocok dengan banyak (%d) cabang pelacak remote"
 
-#: builtin/checkout.c:1279
+#: builtin/checkout.c:1289
 msgid "only one reference expected"
 msgstr "hanya satu referensi yang diharapkan"
 
-#: builtin/checkout.c:1296
+#: builtin/checkout.c:1306
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "hanya satu referensi yang diharapkan, %d diberikan"
 
-#: builtin/checkout.c:1342 builtin/worktree.c:269 builtin/worktree.c:436
+#: builtin/checkout.c:1352 builtin/worktree.c:338 builtin/worktree.c:508
 #, c-format
 msgid "invalid reference: %s"
 msgstr "referensi tidak valid: %s"
 
-#: builtin/checkout.c:1355 builtin/checkout.c:1725
+#: builtin/checkout.c:1365 builtin/checkout.c:1744
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "referensi bukan pohon: %s"
 
-#: builtin/checkout.c:1402
+#: builtin/checkout.c:1413
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "sebuah cabang diharapkan, dapat tag '%s'"
 
-#: builtin/checkout.c:1404
+#: builtin/checkout.c:1415
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "sebuah cabang diharapkan, dapat cabang remote '%s'"
 
-#: builtin/checkout.c:1405 builtin/checkout.c:1413
+#: builtin/checkout.c:1417 builtin/checkout.c:1426
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "sebuah cabang diharapkan, dapat '%s'"
 
-#: builtin/checkout.c:1408
+#: builtin/checkout.c:1420
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "sebuah cabang diharapkan, dapat komit '%s'"
 
-#: builtin/checkout.c:1424
+#: builtin/checkout.c:1429
+msgid ""
+"If you want to detach HEAD at the commit, try again with the --detach option."
+msgstr "Jika Anda ingin lepas HEAD pada komit, coba lagi dengan opsi --detach."
+
+#: builtin/checkout.c:1442
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12290,7 +12768,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git merge --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1428
+#: builtin/checkout.c:1446
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12298,7 +12776,7 @@ msgstr ""
 "tidak dapat mengganti cabang di tengah sesi am\n"
 "Pertimbangkan untuk menggunakan \"git am --quit\" atau \"git worktree add\"."
 
-#: builtin/checkout.c:1432
+#: builtin/checkout.c:1450
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12307,7 +12785,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git rebase --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1436
+#: builtin/checkout.c:1454
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12316,7 +12794,7 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git cherry-pick --quit\" atau \"git "
 "worktree add\"."
 
-#: builtin/checkout.c:1440
+#: builtin/checkout.c:1458
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12325,126 +12803,122 @@ msgstr ""
 "Pertimbangkan untuk menggunakan \"git revert --quit\" atau \"git worktree add"
 "\"."
 
-#: builtin/checkout.c:1444
+#: builtin/checkout.c:1462
 msgid "you are switching branch while bisecting"
 msgstr "Anda mengganti cabang saat pembagian dua"
 
-#: builtin/checkout.c:1451
+#: builtin/checkout.c:1469
 msgid "paths cannot be used with switching branches"
 msgstr "jalur tidak dapat digunakan dengan mengganti cabang"
 
-#: builtin/checkout.c:1454 builtin/checkout.c:1458 builtin/checkout.c:1462
+#: builtin/checkout.c:1472 builtin/checkout.c:1476 builtin/checkout.c:1480
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' tidak dapat digunakan dengan mengganti cabang"
 
-#: builtin/checkout.c:1466 builtin/checkout.c:1469 builtin/checkout.c:1472
-#: builtin/checkout.c:1477 builtin/checkout.c:1482
+#: builtin/checkout.c:1484 builtin/checkout.c:1487 builtin/checkout.c:1490
+#: builtin/checkout.c:1495 builtin/checkout.c:1500
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' tidak dapat digunakan dengan '%s'"
 
-#: builtin/checkout.c:1479
+#: builtin/checkout.c:1497
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' tidak bisa mengambil <titik-awal>"
 
-#: builtin/checkout.c:1487
+#: builtin/checkout.c:1505
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Tidak dapat mengganti cabang ke bukan komit '%s'"
 
-#: builtin/checkout.c:1494
+#: builtin/checkout.c:1512
 msgid "missing branch or commit argument"
 msgstr "kehilangan argumen cabang atau komit"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1555
 msgid "perform a 3-way merge with the new branch"
 msgstr "lakukan penggabungan 3 arah dengan cabang baru"
 
-#: builtin/checkout.c:1538 builtin/log.c:1825 parse-options.h:323
+#: builtin/checkout.c:1556 builtin/log.c:1844 parse-options.h:354
 msgid "style"
 msgstr "gaya"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1557
 msgid "conflict style (merge, diff3, or zdiff3)"
 msgstr "gaya konflik (merge, diff3, atau zdiff3)"
 
-#: builtin/checkout.c:1551 builtin/worktree.c:488
+#: builtin/checkout.c:1569 builtin/worktree.c:560
 msgid "detach HEAD at named commit"
 msgstr "lepas HEAD pada komit bernama"
 
-#: builtin/checkout.c:1553
-msgid "set up tracking mode (see git-pull(1))"
-msgstr "pasang mode pelacakan (lihat git-pull(1))"
-
-#: builtin/checkout.c:1556
+#: builtin/checkout.c:1574
 msgid "force checkout (throw away local modifications)"
 msgstr "paksa checkout (buang modifikasi lokal)"
 
-#: builtin/checkout.c:1558
+#: builtin/checkout.c:1576
 msgid "new-branch"
 msgstr "cabang baru"
 
-#: builtin/checkout.c:1558
+#: builtin/checkout.c:1576
 msgid "new unparented branch"
 msgstr "cabang baru tanpa induk"
 
-#: builtin/checkout.c:1560 builtin/merge.c:305
+#: builtin/checkout.c:1578 builtin/merge.c:305
 msgid "update ignored files (default)"
 msgstr "perbarui berkas yang diabaikan (default)"
 
-#: builtin/checkout.c:1563
+#: builtin/checkout.c:1581
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "jangan periksa jika pohon kerja yang lain mempunyai referensi yang diberikan"
 
-#: builtin/checkout.c:1576
+#: builtin/checkout.c:1594
 msgid "checkout our version for unmerged files"
 msgstr "checkout versi kami untuk berkas yang tak tergabung"
 
-#: builtin/checkout.c:1579
+#: builtin/checkout.c:1597
 msgid "checkout their version for unmerged files"
 msgstr "checkout versi mereka untuk berkas yang tak tergabung"
 
-#: builtin/checkout.c:1583
+#: builtin/checkout.c:1601
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "jangan batasi jalur spek hanya ke entri tipis"
 
-#: builtin/checkout.c:1640
+#: builtin/checkout.c:1659
 #, c-format
 msgid "options '-%c', '-%c', and '%s' cannot be used together"
 msgstr "opsi '-%c', '-%c', dan '%s' tidak dapat digunakan bersamaan"
 
-#: builtin/checkout.c:1681
+#: builtin/checkout.c:1700
 msgid "--track needs a branch name"
 msgstr "--track butuh nama cabang"
 
-#: builtin/checkout.c:1686
+#: builtin/checkout.c:1705
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kehilangan nama cabang; coba -%c"
 
-#: builtin/checkout.c:1718
+#: builtin/checkout.c:1737
 #, c-format
 msgid "could not resolve %s"
 msgstr "tidak dapat menyelesaikan %s"
 
-#: builtin/checkout.c:1734
+#: builtin/checkout.c:1753
 msgid "invalid path specification"
 msgstr "spesifikasi jalur tidak valid"
 
-#: builtin/checkout.c:1741
+#: builtin/checkout.c:1760
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "'%s' bukanlah commit dan cabang '%s' tidak dapat dibuat dari itu"
 
-#: builtin/checkout.c:1745
+#: builtin/checkout.c:1764
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach tidak mengambil argumen jalur '%s'"
 
-#: builtin/checkout.c:1770
+#: builtin/checkout.c:1789
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12452,71 +12926,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force dan --merge tidak kompatibel saat\n"
 "men-checkout index"
 
-#: builtin/checkout.c:1775
+#: builtin/checkout.c:1794
 msgid "you must specify path(s) to restore"
 msgstr "Anda harus sebutkan jalur untuk dipulihkan"
 
-#: builtin/checkout.c:1800 builtin/checkout.c:1802 builtin/checkout.c:1854
-#: builtin/checkout.c:1856 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2959
-#: builtin/submodule--helper.c:3253 builtin/worktree.c:484
-#: builtin/worktree.c:486
+#: builtin/checkout.c:1819 builtin/checkout.c:1821 builtin/checkout.c:1873
+#: builtin/checkout.c:1875 builtin/clone.c:130 builtin/remote.c:171
+#: builtin/remote.c:173 builtin/submodule--helper.c:3038
+#: builtin/submodule--helper.c:3371 builtin/worktree.c:556
+#: builtin/worktree.c:558
 msgid "branch"
 msgstr "cabang"
 
-#: builtin/checkout.c:1801
+#: builtin/checkout.c:1820
 msgid "create and checkout a new branch"
 msgstr "buat dan checkout cabang baru"
 
-#: builtin/checkout.c:1803
+#: builtin/checkout.c:1822
 msgid "create/reset and checkout a branch"
 msgstr "buat/setel ulang dan checkout cabang"
 
-#: builtin/checkout.c:1804
+#: builtin/checkout.c:1823
 msgid "create reflog for new branch"
 msgstr "buat reflog untuk cabang baru"
 
-#: builtin/checkout.c:1806
+#: builtin/checkout.c:1825
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "tebakan kedua 'git checkout <tidak-ada-cabang-seperti-itu>' (default)"
 
-#: builtin/checkout.c:1807
+#: builtin/checkout.c:1826
 msgid "use overlay mode (default)"
 msgstr "gunakan mode hamparan (default)"
 
-#: builtin/checkout.c:1855
+#: builtin/checkout.c:1874
 msgid "create and switch to a new branch"
 msgstr "buat dan ganti ke cabang baru"
 
-#: builtin/checkout.c:1857
+#: builtin/checkout.c:1876
 msgid "create/reset and switch to a branch"
 msgstr "buat/setel ulang dan ganti ke cabang"
 
-#: builtin/checkout.c:1859
+#: builtin/checkout.c:1878
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "tebakan kedua 'git switch <tidak-ada-cabang-seperti-itu>'"
 
-#: builtin/checkout.c:1861
+#: builtin/checkout.c:1880
 msgid "throw away local modifications"
 msgstr "buang modifikasi lokal"
 
-#: builtin/checkout.c:1897
+#: builtin/checkout.c:1916
 msgid "which tree-ish to checkout from"
 msgstr "mana mirip-cabang untuk di-checkout"
 
-#: builtin/checkout.c:1899
+#: builtin/checkout.c:1918
 msgid "restore the index"
 msgstr "pulihkan indeks"
 
-#: builtin/checkout.c:1901
+#: builtin/checkout.c:1920
 msgid "restore the working tree (default)"
 msgstr "pulihkan pohon kerja (default)"
 
-#: builtin/checkout.c:1903
+#: builtin/checkout.c:1922
 msgid "ignore unmerged entries"
 msgstr "abaikan entri yang tak tergabung"
 
-#: builtin/checkout.c:1904
+#: builtin/checkout.c:1923
 msgid "use overlay mode"
 msgstr "gunakan mode hamparan"
 
@@ -12664,8 +13138,8 @@ msgid "remove whole directories"
 msgstr "hapus keseluruhan direktori"
 
 #: builtin/clean.c:932 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:651 builtin/name-rev.c:535 builtin/name-rev.c:537
+#: builtin/grep.c:938 builtin/log.c:185 builtin/log.c:187
+#: builtin/ls-files.c:651 builtin/name-rev.c:585 builtin/name-rev.c:587
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "pola"
@@ -12702,209 +13176,213 @@ msgstr ""
 msgid "-x and -X cannot be used together"
 msgstr "-x dan -X tidak dapat digunakan bersamaan"
 
-#: builtin/clone.c:45
+#: builtin/clone.c:47
 msgid "git clone [<options>] [--] <repo> [<dir>]"
 msgstr "git clone [<opsi>] [--] <repo> [<direktori>]"
 
-#: builtin/clone.c:96
+#: builtin/clone.c:100
 msgid "don't clone shallow repository"
 msgstr "jangan kloning repositori dangkal"
 
-#: builtin/clone.c:98
+#: builtin/clone.c:102
 msgid "don't create a checkout"
 msgstr "jangan buat checkout"
 
-#: builtin/clone.c:99 builtin/clone.c:101 builtin/init-db.c:542
+#: builtin/clone.c:103 builtin/clone.c:105 builtin/init-db.c:542
 msgid "create a bare repository"
 msgstr "buat repositori bare"
 
-#: builtin/clone.c:103
+#: builtin/clone.c:107
 msgid "create a mirror repository (implies bare)"
 msgstr "buat repositori cermin (implikasikan bare)"
 
-#: builtin/clone.c:105
+#: builtin/clone.c:109
 msgid "to clone from a local repository"
 msgstr "kloning dari repositori lokal"
 
-#: builtin/clone.c:107
+#: builtin/clone.c:111
 msgid "don't use local hardlinks, always copy"
 msgstr "jangan gunakan tautan keras lokal, selalu salin"
 
-#: builtin/clone.c:109
+#: builtin/clone.c:113
 msgid "setup as shared repository"
 msgstr "siapkan sebagai repositori berbagi"
 
-#: builtin/clone.c:111
+#: builtin/clone.c:115
 msgid "pathspec"
 msgstr "spek jalur"
 
-#: builtin/clone.c:111
+#: builtin/clone.c:115
 msgid "initialize submodules in the clone"
 msgstr "inisialisasi submodul dalam klon"
 
-#: builtin/clone.c:115
+#: builtin/clone.c:119
 msgid "number of submodules cloned in parallel"
 msgstr "jumlah submodul yang diklon secara paralel"
 
-#: builtin/clone.c:116 builtin/init-db.c:539
+#: builtin/clone.c:120 builtin/init-db.c:539
 msgid "template-directory"
 msgstr "direktori templat"
 
-#: builtin/clone.c:117 builtin/init-db.c:540
+#: builtin/clone.c:121 builtin/init-db.c:540
 msgid "directory from which templates will be used"
 msgstr "direktori dimana templat akan digunakan"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1871
-#: builtin/submodule--helper.c:2514 builtin/submodule--helper.c:3260
+#: builtin/clone.c:123 builtin/clone.c:125 builtin/submodule--helper.c:1885
+#: builtin/submodule--helper.c:2719 builtin/submodule--helper.c:3378
 msgid "reference repository"
 msgstr "repositori rujukan"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1873
-#: builtin/submodule--helper.c:2516
+#: builtin/clone.c:127 builtin/submodule--helper.c:1887
+#: builtin/submodule--helper.c:2721
 msgid "use --reference only while cloning"
 msgstr "gunakan --reference hanya pada saat kloning"
 
-#: builtin/clone.c:124 builtin/column.c:27 builtin/fmt-merge-msg.c:27
+#: builtin/clone.c:128 builtin/column.c:27 builtin/fmt-merge-msg.c:27
 #: builtin/init-db.c:550 builtin/merge-file.c:48 builtin/merge.c:290
-#: builtin/pack-objects.c:3944 builtin/repack.c:665
-#: builtin/submodule--helper.c:3262 t/helper/test-simple-ipc.c:595
+#: builtin/pack-objects.c:3967 builtin/repack.c:669
+#: builtin/submodule--helper.c:3380 t/helper/test-simple-ipc.c:595
 #: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "nama"
 
-#: builtin/clone.c:125
+#: builtin/clone.c:129
 msgid "use <name> instead of 'origin' to track upstream"
 msgstr "gunakan <nama> daripada 'origin' untuk lacak hulu"
 
-#: builtin/clone.c:127
+#: builtin/clone.c:131
 msgid "checkout <branch> instead of the remote's HEAD"
 msgstr "checkout <cabang> daripada HEAD remote"
 
-#: builtin/clone.c:129
+#: builtin/clone.c:133
 msgid "path to git-upload-pack on the remote"
 msgstr "jalur ke git-upload-pack pada remote"
 
-#: builtin/clone.c:130 builtin/fetch.c:181 builtin/grep.c:876
+#: builtin/clone.c:134 builtin/fetch.c:182 builtin/grep.c:877
 #: builtin/pull.c:212
 msgid "depth"
 msgstr "kedalaman"
 
-#: builtin/clone.c:131
+#: builtin/clone.c:135
 msgid "create a shallow clone of that depth"
 msgstr "buat klon dangkal sedalam kedalaman tersebut"
 
-#: builtin/clone.c:132 builtin/fetch.c:183 builtin/pack-objects.c:3933
+#: builtin/clone.c:136 builtin/fetch.c:184 builtin/pack-objects.c:3956
 #: builtin/pull.c:215
 msgid "time"
 msgstr "waktu"
 
-#: builtin/clone.c:133
+#: builtin/clone.c:137
 msgid "create a shallow clone since a specific time"
 msgstr "buat klon dangkal sejak waktu yang disebutkan"
 
-#: builtin/clone.c:134 builtin/fetch.c:185 builtin/fetch.c:208
-#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
+#: builtin/clone.c:138 builtin/fetch.c:186 builtin/fetch.c:212
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1050
 msgid "revision"
 msgstr "revisi"
 
-#: builtin/clone.c:135 builtin/fetch.c:186 builtin/pull.c:219
+#: builtin/clone.c:139 builtin/fetch.c:187 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "perdalam riwayat klon dangkal, tidak termasuk rev"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1883
-#: builtin/submodule--helper.c:2530
+#: builtin/clone.c:141 builtin/submodule--helper.c:1897
+#: builtin/submodule--helper.c:2735
 msgid "clone only one branch, HEAD or --branch"
 msgstr "klon hanya satu cabang, HEAD atau --branch"
 
-#: builtin/clone.c:139
+#: builtin/clone.c:143
 msgid "don't clone any tags, and make later fetches not to follow them"
 msgstr "jangan klon tag apapun, dan buat pengambilan nanti tidak mengikutinya"
 
-#: builtin/clone.c:141
+#: builtin/clone.c:145
 msgid "any cloned submodules will be shallow"
 msgstr "submodul yang diklon akan dangkal"
 
-#: builtin/clone.c:142 builtin/init-db.c:548
+#: builtin/clone.c:146 builtin/init-db.c:548
 msgid "gitdir"
 msgstr "direktori git"
 
-#: builtin/clone.c:143 builtin/init-db.c:549
+#: builtin/clone.c:147 builtin/init-db.c:549
 msgid "separate git dir from working tree"
 msgstr "pisahkan direktori git dari pohon kerja"
 
-#: builtin/clone.c:144
+#: builtin/clone.c:148
 msgid "key=value"
 msgstr "kunci=nilai"
 
-#: builtin/clone.c:145
+#: builtin/clone.c:149
 msgid "set config inside the new repository"
 msgstr "setel konfigurasi di dalam repositori baru"
 
-#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
+#: builtin/clone.c:151 builtin/fetch.c:207 builtin/ls-remote.c:77
 #: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "spesifik ke server"
 
-#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
+#: builtin/clone.c:151 builtin/fetch.c:207 builtin/ls-remote.c:77
 #: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "opsi untuk transmisi"
 
-#: builtin/clone.c:148 builtin/fetch.c:204 builtin/pull.c:238
+#: builtin/clone.c:152 builtin/fetch.c:208 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "gunakan hanya alamat IPv4"
 
-#: builtin/clone.c:150 builtin/fetch.c:206 builtin/pull.c:241
+#: builtin/clone.c:154 builtin/fetch.c:210 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "gunakan hanya alamat IPv6"
 
-#: builtin/clone.c:154
+#: builtin/clone.c:158
+msgid "apply partial clone filters to submodules"
+msgstr "terapkan saringan kloning parsial ke submodul"
+
+#: builtin/clone.c:160
 msgid "any cloned submodules will use their remote-tracking branch"
 msgstr "submodul yang diklon akan menggunakan cabang yang melacak remotenya"
 
-#: builtin/clone.c:156
+#: builtin/clone.c:162
 msgid "initialize sparse-checkout file to include only files at root"
 msgstr ""
 "inisialisasi berkas checkout tipis agar memasukkan hanya berkas pada akar"
 
-#: builtin/clone.c:231
+#: builtin/clone.c:237
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: Tidak dapat menambahkan alternatif untuk '%s': %s\n"
 
-#: builtin/clone.c:304
+#: builtin/clone.c:310
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s ada dan bukan direktori"
 
-#: builtin/clone.c:322
+#: builtin/clone.c:328
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "gagal memulai iterator pada '%s'"
 
-#: builtin/clone.c:353
+#: builtin/clone.c:359
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "gagal membuat tautan '%s'"
 
-#: builtin/clone.c:357
+#: builtin/clone.c:363
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "gagal menyalin berkas ke '%s'"
 
-#: builtin/clone.c:362
+#: builtin/clone.c:368
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "gagal iterasi pada '%s'"
 
-#: builtin/clone.c:389
+#: builtin/clone.c:395
 #, c-format
 msgid "done.\n"
 msgstr "selesai.\n"
 
-#: builtin/clone.c:403
+#: builtin/clone.c:409
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -12914,101 +13392,101 @@ msgstr ""
 "Anda dapat periksa apa yang dicheckout dengan 'git status'\n"
 "dan coba lagi dengan 'git restore --source=HEAD :/'\n"
 
-#: builtin/clone.c:480
+#: builtin/clone.c:486
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Tidak dapat menemukan cabang remote %s untuk diklon."
 
-#: builtin/clone.c:597
+#: builtin/clone.c:603
 #, c-format
 msgid "unable to update %s"
 msgstr "tidak dapat memperbarui %s"
 
-#: builtin/clone.c:645
+#: builtin/clone.c:651
 msgid "failed to initialize sparse-checkout"
 msgstr "gagal menginisalisasi checkout tipis"
 
-#: builtin/clone.c:668
+#: builtin/clone.c:674
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "HEAD remote merujuk pada ref yang tidak ada, tidak dapat men-checkout.\n"
 
-#: builtin/clone.c:701
+#: builtin/clone.c:709
 msgid "unable to checkout working tree"
 msgstr "tidak dapat men-checkout pohon kerja"
 
-#: builtin/clone.c:779
+#: builtin/clone.c:793
 msgid "unable to write parameters to config file"
 msgstr "tidak dapat menulis parameter ke berkas konfigurasi"
 
-#: builtin/clone.c:842
+#: builtin/clone.c:856
 msgid "cannot repack to clean up"
 msgstr "tidak dapat memaket ulang untuk pembersihan"
 
-#: builtin/clone.c:844
+#: builtin/clone.c:858
 msgid "cannot unlink temporary alternates file"
 msgstr "tidak dapat batal-taut berkas alternatif sementara"
 
-#: builtin/clone.c:886
+#: builtin/clone.c:901
 msgid "Too many arguments."
 msgstr "Terlalu banyak argumen."
 
-#: builtin/clone.c:890 contrib/scalar/scalar.c:414
+#: builtin/clone.c:905 contrib/scalar/scalar.c:413
 msgid "You must specify a repository to clone."
 msgstr "Anda harus sebutkan repositori untuk diklon."
 
-#: builtin/clone.c:903
+#: builtin/clone.c:918
 #, c-format
 msgid "options '%s' and '%s %s' cannot be used together"
 msgstr "opsi '%s' dan '%s %s' tidak dapat digunakan bersamaan"
 
-#: builtin/clone.c:920
+#: builtin/clone.c:935
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "repositori '%s' tidak ada"
 
-#: builtin/clone.c:924 builtin/fetch.c:2052
+#: builtin/clone.c:939 builtin/fetch.c:2176
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "kedalaman %s bukan bilangan positif"
 
-#: builtin/clone.c:934
+#: builtin/clone.c:949
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "jalur tujuan '%s' sudah ada dan bukan direktori kosong"
 
-#: builtin/clone.c:940
+#: builtin/clone.c:955
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr "jalur repositori '%s' sudah ada dan bukan direktori kosong"
 
-#: builtin/clone.c:954
+#: builtin/clone.c:969
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "pohon kerja '%s' sudah ada."
 
-#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:256
-#: builtin/log.c:2012 builtin/worktree.c:281 builtin/worktree.c:313
+#: builtin/clone.c:984 builtin/clone.c:1005 builtin/difftool.c:256
+#: builtin/log.c:2037 builtin/worktree.c:350 builtin/worktree.c:382
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "tidak dapat membuat direktori pendahulu '%s'"
 
-#: builtin/clone.c:974
+#: builtin/clone.c:989
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "tidak dapat membuat direktori pohon kerja '%s'"
 
-#: builtin/clone.c:994
+#: builtin/clone.c:1009
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Kloning ke repositori bare '%s'...\n"
 
-#: builtin/clone.c:996
+#: builtin/clone.c:1011
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Kloning ke '%s'...\n"
 
-#: builtin/clone.c:1025
+#: builtin/clone.c:1040
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -13016,47 +13494,51 @@ msgstr ""
 "clone --recursive tidak kompatibel dengan baik --reference dan --reference-"
 "if-able"
 
-#: builtin/clone.c:1080 builtin/remote.c:200 builtin/remote.c:710
+#: builtin/clone.c:1116 builtin/remote.c:201 builtin/remote.c:721
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' bukan nama remote yang valid"
 
-#: builtin/clone.c:1121
+#: builtin/clone.c:1157
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "--depth diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1123
+#: builtin/clone.c:1159
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1125
+#: builtin/clone.c:1161
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1127
+#: builtin/clone.c:1163
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr "--filter diabaikan di klon lokal; gunakan file:// sebagai gantinya."
 
-#: builtin/clone.c:1132
+#: builtin/clone.c:1168
 msgid "source repository is shallow, ignoring --local"
 msgstr "repositori sumber dangkal, abaikan --local"
 
-#: builtin/clone.c:1137
+#: builtin/clone.c:1173
 msgid "--local is ignored"
 msgstr "--local diabaikan"
 
-#: builtin/clone.c:1216 builtin/clone.c:1276
+#: builtin/clone.c:1185
+msgid "cannot clone from filtered bundle"
+msgstr "tidak dapat mengkloning dari bundel tersaring"
+
+#: builtin/clone.c:1265 builtin/clone.c:1324
 msgid "remote transport reported error"
 msgstr "transportasi remote melaporkan kesalahan"
 
-#: builtin/clone.c:1228 builtin/clone.c:1239
+#: builtin/clone.c:1277 builtin/clone.c:1289
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Cabang remote %s tidak ditemukan di hulu %s"
 
-#: builtin/clone.c:1242
+#: builtin/clone.c:1292
 msgid "You appear to have cloned an empty repository."
 msgstr "Anda tampaknya mengklon repositori kosong."
 
@@ -13104,7 +13586,7 @@ msgid ""
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] <split options>"
 msgstr ""
 
-#: builtin/commit-graph.c:51 builtin/fetch.c:192 builtin/log.c:1794
+#: builtin/commit-graph.c:51 builtin/fetch.c:196 builtin/log.c:1813
 msgid "dir"
 msgstr ""
 
@@ -13202,7 +13684,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "induk duplikat %s diabaikan"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:577
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:590
 #, c-format
 msgid "not a valid object name %s"
 msgstr "bukan nama objek valid %s"
@@ -13225,13 +13707,13 @@ msgstr "induk"
 msgid "id of a parent commit object"
 msgstr "id objek komit induk"
 
-#: builtin/commit-tree.c:112 builtin/commit.c:1627 builtin/merge.c:284
-#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1677
-#: builtin/tag.c:454
+#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:284
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1666
+#: builtin/tag.c:455
 msgid "message"
 msgstr "pesan"
 
-#: builtin/commit-tree.c:113 builtin/commit.c:1627
+#: builtin/commit-tree.c:113 builtin/commit.c:1626
 msgid "commit message"
 msgstr "pesan komit"
 
@@ -13239,7 +13721,7 @@ msgstr "pesan komit"
 msgid "read commit log message from file"
 msgstr "baca pesan log komit dari berkas"
 
-#: builtin/commit-tree.c:119 builtin/commit.c:1644 builtin/merge.c:303
+#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:303
 #: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Tandatangani komit dengan GPG"
@@ -13252,15 +13734,15 @@ msgstr "harus berikan tepat satu pohon"
 msgid "git commit-tree: failed to read"
 msgstr "git commit-tree: gagal membaca"
 
-#: builtin/commit.c:42
+#: builtin/commit.c:43
 msgid "git commit [<options>] [--] <pathspec>..."
 msgstr "git commit [<opsi>] [--] <spek jalur>..."
 
-#: builtin/commit.c:47
+#: builtin/commit.c:48
 msgid "git status [<options>] [--] <pathspec>..."
 msgstr "git status [<opsi>] [--] <spek jalur>..."
 
-#: builtin/commit.c:52
+#: builtin/commit.c:53
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -13271,7 +13753,7 @@ msgstr ""
 "dengan --allow-empty, atau Anda dapat menghapus keseluruhan komit\n"
 "dengan \"git reset HEAD^\".\n"
 
-#: builtin/commit.c:57
+#: builtin/commit.c:58
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -13285,15 +13767,15 @@ msgstr ""
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:64
+#: builtin/commit.c:65
 msgid "Otherwise, please use 'git rebase --skip'\n"
 msgstr "Selain itu, gunakan 'git rebase --skip'\n"
 
-#: builtin/commit.c:67
+#: builtin/commit.c:68
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
 msgstr "Selain itu, gunakan 'git cherry-pick --skip'\n"
 
-#: builtin/commit.c:70
+#: builtin/commit.c:71
 msgid ""
 "and then use:\n"
 "\n"
@@ -13314,69 +13796,69 @@ msgstr ""
 "    git cherry-pick --skip\n"
 "\n"
 
-#: builtin/commit.c:325
+#: builtin/commit.c:326
 msgid "failed to unpack HEAD tree object"
 msgstr "gagal membuka objek pohon HEAD"
 
-#: builtin/commit.c:375
+#: builtin/commit.c:376
 msgid "No paths with --include/--only does not make sense."
 msgstr "Tanpa jalur dengan --include/--only tidak masuk akal."
 
-#: builtin/commit.c:387
+#: builtin/commit.c:388
 msgid "unable to create temporary index"
 msgstr "tidak dapat membuat indeks sementara"
 
-#: builtin/commit.c:396
+#: builtin/commit.c:397
 msgid "interactive add failed"
 msgstr "penambahan interaktif gagal"
 
-#: builtin/commit.c:411
+#: builtin/commit.c:412
 msgid "unable to update temporary index"
 msgstr "tidak dapat memperbarui indeks sementara"
 
-#: builtin/commit.c:413
+#: builtin/commit.c:414
 msgid "Failed to update main cache tree"
 msgstr "gagal memperbarui tembolok pohon utama"
 
-#: builtin/commit.c:438 builtin/commit.c:461 builtin/commit.c:509
+#: builtin/commit.c:439 builtin/commit.c:462 builtin/commit.c:510
 msgid "unable to write new_index file"
 msgstr "tidak dapat menulis berkas new_index"
 
-#: builtin/commit.c:490
+#: builtin/commit.c:491
 msgid "cannot do a partial commit during a merge."
 msgstr "tidak dapat melakukan komit sebagian selama penggabungan."
 
-#: builtin/commit.c:492
+#: builtin/commit.c:493
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr "tidak dapat melakukan komit sebagian selama pemetikan ceri."
 
-#: builtin/commit.c:494
+#: builtin/commit.c:495
 msgid "cannot do a partial commit during a rebase."
 msgstr "tidak dapat melakukan komit sebagian selama pendasaran ulang."
 
-#: builtin/commit.c:502
+#: builtin/commit.c:503
 msgid "cannot read the index"
 msgstr "tidak dapat membaca indeks"
 
-#: builtin/commit.c:521
+#: builtin/commit.c:522
 msgid "unable to write temporary index file"
 msgstr "tidak dapat menulis berkas indeks sementara"
 
-#: builtin/commit.c:619
+#: builtin/commit.c:620
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "komit '%s' kurang kepala pengarang"
 
-#: builtin/commit.c:621
+#: builtin/commit.c:622
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "komit '%s' ada baris pengarang cacat"
 
-#: builtin/commit.c:640
+#: builtin/commit.c:641
 msgid "malformed --author parameter"
 msgstr "parameter --author cacat"
 
-#: builtin/commit.c:693
+#: builtin/commit.c:694
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -13384,43 +13866,43 @@ msgstr ""
 "tidak dapat memilih karakter komentar yang tidak terpakai\n"
 "dalam pesan komit saat ini"
 
-#: builtin/commit.c:747 builtin/commit.c:781 builtin/commit.c:1166
+#: builtin/commit.c:750 builtin/commit.c:784 builtin/commit.c:1170
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "tidak dapat mencari komit %s"
 
-#: builtin/commit.c:759 builtin/shortlog.c:416
+#: builtin/commit.c:762 builtin/shortlog.c:417
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(baca pesan log dari standar masukan)\n"
 
-#: builtin/commit.c:761
+#: builtin/commit.c:764
 msgid "could not read log from standard input"
 msgstr "tidak dapat membaca log dari standar masukan"
 
-#: builtin/commit.c:765
+#: builtin/commit.c:768
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "tidak dapat membaca berkas log '%s'"
 
-#: builtin/commit.c:802
+#: builtin/commit.c:805
 #, c-format
 msgid "options '%s' and '%s:%s' cannot be used together"
 msgstr "opsi '%s' dan '%s:%s' tidak dapat digunakan bersamaan"
 
-#: builtin/commit.c:814 builtin/commit.c:830
+#: builtin/commit.c:817 builtin/commit.c:833
 msgid "could not read SQUASH_MSG"
 msgstr "tidak dapat membaca SQUASH_MSG"
 
-#: builtin/commit.c:821
+#: builtin/commit.c:824
 msgid "could not read MERGE_MSG"
 msgstr "tidak dapat membaca MERGE_MSG"
 
-#: builtin/commit.c:881
+#: builtin/commit.c:884
 msgid "could not write commit template"
 msgstr "tidak dapat menulis templat komit"
 
-#: builtin/commit.c:894
+#: builtin/commit.c:897
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13429,7 +13911,7 @@ msgstr ""
 "Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
 "dengan '%c' akan diabaikan.\n"
 
-#: builtin/commit.c:896
+#: builtin/commit.c:899
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13438,7 +13920,7 @@ msgstr ""
 "Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
 "dengan '%c' akan diabaikan, dan pesan kosong batalkan komit.\n"
 
-#: builtin/commit.c:900
+#: builtin/commit.c:903
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13447,7 +13929,7 @@ msgstr ""
 "Mohon masukkan pesan komit untuk perubahan Anda. Baris yang diawali\n"
 "dengan '%c' akan tetap; Anda dapat menghapus itu jika Anda mau.\n"
 
-#: builtin/commit.c:904
+#: builtin/commit.c:907
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13458,7 +13940,7 @@ msgstr ""
 "dengan '%c' akan tetap; Anda dapat menghapus itu jika Anda mau.\n"
 "Pesan kosong batalkan komit.\n"
 
-#: builtin/commit.c:916
+#: builtin/commit.c:919
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -13472,7 +13954,7 @@ msgstr ""
 "\tgit update-ref -d MERGE_HEAD\n"
 "dan coba lagi.\n"
 
-#: builtin/commit.c:921
+#: builtin/commit.c:924
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -13486,169 +13968,147 @@ msgstr ""
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "dan coba lagi.\n"
 
-#: builtin/commit.c:948
+#: builtin/commit.c:951
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sPengarang:    %.*s <%.*s>"
 
-#: builtin/commit.c:956
+#: builtin/commit.c:959
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sTanggal:       %s"
 
-#: builtin/commit.c:963
+#: builtin/commit.c:966
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sPengkomit: %.*s <%.*s>"
 
-#: builtin/commit.c:981
+#: builtin/commit.c:984
 msgid "Cannot read index"
 msgstr "Tidak dapat membaca indeks"
 
-#: builtin/commit.c:1026
+#: builtin/commit.c:1029
 msgid "unable to pass trailers to --trailers"
 msgstr "tidak dapat melewatkan trailer ke --trailers"
 
-#: builtin/commit.c:1066
+#: builtin/commit.c:1069
 msgid "Error building trees"
 msgstr "Kesalahan membangun pohon"
 
-#: builtin/commit.c:1080 builtin/tag.c:316
+#: builtin/commit.c:1083 builtin/tag.c:317
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Mohon berikan pesan baik dengan opsi -m atau -F.\n"
 
-#: builtin/commit.c:1124
+#: builtin/commit.c:1128
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' bukan 'Nama <email>' dan tidak cocok dengan pengarang yang ada"
 
-#: builtin/commit.c:1138
+#: builtin/commit.c:1142
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Mode terabaikan '%s' tidak valid"
 
-#: builtin/commit.c:1156 builtin/commit.c:1451
+#: builtin/commit.c:1160 builtin/commit.c:1450
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Mode berkas tak terlacak '%s' tidak valid"
 
-#: builtin/commit.c:1227
+#: builtin/commit.c:1231
 msgid "You are in the middle of a merge -- cannot reword."
 msgstr "Anda berada di tengah penggabungan -- tidak dapat menulis ulang."
 
-#: builtin/commit.c:1229
+#: builtin/commit.c:1233
 msgid "You are in the middle of a cherry-pick -- cannot reword."
 msgstr "Anda berada di tengah pemetikan ceri -- tidak dapat menulis ulang."
 
-#: builtin/commit.c:1232
+#: builtin/commit.c:1236
 #, c-format
 msgid "reword option of '%s' and path '%s' cannot be used together"
 msgstr "opsi reword '%s' dan jalur '%s' tidak dapat digunakan bersamaan"
 
-#: builtin/commit.c:1234
+#: builtin/commit.c:1238
 #, c-format
 msgid "reword option of '%s' and '%s' cannot be used together"
 msgstr "opsi reword '%s' dan '%s' tidak dapat digunakan bersamaan"
 
-#: builtin/commit.c:1254
-msgid "Using both --reset-author and --author does not make sense"
-msgstr "Menggunakan baik --reset-author dan --author tidak masuk akal"
-
-#: builtin/commit.c:1261
+#: builtin/commit.c:1263
 msgid "You have nothing to amend."
 msgstr "Anda tidak punya apapun untuk diubah."
 
-#: builtin/commit.c:1264
+#: builtin/commit.c:1266
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Anda berada di tengah penggabungan -- tidak dapat mengubah."
 
-#: builtin/commit.c:1266
+#: builtin/commit.c:1268
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "Anda berada di tengah pemetikan ceri -- tidak dapat mengubah."
 
-#: builtin/commit.c:1268
+#: builtin/commit.c:1270
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Anda berada di tengah pendasaran ulang -- tidak dapat mengubah."
 
-#: builtin/commit.c:1271
-msgid "Options --squash and --fixup cannot be used together"
-msgstr "Opsi --squash dan --fixup tidak dapat digunakan bersamaan"
-
-#: builtin/commit.c:1281
-msgid "Only one of -c/-C/-F/--fixup can be used."
-msgstr "Hanya salah satu dari -c/-C/-F/--fixup yang dapat digunakan."
-
-#: builtin/commit.c:1283
-msgid "Option -m cannot be combined with -c/-C/-F."
-msgstr "Opsi -m tidak dapat digabung dengan -c/-C/-F."
-
-#: builtin/commit.c:1292
+#: builtin/commit.c:1290
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset-author hanya dapat digunakan dengan -C, -c atau --amend."
 
-#: builtin/commit.c:1310
-msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
-msgstr ""
-"Hanya salah satu dari --include/--only/--all/--interactive/--patch yang "
-"dapat digunakan."
-
-#: builtin/commit.c:1338
+#: builtin/commit.c:1337
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
-msgstr ""
+msgstr "opsi tidak dikenal: --fixup=%s:%s"
 
-#: builtin/commit.c:1355
+#: builtin/commit.c:1354
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "jalur '%s ...' dengan -a tidak masuk akal"
 
-#: builtin/commit.c:1486 builtin/commit.c:1655
+#: builtin/commit.c:1485 builtin/commit.c:1654
 msgid "show status concisely"
 msgstr "perlihatkan status dengan ringkas"
 
-#: builtin/commit.c:1488 builtin/commit.c:1657
+#: builtin/commit.c:1487 builtin/commit.c:1656
 msgid "show branch information"
 msgstr "perlihatkan informasi cabang"
 
-#: builtin/commit.c:1490
+#: builtin/commit.c:1489
 msgid "show stash information"
 msgstr "perlihatkan informasi stase"
 
-#: builtin/commit.c:1492 builtin/commit.c:1659
+#: builtin/commit.c:1491 builtin/commit.c:1658
 msgid "compute full ahead/behind values"
 msgstr "hitung nilai didepan/dibelakang penuh"
 
-#: builtin/commit.c:1494
+#: builtin/commit.c:1493
 msgid "version"
 msgstr "versi"
 
-#: builtin/commit.c:1494 builtin/commit.c:1661 builtin/push.c:551
-#: builtin/worktree.c:690
+#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
+#: builtin/worktree.c:765
 msgid "machine-readable output"
 msgstr "keluaran yang dapat dibaca mesin"
 
-#: builtin/commit.c:1497 builtin/commit.c:1663
+#: builtin/commit.c:1496 builtin/commit.c:1662
 msgid "show status in long format (default)"
 msgstr "perlihatkan status dalam format panjang (asali)"
 
-#: builtin/commit.c:1500 builtin/commit.c:1666
+#: builtin/commit.c:1499 builtin/commit.c:1665
 msgid "terminate entries with NUL"
 msgstr "akhiri entri dengan NUL"
 
-#: builtin/commit.c:1502 builtin/commit.c:1506 builtin/commit.c:1669
+#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1172 builtin/fast-export.c:1175
-#: builtin/fast-export.c:1178 builtin/rebase.c:1111 parse-options.h:337
+#: builtin/fast-export.c:1178 builtin/rebase.c:1139 parse-options.h:368
 msgid "mode"
 msgstr "mode"
 
-#: builtin/commit.c:1503 builtin/commit.c:1669
+#: builtin/commit.c:1502 builtin/commit.c:1668
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "perlihatkan berkas tak terlacak, mode opsional: all, normal, no. (Asali: all)"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1506
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -13656,11 +14116,11 @@ msgstr ""
 "perlihatkan berkas terabaikan, mode opsional: traditional, matching, no. "
 "(Asali: traditional)"
 
-#: builtin/commit.c:1509 parse-options.h:192
+#: builtin/commit.c:1508 parse-options.h:197
 msgid "when"
 msgstr "bila"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1509
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -13668,192 +14128,192 @@ msgstr ""
 "abaikan perubahan submodul, bila opsional: all, dirty, untracked. (Asali: "
 "all)"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1511
 msgid "list untracked files in columns"
 msgstr "sebut berkas tak terlacak dalam kolom"
 
-#: builtin/commit.c:1513
+#: builtin/commit.c:1512
 msgid "do not detect renames"
 msgstr "jangan deteksi penggantian nama"
 
-#: builtin/commit.c:1515
+#: builtin/commit.c:1514
 msgid "detect renames, optionally set similarity index"
 msgstr "deteksi penggantian nama, setel indeks kemiripan secara opsional"
 
-#: builtin/commit.c:1538
+#: builtin/commit.c:1537
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr "Kombinasi argumen berkas terabaikan dan tak terlacak tidak didukung"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1619
 msgid "suppress summary after successful commit"
 msgstr "sembunyikan rangkuman setelah komit berhasil"
 
-#: builtin/commit.c:1621
+#: builtin/commit.c:1620
 msgid "show diff in commit message template"
 msgstr "perlihatkan diff dalam templat pesan komit"
 
-#: builtin/commit.c:1623
+#: builtin/commit.c:1622
 msgid "Commit message options"
 msgstr "Opsi pesan komit"
 
-#: builtin/commit.c:1624 builtin/merge.c:288 builtin/tag.c:456
+#: builtin/commit.c:1623 builtin/merge.c:288 builtin/tag.c:457
 msgid "read message from file"
 msgstr "Baca pesan dari berkas"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1624
 msgid "author"
 msgstr "pengarang"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1624
 msgid "override author for commit"
 msgstr "timpa pengarang komit"
 
-#: builtin/commit.c:1626 builtin/gc.c:551
+#: builtin/commit.c:1625 builtin/gc.c:551
 msgid "date"
 msgstr "tangal"
 
-#: builtin/commit.c:1626
+#: builtin/commit.c:1625
 msgid "override date for commit"
 msgstr "timpa tanggal komit"
 
-#: builtin/commit.c:1628 builtin/commit.c:1629 builtin/commit.c:1635
-#: parse-options.h:329 ref-filter.h:89
+#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
+#: parse-options.h:360 ref-filter.h:89
 msgid "commit"
 msgstr "komit"
 
-#: builtin/commit.c:1628
+#: builtin/commit.c:1627
 msgid "reuse and edit message from specified commit"
 msgstr "gunakan kembali dan sunting pesan dari komit tersebut"
 
-#: builtin/commit.c:1629
+#: builtin/commit.c:1628
 msgid "reuse message from specified commit"
 msgstr "gunakan kembali pesan dari komit tersebut"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1634
+#: builtin/commit.c:1633
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]komit"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1633
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "gunakan pesan terformat autosquash untuk perbaiki atau ubah/tulis ulang "
 "komit yang disebutkan"
 
-#: builtin/commit.c:1635
+#: builtin/commit.c:1634
 msgid "use autosquash formatted message to squash specified commit"
 msgstr "gunakan pesan terformat autosquash untuk lumat komit tersebut"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1635
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "komit sekarang dikarang olehku (gunakan dengan -C/-c/--amend)"
 
-#: builtin/commit.c:1637 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
 msgid "trailer"
-msgstr ""
+msgstr "trailer"
 
-#: builtin/commit.c:1637
+#: builtin/commit.c:1636
 msgid "add custom trailer(s)"
-msgstr ""
+msgstr "tambahkan trailer kustom"
 
-#: builtin/commit.c:1638 builtin/log.c:1769 builtin/merge.c:306
+#: builtin/commit.c:1637 builtin/log.c:1788 builtin/merge.c:306
 #: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "tambahkan trailer Signed-off-by"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1638
 msgid "use specified template file"
 msgstr "gunakan templat berkas tersebut"
 
-#: builtin/commit.c:1640
+#: builtin/commit.c:1639
 msgid "force edit of commit"
 msgstr "paksa sunting komit"
 
-#: builtin/commit.c:1642
+#: builtin/commit.c:1641
 msgid "include status in commit message template"
 msgstr "masukkan status dalam templat pesaan komit"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1646
 msgid "Commit contents options"
 msgstr "Opsi isi komit"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1647
 msgid "commit all changed files"
 msgstr "komit semua berkas terubah"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1648
 msgid "add specified files to index for commit"
 msgstr "tambahakn berkas tersebut ke indeks untuk dikomit"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1649
 msgid "interactively add files"
 msgstr "tambah berkas secara interaktif"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1650
 msgid "interactively add changes"
 msgstr "tambah perubahan secara interaktif"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1651
 msgid "commit only specified files"
 msgstr "hanya komit berkas tersebut"
 
-#: builtin/commit.c:1653
+#: builtin/commit.c:1652
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "lewati kail pre-commit dan commit-msg"
 
-#: builtin/commit.c:1654
+#: builtin/commit.c:1653
 msgid "show what would be committed"
 msgstr "perlihatkan apa yang akan dikomit"
 
-#: builtin/commit.c:1667
+#: builtin/commit.c:1666
 msgid "amend previous commit"
 msgstr "ubah komit sebelumnya"
 
-#: builtin/commit.c:1668
+#: builtin/commit.c:1667
 msgid "bypass post-rewrite hook"
 msgstr "lewati kail post-rewrite"
 
-#: builtin/commit.c:1675
+#: builtin/commit.c:1674
 msgid "ok to record an empty change"
 msgstr "ok merekam perubahan kosong"
 
-#: builtin/commit.c:1677
+#: builtin/commit.c:1676
 msgid "ok to record a change with an empty message"
 msgstr "ok merekam perubahan dengan pesan kosong"
 
-#: builtin/commit.c:1753
+#: builtin/commit.c:1752
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Berkas MERGE_HEAD (%s) rusak"
 
-#: builtin/commit.c:1760
+#: builtin/commit.c:1759
 msgid "could not read MERGE_MODE"
 msgstr "tidak dapat membaca MERGE_MODE"
 
-#: builtin/commit.c:1781
+#: builtin/commit.c:1780
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "tidak dapat membaca pesan komit: %s"
 
-#: builtin/commit.c:1788
+#: builtin/commit.c:1787
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Batalkan komit karena pesan komit kosong.\n"
 
-#: builtin/commit.c:1793
+#: builtin/commit.c:1792
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Batalkan komit; Anda tidak menyunting pesan.\n"
 
-#: builtin/commit.c:1804
+#: builtin/commit.c:1803
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr "Batalkan komit karena badan pesan komit kosong.\n"
 
-#: builtin/commit.c:1840
+#: builtin/commit.c:1839
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -13975,6 +14435,10 @@ msgstr "temukan setelan warna: slot [stdout-is-tty]"
 #: builtin/config.c:153
 msgid "Type"
 msgstr "Tipe"
+
+#: builtin/config.c:154 builtin/env--helper.c:42 builtin/hash-object.c:97
+msgid "type"
+msgstr "tipe"
 
 #: builtin/config.c:154 builtin/env--helper.c:43
 msgid "value is given this type"
@@ -14189,10 +14653,6 @@ msgstr ""
 msgid "no such section: %s"
 msgstr "tidak ada bagian seperti: %s"
 
-#: builtin/count-objects.c:90
-msgid "git count-objects [-v] [-H | --human-readable]"
-msgstr "git count-objects [-v] [-H | --human-readable]"
-
 #: builtin/count-objects.c:100
 msgid "print sizes in human readable format"
 msgstr "cetak ukuran dalam format yang bisa dibaca manusia"
@@ -14357,7 +14817,7 @@ msgstr "hanya pertimbangkan tag yang cocok dengan <pola>"
 msgid "do not consider tags matching <pattern>"
 msgstr "jangan pertimbangkan tag yang cocok dengan <pola>"
 
-#: builtin/describe.c:570 builtin/name-rev.c:544
+#: builtin/describe.c:570 builtin/name-rev.c:595
 msgid "show abbreviated commit object as fallback"
 msgstr "perlihatkan objek komit singkat sebagai langkah terakhir"
 
@@ -14405,7 +14865,7 @@ msgstr "%s...%s: tidak ada dasar penggabungan"
 msgid "Not a git repository"
 msgstr "bukan repositori git"
 
-#: builtin/diff.c:537 builtin/grep.c:698
+#: builtin/diff.c:537 builtin/grep.c:700
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "objek yang diberikan '%s' tidak valid"
@@ -14523,20 +14983,16 @@ msgstr "dilewatkan ke `diff`"
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool butuh pohon kerja atau --no-index"
 
-#: builtin/difftool.c:744
+#: builtin/difftool.c:745
 msgid "no <tool> given for --tool=<tool>"
 msgstr "tidak ada <alat> yang diberikan untuk --tool=<alat>"
 
-#: builtin/difftool.c:751
+#: builtin/difftool.c:752
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "tidak ada <perintah> yang diberikan untuk --extcmd=<perintah>"
 
 #: builtin/env--helper.c:6
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
-msgstr ""
-
-#: builtin/env--helper.c:42 builtin/hash-object.c:96
-msgid "type"
 msgstr ""
 
 #: builtin/env--helper.c:46
@@ -14560,8 +15016,8 @@ msgid ""
 msgstr ""
 
 #: builtin/fast-export.c:29
-msgid "git fast-export [rev-list-opts]"
-msgstr "git fast-export [opsi rev-list]"
+msgid "git fast-export [<rev-list-opts>]"
+msgstr "git fast-export [<opsi rev-list>]"
 
 #: builtin/fast-export.c:843
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
@@ -14617,7 +15073,7 @@ msgstr "gunakan fitur selesai untuk mengakhiri arus"
 msgid "skip output of blob data"
 msgstr "lewati keluaran data blob"
 
-#: builtin/fast-export.c:1196 builtin/log.c:1841
+#: builtin/fast-export.c:1196 builtin/log.c:1860
 msgid "refspec"
 msgstr "spek referensi"
 
@@ -14649,37 +15105,37 @@ msgstr "perlihatkan id objek asli dari blob/komit"
 msgid "label tags with mark ids"
 msgstr "label tag dengan id tanda"
 
-#: builtin/fast-import.c:3090
+#: builtin/fast-import.c:3097
 #, c-format
 msgid "Missing from marks for submodule '%s'"
 msgstr "Kehilangan tanda dari untuk submodul '%s'"
 
-#: builtin/fast-import.c:3092
+#: builtin/fast-import.c:3099
 #, c-format
 msgid "Missing to marks for submodule '%s'"
 msgstr "Kehilangan tanda ke untuk submodul '%s'"
 
-#: builtin/fast-import.c:3227
+#: builtin/fast-import.c:3234
 #, c-format
 msgid "Expected 'mark' command, got %s"
 msgstr "Perintah 'mark' diharapkan, dapat %s"
 
-#: builtin/fast-import.c:3232
+#: builtin/fast-import.c:3239
 #, c-format
 msgid "Expected 'to' command, got %s"
 msgstr "Perintah 'to' diharapkan, dapat %s"
 
-#: builtin/fast-import.c:3324
+#: builtin/fast-import.c:3331
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr ""
 "Format nama:nama berkas diharapkan untuk operasi penulisan ulang submodul"
 
-#: builtin/fast-import.c:3379
+#: builtin/fast-import.c:3386
 #, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
 msgstr "fitur '%s' dilarang dalam input tanpa --allow-unsafe-features"
 
-#: builtin/fetch-pack.c:242
+#: builtin/fetch-pack.c:246
 #, c-format
 msgid "Lockfile created but not reported: %s"
 msgstr "Berkas kunci dibuat tetapi tidak dilaporkan: %s"
@@ -14700,102 +15156,106 @@ msgstr "git fetch --multiple [<opsi>] [(<repositori> | <grup>)]"
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<opsi>]"
 
-#: builtin/fetch.c:123
+#: builtin/fetch.c:124
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel tidak dapat bernilai negatif"
 
-#: builtin/fetch.c:146 builtin/pull.c:189
+#: builtin/fetch.c:147 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "ambil dari semua remote"
 
-#: builtin/fetch.c:148 builtin/pull.c:249
+#: builtin/fetch.c:149 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "setel hulu untuk git pull/fetch"
 
-#: builtin/fetch.c:150 builtin/pull.c:192
+#: builtin/fetch.c:151 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "tambah ke .git/FETCH_HEAD daripada timpa"
 
-#: builtin/fetch.c:152
+#: builtin/fetch.c:153
 msgid "use atomic transaction to update references"
 msgstr ""
 
-#: builtin/fetch.c:154 builtin/pull.c:195
+#: builtin/fetch.c:155 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "jalur ke paket unggah pada sisi remote"
 
-#: builtin/fetch.c:155
+#: builtin/fetch.c:156
 msgid "force overwrite of local reference"
 msgstr "paksa timpa referensi lokal"
 
-#: builtin/fetch.c:157
+#: builtin/fetch.c:158
 msgid "fetch from multiple remotes"
 msgstr "ambil dari banyak remote"
 
-#: builtin/fetch.c:159 builtin/pull.c:199
+#: builtin/fetch.c:160 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "ambil semua tag dan objek yang bersesuaian"
 
-#: builtin/fetch.c:161
+#: builtin/fetch.c:162
 msgid "do not fetch all tags (--no-tags)"
 msgstr "jangan ambil semua tag (--no-tags)"
 
-#: builtin/fetch.c:163
+#: builtin/fetch.c:164
 msgid "number of submodules fetched in parallel"
 msgstr "jumlah submodul yang diambil secara bersamaan"
 
-#: builtin/fetch.c:165
+#: builtin/fetch.c:166
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
 "modifikasi spek referensi untuk tempatkan semua referensi di dalam refs/"
 "prefetch/"
 
-#: builtin/fetch.c:167 builtin/pull.c:202
+#: builtin/fetch.c:168 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "buang cabang pelacak remote yang tidak ada pada remote"
 
-#: builtin/fetch.c:169
+#: builtin/fetch.c:170
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr "buang tag lokal yang tidak ada pada remote dan klob tag yang berubah"
 
-#: builtin/fetch.c:170 builtin/fetch.c:195 builtin/pull.c:123
+#: builtin/fetch.c:171 builtin/fetch.c:199 builtin/pull.c:123
 msgid "on-demand"
 msgstr "sesuai permintaan"
 
-#: builtin/fetch.c:171
+#: builtin/fetch.c:172
 msgid "control recursive fetching of submodules"
 msgstr "kontrol pengambilan submodul rekursif"
 
-#: builtin/fetch.c:176
+#: builtin/fetch.c:177
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "tulis referensi yang diambil ke berkas FETCH_HEAD"
 
-#: builtin/fetch.c:177 builtin/pull.c:210
+#: builtin/fetch.c:178 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "simpan paket yang diunduh"
 
-#: builtin/fetch.c:179
+#: builtin/fetch.c:180
 msgid "allow updating of HEAD ref"
 msgstr "bolehkan perbarui referensi HEAD"
 
-#: builtin/fetch.c:182 builtin/fetch.c:188 builtin/pull.c:213
+#: builtin/fetch.c:183 builtin/fetch.c:189 builtin/pull.c:213
 #: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "perdalam riwayat klon dangkal"
 
-#: builtin/fetch.c:184 builtin/pull.c:216
+#: builtin/fetch.c:185 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "perdalam riwayat repositori dangkal berdasarkan waktu"
 
-#: builtin/fetch.c:190 builtin/pull.c:225
+#: builtin/fetch.c:191 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "ubah ke repositori penuh"
 
-#: builtin/fetch.c:193
+#: builtin/fetch.c:194
+msgid "re-fetch without negotiating common commits"
+msgstr ""
+
+#: builtin/fetch.c:197
 msgid "prepend this to submodule path output"
 msgstr "tambahkan ini ke jalur keluaran submodul"
 
-#: builtin/fetch.c:196
+#: builtin/fetch.c:200
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -14803,108 +15263,103 @@ msgstr ""
 "default untuk ambil submodul secara rekursif (prioritas lebih rendah "
 "dariberkas konfigurasi)"
 
-#: builtin/fetch.c:200 builtin/pull.c:228
+#: builtin/fetch.c:204 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "terima referensi yang memperbarui .git/shallow"
 
-#: builtin/fetch.c:201 builtin/pull.c:230
+#: builtin/fetch.c:205 builtin/pull.c:230
 msgid "refmap"
 msgstr "peta referensi"
 
-#: builtin/fetch.c:202 builtin/pull.c:231
+#: builtin/fetch.c:206 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "sebutkan ambil peta referensi"
 
-#: builtin/fetch.c:209 builtin/pull.c:244
+#: builtin/fetch.c:213 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "laporkan bahwa kami hanya punya object yang bisa dicapai dari objek ini"
 
-#: builtin/fetch.c:211
+#: builtin/fetch.c:215
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
 "jangan ambil berkas pak; sebagai gantinya cetak leluhur dari ujung negosiasi"
 
-#: builtin/fetch.c:214 builtin/fetch.c:216
+#: builtin/fetch.c:218 builtin/fetch.c:220
 msgid "run 'maintenance --auto' after fetching"
 msgstr "lakukan 'maintenance --auto' setelah pengambilan"
 
-#: builtin/fetch.c:218 builtin/pull.c:247
+#: builtin/fetch.c:222 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "periksa pembaruan terpaksa pada semua cabang"
 
-#: builtin/fetch.c:220
+#: builtin/fetch.c:224
 msgid "write the commit-graph after fetching"
 msgstr "tulis grafik komit setelah pengambilan"
 
-#: builtin/fetch.c:222
+#: builtin/fetch.c:226
 msgid "accept refspecs from stdin"
 msgstr "terima spek referensi dari masukan standar"
 
-#: builtin/fetch.c:592
+#: builtin/fetch.c:618
 msgid "couldn't find remote ref HEAD"
 msgstr "tidak dapat menemukan referensi remote HEAD"
 
-#: builtin/fetch.c:766
-#, c-format
-msgid "configuration fetch.output contains invalid value %s"
-msgstr "konfigurasi fetch.output berisi nilai tidak valid %s"
-
-#: builtin/fetch.c:867
+#: builtin/fetch.c:893
 #, c-format
 msgid "object %s not found"
 msgstr "objek %s tidak ditemukan"
 
-#: builtin/fetch.c:871
+#: builtin/fetch.c:897
 msgid "[up to date]"
 msgstr "[terkini]"
 
-#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
+#: builtin/fetch.c:909 builtin/fetch.c:927 builtin/fetch.c:999
 msgid "[rejected]"
 msgstr "[tertolak]"
 
-#: builtin/fetch.c:885
+#: builtin/fetch.c:911
 msgid "can't fetch in current branch"
 msgstr "tidak dapat mengambil di cabang saat ini"
 
-#: builtin/fetch.c:886
+#: builtin/fetch.c:912
 msgid "checked out in another worktree"
 msgstr "ter-check out di dalam pohon kerja lainnya"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:922
 msgid "[tag update]"
 msgstr "[pembaruan tag]"
 
-#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
-#: builtin/fetch.c:968
+#: builtin/fetch.c:923 builtin/fetch.c:960 builtin/fetch.c:982
+#: builtin/fetch.c:994
 msgid "unable to update local ref"
 msgstr "tidak dapat memperbarui referensi lokal"
 
-#: builtin/fetch.c:901
+#: builtin/fetch.c:927
 msgid "would clobber existing tag"
 msgstr "akan klob tag yang ada"
 
-#: builtin/fetch.c:923
+#: builtin/fetch.c:949
 msgid "[new tag]"
 msgstr "[tag baru]"
 
-#: builtin/fetch.c:926
+#: builtin/fetch.c:952
 msgid "[new branch]"
 msgstr "[cabang baru]"
 
-#: builtin/fetch.c:929
+#: builtin/fetch.c:955
 msgid "[new ref]"
 msgstr "[referensi baru]"
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:994
 msgid "forced update"
 msgstr "pembaruan terpaksa"
 
-#: builtin/fetch.c:973
+#: builtin/fetch.c:999
 msgid "non-fast-forward"
 msgstr "bukan-maju-cepat"
 
-#: builtin/fetch.c:1076
+#: builtin/fetch.c:1102
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
@@ -14916,7 +15371,7 @@ msgstr ""
 "bendera '--show-forced-updates' atau jalankan 'git config fetch."
 "showForcedUpdates true'."
 
-#: builtin/fetch.c:1080
+#: builtin/fetch.c:1106
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -14929,22 +15384,22 @@ msgstr ""
 "'git config fetch.showForcedUpdates false'\n"
 "untuk menghindari pemeriksaan ini.\n"
 
-#: builtin/fetch.c:1112
+#: builtin/fetch.c:1136
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s tidak mengirim semua objek yang diperlukan\n"
 
-#: builtin/fetch.c:1141
+#: builtin/fetch.c:1156
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "tolak %s karena akar dangkal tidak diperkenankan untuk diperbarui"
 
-#: builtin/fetch.c:1231 builtin/fetch.c:1379
+#: builtin/fetch.c:1259 builtin/fetch.c:1418
 #, c-format
 msgid "From %.*s\n"
 msgstr "Dari %.*s\n"
 
-#: builtin/fetch.c:1252
+#: builtin/fetch.c:1269
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -14953,49 +15408,49 @@ msgstr ""
 "beberapa referensi lokal tidak dapat diperbarui; coba jalankan\n"
 " 'git remote prune %s' untuk hapus cabang yang lama dan berkonflik"
 
-#: builtin/fetch.c:1349
+#: builtin/fetch.c:1377
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s akan menjadi terjuntai)"
 
-#: builtin/fetch.c:1350
+#: builtin/fetch.c:1378
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s telah menjadi terjuntai)"
 
-#: builtin/fetch.c:1382
+#: builtin/fetch.c:1421
 msgid "[deleted]"
 msgstr "[dihapus]"
 
-#: builtin/fetch.c:1383 builtin/remote.c:1128
+#: builtin/fetch.c:1422 builtin/remote.c:1153
 msgid "(none)"
 msgstr "(tidak ada)"
 
-#: builtin/fetch.c:1405
+#: builtin/fetch.c:1446
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr "menolak mengambil ke dalam cabang '%s' yang ter-checkout pada '%s'"
 
-#: builtin/fetch.c:1425
+#: builtin/fetch.c:1466
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr "opsi \"%s\" nilai \"%s\" tidak valid untuk %s"
 
-#: builtin/fetch.c:1428
+#: builtin/fetch.c:1469
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr "opsi \"%s\" diabaikan untuk %s\n"
 
-#: builtin/fetch.c:1455
+#: builtin/fetch.c:1496
 #, c-format
 msgid "the object %s does not exist"
 msgstr "objek '%s' tidak ada"
 
-#: builtin/fetch.c:1643
+#: builtin/fetch.c:1748
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "banyak cabang terdeteksi, tidak kompatibel dengan --set-upstream"
 
-#: builtin/fetch.c:1655
+#: builtin/fetch.c:1760
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
@@ -15004,19 +15459,19 @@ msgstr ""
 "tidak dapat menyetel hulu HEAD ke %s dari '%s' ketika itu tak menunjuk pada "
 "cabang apapun."
 
-#: builtin/fetch.c:1668
+#: builtin/fetch.c:1773
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "tidak setel hulu untuk cabang remote pelacak remote"
 
-#: builtin/fetch.c:1670
+#: builtin/fetch.c:1775
 msgid "not setting upstream for a remote tag"
 msgstr "tidak setel hulu untuk tag remote"
 
-#: builtin/fetch.c:1672
+#: builtin/fetch.c:1777
 msgid "unknown branch type"
 msgstr "tipe cabang tidak diketahui"
 
-#: builtin/fetch.c:1674
+#: builtin/fetch.c:1779
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
@@ -15024,22 +15479,22 @@ msgstr ""
 "cabang sumber tidak ditemukan;\n"
 "Anda harus sebutkan tepat satu cabang dengan opsi --set-upstream."
 
-#: builtin/fetch.c:1804 builtin/fetch.c:1867
+#: builtin/fetch.c:1904 builtin/fetch.c:1967
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Mengambil %s\n"
 
-#: builtin/fetch.c:1814 builtin/fetch.c:1869
+#: builtin/fetch.c:1914 builtin/fetch.c:1969
 #, c-format
 msgid "could not fetch %s"
 msgstr "tidak dapat mengambil %s"
 
-#: builtin/fetch.c:1826
+#: builtin/fetch.c:1926
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "tidak dapat mengambil '%s' (kode keluar: %d)\n"
 
-#: builtin/fetch.c:1930
+#: builtin/fetch.c:2030
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
@@ -15047,48 +15502,48 @@ msgstr ""
 "repositori remote tidak disebutkan; mohon sebutkan baik URL atau nama\n"
 "remote yang mana revisi baru sebaiknya diambil"
 
-#: builtin/fetch.c:1966
+#: builtin/fetch.c:2066
 msgid "you need to specify a tag name"
 msgstr "Anda perlu sebutkan sebuah nama tag"
 
-#: builtin/fetch.c:2032
-msgid "--negotiate-only needs one or more --negotiate-tip=*"
-msgstr "--negotiate-only perlu satu atau lebih --negotiate-tip=*"
+#: builtin/fetch.c:2156
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr "--negotiate-only perlu satu atau lebih --negotiation-tip=*"
 
-#: builtin/fetch.c:2036
+#: builtin/fetch.c:2160
 msgid "negative depth in --deepen is not supported"
 msgstr "kedalaman negatif pada --deepen tidak didukung"
 
-#: builtin/fetch.c:2045
+#: builtin/fetch.c:2169
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow pada repositori penuh tidak masuk akal"
 
-#: builtin/fetch.c:2062
+#: builtin/fetch.c:2186
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all tidak mengambil argumen repositori"
 
-#: builtin/fetch.c:2064
+#: builtin/fetch.c:2188
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all tidak masuk akal dengan spek referensi"
 
-#: builtin/fetch.c:2073
+#: builtin/fetch.c:2197
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr "tidak ada remote atau grup remote seperti: %s"
 
-#: builtin/fetch.c:2081
+#: builtin/fetch.c:2205
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr "mengambil sebuah grup dan menyebutkan spek referensi tidak masuk akal"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2221
 msgid "must supply remote when using --negotiate-only"
 msgstr "harus suplai remote ketika menggunakan --negotiate-only"
 
-#: builtin/fetch.c:2102
+#: builtin/fetch.c:2226
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr "protokol tidak mendukung --negotiate-only, keluar."
 
-#: builtin/fetch.c:2121
+#: builtin/fetch.c:2246
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15096,11 +15551,11 @@ msgstr ""
 "--filter hanya dapat digunakan dengan remote yang terkonfigurasi di "
 "extensions.partialclone"
 
-#: builtin/fetch.c:2125
+#: builtin/fetch.c:2250
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic hanya dapat digunakan saat mengambil dari satu remote"
 
-#: builtin/fetch.c:2129
+#: builtin/fetch.c:2254
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin hanya dapat digunakan saat mengambil dari satu remote"
 
@@ -15169,7 +15624,7 @@ msgstr ""
 msgid "show only <n> matched refs"
 msgstr ""
 
-#: builtin/for-each-ref.c:42 builtin/tag.c:481
+#: builtin/for-each-ref.c:42 builtin/tag.c:482
 msgid "respect format colors"
 msgstr ""
 
@@ -15363,7 +15818,7 @@ msgstr "Memeriksa direktori objek"
 msgid "Checking %s link"
 msgstr "Memeriksa tautan %s"
 
-#: builtin/fsck.c:710 builtin/index-pack.c:859
+#: builtin/fsck.c:710 builtin/index-pack.c:862
 #, c-format
 msgid "invalid %s"
 msgstr "%s tidak valid"
@@ -15432,7 +15887,7 @@ msgstr "juga pertimbangkan pak dan objek alternatif"
 msgid "check only connectivity"
 msgstr "hanya periksa konektivitas"
 
-#: builtin/fsck.c:798 builtin/mktag.c:76
+#: builtin/fsck.c:798 builtin/mktag.c:75
 msgid "enable more strict checking"
 msgstr "aktifkan pemeriksaan lebih ketat"
 
@@ -15461,6 +15916,118 @@ msgstr "%s: objek hilang"
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "parameter tidak valid: sha1 diharapkan, dapat '%s'"
+
+#: builtin/fsmonitor--daemon.c:13
+msgid "git fsmonitor--daemon start [<options>]"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:14
+msgid "git fsmonitor--daemon run [<options>]"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:15
+msgid "git fsmonitor--daemon stop"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:16
+msgid "git fsmonitor--daemon status"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:38 builtin/fsmonitor--daemon.c:47
+#, c-format
+msgid "value of '%s' out of range: %d"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:57
+#, c-format
+msgid "value of '%s' not bool or int: %d"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:99
+#, c-format
+msgid "fsmonitor-daemon is watching '%s'\n"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:104
+#, c-format
+msgid "fsmonitor-daemon is not watching '%s'\n"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:170
+#, c-format
+msgid "could not create fsmonitor cookie '%s'"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:753
+#, c-format
+msgid "fsmonitor: cookie_result '%d' != SEEN"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1187
+#, c-format
+msgid "could not start IPC thread pool on '%s'"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1199
+msgid "could not start fsmonitor listener thread"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1297
+msgid "could not initialize listener thread"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1328 builtin/fsmonitor--daemon.c:1383
+#, c-format
+msgid "fsmonitor--daemon is already running '%s'"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1332
+#, c-format
+msgid "running fsmonitor-daemon in '%s'\n"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1387
+#, c-format
+msgid "starting fsmonitor-daemon in '%s'\n"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1413
+msgid "daemon failed to start"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1416
+msgid "daemon not online yet"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1419
+msgid "daemon terminated"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1429
+msgid "detach from console"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1432
+msgid "use <n> ipc worker threads"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1435
+msgid "max seconds to wait for background daemon startup"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1449
+#, c-format
+msgid "invalid 'ipc-threads' value (%d)"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1464
+#, c-format
+msgid "Unhandled subcommand '%s'"
+msgstr ""
+
+#: builtin/fsmonitor--daemon.c:1477
+msgid "fsmonitor--daemon not supported on this platform"
+msgstr ""
 
 #: builtin/gc.c:39
 msgid "git gc [<options>]"
@@ -15710,8 +16277,8 @@ msgstr "gagal memulai systemctl"
 msgid "failed to run systemctl"
 msgstr "gagal menjalankan systemctl"
 
-#: builtin/gc.c:2210 builtin/gc.c:2215 builtin/worktree.c:62
-#: builtin/worktree.c:944
+#: builtin/gc.c:2210 builtin/gc.c:2215 builtin/worktree.c:63
+#: builtin/worktree.c:1024
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "gagal menghapus '%s'"
@@ -15759,16 +16326,16 @@ msgstr "git maintenance <subperintah> [<opsi>]"
 msgid "invalid subcommand: %s"
 msgstr "subperintah tidak valid: %s"
 
-#: builtin/grep.c:30
+#: builtin/grep.c:32
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [<opsi>] [-e] <pola> [<revisi>...] [[--] <pola>...]"
 
-#: builtin/grep.c:239
+#: builtin/grep.c:241
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: gagal membuat utas: %s"
 
-#: builtin/grep.c:293
+#: builtin/grep.c:295
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "jumlah utas yang diberikan (%d) tidak valid untuk %s"
@@ -15777,259 +16344,251 @@ msgstr "jumlah utas yang diberikan (%d) tidak valid untuk %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:301 builtin/index-pack.c:1582 builtin/index-pack.c:1785
-#: builtin/pack-objects.c:3142
+#: builtin/grep.c:303 builtin/index-pack.c:1587 builtin/index-pack.c:1791
+#: builtin/pack-objects.c:3150
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "tidak ada dukungan utas, abaikan %s"
 
-#: builtin/grep.c:488 builtin/grep.c:617 builtin/grep.c:657
+#: builtin/grep.c:490 builtin/grep.c:619 builtin/grep.c:659
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "tidak dapat membaca pohon (%s)"
 
-#: builtin/grep.c:672
+#: builtin/grep.c:674
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "tidak dapan men-grep dari objek dengan tipe %s"
 
-#: builtin/grep.c:752
+#: builtin/grep.c:754
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "saklar '%c' mengharapkan nilai numerik"
 
-#: builtin/grep.c:851
+#: builtin/grep.c:852
 msgid "search in index instead of in the work tree"
 msgstr "cari dalam index daripada dalam pohon kerja"
 
-#: builtin/grep.c:853
+#: builtin/grep.c:854
 msgid "find in contents not managed by git"
 msgstr "temukan dalam konten yang tak dikelola oleh git"
 
-#: builtin/grep.c:855
+#: builtin/grep.c:856
 msgid "search in both tracked and untracked files"
 msgstr "cari dalam berkas terlacak dan tak terlacak"
 
-#: builtin/grep.c:857
+#: builtin/grep.c:858
 msgid "ignore files specified via '.gitignore'"
 msgstr "abaikan berkas yang disebutkan via '.gitignore'"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:860
 msgid "recursively search in each submodule"
 msgstr "cari secara rekursif dalam setiap submodul"
 
-#: builtin/grep.c:862
+#: builtin/grep.c:863
 msgid "show non-matching lines"
 msgstr "perlihatkan baris nir-cocok"
 
-#: builtin/grep.c:864
+#: builtin/grep.c:865
 msgid "case insensitive matching"
 msgstr "pencocokan tak peka kapital"
 
-#: builtin/grep.c:866
+#: builtin/grep.c:867
 msgid "match patterns only at word boundaries"
 msgstr "cocokkan pola hanya pada batas kata"
 
-#: builtin/grep.c:868
+#: builtin/grep.c:869
 msgid "process binary files as text"
 msgstr "proses berkas biner sebagai teks"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:871
 msgid "don't match patterns in binary files"
 msgstr "jangan cocokkan pola pada berkas biner"
 
-#: builtin/grep.c:873
+#: builtin/grep.c:874
 msgid "process binary files with textconv filters"
 msgstr "proses berkas biner dengan saringan textconv"
 
-#: builtin/grep.c:875
+#: builtin/grep.c:876
 msgid "search in subdirectories (default)"
 msgstr "cari dalam subdirektori (asali)"
 
-#: builtin/grep.c:877
+#: builtin/grep.c:878
 msgid "descend at most <depth> levels"
 msgstr "turun paling banyak <kedalaman> tingkat"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:882
 msgid "use extended POSIX regular expressions"
 msgstr "gunakan ekspresi reguler POSIX diperpanjang"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:885
 msgid "use basic POSIX regular expressions (default)"
 msgstr "gunakan ekspresi reguler POSIX dasar (asali)"
 
-#: builtin/grep.c:887
+#: builtin/grep.c:888
 msgid "interpret patterns as fixed strings"
 msgstr "tafsirkan pola sebagai untai tetap"
 
-#: builtin/grep.c:890
+#: builtin/grep.c:891
 msgid "use Perl-compatible regular expressions"
 msgstr "gunakan ekspresi reguler kompatibel dengan Perl"
 
-#: builtin/grep.c:893
+#: builtin/grep.c:894
 msgid "show line numbers"
 msgstr "perlihatkan nomor baris"
 
-#: builtin/grep.c:894
+#: builtin/grep.c:895
 msgid "show column number of first match"
 msgstr "perlihatkan nomor kolom cocokan pertama"
 
-#: builtin/grep.c:895
+#: builtin/grep.c:896
 msgid "don't show filenames"
 msgstr "jangan perlihatkan nama berkas"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:897
 msgid "show filenames"
 msgstr "perlihatkan nama berkas"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:899
 msgid "show filenames relative to top directory"
 msgstr "perlihatkan nama berkas relatif terhadap direktori puncak"
 
-#: builtin/grep.c:900
+#: builtin/grep.c:901
 msgid "show only filenames instead of matching lines"
 msgstr "hanya perlihatkan nama berkas daripada baris yang cocok"
 
-#: builtin/grep.c:902
+#: builtin/grep.c:903
 msgid "synonym for --files-with-matches"
 msgstr "sinonim untuk --files-with-matches"
 
-#: builtin/grep.c:905
+#: builtin/grep.c:906
 msgid "show only the names of files without match"
 msgstr "hanya perlihatkan nama berkas tanpa cocok"
 
-#: builtin/grep.c:907
+#: builtin/grep.c:908
 msgid "print NUL after filenames"
 msgstr "cetak NUL setelah nama berkas"
 
-#: builtin/grep.c:910
+#: builtin/grep.c:911
 msgid "show only matching parts of a line"
 msgstr "hanya perlihatkan bagian cocokan baris"
 
-#: builtin/grep.c:912
+#: builtin/grep.c:913
 msgid "show the number of matches instead of matching lines"
 msgstr "perlihatkan jumlah cocokan daripada baris yang cocok"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:914
 msgid "highlight matches"
 msgstr "sorot cocokan"
 
-#: builtin/grep.c:915
+#: builtin/grep.c:916
 msgid "print empty line between matches from different files"
 msgstr "cetak baris kosong di antara cocokan dari berkas yang berbeda"
 
-#: builtin/grep.c:917
+#: builtin/grep.c:918
 msgid "show filename only once above matches from same file"
 msgstr ""
 "perlihatkan nama berkas hanya sekali di atas cocokan dari berkas yang sama"
 
-#: builtin/grep.c:920
+#: builtin/grep.c:921
 msgid "show <n> context lines before and after matches"
 msgstr "perlihatkan <n> baris konteks sebelum dan sesudah cocokan"
 
-#: builtin/grep.c:923
+#: builtin/grep.c:924
 msgid "show <n> context lines before matches"
 msgstr "perlihatkan <n> baris konteks sebelum cocokan"
 
-#: builtin/grep.c:925
+#: builtin/grep.c:926
 msgid "show <n> context lines after matches"
 msgstr "perlihatkan <n> baris konteks setelah cocokan"
 
-#: builtin/grep.c:927
+#: builtin/grep.c:928
 msgid "use <n> worker threads"
 msgstr "gunakan <n> utas pekerja"
 
-#: builtin/grep.c:928
+#: builtin/grep.c:929
 msgid "shortcut for -C NUM"
 msgstr "pintasan untuk -C NUM"
 
-#: builtin/grep.c:931
+#: builtin/grep.c:932
 msgid "show a line with the function name before matches"
 msgstr "perlihatkan sebuah baris dengan nama fungsi sebelum cocokan"
 
-#: builtin/grep.c:933
+#: builtin/grep.c:934
 msgid "show the surrounding function"
 msgstr "perlihatkan fungsi di sekitar"
 
-#: builtin/grep.c:936
+#: builtin/grep.c:937
 msgid "read patterns from file"
 msgstr "baca pola dari berkas"
 
-#: builtin/grep.c:938
+#: builtin/grep.c:939
 msgid "match <pattern>"
 msgstr "cocokkan <pola>"
 
-#: builtin/grep.c:940
+#: builtin/grep.c:941
 msgid "combine patterns specified with -e"
 msgstr "kombinasikan pola yang disebutkan dengan -e"
 
-#: builtin/grep.c:952
+#: builtin/grep.c:953
 msgid "indicate hit with exit status without output"
 msgstr "tunjukkan kena dengan status keluar tanpa keluaran"
 
-#: builtin/grep.c:954
+#: builtin/grep.c:955
 msgid "show only matches from files that match all patterns"
 msgstr "hanya perlihatkan cocokan dari berkas yang cocok dengan semua pola"
 
-#: builtin/grep.c:957
+#: builtin/grep.c:958
 msgid "pager"
 msgstr "penghalaman"
 
-#: builtin/grep.c:957
+#: builtin/grep.c:958
 msgid "show matching files in the pager"
 msgstr "perlihatkan berkas yang cocok dalam penghalaman"
 
-#: builtin/grep.c:961
+#: builtin/grep.c:962
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "perbolehkan pemanggilan grep(1) (diabaikan oleh bangunan ini)"
 
-#: builtin/grep.c:1027
+#: builtin/grep.c:1028
 msgid "no pattern given"
 msgstr "tidak ada pola yang diberikan"
 
-#: builtin/grep.c:1063
+#: builtin/grep.c:1064
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index atau --untracked tidak dapat digunakan dengan revisi"
 
-#: builtin/grep.c:1071
+#: builtin/grep.c:1072
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "tidak dapat menguraikan revisi: %s"
 
-#: builtin/grep.c:1101
+#: builtin/grep.c:1102
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked tidak didukung dengan --recurse-submodules"
 
-#: builtin/grep.c:1105
+#: builtin/grep.c:1106
 msgid "invalid option combination, ignoring --threads"
 msgstr "kombinasi opsi tidak valid, abaikan --threads"
 
-#: builtin/grep.c:1108 builtin/pack-objects.c:4059
+#: builtin/grep.c:1109 builtin/pack-objects.c:4084
 msgid "no threads support, ignoring --threads"
 msgstr "tidak ada dukungan utas, abaikan --threads"
 
-#: builtin/grep.c:1111 builtin/index-pack.c:1579 builtin/pack-objects.c:3139
+#: builtin/grep.c:1112 builtin/index-pack.c:1584 builtin/pack-objects.c:3147
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "jumlah utas tersebut (%d) tidak valid"
 
-#: builtin/grep.c:1145
+#: builtin/grep.c:1146
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "--open-files-in-pager hanya bekerja pada pohon kerja"
 
-#: builtin/grep.c:1171
-msgid "--cached or --untracked cannot be used with --no-index"
-msgstr "--cached atau --untracked tidak dapat digunakan dengan --no-index"
-
-#: builtin/grep.c:1174
-msgid "--untracked cannot be used with --cached"
-msgstr "--untracked tidak dapat digunakan dengan --cached"
-
-#: builtin/grep.c:1180
+#: builtin/grep.c:1179
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr "--[no-]exclude-standard tidak dapat digunakan untuk konten terlacak"
 
-#: builtin/grep.c:1188
+#: builtin/grep.c:1187
 msgid "both --cached and trees are given"
 msgstr "baik --cached dan pohon diberikan"
 
@@ -16041,108 +16600,100 @@ msgstr ""
 "git hash-object [-t <tipe>] [-w] [--path=<berkas> | --no-filters] [--stdin] "
 "[--] <berkas>..."
 
-#: builtin/hash-object.c:84
-msgid "git hash-object  --stdin-paths"
-msgstr "git hash-object  --stdin-paths"
-
-#: builtin/hash-object.c:96
+#: builtin/hash-object.c:97
 msgid "object type"
 msgstr "tipe objek"
 
-#: builtin/hash-object.c:97
+#: builtin/hash-object.c:98
 msgid "write the object into the object database"
 msgstr "tulis objek ke dalam basis data objek"
 
-#: builtin/hash-object.c:99
+#: builtin/hash-object.c:100
 msgid "read the object from stdin"
 msgstr "baca objek dari masukan standar"
 
-#: builtin/hash-object.c:101
+#: builtin/hash-object.c:102
 msgid "store file as is without filters"
 msgstr "simpan berkas apa adanya tanpa penyaring"
 
-#: builtin/hash-object.c:102
+#: builtin/hash-object.c:103
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr ""
 "hanya hash sampah acak apapun untuk membuat objek rusak demi menirkutukan Git"
 
-#: builtin/hash-object.c:103
+#: builtin/hash-object.c:104
 msgid "process file as it were from this path"
 msgstr "proses berkas seperti dari jalur ini"
 
-#: builtin/help.c:55
+#: builtin/help.c:57
 msgid "print all available commands"
 msgstr "cetak semua perintah yang tersedia"
 
-#: builtin/help.c:57
+#: builtin/help.c:60
+msgid "show external commands in --all"
+msgstr "perlihatkan perintah eksternal dalam --all"
+
+#: builtin/help.c:61
+msgid "show aliases in --all"
+msgstr "perlihatkan alias pada --all"
+
+#: builtin/help.c:62
 msgid "exclude guides"
 msgstr "kecualikan panduan"
 
-#: builtin/help.c:58
+#: builtin/help.c:63
 msgid "show man page"
 msgstr "perlihatkan halaman man"
 
-#: builtin/help.c:59
+#: builtin/help.c:64
 msgid "show manual in web browser"
 msgstr "perlihatkan manual dalam penjelajah web"
 
-#: builtin/help.c:61
+#: builtin/help.c:66
 msgid "show info page"
 msgstr "perlihatkan halaman info"
 
-#: builtin/help.c:63
+#: builtin/help.c:68
 msgid "print command description"
 msgstr "perlihatkan deskripsi perintah"
 
-#: builtin/help.c:65
+#: builtin/help.c:70
 msgid "print list of useful guides"
 msgstr "cetak daftar panduan berguna"
 
-#: builtin/help.c:67
+#: builtin/help.c:72
 msgid "print all configuration variable names"
 msgstr "cetak semua nama variabel konfigurasi"
 
-#: builtin/help.c:78
-msgid ""
-"git help [-a|--all] [--[no-]verbose]]\n"
-"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
-msgstr ""
-"git help [-a|--all] [--[no-]verbose]]\n"
-"         [[-i|--info] [-m|--man] [-w|--web]] [<perintah>]"
+#: builtin/help.c:84
+msgid "git help [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
+msgstr "git help [[-i|--info] [-m|--man] [-w|--web]] [<perintah>]"
 
-#: builtin/help.c:80
-msgid "git help [-g|--guides]"
-msgstr ""
-
-#: builtin/help.c:81
-msgid "git help [-c|--config]"
-msgstr ""
-
-#: builtin/help.c:196
+#: builtin/help.c:201
 #, c-format
 msgid "unrecognized help format '%s'"
 msgstr "format bantuan tidak dikenal '%s'"
 
-#: builtin/help.c:222
+#: builtin/help.c:227
 msgid "Failed to start emacsclient."
 msgstr "gagal menjalankan emacsclient."
 
-#: builtin/help.c:235
+#: builtin/help.c:240
 msgid "Failed to parse emacsclient version."
 msgstr "gagal menguraikan versi emacsclient."
 
-#: builtin/help.c:243
+#: builtin/help.c:248
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "versi emacsclient '%d' terlalu usang (< 22)."
 
-#: builtin/help.c:261 builtin/help.c:283 builtin/help.c:293 builtin/help.c:301
+#: builtin/help.c:266 builtin/help.c:288 builtin/help.c:298 builtin/help.c:306
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "gagal menjalankan '%s'"
 
-#: builtin/help.c:339
+#: builtin/help.c:344
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -16151,7 +16702,7 @@ msgstr ""
 "'%s': jalur untuk pembaca man yang tidak didukung.\n"
 "Mohon gunakan 'man.<tool>.cmd' sebagai gantinya."
 
-#: builtin/help.c:351
+#: builtin/help.c:356
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -16160,41 +16711,55 @@ msgstr ""
 "'%s': cmd untuk pembaca man yang didukung.\n"
 "Mohon gunakan 'man.<tool>.path' sebagai gantinya."
 
-#: builtin/help.c:466
+#: builtin/help.c:471
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "'%s': pembaca man tidak dikenal"
 
-#: builtin/help.c:482
+#: builtin/help.c:487
 msgid "no man viewer handled the request"
 msgstr "tidak ada pembaca man yang menangani permintaan"
 
-#: builtin/help.c:489
+#: builtin/help.c:494
 msgid "no info viewer handled the request"
 msgstr "tidak ada pembaca info yang menangani permintaan"
 
-#: builtin/help.c:550 builtin/help.c:561 git.c:348
+#: builtin/help.c:555 builtin/help.c:566 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "'%s' dialiaskan ke '%s'"
 
-#: builtin/help.c:564 git.c:380
+#: builtin/help.c:569 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "untai alias.%s jelek: %s"
 
-#: builtin/help.c:580
-msgid "this option doesn't take any other arguments"
-msgstr "opsi ini tidak mengambil argumen lainnya"
+#: builtin/help.c:611
+#, c-format
+msgid "the '%s' option doesn't take any non-option arguments"
+msgstr "opsi '%s' tidak mengambil argumen bukan opsi"
 
-#: builtin/help.c:601 builtin/help.c:628
+#: builtin/help.c:631
+msgid ""
+"the '--no-[external-commands|aliases]' options can only be used with '--all'"
+msgstr ""
+
+#: builtin/help.c:643 builtin/help.c:671
 #, c-format
 msgid "usage: %s%s"
 msgstr "penggunaan: %s%s"
 
-#: builtin/help.c:623
+#: builtin/help.c:666
 msgid "'git help config' for more information"
 msgstr "'git help config' untuk informasi lebih lanjut"
+
+#: builtin/hook.c:10
+msgid "git hook run [--ignore-missing] <hook-name> [-- <hook-args>]"
+msgstr ""
+
+#: builtin/hook.c:30
+msgid "silently ignore missing requested <hook-name>"
+msgstr ""
 
 #: builtin/index-pack.c:221
 #, c-format
@@ -16230,244 +16795,245 @@ msgstr "kesalahan baca pada masukan"
 msgid "used more bytes than were available"
 msgstr "gunakan lebih banyak pita dari pada yang tersedia"
 
-#: builtin/index-pack.c:324 builtin/pack-objects.c:756
+#: builtin/index-pack.c:324 builtin/pack-objects.c:754
 msgid "pack too large for current definition of off_t"
 msgstr "paket terlalu besar untuk definisi off_t saat ini"
 
-#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
-msgid "pack exceeds maximum allowed size"
-msgstr "paket melebihi ukuran maksimum yang diperbolehkan"
+#: builtin/index-pack.c:329
+#, c-format
+msgid "pack exceeds maximum allowed size (%s)"
+msgstr "paket melebihi ukuran maksimum yang diperbolehkan (%s)"
 
-#: builtin/index-pack.c:358
+#: builtin/index-pack.c:362
 msgid "pack signature mismatch"
 msgstr "tanda tangan paket tidak cocok"
 
-#: builtin/index-pack.c:360
+#: builtin/index-pack.c:364
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "versi paket %<PRIu32> tidak didukung"
 
-#: builtin/index-pack.c:376
+#: builtin/index-pack.c:380
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "paket ada objek jelek pada offset %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:482
+#: builtin/index-pack.c:485
 #, c-format
 msgid "inflate returned %d"
 msgstr "inflate mengembalikan %d"
 
-#: builtin/index-pack.c:531
+#: builtin/index-pack.c:534
 msgid "offset value overflow for delta base object"
 msgstr "nilai offset meluap untuk objek basis delta"
 
-#: builtin/index-pack.c:539
+#: builtin/index-pack.c:542
 msgid "delta base offset is out of bound"
 msgstr "offset basis delta di luar jangkauan"
 
-#: builtin/index-pack.c:547
+#: builtin/index-pack.c:550
 #, c-format
 msgid "unknown object type %d"
 msgstr "tipe objek tidak diketahui %d"
 
-#: builtin/index-pack.c:578
+#: builtin/index-pack.c:581
 msgid "cannot pread pack file"
 msgstr "tidak dapat pread berkas paket"
 
-#: builtin/index-pack.c:580
+#: builtin/index-pack.c:583
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:606
+#: builtin/index-pack.c:609
 msgid "serious inflate inconsistency"
 msgstr "inkonsistensi inflate serius"
 
-#: builtin/index-pack.c:751 builtin/index-pack.c:757 builtin/index-pack.c:781
-#: builtin/index-pack.c:820 builtin/index-pack.c:829
+#: builtin/index-pack.c:754 builtin/index-pack.c:760 builtin/index-pack.c:784
+#: builtin/index-pack.c:823 builtin/index-pack.c:832
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "TUMBUKAN SHA1 DITEMUKAN DENGAN %s !"
 
-#: builtin/index-pack.c:754 builtin/pack-objects.c:292
-#: builtin/pack-objects.c:352 builtin/pack-objects.c:458
+#: builtin/index-pack.c:757 builtin/pack-objects.c:290
+#: builtin/pack-objects.c:350 builtin/pack-objects.c:456
 #, c-format
 msgid "unable to read %s"
 msgstr "tidak dapat membaca %s"
 
-#: builtin/index-pack.c:818
+#: builtin/index-pack.c:821
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "tidak dapat membaca info objek yang ada %s"
 
-#: builtin/index-pack.c:826
+#: builtin/index-pack.c:829
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "tidak dapat membaca objek yang ada %s"
 
-#: builtin/index-pack.c:840
+#: builtin/index-pack.c:843
 #, c-format
 msgid "invalid blob object %s"
 msgstr "objek blob tidak valid %s"
 
-#: builtin/index-pack.c:843 builtin/index-pack.c:862
+#: builtin/index-pack.c:846 builtin/index-pack.c:865
 msgid "fsck error in packed object"
 msgstr "kesalahan fsck dalam objek terpaket"
 
-#: builtin/index-pack.c:864
+#: builtin/index-pack.c:867
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Tidak semua objek anak dari %s bisa dicapai"
 
-#: builtin/index-pack.c:925 builtin/index-pack.c:972
+#: builtin/index-pack.c:928 builtin/index-pack.c:975
 msgid "failed to apply delta"
 msgstr "gagal menerapkan delta"
 
-#: builtin/index-pack.c:1156
+#: builtin/index-pack.c:1161
 msgid "Receiving objects"
 msgstr "Menerima objek"
 
-#: builtin/index-pack.c:1156
+#: builtin/index-pack.c:1161
 msgid "Indexing objects"
 msgstr "Mengindeks objek"
 
-#: builtin/index-pack.c:1190
+#: builtin/index-pack.c:1195
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "paket rusak (SHA1 tidak cocok)"
 
-#: builtin/index-pack.c:1195
+#: builtin/index-pack.c:1200
 msgid "cannot fstat packfile"
 msgstr "tidak dapat fstat berkas paket"
 
-#: builtin/index-pack.c:1198
+#: builtin/index-pack.c:1203
 msgid "pack has junk at the end"
 msgstr "paket memiliki sampah pada ujung"
 
-#: builtin/index-pack.c:1210
+#: builtin/index-pack.c:1215
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "bingung di luar kegilaan di parse_pack_objects()"
 
-#: builtin/index-pack.c:1233
+#: builtin/index-pack.c:1238
 msgid "Resolving deltas"
 msgstr "Menguraikan delta"
 
-#: builtin/index-pack.c:1244 builtin/pack-objects.c:2905
+#: builtin/index-pack.c:1249 builtin/pack-objects.c:2913
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "tidak dapat membuat utas: %s"
 
-#: builtin/index-pack.c:1277
+#: builtin/index-pack.c:1282
 msgid "confusion beyond insanity"
 msgstr "bingung di luar kegilaan"
 
-#: builtin/index-pack.c:1283
+#: builtin/index-pack.c:1288
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1295
+#: builtin/index-pack.c:1300
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Checksum ekor tidak diharapkan untuk %s (kerusakan disk?)"
 
-#: builtin/index-pack.c:1299
+#: builtin/index-pack.c:1304
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1323
+#: builtin/index-pack.c:1328
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "tidak dapat menggemboskan objek tertambah (%d)"
 
-#: builtin/index-pack.c:1419
+#: builtin/index-pack.c:1423
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "objek lokal %s rusak"
 
-#: builtin/index-pack.c:1440
+#: builtin/index-pack.c:1445
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "nama berkas paket '%s' tidak diakhiri dengan '.%s'"
 
-#: builtin/index-pack.c:1464
+#: builtin/index-pack.c:1469
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "tidak dapat menulis %s berkas '%s'"
 
-#: builtin/index-pack.c:1472
+#: builtin/index-pack.c:1477
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "tidak dapat menutup %s berkas tertulis '%s'"
 
-#: builtin/index-pack.c:1489
+#: builtin/index-pack.c:1494
 #, c-format
 msgid "unable to rename temporary '*.%s' file to '%s'"
 msgstr "tidak dapat menamai ulang berkas sementara '*.%s' ke '%s'"
 
-#: builtin/index-pack.c:1514
+#: builtin/index-pack.c:1519
 msgid "error while closing pack file"
 msgstr "kesalahan menutup berkas paket"
 
-#: builtin/index-pack.c:1573 builtin/pack-objects.c:3150
+#: builtin/index-pack.c:1578 builtin/pack-objects.c:3158
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "pack.indexversion=%<PRIu32> jelek"
 
-#: builtin/index-pack.c:1643
+#: builtin/index-pack.c:1648
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "tidak dapat membuka berkas paket yang ada '%s'"
 
-#: builtin/index-pack.c:1645
+#: builtin/index-pack.c:1650
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "tidak dapat membuka berkas indeks paket untuk '%s'"
 
-#: builtin/index-pack.c:1693
+#: builtin/index-pack.c:1698
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1700
+#: builtin/index-pack.c:1705
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1742
+#: builtin/index-pack.c:1748
 msgid "Cannot come back to cwd"
 msgstr "tidak dapat kembali ke direktori kerja saat ini"
 
-#: builtin/index-pack.c:1796 builtin/index-pack.c:1799
-#: builtin/index-pack.c:1819 builtin/index-pack.c:1823
+#: builtin/index-pack.c:1802 builtin/index-pack.c:1805
+#: builtin/index-pack.c:1825 builtin/index-pack.c:1829
 #, c-format
 msgid "bad %s"
 msgstr "%s jelek"
 
-#: builtin/index-pack.c:1829 builtin/init-db.c:379 builtin/init-db.c:614
+#: builtin/index-pack.c:1835 builtin/init-db.c:379 builtin/init-db.c:614
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algoritma hash tak dikenal '%s'"
 
-#: builtin/index-pack.c:1850
+#: builtin/index-pack.c:1856
 msgid "--stdin requires a git repository"
 msgstr "--stdin memerlukan repositori git"
 
-#: builtin/index-pack.c:1867
+#: builtin/index-pack.c:1873
 msgid "--verify with no packfile name given"
 msgstr "--verify tanpa nama berkas paket diberikan"
 
-#: builtin/index-pack.c:1933 builtin/unpack-objects.c:584
+#: builtin/index-pack.c:1939 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "kesalahan fsck dalam objek paket"
 
@@ -16675,40 +17241,40 @@ msgstr ""
 msgid "no input file given for in-place editing"
 msgstr ""
 
-#: builtin/log.c:59
+#: builtin/log.c:60
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git log [<opsi>] [<rentang revisi>] [[--] <jalur>...]"
 
-#: builtin/log.c:60
+#: builtin/log.c:61
 msgid "git show [<options>] <object>..."
 msgstr "git show [<opsi>] <objek>..."
 
-#: builtin/log.c:113
+#: builtin/log.c:114
 #, c-format
 msgid "invalid --decorate option: %s"
 msgstr "opsi --decorate tidak valid: %s"
 
-#: builtin/log.c:180
+#: builtin/log.c:181
 msgid "show source"
 msgstr "perlihatkan sumber"
 
-#: builtin/log.c:181
+#: builtin/log.c:182
 msgid "use mail map file"
 msgstr "gunakan berkas peta surat"
 
-#: builtin/log.c:184
+#: builtin/log.c:185
 msgid "only decorate refs that match <pattern>"
 msgstr "hanya dekorasi referensi yang cocok dengan <pola>"
 
-#: builtin/log.c:186
+#: builtin/log.c:187
 msgid "do not decorate refs that match <pattern>"
 msgstr "jangan dekorasi referensi yang cocok dengan <pola>"
 
-#: builtin/log.c:187
+#: builtin/log.c:188
 msgid "decorate options"
 msgstr "opsi dekorasi"
 
-#: builtin/log.c:190
+#: builtin/log.c:191
 msgid ""
 "trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
@@ -16716,89 +17282,93 @@ msgstr ""
 "lacak evolusi rentang baris <awal>,<akhir> atau fungsi :<nama fungsi> dalam "
 "<berkas>"
 
-#: builtin/log.c:213
+#: builtin/log.c:214
 msgid "-L<range>:<file> cannot be used with pathspec"
 msgstr "-L<rentang>:<berkas> tidak dapat digunakan dengan spek jalur"
 
-#: builtin/log.c:321
+#: builtin/log.c:322
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Keluaran terakhir: %d %s\n"
 
-#: builtin/log.c:586
+#: builtin/log.c:429
+msgid "unable to create temporary object directory"
+msgstr "tidak dapat membuat direktori objek sementara"
+
+#: builtin/log.c:599
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: berkas jelek"
 
-#: builtin/log.c:601 builtin/log.c:691
+#: builtin/log.c:614 builtin/log.c:706
 #, c-format
 msgid "could not read object %s"
 msgstr "tidak dapat membaca objek %s"
 
-#: builtin/log.c:716
+#: builtin/log.c:731
 #, c-format
 msgid "unknown type: %d"
 msgstr "tipe tidak dikenal: %d"
 
-#: builtin/log.c:861
+#: builtin/log.c:880
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr "%s: sampul tidak valid dari mode deskripsi"
 
-#: builtin/log.c:868
+#: builtin/log.c:887
 msgid "format.headers without value"
 msgstr "format.headers tanpa nilai"
 
-#: builtin/log.c:997
+#: builtin/log.c:1016
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "tidak dapat membuka berkas tambalan %s"
 
-#: builtin/log.c:1014
+#: builtin/log.c:1033
 msgid "need exactly one range"
 msgstr "butuh tepatnya satu rentang"
 
-#: builtin/log.c:1024
+#: builtin/log.c:1043
 msgid "not a range"
 msgstr "bukan sebuah rentang"
 
-#: builtin/log.c:1188
+#: builtin/log.c:1207
 msgid "cover letter needs email format"
 msgstr "sampul surat butuh format email"
 
-#: builtin/log.c:1194
+#: builtin/log.c:1213
 msgid "failed to create cover-letter file"
 msgstr "gagal membuat berkas sampul surat"
 
-#: builtin/log.c:1281
+#: builtin/log.c:1300
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "in-reply-to gila: %s"
 
-#: builtin/log.c:1308
+#: builtin/log.c:1327
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<opsi>] [<sejak> | <rentang revisi>]"
 
-#: builtin/log.c:1366
+#: builtin/log.c:1385
 msgid "two output directories?"
 msgstr "dua direktori keluaran?"
 
-#: builtin/log.c:1517 builtin/log.c:2344 builtin/log.c:2346 builtin/log.c:2358
+#: builtin/log.c:1536 builtin/log.c:2369 builtin/log.c:2371 builtin/log.c:2383
 #, c-format
 msgid "unknown commit %s"
 msgstr "komit tidak dikenal %s"
 
-#: builtin/log.c:1528 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1547 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "gagal menguraikan '%s' sebagai referensi valid"
 
-#: builtin/log.c:1537
+#: builtin/log.c:1556
 msgid "could not find exact merge base"
 msgstr "tidak dapat menemukan dasar penggabungan eksak"
 
-#: builtin/log.c:1547
+#: builtin/log.c:1566
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -16810,276 +17380,280 @@ msgstr ""
 "Atau Anda dapat menyebutkan dasar komit secara manual dengan --base=<id "
 "dasar komit>"
 
-#: builtin/log.c:1570
+#: builtin/log.c:1589
 msgid "failed to find exact merge base"
 msgstr "tidak dapat menemukan dasar penggabungan eksak"
 
-#: builtin/log.c:1587
+#: builtin/log.c:1606
 msgid "base commit should be the ancestor of revision list"
 msgstr "dasar komit seharusnya menjadi leluhur daftar revisi"
 
-#: builtin/log.c:1597
+#: builtin/log.c:1616
 msgid "base commit shouldn't be in revision list"
 msgstr "dasar komit tidak seharusnya dalam daftar revisi"
 
-#: builtin/log.c:1655
+#: builtin/log.c:1674
 msgid "cannot get patch id"
 msgstr "tidak dapat mendapatkan id tambalan"
 
-#: builtin/log.c:1718
+#: builtin/log.c:1737
 msgid "failed to infer range-diff origin of current series"
 msgstr "gagal menduga asal range-diff dari seri saat ini"
 
-#: builtin/log.c:1720
+#: builtin/log.c:1739
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
 msgstr "menggunakan '%s' sebagai asal range-diff dari seri saat ini"
 
-#: builtin/log.c:1764
+#: builtin/log.c:1783
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "gunakan [PATCH n/m] bahkan dengan satu tambalan"
 
-#: builtin/log.c:1767
+#: builtin/log.c:1786
 msgid "use [PATCH] even with multiple patches"
 msgstr "gunakan [PATCH] bahkan dengan banyak tambalan"
 
-#: builtin/log.c:1771
+#: builtin/log.c:1790
 msgid "print patches to standard out"
 msgstr "cetak tambalan ke keluaran standar"
 
-#: builtin/log.c:1773
+#: builtin/log.c:1792
 msgid "generate a cover letter"
 msgstr "buat sampul surat"
 
-#: builtin/log.c:1775
+#: builtin/log.c:1794
 msgid "use simple number sequence for output file names"
 msgstr "gunakan urutan bilangan sederhana untuk keluarkan nama berkas"
 
-#: builtin/log.c:1776
+#: builtin/log.c:1795
 msgid "sfx"
 msgstr "sfx"
 
-#: builtin/log.c:1777
+#: builtin/log.c:1796
 msgid "use <sfx> instead of '.patch'"
 msgstr "gunakan <akhiran> daripada '.patch'"
 
-#: builtin/log.c:1779
+#: builtin/log.c:1798
 msgid "start numbering patches at <n> instead of 1"
 msgstr "mulai menomorkan tambalan pada <n> daripada 1"
 
-#: builtin/log.c:1780
+#: builtin/log.c:1799
 msgid "reroll-count"
 msgstr ""
 
-#: builtin/log.c:1781
+#: builtin/log.c:1800
 msgid "mark the series as Nth re-roll"
 msgstr "tandai seri sebagai gulung ulang ke-N"
 
-#: builtin/log.c:1783
+#: builtin/log.c:1802
 msgid "max length of output filename"
 msgstr "panjang nama berkas keluaran maksimum"
 
-#: builtin/log.c:1785
+#: builtin/log.c:1804
 msgid "use [RFC PATCH] instead of [PATCH]"
 msgstr "gunakan [RFC PATCH] daripada [PATCH]"
 
-#: builtin/log.c:1788
+#: builtin/log.c:1807
 msgid "cover-from-description-mode"
 msgstr "cover-from-description-mode"
 
-#: builtin/log.c:1789
+#: builtin/log.c:1808
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr "buat bagian dari sampul surat berdasarkan deskripsi cabang"
 
-#: builtin/log.c:1791
+#: builtin/log.c:1810
 msgid "use [<prefix>] instead of [PATCH]"
 msgstr "gunakan [<prefix>] daripada [PATCH]"
 
-#: builtin/log.c:1794
+#: builtin/log.c:1813
 msgid "store resulting files in <dir>"
 msgstr "simpan hasil berkas di <direktori>"
 
-#: builtin/log.c:1797
+#: builtin/log.c:1816
 msgid "don't strip/add [PATCH]"
 msgstr "jangan copot/tambah [PATCH]"
 
-#: builtin/log.c:1800
+#: builtin/log.c:1819
 msgid "don't output binary diffs"
 msgstr "jangan keluarkan diff biner"
 
-#: builtin/log.c:1802
+#: builtin/log.c:1821
 msgid "output all-zero hash in From header"
 msgstr "keluarkan hash semua-nol di kepala From"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1823
 msgid "don't include a patch matching a commit upstream"
 msgstr "jangan termasuk tambalan yang cocok dengan komit hulu"
 
-#: builtin/log.c:1806
+#: builtin/log.c:1825
 msgid "show patch format instead of default (patch + stat)"
 msgstr "perlihatkan format tambalan daripada asali (tambalan + stat)"
 
-#: builtin/log.c:1808
+#: builtin/log.c:1827
 msgid "Messaging"
 msgstr "Perpesanan"
 
-#: builtin/log.c:1809
+#: builtin/log.c:1828
 msgid "header"
 msgstr "kepala"
 
-#: builtin/log.c:1810
+#: builtin/log.c:1829
 msgid "add email header"
 msgstr "tambahkan kepala email"
 
-#: builtin/log.c:1811 builtin/log.c:1812
+#: builtin/log.c:1830 builtin/log.c:1831
 msgid "email"
 msgstr "email"
 
-#: builtin/log.c:1811
+#: builtin/log.c:1830
 msgid "add To: header"
 msgstr "tambahkan kepala To:"
 
-#: builtin/log.c:1812
+#: builtin/log.c:1831
 msgid "add Cc: header"
 msgstr "tambahkan kepala Cc:"
 
-#: builtin/log.c:1813
+#: builtin/log.c:1832
 msgid "ident"
 msgstr "ident"
 
-#: builtin/log.c:1814
+#: builtin/log.c:1833
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "setel alamat From ke <identitas> (atau identitas pengkomit jika tidak ada)"
 
-#: builtin/log.c:1816
+#: builtin/log.c:1835
 msgid "message-id"
 msgstr "message-id"
 
-#: builtin/log.c:1817
+#: builtin/log.c:1836
 msgid "make first mail a reply to <message-id>"
 msgstr "buat surat pertama balasan ke <id pesan>"
 
-#: builtin/log.c:1818 builtin/log.c:1821
+#: builtin/log.c:1837 builtin/log.c:1840
 msgid "boundary"
 msgstr "perbatasan"
 
-#: builtin/log.c:1819
+#: builtin/log.c:1838
 msgid "attach the patch"
 msgstr "lampirkan tambalan"
 
-#: builtin/log.c:1822
+#: builtin/log.c:1841
 msgid "inline the patch"
 msgstr "bariskan tambalan"
 
-#: builtin/log.c:1826
+#: builtin/log.c:1845
 msgid "enable message threading, styles: shallow, deep"
 msgstr "aktifkan utasan pesan, gaya: shallow, deep"
 
-#: builtin/log.c:1828
+#: builtin/log.c:1847
 msgid "signature"
 msgstr "tanda tangan"
 
-#: builtin/log.c:1829
+#: builtin/log.c:1848
 msgid "add a signature"
 msgstr "tambah tanda tangan"
 
-#: builtin/log.c:1830
+#: builtin/log.c:1849
 msgid "base-commit"
 msgstr "dasar komit"
 
-#: builtin/log.c:1831
+#: builtin/log.c:1850
 msgid "add prerequisite tree info to the patch series"
 msgstr "tambahkan info pohon prasyarat ke seri tambalan"
 
-#: builtin/log.c:1834
+#: builtin/log.c:1853
 msgid "add a signature from a file"
 msgstr "tambahkan tandatangan dari berkas"
 
-#: builtin/log.c:1835
+#: builtin/log.c:1854
 msgid "don't print the patch filenames"
 msgstr "jangan cetak nama berkas tambalan"
 
-#: builtin/log.c:1837
+#: builtin/log.c:1856
 msgid "show progress while generating patches"
 msgstr "perlihatkan perkembangan ketika membuat tambalan"
 
-#: builtin/log.c:1839
+#: builtin/log.c:1858
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "perlihatkan perubahan terhadap <revisi> di sampul surat atau satu tambalan"
 
-#: builtin/log.c:1842
+#: builtin/log.c:1861
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "perlihatkan perubahan terhadap <spek referensi> di sampul surat atau satu "
 "tambalan"
 
-#: builtin/log.c:1844 builtin/range-diff.c:28
+#: builtin/log.c:1863 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
 msgstr "persentase dimana pembuatan tertimbang"
 
-#: builtin/log.c:1931
+#: builtin/log.c:1953
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "baris identitas tidak valid: %s"
 
-#: builtin/log.c:1956
+#: builtin/log.c:1978
 msgid "--name-only does not make sense"
 msgstr "--name-only tidak masuk akal"
 
-#: builtin/log.c:1958
+#: builtin/log.c:1980
 msgid "--name-status does not make sense"
 msgstr "--name-status tidak masuk akal"
 
-#: builtin/log.c:1960
+#: builtin/log.c:1982
 msgid "--check does not make sense"
 msgstr "--check tidak masuk akal"
 
-#: builtin/log.c:2104
+#: builtin/log.c:1984
+msgid "--remerge-diff does not make sense"
+msgstr "--remerge-diff tidak masuk akal"
+
+#: builtin/log.c:2129
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff butuh --cover-letter atau satu tambalan"
 
-#: builtin/log.c:2108
+#: builtin/log.c:2133
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:2109
+#: builtin/log.c:2134
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff terhadap v%d:"
 
-#: builtin/log.c:2119
+#: builtin/log.c:2144
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff butuh --cover-letter atau satu tambalan"
 
-#: builtin/log.c:2127
+#: builtin/log.c:2152
 msgid "Range-diff:"
 msgstr "Range-diff:"
 
-#: builtin/log.c:2128
+#: builtin/log.c:2153
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Range-diff terhadap v%d:"
 
-#: builtin/log.c:2139
+#: builtin/log.c:2164
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "tidak dapat membaca berkas tanda tangan '%s'"
 
-#: builtin/log.c:2175
+#: builtin/log.c:2200
 msgid "Generating patches"
 msgstr "Membuat tambalan"
 
-#: builtin/log.c:2219
+#: builtin/log.c:2244
 msgid "failed to create output files"
 msgstr "tidak dapat membuat berkas keluaran"
 
-#: builtin/log.c:2279
+#: builtin/log.c:2304
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<hulu> [<kepala> [<batas>]]]"
 
-#: builtin/log.c:2333
+#: builtin/log.c:2358
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -17175,10 +17749,6 @@ msgstr "tambahkan pengecualian git standar"
 msgid "make the output relative to the project top directory"
 msgstr "buat keluaran relatif terhadap direktori puncak proyek"
 
-#: builtin/ls-files.c:667
-msgid "recurse through submodules"
-msgstr "rekursi melalui submodul"
-
 #: builtin/ls-files.c:669
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr ""
@@ -17218,7 +17788,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "jangan cetak URL remote"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1103
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1131
 msgid "exec"
 msgstr "exec"
 
@@ -17251,43 +17821,71 @@ msgstr ""
 msgid "show underlying ref in addition to the object pointed by it"
 msgstr "perlihatkan referensi pokok selain objek yang ditunjuk olehnya"
 
-#: builtin/ls-tree.c:30
+#: builtin/ls-tree.c:36
 msgid "git ls-tree [<options>] <tree-ish> [<path>...]"
 msgstr "git ls-tree [<opsi>] <mirip-pohon> [<jalur>...]"
 
-#: builtin/ls-tree.c:128
+#: builtin/ls-tree.c:54
+#, c-format
+msgid "could not get object info about '%s'"
+msgstr "tidak dapat mendapatkan info objek tentang '%s'"
+
+#: builtin/ls-tree.c:79
+#, c-format
+msgid "bad ls-tree format: element '%s' does not start with '('"
+msgstr "format ls-tree jelek: elemen '%s' tidak dimulai dengan '('"
+
+#: builtin/ls-tree.c:83
+#, c-format
+msgid "bad ls-tree format: element '%s' does not end in ')'"
+msgstr "format ls-tree jelek: elemen '%s' tidak diakhiri dengan ')'"
+
+#: builtin/ls-tree.c:109
+#, c-format
+msgid "bad ls-tree format: %%%.*s"
+msgstr "format ls-tree jelek: %%%.*s"
+
+#: builtin/ls-tree.c:336
 msgid "only show trees"
 msgstr "hanya perlihatkan pohon"
 
-#: builtin/ls-tree.c:130
+#: builtin/ls-tree.c:338
 msgid "recurse into subtrees"
 msgstr "rekursi ke dalam subpohon"
 
-#: builtin/ls-tree.c:132
+#: builtin/ls-tree.c:340
 msgid "show trees when recursing"
 msgstr "perlihatkan pohon ketika rekursi"
 
-#: builtin/ls-tree.c:135
+#: builtin/ls-tree.c:343
 msgid "terminate entries with NUL byte"
 msgstr "akhiri entri dengan bita NUL"
 
-#: builtin/ls-tree.c:136
+#: builtin/ls-tree.c:344
 msgid "include object size"
 msgstr "masukkan ukuran objek"
 
-#: builtin/ls-tree.c:138 builtin/ls-tree.c:140
+#: builtin/ls-tree.c:346 builtin/ls-tree.c:348
 msgid "list only filenames"
 msgstr "hanya daftar nama berkas"
 
-#: builtin/ls-tree.c:143
+#: builtin/ls-tree.c:350
+msgid "list only objects"
+msgstr "hanya daftar objek"
+
+#: builtin/ls-tree.c:353
 msgid "use full path names"
 msgstr "gunakan nama berkas lengkap"
 
-#: builtin/ls-tree.c:145
+#: builtin/ls-tree.c:355
 msgid "list entire tree; not just current directory (implies --full-name)"
 msgstr ""
 "daftar pohon keseluruhan; bukan hanya direktori saat ini (menyiratkan --full-"
 "name)"
+
+#: builtin/ls-tree.c:391
+msgid "--format can't be combined with other format-altering options"
+msgstr "--format tidak dapat digabungkan opsi pengubah format lainnya"
 
 #. TRANSLATORS: keep <> in "<" mail ">" info.
 #: builtin/mailinfo.c:14
@@ -17338,50 +17936,54 @@ msgstr ""
 msgid "use headers in message's body"
 msgstr ""
 
-#: builtin/mailsplit.c:239
+#: builtin/mailsplit.c:227
+msgid "reading patches from stdin/tty..."
+msgstr ""
+
+#: builtin/mailsplit.c:242
 #, c-format
 msgid "empty mbox: '%s'"
 msgstr ""
 
 #: builtin/merge-base.c:32
 msgid "git merge-base [-a | --all] <commit> <commit>..."
-msgstr ""
+msgstr "git merge-base [-a | --all] <komit> <komit>..."
 
 #: builtin/merge-base.c:33
 msgid "git merge-base [-a | --all] --octopus <commit>..."
-msgstr ""
+msgstr "git merge-base [-a | --all] --octopus <komit>..."
 
 #: builtin/merge-base.c:34
 msgid "git merge-base --independent <commit>..."
-msgstr ""
+msgstr "git merge-base --independent <komit>..."
 
 #: builtin/merge-base.c:35
 msgid "git merge-base --is-ancestor <commit> <commit>"
-msgstr ""
+msgstr "git merge-base --is-ancestor <komit> <komit>"
 
 #: builtin/merge-base.c:36
 msgid "git merge-base --fork-point <ref> [<commit>]"
-msgstr ""
+msgstr "git merge-base --fork-point <referensi> [<komit>]"
 
-#: builtin/merge-base.c:143
+#: builtin/merge-base.c:144
 msgid "output all common ancestors"
-msgstr ""
+msgstr "keluarkan semua leluhur umum"
 
-#: builtin/merge-base.c:145
+#: builtin/merge-base.c:146
 msgid "find ancestors for a single n-way merge"
-msgstr ""
+msgstr "temukan leluhur untuk sebuah penggabungan n-arah"
 
-#: builtin/merge-base.c:147
+#: builtin/merge-base.c:148
 msgid "list revs not reachable from others"
-msgstr ""
+msgstr "daftarkan revisi yang tak terjangkau dari yang lainnya"
 
-#: builtin/merge-base.c:149
+#: builtin/merge-base.c:150
 msgid "is the first one ancestor of the other?"
-msgstr ""
+msgstr "apakah yang pertama leluhur yang lain?"
 
-#: builtin/merge-base.c:151
+#: builtin/merge-base.c:152
 msgid "find where <commit> forked from reflog of <ref>"
-msgstr ""
+msgstr "temukan dimana <komit> digarpu dari log referensi <referensi>"
 
 #: builtin/merge-file.c:9
 msgid ""
@@ -17526,7 +18128,7 @@ msgid "verify that the named commit has a valid GPG signature"
 msgstr "periksa bahwa komit bernama punya tandatangan GPG yang valid"
 
 #: builtin/merge.c:280 builtin/notes.c:785 builtin/pull.c:172
-#: builtin/rebase.c:1117 builtin/revert.c:114
+#: builtin/rebase.c:1145 builtin/revert.c:114
 msgid "strategy"
 msgstr "strategi"
 
@@ -17660,72 +18262,72 @@ msgstr ""
 "Baris yang diawali dengan '%c' akan diabaikan, dan pesan kosong batalkan\n"
 "komit.\n"
 
-#: builtin/merge.c:894
+#: builtin/merge.c:900
 msgid "Empty commit message."
 msgstr "Pesan komit kosong"
 
-#: builtin/merge.c:909
+#: builtin/merge.c:915
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Luar biasa.\n"
 
-#: builtin/merge.c:970
+#: builtin/merge.c:976
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr "Penggabungan otomatis gagal; selesaikan konflik lalu komit hasilnya.\n"
 
-#: builtin/merge.c:1009
+#: builtin/merge.c:1015
 msgid "No current branch."
 msgstr "Tidak ada cabang saat ini."
 
-#: builtin/merge.c:1011
+#: builtin/merge.c:1017
 msgid "No remote for the current branch."
 msgstr "Tidak ada remote untuk cabang saat ini."
 
-#: builtin/merge.c:1013
+#: builtin/merge.c:1019
 msgid "No default upstream defined for the current branch."
 msgstr "Tidak ada hulu asali yang ditentukan untuk cabang saat ini."
 
-#: builtin/merge.c:1018
+#: builtin/merge.c:1024
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Tidak ada cabang pelacak remote untuk %s dari %s"
 
-#: builtin/merge.c:1075
+#: builtin/merge.c:1081
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Nilai jelek '%s' dalam lingkungan '%s'"
 
-#: builtin/merge.c:1177
+#: builtin/merge.c:1183
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "bukan sesuatu yang kami bisa gabungkan di %s: %s"
 
-#: builtin/merge.c:1211
+#: builtin/merge.c:1217
 msgid "not something we can merge"
 msgstr "bukan sesuatu yang kami bisa gabungkan"
 
-#: builtin/merge.c:1324
+#: builtin/merge.c:1330
 msgid "--abort expects no arguments"
 msgstr "--abort harap tanpa argumen"
 
-#: builtin/merge.c:1328
+#: builtin/merge.c:1334
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Tidak ada penggabungan yang bisa dibatalkan (MERGE_HEAD hilang)."
 
-#: builtin/merge.c:1346
+#: builtin/merge.c:1352
 msgid "--quit expects no arguments"
 msgstr "--quit harap tanpa argumen"
 
-#: builtin/merge.c:1359
+#: builtin/merge.c:1365
 msgid "--continue expects no arguments"
 msgstr "--continue harap tanpa argumen"
 
-#: builtin/merge.c:1363
+#: builtin/merge.c:1369
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Tidak ada penggabungan yang sedang berlangsung (MERGE_HEAD hilang)."
 
-#: builtin/merge.c:1379
+#: builtin/merge.c:1385
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17733,7 +18335,7 @@ msgstr ""
 "Anda belum mengakhiri penggabungan Anda (MERGE_HEAD ada).\n"
 "Mohon komit perubahan Anda sebelum Anda gabungkan."
 
-#: builtin/merge.c:1386
+#: builtin/merge.c:1392
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17741,86 +18343,82 @@ msgstr ""
 "Anda belum mengakhiri pemetikan ceri Anda (CHERRY_PICK_HEAD ada).\n"
 "Mohon komit perubahan Anda sebelum Anda gabungkan."
 
-#: builtin/merge.c:1389
+#: builtin/merge.c:1395
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Anda belum mengakhiri pemetikan ceri Anda (CHERRY_PICK_HEAD ada)."
 
-#: builtin/merge.c:1421
+#: builtin/merge.c:1427
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
 "Tidak ada komit yang disebutkan dan merge.defaultToUpstream tidak disetel."
 
-#: builtin/merge.c:1438
+#: builtin/merge.c:1444
 msgid "Squash commit into empty head not supported yet"
 msgstr "Lumat komit ke kepala kosong belum didukung"
 
-#: builtin/merge.c:1440
+#: builtin/merge.c:1446
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Komit nir maju cepat tidak masuk akal ke kepala kosong"
 
-#: builtin/merge.c:1445
+#: builtin/merge.c:1451
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - bukan sesuatu yang kami bisa gabungkan"
 
-#: builtin/merge.c:1447
+#: builtin/merge.c:1453
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Hanya bisa menggabungkan tepantnya satu komit ke kepala kosong"
 
-#: builtin/merge.c:1534
+#: builtin/merge.c:1540
 msgid "refusing to merge unrelated histories"
 msgstr "menolak menggabungkan riwayat tak terkait"
 
-#: builtin/merge.c:1553
+#: builtin/merge.c:1559
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Memperbarui %s..%s\n"
 
-#: builtin/merge.c:1601
+#: builtin/merge.c:1606
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Mencoba penggabungan dalam indeks yang sangat sepele\n"
 
-#: builtin/merge.c:1608
+#: builtin/merge.c:1613
 #, c-format
 msgid "Nope.\n"
 msgstr "Tidak.\n"
 
-#: builtin/merge.c:1667 builtin/merge.c:1733
+#: builtin/merge.c:1671 builtin/merge.c:1737
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Memutar ulang pohon ke asli...\n"
 
-#: builtin/merge.c:1671
+#: builtin/merge.c:1675
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Mencoba strategi penggabungan %s...\n"
 
-#: builtin/merge.c:1723
+#: builtin/merge.c:1727
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Tidak ada strategi yang menangani penggabungan.\n"
 
-#: builtin/merge.c:1725
+#: builtin/merge.c:1729
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Penggabungan dengan strategi %s gagal.\n"
 
-#: builtin/merge.c:1735
+#: builtin/merge.c:1739
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "Menggunakan strategi %s untuk menyiapkan penyelesaian dengan tangan.\n"
 
-#: builtin/merge.c:1749
+#: builtin/merge.c:1753
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
 "Penggabungan otomatis berjalan baik; berhenti sebelum mengkomit seperti yang "
 "diminta\n"
-
-#: builtin/mktag.c:10
-msgid "git mktag"
-msgstr ""
 
 #: builtin/mktag.c:27
 #, c-format
@@ -17847,20 +18445,16 @@ msgstr ""
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr ""
 
-#: builtin/mktag.c:98
+#: builtin/mktag.c:97
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr ""
 
-#: builtin/mktag.c:101
+#: builtin/mktag.c:100
 msgid "tag on stdin did not refer to a valid object"
 msgstr ""
 
-#: builtin/mktag.c:104 builtin/tag.c:242
+#: builtin/mktag.c:103 builtin/tag.c:243
 msgid "unable to write tag file"
-msgstr ""
-
-#: builtin/mktree.c:66
-msgid "git mktree [-z] [--missing] [--batch]"
 msgstr ""
 
 #: builtin/mktree.c:154
@@ -17880,48 +18474,52 @@ msgid ""
 "git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
 "snapshot=<path>]"
 msgstr ""
+"git multi-pack-index [<opsi>] write [--preferred-pack=<pak>] [--refs-"
+"snapshot=<jalur>]"
 
 #: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
-msgstr ""
+msgstr "git multi-pack-index [<opsi>] verify"
 
 #: builtin/multi-pack-index.c:17
 msgid "git multi-pack-index [<options>] expire"
-msgstr ""
+msgstr "git multi-pack-index [<opsi>] expire"
 
 #: builtin/multi-pack-index.c:20
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
-msgstr ""
+msgstr "git multi-pack-index [<opsi>] repack [--batch-size=<ukuran>]"
 
 #: builtin/multi-pack-index.c:57
 msgid "object directory containing set of packfile and pack-index pairs"
-msgstr ""
+msgstr "direktori objek berisi set berkas pak dan pasangan pak-indeks"
 
 #: builtin/multi-pack-index.c:98
 msgid "preferred-pack"
-msgstr ""
+msgstr "pak pilihan"
 
 #: builtin/multi-pack-index.c:99
 msgid "pack for reuse when computing a multi-pack bitmap"
-msgstr ""
+msgstr "pak untuk digunakan ulang saat menghitung bitmap multipak"
 
 #: builtin/multi-pack-index.c:100
 msgid "write multi-pack bitmap"
-msgstr ""
+msgstr "tulis bitmap multipak"
 
 #: builtin/multi-pack-index.c:105
 msgid "write multi-pack index containing only given indexes"
-msgstr ""
+msgstr "tulis indeks multipak yang hanya berisi indeks yang diberikan"
 
 #: builtin/multi-pack-index.c:107
 msgid "refs snapshot for selecting bitmap commits"
-msgstr ""
+msgstr "potret referensi untuk memilih komit bitmap"
 
 #: builtin/multi-pack-index.c:206
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
+"selama pengepakan ulang, kumpulkan berkas pak berukuran lebih kecil ke dalam "
+"sebuah batch yang lebih besar dari ukuran ini"
 
 #: builtin/mv.c:18
 msgid "git mv [<options>] <source>... <destination>"
@@ -18015,52 +18613,56 @@ msgstr "%s, source=%s, destination=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Mengganti nama %s ke %s\n"
 
-#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:857
+#: builtin/mv.c:314 builtin/remote.c:812 builtin/repack.c:861
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "gagal mengganti nama '%s'"
 
-#: builtin/name-rev.c:474
+#: builtin/name-rev.c:524
 msgid "git name-rev [<options>] <commit>..."
 msgstr ""
 
-#: builtin/name-rev.c:475
+#: builtin/name-rev.c:525
 msgid "git name-rev [<options>] --all"
 msgstr ""
 
-#: builtin/name-rev.c:476
-msgid "git name-rev [<options>] --stdin"
+#: builtin/name-rev.c:526
+msgid "git name-rev [<options>] --annotate-stdin"
 msgstr ""
 
-#: builtin/name-rev.c:533
+#: builtin/name-rev.c:583
 msgid "print only ref-based names (no object names)"
 msgstr ""
 
-#: builtin/name-rev.c:534
+#: builtin/name-rev.c:584
 msgid "only use tags to name the commits"
 msgstr ""
 
-#: builtin/name-rev.c:536
+#: builtin/name-rev.c:586
 msgid "only use refs matching <pattern>"
 msgstr ""
 
-#: builtin/name-rev.c:538
+#: builtin/name-rev.c:588
 msgid "ignore refs matching <pattern>"
 msgstr ""
 
-#: builtin/name-rev.c:540
+#: builtin/name-rev.c:590
 msgid "list all commits reachable from all refs"
 msgstr ""
 
-#: builtin/name-rev.c:541
-msgid "read from stdin"
+#: builtin/name-rev.c:591
+msgid "deprecated: use annotate-stdin instead"
 msgstr ""
 
-#: builtin/name-rev.c:542
+#: builtin/name-rev.c:592
+msgid "annotate text from stdin"
+msgstr ""
+
+#: builtin/name-rev.c:593
 msgid "allow to print `undefined` names (default)"
 msgstr ""
 
-#: builtin/name-rev.c:548
+#: builtin/name-rev.c:599
 msgid "dereference tags in the input (internal use)"
 msgstr ""
 
@@ -18073,164 +18675,159 @@ msgid ""
 "git notes [--ref <notes-ref>] add [-f] [--allow-empty] [-m <msg> | -F <file> "
 "| (-c | -C) <object>] [<object>]"
 msgstr ""
+"git notes [--ref <referensi catatan>] add [-f] [--allow-empty] [-m <pesan | -"
+"F <berkas> | (-c | -C) <objek>] [<objek>]"
 
 #: builtin/notes.c:30
 msgid "git notes [--ref <notes-ref>] copy [-f] <from-object> <to-object>"
 msgstr ""
+"git notes [--ref <referensi catatan>] copy [-f] <objek asal> <objek tujuan>"
 
 #: builtin/notes.c:31
 msgid ""
 "git notes [--ref <notes-ref>] append [--allow-empty] [-m <msg> | -F <file> | "
 "(-c | -C) <object>] [<object>]"
 msgstr ""
+"git notes [--ref <referensi catatan>] append [--alow-empty] [-m <pesan> | -F "
+"<berkas> | (-c | -C) <objek>] [<objek>]"
 
 #: builtin/notes.c:32
 msgid "git notes [--ref <notes-ref>] edit [--allow-empty] [<object>]"
-msgstr ""
+msgstr "git notes [--ref <referensi catatan>] edit [--allow-empty] [<objek>]"
 
 #: builtin/notes.c:33
 msgid "git notes [--ref <notes-ref>] show [<object>]"
-msgstr ""
+msgstr "git notes [--ref <referensi catatan>] show [<objek>]"
 
 #: builtin/notes.c:34
 msgid ""
 "git notes [--ref <notes-ref>] merge [-v | -q] [-s <strategy>] <notes-ref>"
 msgstr ""
-
-#: builtin/notes.c:35
-msgid "git notes merge --commit [-v | -q]"
-msgstr ""
-
-#: builtin/notes.c:36
-msgid "git notes merge --abort [-v | -q]"
-msgstr ""
+"git notes [--ref <referensi catatan>] merge [-v | -q] [-s <strategi>] "
+"<referensi catatan> "
 
 #: builtin/notes.c:37
 msgid "git notes [--ref <notes-ref>] remove [<object>...]"
-msgstr ""
+msgstr "git notes [--ref <referensi catatan>] remove [<objek>...]"
 
 #: builtin/notes.c:38
 msgid "git notes [--ref <notes-ref>] prune [-n] [-v]"
-msgstr ""
+msgstr "git notes [--ref <referensi catatan>] prune [-n] [-v]"
 
 #: builtin/notes.c:39
 msgid "git notes [--ref <notes-ref>] get-ref"
-msgstr ""
+msgstr "git notes [--ref <referensi catatan>] get-ref"
 
 #: builtin/notes.c:44
 msgid "git notes [list [<object>]]"
-msgstr ""
+msgstr "git notes [list [<objek>]]"
 
 #: builtin/notes.c:49
 msgid "git notes add [<options>] [<object>]"
-msgstr ""
+msgstr "git notes add [<opsi>] [<objek>]"
 
 #: builtin/notes.c:54
 msgid "git notes copy [<options>] <from-object> <to-object>"
-msgstr ""
+msgstr "git notes copy [<opsi>] <objek asal> <objek tujuan>"
 
 #: builtin/notes.c:55
 msgid "git notes copy --stdin [<from-object> <to-object>]..."
-msgstr ""
+msgstr "git notes copy --stdin [<objek asal> <objek tujuan>]..."
 
 #: builtin/notes.c:60
 msgid "git notes append [<options>] [<object>]"
-msgstr ""
+msgstr "git notes append [<opsi>] [<objek>]"
 
 #: builtin/notes.c:65
 msgid "git notes edit [<object>]"
-msgstr ""
+msgstr "git notes edit [<objek>]"
 
 #: builtin/notes.c:70
 msgid "git notes show [<object>]"
-msgstr ""
+msgstr "git notes show [<objek>]"
 
 #: builtin/notes.c:75
 msgid "git notes merge [<options>] <notes-ref>"
-msgstr ""
+msgstr "git notes merge [<opsi>] <referensi catatan>"
 
 #: builtin/notes.c:76
 msgid "git notes merge --commit [<options>]"
-msgstr ""
+msgstr "git notes merge --commit [<opsi>]"
 
 #: builtin/notes.c:77
 msgid "git notes merge --abort [<options>]"
-msgstr ""
+msgstr "git notes merge --abort [<opsi>]"
 
 #: builtin/notes.c:82
 msgid "git notes remove [<object>]"
-msgstr ""
+msgstr "git notes remove [<objek>]"
 
 #: builtin/notes.c:87
 msgid "git notes prune [<options>]"
-msgstr ""
-
-#: builtin/notes.c:92
-msgid "git notes get-ref"
-msgstr ""
+msgstr "git notes prune [<opsi>]"
 
 #: builtin/notes.c:97
 msgid "Write/edit the notes for the following object:"
-msgstr ""
+msgstr "Tulis/sunting catatan untuk objek berikut:"
 
 #: builtin/notes.c:149
 #, c-format
 msgid "unable to start 'show' for object '%s'"
-msgstr ""
+msgstr "tidak dapat memulai 'show' untuk objek '%s'"
 
 #: builtin/notes.c:153
 msgid "could not read 'show' output"
-msgstr ""
+msgstr "tidak dapat membaca keluaran 'show'"
 
 #: builtin/notes.c:161
 #, c-format
 msgid "failed to finish 'show' for object '%s'"
-msgstr ""
+msgstr "gagal menyelesaikan 'show' untuk objek '%s'"
 
 #: builtin/notes.c:194
 msgid "please supply the note contents using either -m or -F option"
-msgstr ""
+msgstr "mohon berikan isi catatan baik menggunakan opsi -m ataupun -F"
 
 #: builtin/notes.c:203
 msgid "unable to write note object"
-msgstr ""
+msgstr "tidak dapat menulis objek catatan"
 
 #: builtin/notes.c:206
 #, c-format
 msgid "the note contents have been left in %s"
-msgstr ""
+msgstr "isi catatan telah ditinggalkan di %s"
 
-#: builtin/notes.c:240 builtin/tag.c:581
+#: builtin/notes.c:240 builtin/tag.c:582
 #, c-format
 msgid "could not open or read '%s'"
-msgstr ""
+msgstr "tidak dapat membuka atau membaca '%s'"
 
 #: builtin/notes.c:261 builtin/notes.c:311 builtin/notes.c:313
 #: builtin/notes.c:381 builtin/notes.c:436 builtin/notes.c:524
 #: builtin/notes.c:529 builtin/notes.c:608 builtin/notes.c:670
 #, c-format
 msgid "failed to resolve '%s' as a valid ref."
-msgstr ""
+msgstr "gagal menguraikan '%s' sebagai sebuah referensi valid."
 
 #: builtin/notes.c:263
 #, c-format
 msgid "failed to read object '%s'."
-msgstr ""
+msgstr "gagal membaca objek '%s'."
 
 #: builtin/notes.c:266
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
-msgstr ""
+msgstr "gagal membaca data catatan dari objek bukan blob '%s'."
 
 #: builtin/notes.c:307
 #, c-format
 msgid "malformed input line: '%s'."
-msgstr ""
+msgstr "baris masukan jelek: '%s'."
 
 #: builtin/notes.c:322
 #, c-format
 msgid "failed to copy notes from '%s' to '%s'"
-msgstr ""
+msgstr "gagal menyalin catatan dari '%s' ke '%s'"
 
 #. TRANSLATORS: the first %s will be replaced by a git
 #. notes command: 'add', 'merge', 'remove', etc.
@@ -18238,43 +18835,36 @@ msgstr ""
 #: builtin/notes.c:354
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
-msgstr ""
-
-#: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
-#: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
-#: builtin/notes.c:813 builtin/notes.c:965 builtin/notes.c:987
-#: builtin/prune-packed.c:25 builtin/receive-pack.c:2487 builtin/tag.c:591
-msgid "too many arguments"
-msgstr ""
+msgstr "gagal men-%s catatan di %s (di luar refs/notes/)"
 
 #: builtin/notes.c:387 builtin/notes.c:676
 #, c-format
 msgid "no note found for object %s."
-msgstr ""
+msgstr "tidak ada catatan yang ditemukan untuk objek %s."
 
 #: builtin/notes.c:408 builtin/notes.c:574
 msgid "note contents as a string"
-msgstr ""
+msgstr "isi catatan sebagai sebuah untai"
 
 #: builtin/notes.c:411 builtin/notes.c:577
 msgid "note contents in a file"
-msgstr ""
+msgstr "isi catatan di dalam berkas"
 
 #: builtin/notes.c:414 builtin/notes.c:580
 msgid "reuse and edit specified note object"
-msgstr ""
+msgstr "gunakan ulang dan sunting objek catatan yang disebutkan"
 
 #: builtin/notes.c:417 builtin/notes.c:583
 msgid "reuse specified note object"
-msgstr ""
+msgstr "gunakan ulang objek catatan yang disebutkan"
 
 #: builtin/notes.c:420 builtin/notes.c:586
 msgid "allow storing empty note"
-msgstr ""
+msgstr "perbolehkan menyimpan catatan kosong"
 
 #: builtin/notes.c:421 builtin/notes.c:494
 msgid "replace existing notes"
-msgstr ""
+msgstr "timpa catatan yang sudah ada"
 
 #: builtin/notes.c:446
 #, c-format
@@ -18282,28 +18872,31 @@ msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
+"Tidak dapat menambahkan catatan. Catatan yang sudah ada ditemukan untuk "
+"objek %s. Gunakan '-f' untuk menimpa catatan yang sudah ada"
 
 #: builtin/notes.c:461 builtin/notes.c:542
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
-msgstr ""
+msgstr "Menimpa catatan yang sudah ada untuk objek %s\n"
 
 #: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:904
 #, c-format
 msgid "Removing note for object %s\n"
-msgstr ""
+msgstr "Menghapus catatan untuk objek %s\n"
 
 #: builtin/notes.c:495
 msgid "read objects from stdin"
-msgstr ""
+msgstr "baca objek dari masukan standar"
 
 #: builtin/notes.c:497
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr ""
+"muat konfigurasi penulisan ulang untuk <perintah> (menyiratkan --stdin)"
 
 #: builtin/notes.c:515
 msgid "too few arguments"
-msgstr ""
+msgstr "argumen terlalu sedikit"
 
 #: builtin/notes.c:536
 #, c-format
@@ -18311,11 +18904,13 @@ msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
+"Tidak dapat menyalin catatan. Catatan yang sudah ada ditemukan untuk %s. "
+"Gunakan '-f' untuk menimpa catatan yang sudah ada"
 
 #: builtin/notes.c:548
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
-msgstr ""
+msgstr "catatan hilang pada objek sumber %s. Tidak dapat menyalin."
 
 #: builtin/notes.c:601
 #, c-format
@@ -18323,96 +18918,101 @@ msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
 "Please use 'git notes add -f -m/-F/-c/-C' instead.\n"
 msgstr ""
+"Opsi -m/-F/-c/-C sudah usang untuk subperintah 'edit.\n"
+"'Mohon gunakan 'git notes add -f -m/-F/-c/-C' sebagai gantinya.\n"
 
 #: builtin/notes.c:696
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
-msgstr ""
+msgstr "gagal menghapus referensi NOTES_MERGE_PARTIAL"
 
 #: builtin/notes.c:698
 msgid "failed to delete ref NOTES_MERGE_REF"
-msgstr ""
+msgstr "gagal menghapus referensi NOTES_MERGE_REF"
 
 #: builtin/notes.c:700
 msgid "failed to remove 'git notes merge' worktree"
-msgstr ""
+msgstr "gagal menghapus pohon kerja 'git notes merge'"
 
 #: builtin/notes.c:720
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
-msgstr ""
+msgstr "gagal membaca referensi NOTES_MERGE_PARTIAL"
 
 #: builtin/notes.c:722
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
-msgstr ""
+msgstr "gagal menemukan komit dari NOTES_MERGE_PARTIAL."
 
 #: builtin/notes.c:724
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
-msgstr ""
+msgstr "gagal menguraikan komit dari NOTES_MERGE_PARTIAL."
 
 #: builtin/notes.c:737
 msgid "failed to resolve NOTES_MERGE_REF"
-msgstr ""
+msgstr "gagal menguraikan NOTES_MERGE_REF"
 
 #: builtin/notes.c:740
 msgid "failed to finalize notes merge"
-msgstr ""
+msgstr "gagal menyelesaikan penggabungan catatan"
 
 #: builtin/notes.c:766
 #, c-format
 msgid "unknown notes merge strategy %s"
-msgstr ""
+msgstr "strategi penggabungan catatan %s tidak dikenal"
 
 #: builtin/notes.c:782
 msgid "General options"
-msgstr ""
+msgstr "Opsi umum"
 
 #: builtin/notes.c:784
 msgid "Merge options"
-msgstr ""
+msgstr "Opsi penggabungan"
 
 #: builtin/notes.c:786
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
 msgstr ""
+"selesaikan konflik catatan menggunakan strategi yang diberikan (manual/ours/"
+"theirs/union/cat_sort_uniq)"
 
 #: builtin/notes.c:788
 msgid "Committing unmerged notes"
-msgstr ""
+msgstr "Mengkomitkan catatan tak tergabung"
 
 #: builtin/notes.c:790
 msgid "finalize notes merge by committing unmerged notes"
 msgstr ""
+"selesaikan penggabungan catatan dengan mengkomitkan catatan tak tergabung"
 
 #: builtin/notes.c:792
 msgid "Aborting notes merge resolution"
-msgstr ""
+msgstr "Membatalkan resolusi penggabungan catatan"
 
 #: builtin/notes.c:794
 msgid "abort notes merge"
-msgstr ""
+msgstr "batalkan penggabungan catatan"
 
 #: builtin/notes.c:805
 msgid "cannot mix --commit, --abort or -s/--strategy"
-msgstr ""
+msgstr "tidak dapat mencampurkan --commit, --abort atau -s/--strategy"
 
 #: builtin/notes.c:810
 msgid "must specify a notes ref to merge"
-msgstr ""
+msgstr "harus menyebutkan sebuah referensi catatan untuk digabungkan"
 
 #: builtin/notes.c:834
 #, c-format
 msgid "unknown -s/--strategy: %s"
-msgstr ""
+msgstr "-s/--strategy tidak dikenal: %s"
 
 #: builtin/notes.c:874
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
-msgstr ""
+msgstr "sebuah penggabungan catatan ke %s sudah berjalan pada %s"
 
 #: builtin/notes.c:878
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
-msgstr ""
+msgstr "gagal menyimpan tautan ke referensi catatan saat ini (%s)"
 
 #: builtin/notes.c:880
 #, c-format
@@ -18421,45 +19021,48 @@ msgid ""
 "'git notes merge --commit', or abort the merge with 'git notes merge --"
 "abort'.\n"
 msgstr ""
+"Penggabungan catatan otomatis gagal. Selesaikan konflik dalam %s dan komit "
+"hasilnya dengan 'git notes merge --commit', atau batalkan penggabungan "
+"dengan 'git notes merge --abort'.\n"
 
-#: builtin/notes.c:899 builtin/tag.c:594
+#: builtin/notes.c:899 builtin/tag.c:595
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
-msgstr ""
+msgstr "Gagal menguraikan '%s' sebagai referensi valid."
 
 #: builtin/notes.c:902
 #, c-format
 msgid "Object %s has no note\n"
-msgstr ""
+msgstr "Objek %s tidak punya catatan\n"
 
 #: builtin/notes.c:914
 msgid "attempt to remove non-existent note is not an error"
-msgstr ""
+msgstr "mencoba menghapus catatan yang tidak ada bukanlah sebuah kesalahan"
 
 #: builtin/notes.c:917
 msgid "read object names from the standard input"
-msgstr ""
+msgstr "baca nama objek dari masukan standar"
 
-#: builtin/notes.c:956 builtin/prune.c:144 builtin/worktree.c:147
+#: builtin/notes.c:956 builtin/prune.c:144 builtin/worktree.c:148
 msgid "do not remove, show only"
-msgstr ""
+msgstr "jangan hapus, hanya perlihatkan"
 
 #: builtin/notes.c:957
 msgid "report pruned notes"
-msgstr ""
+msgstr "laporkan catatan terpangkas"
 
 #: builtin/notes.c:1000
 msgid "notes-ref"
-msgstr ""
+msgstr "referensi catatan"
 
 #: builtin/notes.c:1001
 msgid "use notes from <notes-ref>"
-msgstr ""
+msgstr "gunakan catatan dari <referensi catatan>"
 
-#: builtin/notes.c:1036 builtin/stash.c:1818
+#: builtin/notes.c:1036 builtin/stash.c:1802
 #, c-format
 msgid "unknown subcommand: %s"
-msgstr ""
+msgstr "subperintah tidak dikenal: %s"
 
 #: builtin/pack-objects.c:182
 msgid ""
@@ -18471,390 +19074,386 @@ msgid ""
 "git pack-objects [<options>...] <base-name> [< <ref-list> | < <object-list>]"
 msgstr ""
 
-#: builtin/pack-objects.c:572
+#: builtin/pack-objects.c:570
 #, c-format
 msgid ""
 "write_reuse_object: could not locate %s, expected at offset %<PRIuMAX> in "
 "pack %s"
 msgstr ""
 
-#: builtin/pack-objects.c:580
+#: builtin/pack-objects.c:578
 #, c-format
 msgid "bad packed object CRC for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:591
+#: builtin/pack-objects.c:589
 #, c-format
 msgid "corrupt packed object for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:722
+#: builtin/pack-objects.c:720
 #, c-format
 msgid "recursive delta detected for object %s"
 msgstr ""
 
-#: builtin/pack-objects.c:941
+#: builtin/pack-objects.c:939
 #, c-format
 msgid "ordered %u objects, expected %<PRIu32>"
 msgstr ""
 
-#: builtin/pack-objects.c:1036
+#: builtin/pack-objects.c:1034
 #, c-format
 msgid "expected object at offset %<PRIuMAX> in pack %s"
 msgstr ""
 
-#: builtin/pack-objects.c:1160
+#: builtin/pack-objects.c:1158
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 
-#: builtin/pack-objects.c:1173
+#: builtin/pack-objects.c:1171
 msgid "Writing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:1235 builtin/update-index.c:90
+#: builtin/pack-objects.c:1243 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr ""
 
-#: builtin/pack-objects.c:1268
+#: builtin/pack-objects.c:1276
 msgid "failed to write bitmap index"
 msgstr ""
 
-#: builtin/pack-objects.c:1294
+#: builtin/pack-objects.c:1302
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr ""
 
-#: builtin/pack-objects.c:1536
+#: builtin/pack-objects.c:1544
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 
-#: builtin/pack-objects.c:1984
+#: builtin/pack-objects.c:1992
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:1993
+#: builtin/pack-objects.c:2001
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr ""
 
-#: builtin/pack-objects.c:2274
+#: builtin/pack-objects.c:2282
 msgid "Counting objects"
 msgstr ""
 
-#: builtin/pack-objects.c:2439
+#: builtin/pack-objects.c:2447
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr ""
 
-#: builtin/pack-objects.c:2509 builtin/pack-objects.c:2525
-#: builtin/pack-objects.c:2535
+#: builtin/pack-objects.c:2517 builtin/pack-objects.c:2533
+#: builtin/pack-objects.c:2543
 #, c-format
 msgid "object %s cannot be read"
 msgstr ""
 
-#: builtin/pack-objects.c:2512 builtin/pack-objects.c:2539
+#: builtin/pack-objects.c:2520 builtin/pack-objects.c:2547
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr ""
 
-#: builtin/pack-objects.c:2549
+#: builtin/pack-objects.c:2557
 msgid "suboptimal pack - out of memory"
 msgstr ""
 
-#: builtin/pack-objects.c:2864
+#: builtin/pack-objects.c:2872
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr ""
 
-#: builtin/pack-objects.c:3003
+#: builtin/pack-objects.c:3011
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3089
+#: builtin/pack-objects.c:3097
 msgid "Compressing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3095
+#: builtin/pack-objects.c:3103
 msgid "inconsistency with delta count"
 msgstr ""
 
-#: builtin/pack-objects.c:3174
+#: builtin/pack-objects.c:3182
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
 "hash> <uri>' (got '%s')"
 msgstr ""
 
-#: builtin/pack-objects.c:3177
+#: builtin/pack-objects.c:3185
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
 msgstr ""
 
-#: builtin/pack-objects.c:3212
+#: builtin/pack-objects.c:3220
 #, c-format
 msgid "could not get type of object %s in pack %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3340 builtin/pack-objects.c:3351
-#: builtin/pack-objects.c:3365
+#: builtin/pack-objects.c:3348 builtin/pack-objects.c:3359
+#: builtin/pack-objects.c:3373
 #, c-format
 msgid "could not find pack '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3408
+#: builtin/pack-objects.c:3416
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
 " %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3414
+#: builtin/pack-objects.c:3422
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
 " %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3507
-msgid "invalid value for --missing"
-msgstr ""
-
-#: builtin/pack-objects.c:3532 builtin/pack-objects.c:3619
+#: builtin/pack-objects.c:3540 builtin/pack-objects.c:3627
 msgid "cannot open pack index"
 msgstr ""
 
-#: builtin/pack-objects.c:3541
+#: builtin/pack-objects.c:3549
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr ""
 
-#: builtin/pack-objects.c:3627
+#: builtin/pack-objects.c:3635
 msgid "unable to force loose object"
 msgstr ""
 
-#: builtin/pack-objects.c:3757
+#: builtin/pack-objects.c:3763
 #, c-format
 msgid "not a rev '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3760 builtin/rev-parse.c:1061
+#: builtin/pack-objects.c:3766 builtin/rev-parse.c:1061
 #, c-format
 msgid "bad revision '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3788
+#: builtin/pack-objects.c:3794
 msgid "unable to add recent objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3841
+#: builtin/pack-objects.c:3847
 #, c-format
 msgid "unsupported index version %s"
 msgstr ""
 
-#: builtin/pack-objects.c:3845
+#: builtin/pack-objects.c:3851
 #, c-format
 msgid "bad index version '%s'"
 msgstr ""
 
-#: builtin/pack-objects.c:3884
+#: builtin/pack-objects.c:3907
 msgid "<version>[,<offset>]"
 msgstr ""
 
-#: builtin/pack-objects.c:3885
+#: builtin/pack-objects.c:3908
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 
-#: builtin/pack-objects.c:3888
+#: builtin/pack-objects.c:3911
 msgid "maximum size of each output pack file"
 msgstr ""
 
-#: builtin/pack-objects.c:3890
+#: builtin/pack-objects.c:3913
 msgid "ignore borrowed objects from alternate object store"
 msgstr ""
 
-#: builtin/pack-objects.c:3892
+#: builtin/pack-objects.c:3915
 msgid "ignore packed objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3894
+#: builtin/pack-objects.c:3917
 msgid "limit pack window by objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3896
+#: builtin/pack-objects.c:3919
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 
-#: builtin/pack-objects.c:3898
+#: builtin/pack-objects.c:3921
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 
-#: builtin/pack-objects.c:3900
+#: builtin/pack-objects.c:3923
 msgid "reuse existing deltas"
 msgstr ""
 
-#: builtin/pack-objects.c:3902
+#: builtin/pack-objects.c:3925
 msgid "reuse existing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3904
+#: builtin/pack-objects.c:3927
 msgid "use OFS_DELTA objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3906
+#: builtin/pack-objects.c:3929
 msgid "use threads when searching for best delta matches"
 msgstr ""
 
-#: builtin/pack-objects.c:3908
+#: builtin/pack-objects.c:3931
 msgid "do not create an empty pack output"
 msgstr ""
 
-#: builtin/pack-objects.c:3910
+#: builtin/pack-objects.c:3933
 msgid "read revision arguments from standard input"
 msgstr ""
 
-#: builtin/pack-objects.c:3912
+#: builtin/pack-objects.c:3935
 msgid "limit the objects to those that are not yet packed"
 msgstr ""
 
-#: builtin/pack-objects.c:3915
+#: builtin/pack-objects.c:3938
 msgid "include objects reachable from any reference"
 msgstr ""
 
-#: builtin/pack-objects.c:3918
+#: builtin/pack-objects.c:3941
 msgid "include objects referred by reflog entries"
 msgstr ""
 
-#: builtin/pack-objects.c:3921
+#: builtin/pack-objects.c:3944
 msgid "include objects referred to by the index"
 msgstr ""
 
-#: builtin/pack-objects.c:3924
+#: builtin/pack-objects.c:3947
 msgid "read packs from stdin"
 msgstr ""
 
-#: builtin/pack-objects.c:3926
+#: builtin/pack-objects.c:3949
 msgid "output pack to stdout"
 msgstr ""
 
-#: builtin/pack-objects.c:3928
+#: builtin/pack-objects.c:3951
 msgid "include tag objects that refer to objects to be packed"
 msgstr ""
 
-#: builtin/pack-objects.c:3930
+#: builtin/pack-objects.c:3953
 msgid "keep unreachable objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3932
+#: builtin/pack-objects.c:3955
 msgid "pack loose unreachable objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3934
+#: builtin/pack-objects.c:3957
 msgid "unpack unreachable objects newer than <time>"
 msgstr ""
 
-#: builtin/pack-objects.c:3937
+#: builtin/pack-objects.c:3960
 msgid "use the sparse reachability algorithm"
 msgstr ""
 
-#: builtin/pack-objects.c:3939
+#: builtin/pack-objects.c:3962
 msgid "create thin packs"
 msgstr ""
 
-#: builtin/pack-objects.c:3941
+#: builtin/pack-objects.c:3964
 msgid "create packs suitable for shallow fetches"
 msgstr ""
 
-#: builtin/pack-objects.c:3943
+#: builtin/pack-objects.c:3966
 msgid "ignore packs that have companion .keep file"
 msgstr ""
 
-#: builtin/pack-objects.c:3945
+#: builtin/pack-objects.c:3968
 msgid "ignore this pack"
 msgstr ""
 
-#: builtin/pack-objects.c:3947
+#: builtin/pack-objects.c:3970
 msgid "pack compression level"
 msgstr ""
 
-#: builtin/pack-objects.c:3949
+#: builtin/pack-objects.c:3972
 msgid "do not hide commits by grafts"
 msgstr ""
 
-#: builtin/pack-objects.c:3951
+#: builtin/pack-objects.c:3974
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3953
+#: builtin/pack-objects.c:3976
 msgid "write a bitmap index together with the pack index"
 msgstr ""
 
-#: builtin/pack-objects.c:3957
+#: builtin/pack-objects.c:3980
 msgid "write a bitmap index if possible"
 msgstr ""
 
-#: builtin/pack-objects.c:3961
+#: builtin/pack-objects.c:3984
 msgid "handling for missing objects"
 msgstr ""
 
-#: builtin/pack-objects.c:3964
+#: builtin/pack-objects.c:3987
 msgid "do not pack objects in promisor packfiles"
 msgstr ""
 
-#: builtin/pack-objects.c:3966
+#: builtin/pack-objects.c:3989
 msgid "respect islands during delta compression"
 msgstr ""
 
-#: builtin/pack-objects.c:3968
+#: builtin/pack-objects.c:3991
 msgid "protocol"
 msgstr ""
 
-#: builtin/pack-objects.c:3969
+#: builtin/pack-objects.c:3992
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
 
-#: builtin/pack-objects.c:4002
+#: builtin/pack-objects.c:4027
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr ""
 
-#: builtin/pack-objects.c:4007
+#: builtin/pack-objects.c:4032
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr ""
 
-#: builtin/pack-objects.c:4063
+#: builtin/pack-objects.c:4088
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 
-#: builtin/pack-objects.c:4065
+#: builtin/pack-objects.c:4090
 msgid "minimum pack size limit is 1 MiB"
 msgstr ""
 
-#: builtin/pack-objects.c:4070
+#: builtin/pack-objects.c:4095
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 
-#: builtin/pack-objects.c:4079
+#: builtin/pack-objects.c:4104
 msgid "cannot use --filter without --stdout"
 msgstr ""
 
-#: builtin/pack-objects.c:4081
+#: builtin/pack-objects.c:4106
 msgid "cannot use --filter with --stdin-packs"
 msgstr ""
 
-#: builtin/pack-objects.c:4085
+#: builtin/pack-objects.c:4110
 msgid "cannot use internal rev list with --stdin-packs"
 msgstr ""
 
-#: builtin/pack-objects.c:4144
+#: builtin/pack-objects.c:4169
 msgid "Enumerating objects"
 msgstr ""
 
-#: builtin/pack-objects.c:4180
+#: builtin/pack-objects.c:4210
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -18882,10 +19481,6 @@ msgstr ""
 msgid "prune loose refs (default)"
 msgstr ""
 
-#: builtin/prune-packed.c:6
-msgid "git prune-packed [-n | --dry-run] [-q | --quiet]"
-msgstr ""
-
 #: builtin/prune.c:14
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
 msgstr ""
@@ -18905,11 +19500,6 @@ msgstr ""
 #: builtin/prune.c:163
 msgid "cannot prune in a precious-objects repo"
 msgstr ""
-
-#: builtin/pull.c:45 builtin/pull.c:47
-#, c-format
-msgid "Invalid value for %s: %s"
-msgstr "Nilai tidak valid untuk %s: %s"
 
 #: builtin/pull.c:67
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
@@ -18935,7 +19525,7 @@ msgstr "perbolehkan maju cepat"
 msgid "control use of pre-merge-commit and commit-msg hooks"
 msgstr "kontrol penggunaan kail pre-merge-commit dan commit-msg"
 
-#: builtin/pull.c:171 parse-options.h:340
+#: builtin/pull.c:171 parse-options.h:371
 msgid "automatically stash/stash pop before and after"
 msgstr "stash/stash pop otomatis sebelum dan sesudah"
 
@@ -18950,11 +19540,6 @@ msgstr "paksa timpa cabang lokal"
 #: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "nomor submodul ditarik dalam paralel"
-
-#: builtin/pull.c:321
-#, c-format
-msgid "Invalid value for pull.ff: %s"
-msgstr "Nilai tidak valid untuk pull.ff: %s"
 
 #: builtin/pull.c:449
 msgid ""
@@ -18990,7 +19575,7 @@ msgstr ""
 "satu cabang. Oleh karena ini bukan remote terkonfigurasi asali untuk\n"
 "cabang Anda saat ini, Anda harus sebutkan satu cabang pada baris perintah."
 
-#: builtin/pull.c:460 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:978
 msgid "You are not currently on a branch."
 msgstr "Anda tidak berada pada sebuah cabang."
 
@@ -19007,16 +19592,16 @@ msgid "See git-pull(1) for details."
 msgstr "Lihat git-pull(1) untuk selengkapnya."
 
 #: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
-#: builtin/rebase.c:957
+#: builtin/rebase.c:984
 msgid "<remote>"
 msgstr "<remote>"
 
 #: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
-#: contrib/scalar/scalar.c:375
+#: contrib/scalar/scalar.c:374
 msgid "<branch>"
 msgstr "<cabang>"
 
-#: builtin/pull.c:475 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:976
 msgid "There is no tracking information for the current branch."
 msgstr "Tidak ada informasi pelacakan untuk cabang saat ini."
 
@@ -19076,21 +19661,21 @@ msgstr ""
 "--rebase, --no-rebase, atau --ff-only pada baris perintah untuk menimpa\n"
 "asali terkonfigurasi untuk setiap invokasi.\n"
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1047
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Memperbarui cabang yang belum lahir dengan perubahan yang ditambahkan ke "
 "indeks."
 
-#: builtin/pull.c:1050
+#: builtin/pull.c:1051
 msgid "pull with rebase"
 msgstr "tarik dengan pendasaran ulang"
 
-#: builtin/pull.c:1051
+#: builtin/pull.c:1052
 msgid "please commit or stash them."
 msgstr "mohon komit atau stase itu."
 
-#: builtin/pull.c:1076
+#: builtin/pull.c:1077
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19100,7 +19685,7 @@ msgstr ""
 "fetch memperbarui kepala cabang saat ini.\n"
 "memajukan-cepat pohon kerja Anda dari komit %s."
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1083
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19117,23 +19702,23 @@ msgstr ""
 "$ git reset --hard\n"
 "untuk memulihkan."
 
-#: builtin/pull.c:1097
+#: builtin/pull.c:1098
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Tidak dapat menggabungkan banyak cabang ke kepala kosong."
 
-#: builtin/pull.c:1102
+#: builtin/pull.c:1103
 msgid "Cannot rebase onto multiple branches."
 msgstr "Tidak dapat mendasarkan ulang pada banyak cabang."
 
-#: builtin/pull.c:1104
+#: builtin/pull.c:1105
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Tidak dapat maju cepat ke banyak cabang."
 
-#: builtin/pull.c:1119
+#: builtin/pull.c:1120
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "Perlu sebutkan cara merujukkan cabang yang berlainan."
 
-#: builtin/pull.c:1133
+#: builtin/pull.c:1134
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "tidak dapat mendasarkan ulang dengan modifikasi submodul yang terekam lokal."
@@ -19309,7 +19894,7 @@ msgstr "Mendorong ke %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "gagal dorong beberapa referensi ke '%s'"
 
-#: builtin/push.c:544 builtin/submodule--helper.c:3259
+#: builtin/push.c:544 builtin/submodule--helper.c:3377
 msgid "repository"
 msgstr "repositori"
 
@@ -19550,11 +20135,11 @@ msgstr "nirkutukan unpack-trees"
 msgid "suppress feedback messages"
 msgstr "matikan pesan umpan balik"
 
-#: builtin/read-tree.c:183
+#: builtin/read-tree.c:190
 msgid "You need to resolve your current index first"
 msgstr "Anda perlu menguraikan indeks Anda saat ini dulu"
 
-#: builtin/rebase.c:35
+#: builtin/rebase.c:36
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase> | --keep-base] "
 "[<upstream> [<branch>]]"
@@ -19562,55 +20147,51 @@ msgstr ""
 "git rebase [-i] [opsi] [--exec <perintah>] [--onto <basis baru> | --keep-"
 "base][<hulu> [<cabang>]]"
 
-#: builtin/rebase.c:37
+#: builtin/rebase.c:38
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] --root [<branch>]"
 msgstr ""
 "git rebase [-i] [opsi] [--exec <perintah>] [--onto <basis baru>] --root "
 "[<cabang>]"
 
-#: builtin/rebase.c:39
-msgid "git rebase --continue | --abort | --skip | --edit-todo"
-msgstr "git rebase --continue | --abort | --skip | --edit-todo"
-
-#: builtin/rebase.c:230
+#: builtin/rebase.c:231
 #, c-format
 msgid "could not create temporary %s"
 msgstr "tidak dapat membuat %s sementara"
 
-#: builtin/rebase.c:236
+#: builtin/rebase.c:237
 msgid "could not mark as interactive"
 msgstr "tidak dapat menandai sebagai interaktif"
 
-#: builtin/rebase.c:289
+#: builtin/rebase.c:290
 msgid "could not generate todo list"
 msgstr "tidak dapat membuat daftar todo"
 
-#: builtin/rebase.c:331
+#: builtin/rebase.c:332
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "basis komit harus diberikan dengan --upstream atau --onto"
 
-#: builtin/rebase.c:390
+#: builtin/rebase.c:391
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s butuh tulang belakang penggabungan"
 
-#: builtin/rebase.c:432
+#: builtin/rebase.c:433
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "tidak dapat mendapatkan 'ke': '%s'"
 
-#: builtin/rebase.c:449
+#: builtin/rebase.c:450
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "orig-head tidak valid: '%s'"
 
-#: builtin/rebase.c:474
+#: builtin/rebase.c:475
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "abaikan allow_rerere_autoupdate yang tak valid: '%s'"
 
-#: builtin/rebase.c:597
+#: builtin/rebase.c:600
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -19625,7 +20206,7 @@ msgstr ""
 "Untuk membatalkan dan kembali ke kondisi sebelum \"git rebase\",jalankan "
 "\"git rebase --abort\"."
 
-#: builtin/rebase.c:680
+#: builtin/rebase.c:685
 #, c-format
 msgid ""
 "\n"
@@ -19644,7 +20225,12 @@ msgstr ""
 "\n"
 "Hasilnya git tidak dapat mendasarkan ulang itu."
 
-#: builtin/rebase.c:925
+#: builtin/rebase.c:836
+#, c-format
+msgid "could not switch to %s"
+msgstr "tidak dapat mengganti ke %s"
+
+#: builtin/rebase.c:952
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -19653,7 +20239,7 @@ msgstr ""
 "tipe kosong tak dikenali '%s'; nilai yang valid adalah \"drop\", \"keep\", "
 "dan \"ask\"."
 
-#: builtin/rebase.c:943
+#: builtin/rebase.c:970
 #, c-format
 msgid ""
 "%s\n"
@@ -19670,7 +20256,7 @@ msgstr ""
 "    git rebase '<cabang>'.\n"
 "\n"
 
-#: builtin/rebase.c:959
+#: builtin/rebase.c:986
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -19683,181 +20269,181 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<cabang> %s\n"
 "\n"
 
-#: builtin/rebase.c:989
+#: builtin/rebase.c:1016
 msgid "exec commands cannot contain newlines"
 msgstr "perintah exec tidak dapat berisi baris baru"
 
-#: builtin/rebase.c:993
+#: builtin/rebase.c:1020
 msgid "empty exec command"
 msgstr "perintah exec kosong"
 
-#: builtin/rebase.c:1023
+#: builtin/rebase.c:1051
 msgid "rebase onto given branch instead of upstream"
 msgstr "dasarkan ulang kepada cabang yang diberikan daripada hulu"
 
-#: builtin/rebase.c:1025
+#: builtin/rebase.c:1053
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "gunakan merge-base hulu dan cabang sebagai dasar saat ini"
 
-#: builtin/rebase.c:1027
+#: builtin/rebase.c:1055
 msgid "allow pre-rebase hook to run"
 msgstr "perbolehkan kail pre-rebase untuk dijalankan"
 
-#: builtin/rebase.c:1029
+#: builtin/rebase.c:1057
 msgid "be quiet. implies --no-stat"
 msgstr "diam. menyiratkan --no-stat"
 
-#: builtin/rebase.c:1032
+#: builtin/rebase.c:1060
 msgid "display a diffstat of what changed upstream"
 msgstr "perlihatkan diffstat apa yang berubah di hulu"
 
-#: builtin/rebase.c:1035
+#: builtin/rebase.c:1063
 msgid "do not show diffstat of what changed upstream"
 msgstr "jangan perlihatkan diffstat apa yang berubah di hulu"
 
-#: builtin/rebase.c:1038
+#: builtin/rebase.c:1066
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "tambahkan trailer Signed-off-by ke setiap komit"
 
-#: builtin/rebase.c:1041
+#: builtin/rebase.c:1069
 msgid "make committer date match author date"
 msgstr "jadikan tanggal pengkomit sama dengan tanggal pengarang"
 
-#: builtin/rebase.c:1043
+#: builtin/rebase.c:1071
 msgid "ignore author date and use current date"
 msgstr "abaikan tanggal pengarang dan gunakan tanggal saat ini"
 
-#: builtin/rebase.c:1045
+#: builtin/rebase.c:1073
 msgid "synonym of --reset-author-date"
 msgstr "sinonim dari --reset-author-date"
 
-#: builtin/rebase.c:1047 builtin/rebase.c:1051
+#: builtin/rebase.c:1075 builtin/rebase.c:1079
 msgid "passed to 'git apply'"
 msgstr "lewatkan ke 'git apply'"
 
-#: builtin/rebase.c:1049
+#: builtin/rebase.c:1077
 msgid "ignore changes in whitespace"
 msgstr "abaikan perubahan spasi"
 
-#: builtin/rebase.c:1053 builtin/rebase.c:1056
+#: builtin/rebase.c:1081 builtin/rebase.c:1084
 msgid "cherry-pick all commits, even if unchanged"
 msgstr "petik ceri semua komit, bahkan jika tak berubah"
 
-#: builtin/rebase.c:1058
+#: builtin/rebase.c:1086
 msgid "continue"
 msgstr "lanjutkan"
 
-#: builtin/rebase.c:1061
+#: builtin/rebase.c:1089
 msgid "skip current patch and continue"
 msgstr "lewatkan tambalan saat ini dan lanjutkan"
 
-#: builtin/rebase.c:1063
+#: builtin/rebase.c:1091
 msgid "abort and check out the original branch"
 msgstr "hentikan dan check out cabang asli"
 
-#: builtin/rebase.c:1066
+#: builtin/rebase.c:1094
 msgid "abort but keep HEAD where it is"
 msgstr "hentikan tapi simpan HEAD dimana itu berada"
 
-#: builtin/rebase.c:1067
+#: builtin/rebase.c:1095
 msgid "edit the todo list during an interactive rebase"
 msgstr "sunting daftar todo selama pendasaran ulang interaktif"
 
-#: builtin/rebase.c:1070
+#: builtin/rebase.c:1098
 msgid "show the patch file being applied or merged"
 msgstr "perlihatkan berkas tambalan yang sedang diterapkan atau digabungkan"
 
-#: builtin/rebase.c:1073
+#: builtin/rebase.c:1101
 msgid "use apply strategies to rebase"
 msgstr "gunakan strategi penerapan ke pendasaran ulang"
 
-#: builtin/rebase.c:1077
+#: builtin/rebase.c:1105
 msgid "use merging strategies to rebase"
 msgstr "gunakan strategi penggabungan ke pendasaran ulang"
 
-#: builtin/rebase.c:1081
+#: builtin/rebase.c:1109
 msgid "let the user edit the list of commits to rebase"
 msgstr "biarkan pengguna menyunting daftar komit untuk didasarkan ulang"
 
-#: builtin/rebase.c:1085
+#: builtin/rebase.c:1113
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(USANG) coba buat ulang penggabungan daripada abaikan itu"
 
-#: builtin/rebase.c:1090
+#: builtin/rebase.c:1118
 msgid "how to handle commits that become empty"
 msgstr "bagaimana cara menangani komit yang menjadi kosong"
 
-#: builtin/rebase.c:1093
+#: builtin/rebase.c:1121
 msgid "keep commits which start empty"
 msgstr "simpan komit yang dimulai kosong"
 
-#: builtin/rebase.c:1097
+#: builtin/rebase.c:1125
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "pindahakan komit yang diawali dengan squash!/fixup! di bawah -i"
 
-#: builtin/rebase.c:1104
+#: builtin/rebase.c:1132
 msgid "add exec lines after each commit of the editable list"
 msgstr ""
 "tambahkan baris exec setelah setiap komit dari daftar yang bisa disunting"
 
-#: builtin/rebase.c:1108
+#: builtin/rebase.c:1136
 msgid "allow rebasing commits with empty messages"
 msgstr "perbolehkan mendasarkan ulang komit dengan pesan kosong"
 
-#: builtin/rebase.c:1112
+#: builtin/rebase.c:1140
 msgid "try to rebase merges instead of skipping them"
 msgstr "coba mendasarkan ulang penggabungan daripada melewatkan itu"
 
-#: builtin/rebase.c:1115
+#: builtin/rebase.c:1143
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr "gunakan 'merge-base --fork-point' untuk menyaring hulu"
 
-#: builtin/rebase.c:1117
+#: builtin/rebase.c:1145
 msgid "use the given merge strategy"
 msgstr "gunakan strategi penggabungan yang diberikan"
 
-#: builtin/rebase.c:1119 builtin/revert.c:115
+#: builtin/rebase.c:1147 builtin/revert.c:115
 msgid "option"
 msgstr "opsi"
 
-#: builtin/rebase.c:1120
+#: builtin/rebase.c:1148
 msgid "pass the argument through to the merge strategy"
 msgstr "lewatkan argumen ke strategi penggabungan"
 
-#: builtin/rebase.c:1123
+#: builtin/rebase.c:1151
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "dasarkan ulang semua komit yang bisa dicapai hingga ke akar"
 
-#: builtin/rebase.c:1126
+#: builtin/rebase.c:1154
 msgid "automatically re-schedule any `exec` that fails"
 msgstr "jadwal ulang otomatis `exec` apa saja yang gagal"
 
-#: builtin/rebase.c:1128
+#: builtin/rebase.c:1156
 msgid "apply all changes, even those already present upstream"
 msgstr "terapkan semua perubahan, bahkan yang sudah ada di hulu"
 
-#: builtin/rebase.c:1149
+#: builtin/rebase.c:1177
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "Sepertinya 'git am' sedang berjalan. Tidak dapat mendasarkan ulang"
 
-#: builtin/rebase.c:1180
+#: builtin/rebase.c:1208
 msgid "--preserve-merges was replaced by --rebase-merges"
 msgstr "--preserve-merges digantikan oleh --rebase-merges"
 
-#: builtin/rebase.c:1202
+#: builtin/rebase.c:1230
 msgid "No rebase in progress?"
 msgstr "Tidak ada pendasaran ulang yang sedang berjalan?"
 
-#: builtin/rebase.c:1206
+#: builtin/rebase.c:1234
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Aksi --edit-todo hanya dapat digunakan selama pendasaran ulang interaktif."
 
-#: builtin/rebase.c:1229 t/helper/test-fast-rebase.c:122
+#: builtin/rebase.c:1257 t/helper/test-fast-rebase.c:122
 msgid "Cannot read HEAD"
 msgstr "Tidak dapat membaca HEAD"
 
-#: builtin/rebase.c:1241
+#: builtin/rebase.c:1269
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -19865,16 +20451,16 @@ msgstr ""
 "Anda harus menyunting semua konflik penggabungan lalu\n"
 "tandai itu sebagai terselesaikan menggunakan git add"
 
-#: builtin/rebase.c:1260
+#: builtin/rebase.c:1287
 msgid "could not discard worktree changes"
 msgstr "tidak dapat menyingkirkan perubahan pohon kerja"
 
-#: builtin/rebase.c:1279
+#: builtin/rebase.c:1308
 #, c-format
 msgid "could not move back to %s"
 msgstr "tidak dapt memindahkan kembali ke %s"
 
-#: builtin/rebase.c:1325
+#: builtin/rebase.c:1354
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -19895,124 +20481,119 @@ msgstr ""
 "dan jalankan saya lagi. Saya berhenti seandainya Anda masih punya\n"
 "sesuatu yang berharga di sana.\n"
 
-#: builtin/rebase.c:1353
+#: builtin/rebase.c:1382
 msgid "switch `C' expects a numerical value"
 msgstr "tombol `C' harap nilai numerik"
 
-#: builtin/rebase.c:1395
+#: builtin/rebase.c:1424
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Mode tidak dikenal: %s"
 
-#: builtin/rebase.c:1434
+#: builtin/rebase.c:1463
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy butuh --merge atau --interactive"
 
-#: builtin/rebase.c:1463
+#: builtin/rebase.c:1492
 msgid "apply options and merge options cannot be used together"
 msgstr "opsi apply dan opsi merge tidak dapat digunakan bersamaan"
 
-#: builtin/rebase.c:1476
+#: builtin/rebase.c:1505
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Tulang belakang pendasaran ulang tidak dikenal: %s"
 
-#: builtin/rebase.c:1505
+#: builtin/rebase.c:1534
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec butuh --exec atau --interactive"
 
-#: builtin/rebase.c:1536
+#: builtin/rebase.c:1565
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "hulu tidak valid '%s'"
 
-#: builtin/rebase.c:1542
+#: builtin/rebase.c:1571
 msgid "Could not create new root commit"
 msgstr "tidak dapat membuat komit akar baru"
 
-#: builtin/rebase.c:1568
+#: builtin/rebase.c:1597
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': butuh tepatnya satu dasar penggabungan dengan cabang"
 
-#: builtin/rebase.c:1571
+#: builtin/rebase.c:1600
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': butuh tepatnya satu dasar penggabungan"
 
-#: builtin/rebase.c:1580
+#: builtin/rebase.c:1609
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "Tidak menunjuk pada komit yang valid '%s'"
 
-#: builtin/rebase.c:1607
+#: builtin/rebase.c:1636
 #, c-format
 msgid "no such branch/commit '%s'"
 msgstr "tidak ada cabang/komit seperti '%s'"
 
-#: builtin/rebase.c:1618 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2659
+#: builtin/rebase.c:1647 builtin/submodule--helper.c:43
+#: builtin/submodule--helper.c:2477
 #, c-format
 msgid "No such ref: %s"
 msgstr "Tidak ada referensi seperti: %s"
 
-#: builtin/rebase.c:1629
+#: builtin/rebase.c:1658
 msgid "Could not resolve HEAD to a revision"
 msgstr "Tidak dapat menguraikan HEAD ke sebuah revisi"
 
-#: builtin/rebase.c:1650
+#: builtin/rebase.c:1679
 msgid "Please commit or stash them."
 msgstr "Mohon komit atau stase itu."
 
-#: builtin/rebase.c:1686
-#, c-format
-msgid "could not switch to %s"
-msgstr "tidak dapat mengganti ke %s"
-
-#: builtin/rebase.c:1697
+#: builtin/rebase.c:1714
 msgid "HEAD is up to date."
 msgstr "HEAD terbaru."
 
-#: builtin/rebase.c:1699
+#: builtin/rebase.c:1716
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Cabang saat ini %s terbaru.\n"
 
-#: builtin/rebase.c:1707
+#: builtin/rebase.c:1724
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD terbaru, pendasaran ulang dipaksa."
 
-#: builtin/rebase.c:1709
+#: builtin/rebase.c:1726
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Cabang saat ini %s terbaru, pendasaran ulang dipaksa.\n"
 
-#: builtin/rebase.c:1717
+#: builtin/rebase.c:1734
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Kail pre-rebase menolak mendasarkan ulang."
 
-#: builtin/rebase.c:1724
+#: builtin/rebase.c:1741
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Perubahan unuk %s:\n"
 
-#: builtin/rebase.c:1727
+#: builtin/rebase.c:1744
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Perubahan dari %s ke %s:\n"
 
-#: builtin/rebase.c:1752
+#: builtin/rebase.c:1769
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Pertama, memutar ulang kepala untuk memainkan ulang karya Anda diatas "
 "itu...\n"
 
-#: builtin/rebase.c:1761
+#: builtin/rebase.c:1781
 msgid "Could not detach HEAD"
 msgstr "Tidak dapat melepas HEAD"
 
-#: builtin/rebase.c:1770
+#: builtin/rebase.c:1790
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Maju-cepat %s ke %s.\n"
@@ -20021,7 +20602,7 @@ msgstr "Maju-cepat %s ke %s.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <direktori git>"
 
-#: builtin/receive-pack.c:1275
+#: builtin/receive-pack.c:1263
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -20050,7 +20631,7 @@ msgstr ""
 "Untuk mematikan pesan ini dan tetap menjaga kebiasaan asali, setel\n"
 "variabel konfigurasi 'receive.denyCurrentBranch' ke 'refuse'."
 
-#: builtin/receive-pack.c:1295
+#: builtin/receive-pack.c:1283
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -20070,79 +20651,112 @@ msgstr ""
 "\n"
 "Untuk mematikan pesan ini, Anda dapat menyetelnya ke 'refuse'."
 
-#: builtin/receive-pack.c:2474
+#: builtin/receive-pack.c:2476
 msgid "quiet"
 msgstr "diam"
 
-#: builtin/receive-pack.c:2489
+#: builtin/receive-pack.c:2491
 msgid "you must specify a directory"
 msgstr "Anda harus menyebutkan sebuah direktori"
 
+#: builtin/reflog.c:9
+msgid "git reflog [show] [<log-options>] [<ref>]"
+msgstr "git remote [show] [<opsi log>] [<referensi>]"
+
+#: builtin/reflog.c:12
+msgid ""
+"git reflog expire [--expire=<time>] [--expire-unreachable=<time>]\n"
+"                  [--rewrite] [--updateref] [--stale-fix]\n"
+"                  [--dry-run | -n] [--verbose] [--all [--single-worktree] | "
+"<refs>...]"
+msgstr ""
+"git reflog expire [--expire=<waktu>] [--expire-unreachable=<waktu>]\n"
+"                  [--rewrite] [--updateref] [--stale-fix]\n"
+"                  [--dry-run | -n] [--verbose] [--all [--single-worktree] | "
+"<referensi>...]"
+
 #: builtin/reflog.c:17
 msgid ""
-"git reflog expire [--expire=<time>] [--expire-unreachable=<time>] [--"
-"rewrite] [--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all] "
-"<refs>..."
+"git reflog delete [--rewrite] [--updateref]\n"
+"                  [--dry-run | -n] [--verbose] <ref>@{<specifier>}..."
 msgstr ""
-"git reflog expire [--expire=<waktu>] [--expire-unreachable=<waktu>] [--"
-"rewrite] [--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all] "
-"<referensi>..."
+"git reflog delete [--rewrite] [--updateref]\n"
+"                  [--dry-run | -n] [--verbose] <referensi>@{<penyebut>}..."
 
-#: builtin/reflog.c:22
-msgid ""
-"git reflog delete [--rewrite] [--updateref] [--dry-run | -n] [--verbose] "
-"<refs>..."
-msgstr ""
-"git reflog delete [--rewrite] [--updateref] [--dry-run | -n] [--verbose] "
-"<referensi>..."
-
-#: builtin/reflog.c:25
+#: builtin/reflog.c:21
 msgid "git reflog exists <ref>"
 msgstr "git reflog exists <referensi>"
 
-#: builtin/reflog.c:585 builtin/reflog.c:590
+#: builtin/reflog.c:197 builtin/reflog.c:211
 #, c-format
-msgid "'%s' is not a valid timestamp"
-msgstr "'%s' bukan stempel waktu valid"
+msgid "invalid timestamp '%s' given to '--%s'"
+msgstr "stempel waktu tidak valid '%s' diberikan ke '--%s'"
 
-#: builtin/reflog.c:631
+#: builtin/reflog.c:240 builtin/reflog.c:359
+msgid "do not actually prune any entries"
+msgstr "jangan benar-benar pangkas entri apapun"
+
+#: builtin/reflog.c:243 builtin/reflog.c:362
+msgid ""
+"rewrite the old SHA1 with the new SHA1 of the entry that now precedes it"
+msgstr "tulis ulang SHA1 lama dengan SHA1 baru dari entri yang mendahuluinya"
+
+#: builtin/reflog.c:246 builtin/reflog.c:365
+msgid "update the reference to the value of the top reflog entry"
+msgstr "perbarui referensi ke nilai dari entri log referensi atas"
+
+#: builtin/reflog.c:248 builtin/reflog.c:367
+msgid "print extra information on screen"
+msgstr "cetak informasi tambahan pada layar"
+
+#: builtin/reflog.c:249 builtin/reflog.c:253
+msgid "timestamp"
+msgstr "stempel"
+
+#: builtin/reflog.c:250
+msgid "prune entries older than the specified time"
+msgstr "pangkas entri yang lebih tua dari waktu yang disebutkan"
+
+#: builtin/reflog.c:254
+msgid ""
+"prune entries older than <time> that are not reachable from the current tip "
+"of the branch"
+msgstr ""
+"pangkas entri yang lebih tua dari <waktu> yang tak terjangkau dari ujung "
+"cabang saat ini"
+
+#: builtin/reflog.c:258
+msgid "prune any reflog entries that point to broken commits"
+msgstr "pangkas entri reflog apapun yang menunjuk ke komit yang rusak"
+
+#: builtin/reflog.c:259
+msgid "process the reflogs of all references"
+msgstr "proses reflog semua referensi"
+
+#: builtin/reflog.c:261
+msgid "limits processing to reflogs from the current worktree only"
+msgstr "batasi pemrosesan ke hanya log referensi dari pohon kerja saat ini"
+
+#: builtin/reflog.c:294
 #, c-format
 msgid "Marking reachable objects..."
 msgstr "Menandai objek yang bisa dicapai..."
 
-#: builtin/reflog.c:675
+#: builtin/reflog.c:338
 #, c-format
 msgid "%s points nowhere!"
 msgstr "%s tidak menunjuk ke apapun!"
 
-#: builtin/reflog.c:731
+#: builtin/reflog.c:374
 msgid "no reflog specified to delete"
 msgstr "tidak ada log referensi yang disebutkan untuk dihapus"
 
-#: builtin/reflog.c:742
-#, c-format
-msgid "not a reflog: %s"
-msgstr "bukan sebuah log referensi: %s"
-
-#: builtin/reflog.c:747
-#, c-format
-msgid "no reflog for '%s'"
-msgstr "tidak ada log referensi untuk '%s'"
-
-#: builtin/reflog.c:794
+#: builtin/reflog.c:396
 #, c-format
 msgid "invalid ref format: %s"
 msgstr "format referensi tidak valid: %s"
 
-#: builtin/reflog.c:803
-msgid "git reflog [ show | expire | delete | exists ]"
-msgstr "git reflog [ show | expire | delete | exists ]"
-
-#: builtin/remote.c:17
-msgid "git remote [-v | --verbose]"
-msgstr "git remote [-v | --verbose]"
-
-#: builtin/remote.c:18
+#: builtin/remote.c:19
 msgid ""
 "git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--"
 "mirror=<fetch|push>] <name> <url>"
@@ -20150,87 +20764,87 @@ msgstr ""
 "git remote add [-t <cabang>] [-m <master>] [-f] [--tags | --no-tags] [--"
 "mirror=<fetch|push>] <nama> <url>"
 
-#: builtin/remote.c:19 builtin/remote.c:39
-msgid "git remote rename <old> <new>"
-msgstr "git remote rename <lama> <baru>"
+#: builtin/remote.c:20 builtin/remote.c:40
+msgid "git remote rename [--[no-]progress] <old> <new>"
+msgstr "git remote rename [--[no-]progress] <lama> <baru>"
 
-#: builtin/remote.c:20 builtin/remote.c:44
+#: builtin/remote.c:21 builtin/remote.c:45
 msgid "git remote remove <name>"
 msgstr "git remote remove <nama>"
 
-#: builtin/remote.c:21 builtin/remote.c:49
+#: builtin/remote.c:22 builtin/remote.c:50
 msgid "git remote set-head <name> (-a | --auto | -d | --delete | <branch>)"
 msgstr "git remote set-head <nama> (-a | --auto | -d | --delete | <cabang>)"
 
-#: builtin/remote.c:22
+#: builtin/remote.c:23
 msgid "git remote [-v | --verbose] show [-n] <name>"
 msgstr "git remote [-v | --verbose] show [-n] <nama>"
 
-#: builtin/remote.c:23
+#: builtin/remote.c:24
 msgid "git remote prune [-n | --dry-run] <name>"
 msgstr "git remote prune [-n | --dry-run] <nama>"
 
-#: builtin/remote.c:24
+#: builtin/remote.c:25
 msgid ""
 "git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]"
 msgstr ""
 "git remote [-v | --verbose] update [-p | --prune] [(<grup> | <remote>)...]"
 
-#: builtin/remote.c:25
+#: builtin/remote.c:26
 msgid "git remote set-branches [--add] <name> <branch>..."
 msgstr "git remote set-branches [--add] <nama> <cabang>..."
 
-#: builtin/remote.c:26 builtin/remote.c:75
+#: builtin/remote.c:27 builtin/remote.c:76
 msgid "git remote get-url [--push] [--all] <name>"
 msgstr "git remote get-url [--push] [--all] <nama>"
 
-#: builtin/remote.c:27 builtin/remote.c:80
+#: builtin/remote.c:28 builtin/remote.c:81
 msgid "git remote set-url [--push] <name> <newurl> [<oldurl>]"
 msgstr "git remote set-url [--push] <nama> <url baru> [<url lama>]"
 
-#: builtin/remote.c:28 builtin/remote.c:81
+#: builtin/remote.c:29 builtin/remote.c:82
 msgid "git remote set-url --add <name> <newurl>"
 msgstr "git remote set-url --add <nama> <url baru>"
 
-#: builtin/remote.c:29 builtin/remote.c:82
+#: builtin/remote.c:30 builtin/remote.c:83
 msgid "git remote set-url --delete <name> <url>"
 msgstr "git remote set-url --delete <nama> <url>"
 
-#: builtin/remote.c:34
+#: builtin/remote.c:35
 msgid "git remote add [<options>] <name> <url>"
 msgstr "git remote add [<opsi>] <nama> <url>"
 
-#: builtin/remote.c:54
+#: builtin/remote.c:55
 msgid "git remote set-branches <name> <branch>..."
 msgstr "git remote set-branches <nama> <cabang>"
 
-#: builtin/remote.c:55
+#: builtin/remote.c:56
 msgid "git remote set-branches --add <name> <branch>..."
 msgstr "git remote set-branches --add <nama> <cabang>"
 
-#: builtin/remote.c:60
+#: builtin/remote.c:61
 msgid "git remote show [<options>] <name>"
 msgstr "git remote show [<opsi>] <nama>"
 
-#: builtin/remote.c:65
+#: builtin/remote.c:66
 msgid "git remote prune [<options>] <name>"
 msgstr "git remote prune [<opsi>] <nama>"
 
-#: builtin/remote.c:70
+#: builtin/remote.c:71
 msgid "git remote update [<options>] [<group> | <remote>]..."
 msgstr "git remote update [<opsi>] [<group> | <remote>]..."
 
-#: builtin/remote.c:99
+#: builtin/remote.c:100
 #, c-format
 msgid "Updating %s"
 msgstr "Memperbarui %s"
 
-#: builtin/remote.c:101
+#: builtin/remote.c:102
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Tidak dapat mengambil %s"
 
-#: builtin/remote.c:131
+#: builtin/remote.c:132
 msgid ""
 "--mirror is dangerous and deprecated; please\n"
 "\t use --mirror=fetch or --mirror=push instead"
@@ -20238,77 +20852,77 @@ msgstr ""
 "--mirror berbahaya dan usang; mohon gunakan --mirror=fetch\n"
 "\t atau --mirror=push sebagai gantinya"
 
-#: builtin/remote.c:148
+#: builtin/remote.c:149
 #, c-format
 msgid "unknown mirror argument: %s"
 msgstr "argumen mirror tidak dikenal: %s"
 
-#: builtin/remote.c:164
+#: builtin/remote.c:165
 msgid "fetch the remote branches"
 msgstr "ambil cabang remote"
 
-#: builtin/remote.c:166
+#: builtin/remote.c:167
 msgid "import all tags and associated objects when fetching"
 msgstr "impor semua tag dan objek yang terkait ketika mengambil"
 
-#: builtin/remote.c:169
+#: builtin/remote.c:170
 msgid "or do not fetch any tag at all (--no-tags)"
 msgstr "atau jangan mengambil tag apapun (--no-tags)"
 
-#: builtin/remote.c:171
+#: builtin/remote.c:172
 msgid "branch(es) to track"
 msgstr "cabang untuk dilacak"
 
-#: builtin/remote.c:172
+#: builtin/remote.c:173
 msgid "master branch"
 msgstr "cabang master"
 
-#: builtin/remote.c:174
+#: builtin/remote.c:175
 msgid "set up remote as a mirror to push to or fetch from"
 msgstr "atur remote sebagai cermin untuk didorong atau diambil"
 
-#: builtin/remote.c:186
+#: builtin/remote.c:187
 msgid "specifying a master branch makes no sense with --mirror"
 msgstr "menyebutkan cabang master tidak masuk akal dengan --mirror"
 
-#: builtin/remote.c:188
+#: builtin/remote.c:189
 msgid "specifying branches to track makes sense only with fetch mirrors"
 msgstr "menyebutkan cabang untuk dilacak hanya masuk akal dengan cermin ambil"
 
-#: builtin/remote.c:195 builtin/remote.c:705
+#: builtin/remote.c:196 builtin/remote.c:716
 #, c-format
 msgid "remote %s already exists."
 msgstr "remote %s sudah ada"
 
-#: builtin/remote.c:240
+#: builtin/remote.c:241
 #, c-format
 msgid "Could not setup master '%s'"
 msgstr "Tidak dapat mengatur master '%s'"
 
-#: builtin/remote.c:322
+#: builtin/remote.c:323
 #, c-format
 msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
-msgstr ""
+msgstr "branch.%s.rebase=%s tak tertangani; diasumsikan 'true'"
 
-#: builtin/remote.c:366
+#: builtin/remote.c:367
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr "Tidak dapat mendapatkan peta pengambilan untuk spek referensi %s"
 
-#: builtin/remote.c:460 builtin/remote.c:468
+#: builtin/remote.c:461 builtin/remote.c:469
 msgid "(matching)"
 msgstr "(sepadan)"
 
-#: builtin/remote.c:472
+#: builtin/remote.c:473
 msgid "(delete)"
 msgstr "(hapus)"
 
-#: builtin/remote.c:660
+#: builtin/remote.c:664
 #, c-format
 msgid "could not set '%s'"
 msgstr "tidak dapat menyetel '%s'"
 
-#: builtin/remote.c:665
+#: builtin/remote.c:669
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -20319,17 +20933,17 @@ msgstr ""
 "\t%s:%d\n"
 "sekarang menamai remote yang tiada '%s'"
 
-#: builtin/remote.c:696 builtin/remote.c:841 builtin/remote.c:948
+#: builtin/remote.c:707 builtin/remote.c:866 builtin/remote.c:973
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Tidak ada remote seperti: '%s'"
 
-#: builtin/remote.c:715
+#: builtin/remote.c:726
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "Tidak dapat menamai ulang bagian konfigurasi '%s' ke '%s'"
 
-#: builtin/remote.c:735
+#: builtin/remote.c:746
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -20340,17 +20954,21 @@ msgstr ""
 "\t%s\n"
 "\tMohon perbarui konfigurasi secara manual bila diperlukan."
 
-#: builtin/remote.c:775
+#: builtin/remote.c:783
+msgid "Renaming remote references"
+msgstr "Menamai ulang referensi remote"
+
+#: builtin/remote.c:794
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "menghapus '%s' gagal"
 
-#: builtin/remote.c:809
+#: builtin/remote.c:832
 #, c-format
 msgid "creating '%s' failed"
 msgstr "membuat '%s' gagal"
 
-#: builtin/remote.c:887
+#: builtin/remote.c:912
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -20364,120 +20982,120 @@ msgstr[1] ""
 "Catatan: Beberapa cabang diluar hierarki refs/remotes tidak dihapus;\n"
 "untuk menghapus itu, gunakan:"
 
-#: builtin/remote.c:901
+#: builtin/remote.c:926
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Tidak dapat menghapus bagian konfigurasi '%s'"
 
-#: builtin/remote.c:1009
+#: builtin/remote.c:1034
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " baru (pengambilan berikutnya akan simpan di remotes/%s)"
 
-#: builtin/remote.c:1012
+#: builtin/remote.c:1037
 msgid " tracked"
 msgstr " dilacak"
 
-#: builtin/remote.c:1014
+#: builtin/remote.c:1039
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " basi (gunakan 'git remote prune' untuk hapus)"
 
-#: builtin/remote.c:1016
+#: builtin/remote.c:1041
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1057
+#: builtin/remote.c:1082
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr ""
 "branch.%s.merge tidak valid; tidak dapat mendasarkan ulang ke lebih dari "
 "satu cabang"
 
-#: builtin/remote.c:1066
+#: builtin/remote.c:1091
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "dasarkan ulang secara interaktif ke remote %s"
 
-#: builtin/remote.c:1068
+#: builtin/remote.c:1093
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "dasarkan ulang secara interaktif (dengan penggabungan) ke remote %s"
 
-#: builtin/remote.c:1071
+#: builtin/remote.c:1096
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "dasarkan ulang ke remote %s"
 
-#: builtin/remote.c:1075
+#: builtin/remote.c:1100
 #, c-format
 msgid " merges with remote %s"
 msgstr " gabungkan dengan remote %s"
 
-#: builtin/remote.c:1078
+#: builtin/remote.c:1103
 #, c-format
 msgid "merges with remote %s"
 msgstr "gabungkan dengan remote %s"
 
-#: builtin/remote.c:1081
+#: builtin/remote.c:1106
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    dan dengan remote %s\n"
 
-#: builtin/remote.c:1124
+#: builtin/remote.c:1149
 msgid "create"
 msgstr "buat"
 
-#: builtin/remote.c:1127
+#: builtin/remote.c:1152
 msgid "delete"
 msgstr "hapus"
 
-#: builtin/remote.c:1131
+#: builtin/remote.c:1156
 msgid "up to date"
 msgstr "terbaru"
 
-#: builtin/remote.c:1134
+#: builtin/remote.c:1159
 msgid "fast-forwardable"
 msgstr "bisa dimaju cepat"
 
-#: builtin/remote.c:1137
+#: builtin/remote.c:1162
 msgid "local out of date"
 msgstr "lokal kuno"
 
-#: builtin/remote.c:1144
+#: builtin/remote.c:1169
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s memaksa untuk %-*s (%s)"
 
-#: builtin/remote.c:1147
+#: builtin/remote.c:1172
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s mendorong ke %-*s (%s)"
 
-#: builtin/remote.c:1151
+#: builtin/remote.c:1176
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s memaksa untuk %s"
 
-#: builtin/remote.c:1154
+#: builtin/remote.c:1179
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s mendorong ke %s"
 
-#: builtin/remote.c:1222
+#: builtin/remote.c:1247
 msgid "do not query remotes"
 msgstr "jangan tanyakan remote"
 
-#: builtin/remote.c:1243
+#: builtin/remote.c:1268
 #, c-format
 msgid "* remote %s"
 msgstr "* remote %s"
 
-#: builtin/remote.c:1244
+#: builtin/remote.c:1269
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL pengambilan: %s"
 
-#: builtin/remote.c:1245 builtin/remote.c:1261 builtin/remote.c:1398
+#: builtin/remote.c:1270 builtin/remote.c:1286 builtin/remote.c:1423
 msgid "(no URL)"
 msgstr "(tidak ada URL)"
 
@@ -20485,189 +21103,189 @@ msgstr "(tidak ada URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1259 builtin/remote.c:1261
+#: builtin/remote.c:1284 builtin/remote.c:1286
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL pendorongan: %s"
 
-#: builtin/remote.c:1263 builtin/remote.c:1265 builtin/remote.c:1267
+#: builtin/remote.c:1288 builtin/remote.c:1290 builtin/remote.c:1292
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Cabang HEAD: %s"
 
-#: builtin/remote.c:1263
+#: builtin/remote.c:1288
 msgid "(not queried)"
 msgstr "(tidak ditanyakan)"
 
-#: builtin/remote.c:1265
+#: builtin/remote.c:1290
 msgid "(unknown)"
 msgstr "(tidak diketahui)"
 
-#: builtin/remote.c:1269
+#: builtin/remote.c:1294
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr ""
 "  Cabang HEAD (HEAD remote ambigu, bisa jadi salah satu dari yang berikut):\n"
 
-#: builtin/remote.c:1281
+#: builtin/remote.c:1306
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Cabang remote:%s"
 msgstr[1] "  Cabang remote:%s"
 
-#: builtin/remote.c:1284 builtin/remote.c:1310
+#: builtin/remote.c:1309 builtin/remote.c:1335
 msgid " (status not queried)"
 msgstr " (status tidak ditanyakan)"
 
-#: builtin/remote.c:1293
+#: builtin/remote.c:1318
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Cabang lokal dikonfigurasi untuk 'git pull':"
 msgstr[1] "  Cabang lokal dikonfigurasi untuk 'git pull':"
 
-#: builtin/remote.c:1301
+#: builtin/remote.c:1326
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  Referensi lokal yang akan dicerminkan oleh 'git push'"
 
-#: builtin/remote.c:1307
+#: builtin/remote.c:1332
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Referensi lokal dikonfigurasi untuk 'git push'%s:"
 msgstr[1] "  Referensi lokal dikonfigurasi untuk 'git push'%s:"
 
-#: builtin/remote.c:1328
+#: builtin/remote.c:1353
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "setel refs/remotes/<nama>/HEAD tergantung remote"
 
-#: builtin/remote.c:1330
+#: builtin/remote.c:1355
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "hapus refs/remotes/<nama>/HEAD"
 
-#: builtin/remote.c:1344
+#: builtin/remote.c:1369
 msgid "Cannot determine remote HEAD"
 msgstr "Tidak dapat menentukan HEAD remote"
 
-#: builtin/remote.c:1346
+#: builtin/remote.c:1371
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr "Banyak cabang HEAD remote. Mohon pilih satu secara eksplisit dengan:"
 
-#: builtin/remote.c:1356
+#: builtin/remote.c:1381
 #, c-format
 msgid "Could not delete %s"
 msgstr "Tidak dapat menghapus %s"
 
-#: builtin/remote.c:1364
+#: builtin/remote.c:1389
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "Bukan referensi valid: %s"
 
-#: builtin/remote.c:1366
+#: builtin/remote.c:1391
 #, c-format
 msgid "Could not setup %s"
 msgstr "Tidak dapat mengatur %s"
 
-#: builtin/remote.c:1384
+#: builtin/remote.c:1409
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s akan menjadi teruntai!"
 
-#: builtin/remote.c:1385
+#: builtin/remote.c:1410
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s telah menjadi teruntai!"
 
-#: builtin/remote.c:1394
+#: builtin/remote.c:1419
 #, c-format
 msgid "Pruning %s"
 msgstr "Memangkas %s"
 
-#: builtin/remote.c:1395
+#: builtin/remote.c:1420
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1411
+#: builtin/remote.c:1436
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [akan pangkas] %s"
 
-#: builtin/remote.c:1414
+#: builtin/remote.c:1439
 #, c-format
 msgid " * [pruned] %s"
 msgstr " * [dipangkas] %s"
 
-#: builtin/remote.c:1459
+#: builtin/remote.c:1484
 msgid "prune remotes after fetching"
 msgstr "pangkas remote setelah pengambilan"
 
-#: builtin/remote.c:1523 builtin/remote.c:1579 builtin/remote.c:1649
+#: builtin/remote.c:1548 builtin/remote.c:1604 builtin/remote.c:1674
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Tidak ada remote seperti '%s'"
 
-#: builtin/remote.c:1541
+#: builtin/remote.c:1566
 msgid "add branch"
 msgstr "tambah cabang"
 
-#: builtin/remote.c:1548
+#: builtin/remote.c:1573
 msgid "no remote specified"
 msgstr "tidak ada remote yang disebutkan"
 
-#: builtin/remote.c:1565
+#: builtin/remote.c:1590
 msgid "query push URLs rather than fetch URLs"
 msgstr "tanyakan URL pendorongan daripada URL pengambilan"
 
-#: builtin/remote.c:1567
+#: builtin/remote.c:1592
 msgid "return all URLs"
 msgstr "kembalikan semua URL"
 
-#: builtin/remote.c:1597
+#: builtin/remote.c:1622
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "tidak ada URL yang dikonfigurasi untuk remote '%s'"
 
-#: builtin/remote.c:1623
+#: builtin/remote.c:1648
 msgid "manipulate push URLs"
 msgstr "manipulasi URL pendorongan"
 
-#: builtin/remote.c:1625
+#: builtin/remote.c:1650
 msgid "add URL"
 msgstr "tambah URL"
 
-#: builtin/remote.c:1627
+#: builtin/remote.c:1652
 msgid "delete URLs"
 msgstr "hapus URL"
 
-#: builtin/remote.c:1634
+#: builtin/remote.c:1659
 msgid "--add --delete doesn't make sense"
 msgstr "--add --delete tidak masuk akal"
 
-#: builtin/remote.c:1675
+#: builtin/remote.c:1700
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "pola URL lama tidak valid: %s"
 
-#: builtin/remote.c:1683
+#: builtin/remote.c:1708
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Tidak ada URL yang ditemukan seperti: %s"
 
-#: builtin/remote.c:1685
+#: builtin/remote.c:1710
 msgid "Will not delete all non-push URLs"
 msgstr "Tidak akan hapus semua URL non-dorong"
 
-#: builtin/remote.c:1702
+#: builtin/remote.c:1727
 msgid "be verbose; must be placed before a subcommand"
 msgstr "jadi lebih bertele-tele; harus ditempatkan sebelum subperintah"
 
-#: builtin/repack.c:28
+#: builtin/repack.c:29
 msgid "git repack [<options>]"
 msgstr "git repack [<opsi>]"
 
-#: builtin/repack.c:33
+#: builtin/repack.c:34
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writebitmaps configuration."
@@ -20675,147 +21293,147 @@ msgstr ""
 "Pengepakan ulang tambahan tidak kompatibel dengan indeks bitmap. Gunakan\n"
 " --no-write-bitmap-index atau nonaktifkan konfigurasi pack.writebitmaps."
 
-#: builtin/repack.c:201
+#: builtin/repack.c:206
 msgid "could not start pack-objects to repack promisor objects"
 msgstr "tidak dapat memulai pack-objects untuk mengepak ulang objek pejanji"
 
-#: builtin/repack.c:275 builtin/repack.c:820
+#: builtin/repack.c:280 builtin/repack.c:824
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr "repack: Mengharapkan baris ID objek hex penuh hanya dari pack-objects."
 
-#: builtin/repack.c:299
+#: builtin/repack.c:304
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "tidak dapat menyelesaikan pack-objects untuk mengepak ulang objek pejanji"
 
-#: builtin/repack.c:314
+#: builtin/repack.c:319
 #, c-format
 msgid "cannot open index for %s"
 msgstr "tidak dapat membuka indeks untuk %s"
 
-#: builtin/repack.c:373
+#: builtin/repack.c:378
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr "pak %s terlalu besar untuk dipertimbangkan dalam deret geometri"
 
-#: builtin/repack.c:406 builtin/repack.c:413 builtin/repack.c:418
+#: builtin/repack.c:411 builtin/repack.c:418 builtin/repack.c:423
 #, c-format
 msgid "pack %s too large to roll up"
 msgstr "pak %s terlalu besar untuk digulung"
 
-#: builtin/repack.c:498
+#: builtin/repack.c:503
 #, c-format
 msgid "could not open tempfile %s for writing"
 msgstr "tidak dapat membuka berkas sementara '%s' untuk ditulis"
 
-#: builtin/repack.c:516
+#: builtin/repack.c:521
 msgid "could not close refs snapshot tempfile"
 msgstr "tidak dapat menutup berkas sementara jepretan referensi"
 
-#: builtin/repack.c:630
+#: builtin/repack.c:634
 msgid "pack everything in a single pack"
 msgstr "pak semuanya dalam satu pak"
 
-#: builtin/repack.c:632
+#: builtin/repack.c:636
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "sama seperti -a, dan jadikan objek yang tak dapat dicapai longgar"
 
-#: builtin/repack.c:635
+#: builtin/repack.c:639
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "hapus pak berlebihan, dan jalankan git-prune-packed"
 
-#: builtin/repack.c:637
+#: builtin/repack.c:641
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "lewatkan --no-reuse-delta ke git-pack-objects"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:643
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "lewatkan --no-reuse-object ke git-pack-objects"
 
-#: builtin/repack.c:641
+#: builtin/repack.c:645
 msgid "do not run git-update-server-info"
 msgstr "jangan jalankan git-update-server-info"
 
-#: builtin/repack.c:644
+#: builtin/repack.c:648
 msgid "pass --local to git-pack-objects"
 msgstr "lewatkan --local ke git-pack-objects"
 
-#: builtin/repack.c:646
+#: builtin/repack.c:650
 msgid "write bitmap index"
 msgstr "tulis indeks bitmap"
 
-#: builtin/repack.c:648
+#: builtin/repack.c:652
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "lewatkan --delta-islands ke git-pack-objects"
 
-#: builtin/repack.c:649
+#: builtin/repack.c:653
 msgid "approxidate"
 msgstr "tanggal aproksimasi"
 
-#: builtin/repack.c:650
+#: builtin/repack.c:654
 msgid "with -A, do not loosen objects older than this"
 msgstr "dengan -A, jangan longgarkan objek lebih lama dari ini"
 
-#: builtin/repack.c:652
+#: builtin/repack.c:656
 msgid "with -a, repack unreachable objects"
 msgstr "dengan -a, pak ulang objek yang tak dapat dicapai"
 
-#: builtin/repack.c:654
+#: builtin/repack.c:658
 msgid "size of the window used for delta compression"
 msgstr "ukuran jendela yang digunakan untuk kompresi delta"
 
-#: builtin/repack.c:655 builtin/repack.c:661
+#: builtin/repack.c:659 builtin/repack.c:665
 msgid "bytes"
 msgstr "bita"
 
-#: builtin/repack.c:656
+#: builtin/repack.c:660
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "sama seperti yang diatas, tetapi batasi penggunaan memori daripada hitungan "
 "entri"
 
-#: builtin/repack.c:658
+#: builtin/repack.c:662
 msgid "limits the maximum delta depth"
 msgstr "batasi kedalaman delta maksimum"
 
-#: builtin/repack.c:660
+#: builtin/repack.c:664
 msgid "limits the maximum number of threads"
 msgstr "batasi jumlah utas maksimum"
 
-#: builtin/repack.c:662
+#: builtin/repack.c:666
 msgid "maximum size of each packfile"
 msgstr "ukuran maksimum setiap berkas pak"
 
-#: builtin/repack.c:664
+#: builtin/repack.c:668
 msgid "repack objects in packs marked with .keep"
 msgstr "pak ulang objek dalam pak yang ditandai dengan .keep"
 
-#: builtin/repack.c:666
+#: builtin/repack.c:670
 msgid "do not repack this pack"
 msgstr "jangan pak ulang pak ini"
 
-#: builtin/repack.c:668
+#: builtin/repack.c:672
 msgid "find a geometric progression with factor <N>"
 msgstr "temukan deret geometri dengan faktor <N>"
 
-#: builtin/repack.c:670
+#: builtin/repack.c:674
 msgid "write a multi-pack index of the resulting packs"
 msgstr "tulis indeks multipak dari pak yang dihasilkan"
 
-#: builtin/repack.c:680
+#: builtin/repack.c:684
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "tidak dapat menghapus pak dalam repositori objek berharga"
 
-#: builtin/repack.c:829
+#: builtin/repack.c:833
 msgid "Nothing new to pack."
 msgstr "Tidak ada yang baru untuk dipak."
 
-#: builtin/repack.c:859
+#: builtin/repack.c:863
 #, c-format
 msgid "missing required file: %s"
 msgstr "berkas yang diperlukan hilang: %s"
 
-#: builtin/repack.c:861
+#: builtin/repack.c:865
 #, c-format
 msgid "could not unlink: %s"
 msgstr "tidak dapat membatal taut: %s"
@@ -20830,10 +21448,6 @@ msgstr ""
 
 #: builtin/replace.c:24
 msgid "git replace [-f] --graft <commit> [<parent>...]"
-msgstr ""
-
-#: builtin/replace.c:25
-msgid "git replace [-f] --convert-graft-file"
 msgstr ""
 
 #: builtin/replace.c:26
@@ -21128,96 +21742,92 @@ msgstr "Gagal menemukan pohon dari %s."
 msgid "HEAD is now at %s"
 msgstr "HEAD sekarang pada %s"
 
-#: builtin/reset.c:299
+#: builtin/reset.c:304
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Tidak dapat lakukan reset %s di tengah-tengah penggabungan."
 
-#: builtin/reset.c:396 builtin/stash.c:606 builtin/stash.c:680
-#: builtin/stash.c:704
+#: builtin/reset.c:402 builtin/stash.c:606 builtin/stash.c:669
+#: builtin/stash.c:693
 msgid "be quiet, only report errors"
 msgstr "diam, hanya laporkan kesalahan"
 
-#: builtin/reset.c:398
+#: builtin/reset.c:404
+msgid "skip refreshing the index after reset"
+msgstr ""
+
+#: builtin/reset.c:406
 msgid "reset HEAD and index"
 msgstr "setel ulang HEAD dan indeks"
 
-#: builtin/reset.c:399
+#: builtin/reset.c:407
 msgid "reset only HEAD"
 msgstr "hanya setel ulang HEAD"
 
-#: builtin/reset.c:401 builtin/reset.c:403
+#: builtin/reset.c:409 builtin/reset.c:411
 msgid "reset HEAD, index and working tree"
 msgstr "setel ulang HEAD, indeks dan pohon kerja"
 
-#: builtin/reset.c:405
+#: builtin/reset.c:413
 msgid "reset HEAD but keep local changes"
 msgstr "setel ulang HEAD tapi simpan perubahan lokal"
 
-#: builtin/reset.c:411
+#: builtin/reset.c:419
 msgid "record only the fact that removed paths will be added later"
 msgstr "hanya rekam fakta bahwa jalur yang terhapus akan ditambahkan nanti"
 
-#: builtin/reset.c:445
+#: builtin/reset.c:452
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Gagal menguraikan '%s' sebagai revisi yang valid."
 
-#: builtin/reset.c:453
+#: builtin/reset.c:460
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Gagal menguraikan '%s' sebagaikan pohon yang valid."
 
-#: builtin/reset.c:472
+#: builtin/reset.c:479
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed dengan jalur usang; sebagai gantinya gunakan 'git reset --<jalur>'."
 
-#: builtin/reset.c:474
+#: builtin/reset.c:481
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Tidak dapat lakukan reset %s dengan jalur."
 
-#: builtin/reset.c:489
+#: builtin/reset.c:496
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "Reset %s tidak diperbolehkan dalam repositori bare"
 
-#: builtin/reset.c:520
+#: builtin/reset.c:527
 msgid "Unstaged changes after reset:"
 msgstr "Perubahan tak tergelar setelah setel ulang:"
 
-#: builtin/reset.c:523
+#: builtin/reset.c:530
 #, c-format
 msgid ""
-"\n"
-"It took %.2f seconds to enumerate unstaged changes after reset.  You can\n"
-"use '--quiet' to avoid this.  Set the config setting reset.quiet to true\n"
-"to make this the default.\n"
+"It took %.2f seconds to refresh the index after reset.  You can use\n"
+"'--no-refresh' to avoid this."
 msgstr ""
-"\n"
-"Butuh %.2f detik untuk daftar perubahan tak tergelar setelah setel ulang.\n"
-"Anda dapat menggunakan '--quiet' untuk hindari hal ini. Setel konfigurasi\n"
-"reset.quiet ke true untuk membuat hal tersebut asali.\n"
+"Butuh %.2f detik untuk menyegarkan indeks setelah penyetelan ulang.\n"
+"Anda bisa gunakan '--no-refresh' untuk menghindari hal tersebut."
 
-#: builtin/reset.c:541
+#: builtin/reset.c:547
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Tidak dapat menyetel ulang berkas indeks ke revisi '%s'."
 
-#: builtin/reset.c:546
+#: builtin/reset.c:552
 msgid "Could not write new index file."
 msgstr "Tidak dapat menulis berkas indeks baru."
 
-#: builtin/rev-list.c:602
-msgid "object filtering requires --objects"
-msgstr "penyaringan objek memerlukan --objects"
-
-#: builtin/rev-list.c:674
+#: builtin/rev-list.c:659
 msgid "rev-list does not support display of notes"
 msgstr "rev-list tidak mendukung penampilan catatan"
 
-#: builtin/rev-list.c:679
+#: builtin/rev-list.c:664
 #, c-format
 msgid "marked counting and '%s' cannot be used together"
 msgstr "hitungan tertanda dan '%s' tidak dapat digunakan bersamaan."
@@ -21565,11 +22175,11 @@ msgstr "bidang"
 msgid "group by field"
 msgstr "kelompokkan oleh bidang"
 
-#: builtin/shortlog.c:394
+#: builtin/shortlog.c:395
 msgid "too many arguments given outside repository"
 msgstr "terlalu banyak argumen diberikan di luar repositori"
 
-#: builtin/show-branch.c:13
+#: builtin/show-branch.c:14
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
 "                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -21581,120 +22191,120 @@ msgstr ""
 "                [--more=<n> | --list | --independent | --merge-base]\n"
 "                [--no-name | --sha1-name] [--topics] [(<revisi> | <glob>)...]"
 
-#: builtin/show-branch.c:17
+#: builtin/show-branch.c:18
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
 msgstr "git show-branch (-g | --reflog)[=<n>[,<dasar>]] [--list] [<referensi>]"
 
-#: builtin/show-branch.c:395
+#: builtin/show-branch.c:396
 #, c-format
 msgid "ignoring %s; cannot handle more than %d ref"
 msgid_plural "ignoring %s; cannot handle more than %d refs"
 msgstr[0] "mengabaikan %s; tidak dapat menangani lebih dari %d referensi"
 msgstr[1] "mengabaikan %s; tidak dapat menangani lebih dari %d referensi"
 
-#: builtin/show-branch.c:547
+#: builtin/show-branch.c:548
 #, c-format
 msgid "no matching refs with %s"
 msgstr "tidak ada referensi yang cocok dengan %s"
 
-#: builtin/show-branch.c:644
+#: builtin/show-branch.c:645
 msgid "show remote-tracking and local branches"
 msgstr "perlihatkan cabang pelacak remote dan lokal"
 
-#: builtin/show-branch.c:646
+#: builtin/show-branch.c:647
 msgid "show remote-tracking branches"
 msgstr "perlihatkan cabang pelacak remote"
 
-#: builtin/show-branch.c:648
+#: builtin/show-branch.c:649
 msgid "color '*!+-' corresponding to the branch"
 msgstr "warna '*!+-' bersesuaian pada cabang"
 
-#: builtin/show-branch.c:650
+#: builtin/show-branch.c:651
 msgid "show <n> more commits after the common ancestor"
 msgstr "perlihatkan <n> komit lagi setelah nenek moyang yang sama"
 
-#: builtin/show-branch.c:652
+#: builtin/show-branch.c:653
 msgid "synonym to more=-1"
 msgstr "sinonim untuk more=-1"
 
-#: builtin/show-branch.c:653
+#: builtin/show-branch.c:654
 msgid "suppress naming strings"
 msgstr "sembunyikan untai penamaan"
 
-#: builtin/show-branch.c:655
+#: builtin/show-branch.c:656
 msgid "include the current branch"
 msgstr "masukkan cabang saat ini"
 
-#: builtin/show-branch.c:657
+#: builtin/show-branch.c:658
 msgid "name commits with their object names"
 msgstr "namai komit dengan nama objeknya"
 
-#: builtin/show-branch.c:659
+#: builtin/show-branch.c:660
 msgid "show possible merge bases"
 msgstr "perlihatkan dasar penggabungan yang mungkin"
 
-#: builtin/show-branch.c:661
+#: builtin/show-branch.c:662
 msgid "show refs unreachable from any other ref"
 msgstr ""
 "perlihatkan referensi yang tidak dapat dicapai dari referensi yang lainnya"
 
-#: builtin/show-branch.c:663
+#: builtin/show-branch.c:664
 msgid "show commits in topological order"
 msgstr "perlihatkan komit dalam urutan topologis"
 
-#: builtin/show-branch.c:666
+#: builtin/show-branch.c:667
 msgid "show only commits not on the first branch"
 msgstr "hanya perlihatkan komit yang bukan pada cabang pertama"
 
-#: builtin/show-branch.c:668
+#: builtin/show-branch.c:669
 msgid "show merges reachable from only one tip"
 msgstr "perlihatkan penggabungan yang bisa dicapai hanya dari satu ujung"
 
-#: builtin/show-branch.c:670
+#: builtin/show-branch.c:671
 msgid "topologically sort, maintaining date order where possible"
 msgstr "urutkan secara topologis, pelihara urutan tanggal bila memungkinkan"
 
-#: builtin/show-branch.c:673
+#: builtin/show-branch.c:674
 msgid "<n>[,<base>]"
 msgstr "<n>[,<dasar>]"
 
-#: builtin/show-branch.c:674
+#: builtin/show-branch.c:675
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "perlihatkan <n> entri ref-log terkini dimulai dari dasar"
 
-#: builtin/show-branch.c:734
+#: builtin/show-branch.c:735
 msgid "no branches given, and HEAD is not valid"
 msgstr "tidak ada cabang yang diberikan, dan HEAD tidak valid"
 
-#: builtin/show-branch.c:737
+#: builtin/show-branch.c:738
 msgid "--reflog option needs one branch name"
 msgstr "opsi --reflog butuh satu nama cabang"
 
-#: builtin/show-branch.c:740
+#: builtin/show-branch.c:741
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
 msgstr[0] "hanya %d entri yang bisa diperlihatkan pada satu waktu."
 msgstr[1] "hanya %d entri yang bisa diperlihatkan pada satu waktu."
 
-#: builtin/show-branch.c:744
+#: builtin/show-branch.c:745
 #, c-format
 msgid "no such ref %s"
 msgstr "tidak ada referensi seperti %s"
 
-#: builtin/show-branch.c:830
+#: builtin/show-branch.c:831
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "tidak dapat menangani lebih dari %d revisi."
 msgstr[1] "tidak dapat menangani lebih dari %d revisi."
 
-#: builtin/show-branch.c:834
+#: builtin/show-branch.c:835
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "'%s' bukan sebuah referensi yang valid."
 
-#: builtin/show-branch.c:837
+#: builtin/show-branch.c:838
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "tidak dapat menemukan komit %s (%s)"
@@ -21753,122 +22363,153 @@ msgstr ""
 "perlihatkan referensi dari masukan standar yang tidak ada dalam repositori "
 "lokal"
 
-#: builtin/sparse-checkout.c:22
+#: builtin/sparse-checkout.c:23
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
 msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <opsi>"
 
-#: builtin/sparse-checkout.c:46
-msgid "git sparse-checkout list"
-msgstr "git sparse-checkout list"
-
-#: builtin/sparse-checkout.c:60
+#: builtin/sparse-checkout.c:61
 msgid "this worktree is not sparse"
 msgstr "pohon kerja ini bukan tipis"
 
-#: builtin/sparse-checkout.c:75
+#: builtin/sparse-checkout.c:76
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr "pohon kerja ini bukan tipis (berkas sparse-checkout mungkin tidak ada)"
 
-#: builtin/sparse-checkout.c:176
+#: builtin/sparse-checkout.c:177
 #, c-format
 msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
 "cone"
 msgstr ""
-"directori '%s' berisi berkas tak teracak, tapi tidak di dalam kerucut "
-"sparse-checkout"
+"directori '%s' berisi berkas tak teracak, tapi tidak di dalam kerucut sparse-"
+"checkout"
 
-#: builtin/sparse-checkout.c:184
+#: builtin/sparse-checkout.c:185
 #, c-format
 msgid "failed to remove directory '%s'"
 msgstr "gagal menghapus direktori '%s'"
 
-#: builtin/sparse-checkout.c:324
+#: builtin/sparse-checkout.c:327
 msgid "failed to create directory for sparse-checkout file"
 msgstr "gagal membuat direktori untuk berkas sparse-checkout"
 
-#: builtin/sparse-checkout.c:365
-msgid "unable to upgrade repository format to enable worktreeConfig"
-msgstr "gagal mengupgrade format repositori untuk mengaktifkan worktreeConfig"
-
-#: builtin/sparse-checkout.c:367
-msgid "failed to set extensions.worktreeConfig setting"
-msgstr "gagal menyetel setelan extensions.worktreeConfig"
+#: builtin/sparse-checkout.c:366
+msgid "failed to initialize worktree config"
+msgstr "gagal menginisialisasi konfigurasi pohon kerja"
 
 #: builtin/sparse-checkout.c:411
 msgid "failed to modify sparse-index config"
 msgstr "gagal memodifikasi konfigurasi sparse-index"
 
-#: builtin/sparse-checkout.c:422
-msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-
-#: builtin/sparse-checkout.c:441 builtin/sparse-checkout.c:729
-#: builtin/sparse-checkout.c:778
+#: builtin/sparse-checkout.c:441 builtin/sparse-checkout.c:793
+#: builtin/sparse-checkout.c:847
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "inisialisasi checkout tipis dalam mode kerucut"
 
-#: builtin/sparse-checkout.c:443 builtin/sparse-checkout.c:731
-#: builtin/sparse-checkout.c:780
+#: builtin/sparse-checkout.c:443 builtin/sparse-checkout.c:795
+#: builtin/sparse-checkout.c:849
 msgid "toggle the use of a sparse index"
 msgstr "gunakan indeks tipis"
 
-#: builtin/sparse-checkout.c:476
+#: builtin/sparse-checkout.c:479
 #, c-format
 msgid "failed to open '%s'"
 msgstr "gagal membuka '%s'"
 
-#: builtin/sparse-checkout.c:528
+#: builtin/sparse-checkout.c:531
 #, c-format
 msgid "could not normalize path %s"
 msgstr "tidak dapat menormalkan jalur %s"
 
-#: builtin/sparse-checkout.c:557
+#: builtin/sparse-checkout.c:560
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "tidak dapat membatal-kutip untai gaya C '%s'"
 
-#: builtin/sparse-checkout.c:612 builtin/sparse-checkout.c:640
+#: builtin/sparse-checkout.c:615 builtin/sparse-checkout.c:643
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "tidak dapat memuat pola checkout tipis yang sudah ada"
 
-#: builtin/sparse-checkout.c:616
+#: builtin/sparse-checkout.c:619
 msgid "existing sparse-checkout patterns do not use cone mode"
 msgstr "pola checkout tipis yang sudah ada tidak menggunakan mode kerucut"
 
-#: builtin/sparse-checkout.c:682
-msgid "git sparse-checkout add (--stdin | <patterns>)"
-msgstr "git sparse-checkout add (--stdin | <pola>)"
+#: builtin/sparse-checkout.c:707
+msgid "please run from the toplevel directory in non-cone mode"
+msgstr "mohon jalankan dari direktori tingkat atas pada mode bukan kerucut"
 
-#: builtin/sparse-checkout.c:694 builtin/sparse-checkout.c:733
+#: builtin/sparse-checkout.c:712
+msgid "specify directories rather than patterns (no leading slash)"
+msgstr "sebutkan direktori daripada pola (tanpa garis miring terdepan)"
+
+#: builtin/sparse-checkout.c:714
+msgid ""
+"specify directories rather than patterns.  If your directory starts with a "
+"'!', pass --skip-checks"
+msgstr ""
+"sebutkan direktori daripada pola. Jika direktori Anda dimulai dengan '!', "
+"lewatkan --skip-checks"
+
+#: builtin/sparse-checkout.c:716
+msgid ""
+"specify directories rather than patterns.  If your directory really has any "
+"of '*?[]\\' in it, pass --skip-checks"
+msgstr ""
+"sebutkan direktori daripada pola. Jika direktori Anda benar-benar berisi "
+"salah satu dari '*?[]\\', lewatkan --skip-checks"
+
+#: builtin/sparse-checkout.c:732
+#, c-format
+msgid ""
+"'%s' is not a directory; to treat it as a directory anyway, rerun with --"
+"skip-checks"
+msgstr ""
+"'%s' bukan sebuah direktori; untuk perlakukan juga sebagai direktori, "
+"jalankan ulang dengan --skip-checks"
+
+#: builtin/sparse-checkout.c:734
+#, c-format
+msgid ""
+"pass a leading slash before paths such as '%s' if you want a single file "
+"(see NON-CONE PROBLEMS in the git-sparse-checkout manual)."
+msgstr ""
+"lewatkan sebuah garis miring terdepan sebelum jalur seperti '%s' jika Anda "
+"ingin sebuah berkas (lihat NON-CONE PROBLEMS dalam manual git-sparse-"
+"checkout)."
+
+#: builtin/sparse-checkout.c:739
+msgid "git sparse-checkout add [--skip-checks] (--stdin | <patterns>)"
+msgstr "git sparse-checkout add [--skip-checks] (--stdin | <pola>)"
+
+#: builtin/sparse-checkout.c:752 builtin/sparse-checkout.c:797
+msgid ""
+"skip some sanity checks on the given paths that might give false positives"
+msgstr ""
+"lewati beberapa pemeriksaan kewarasan pada jalur yang diberikan yang mana "
+"dapat memberikan positif palsu"
+
+#: builtin/sparse-checkout.c:755 builtin/sparse-checkout.c:800
 msgid "read patterns from standard in"
 msgstr "baca pola dari masukan standar"
 
-#: builtin/sparse-checkout.c:699
+#: builtin/sparse-checkout.c:760
 msgid "no sparse-checkout to add to"
 msgstr "tidak ada checkout tipis untuk ditambahkan"
 
-#: builtin/sparse-checkout.c:712
+#: builtin/sparse-checkout.c:775
 msgid ""
-"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
-"<patterns>)"
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] [--skip-checks] "
+"(--stdin | <patterns>)"
 msgstr ""
-"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
-"<pola>)"
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] [--skip-checks] "
+"(--stdin | <pola>)"
 
-#: builtin/sparse-checkout.c:765
-msgid "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
-msgstr "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
-
-#: builtin/sparse-checkout.c:785
+#: builtin/sparse-checkout.c:854
 msgid "must be in a sparse-checkout to reapply sparsity patterns"
-msgstr "harus berada di dalam checkout tipis untuk menerapkan ulang pola kejarangan"
+msgstr ""
+"harus berada di dalam checkout tipis untuk menerapkan ulang pola kejarangan"
 
-#: builtin/sparse-checkout.c:803
-msgid "git sparse-checkout disable"
-msgstr "git sparse-checkout disable"
-
-#: builtin/sparse-checkout.c:845
+#: builtin/sparse-checkout.c:914
 msgid "error while refreshing working directory"
 msgstr "kesalahan saat menyegarkan direktori kerja"
 
@@ -22009,170 +22650,154 @@ msgstr "Indeks tak dibatal-stasekan."
 msgid "could not restore untracked files from stash"
 msgstr "tidak dapat mengembalikan berkas tak terlacak dari stase"
 
-#: builtin/stash.c:608 builtin/stash.c:706
+#: builtin/stash.c:608 builtin/stash.c:695
 msgid "attempt to recreate the index"
 msgstr "coba membuat ulang indeks"
 
-#: builtin/stash.c:652
+#: builtin/stash.c:641
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "%s (%s) dijatuhkan"
 
-#: builtin/stash.c:655
+#: builtin/stash.c:644
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Tidak dapat menjatuhkan entri stase"
 
-#: builtin/stash.c:668
+#: builtin/stash.c:657
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' bukan referensi stase"
 
-#: builtin/stash.c:718
+#: builtin/stash.c:707
 msgid "The stash entry is kept in case you need it again."
 msgstr "Entri stase disimpan jika Anda butuh itu lagi."
 
-#: builtin/stash.c:741
+#: builtin/stash.c:730
 msgid "No branch name specified"
 msgstr "Tidak ada nama cabang yang disebutkan"
 
-#: builtin/stash.c:825
+#: builtin/stash.c:809
 msgid "failed to parse tree"
 msgstr "gagal menguraikan pohon"
 
-#: builtin/stash.c:836
+#: builtin/stash.c:820
 msgid "failed to unpack trees"
 msgstr "gagal membongkar pohon"
 
-#: builtin/stash.c:856
+#: builtin/stash.c:840
 msgid "include untracked files in the stash"
 msgstr "masukkan berkas tak terlacak ke dalam stase"
 
-#: builtin/stash.c:859
+#: builtin/stash.c:843
 msgid "only show untracked files in the stash"
 msgstr "hanya perlihatkan berkas tak terlacak dalam stase"
 
-#: builtin/stash.c:946 builtin/stash.c:983
+#: builtin/stash.c:930 builtin/stash.c:967
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Tidak dapat memperbarui %s dengan %s"
 
-#: builtin/stash.c:964 builtin/stash.c:1678 builtin/stash.c:1750
+#: builtin/stash.c:948 builtin/stash.c:1667 builtin/stash.c:1739
 msgid "stash message"
 msgstr "pesan stase"
 
-#: builtin/stash.c:974
+#: builtin/stash.c:958
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" butuh satu argumen <komit>"
 
-#: builtin/stash.c:1159
+#: builtin/stash.c:1143
 msgid "No staged changes"
 msgstr "Tidak ada perubahan yang tergelar"
 
-#: builtin/stash.c:1220
+#: builtin/stash.c:1204
 msgid "No changes selected"
 msgstr "Tidak ada perubahan yang dipilih"
 
-#: builtin/stash.c:1320
+#: builtin/stash.c:1304
 msgid "You do not have the initial commit yet"
 msgstr "Anda belum punya komit awal"
 
-#: builtin/stash.c:1347
+#: builtin/stash.c:1331
 msgid "Cannot save the current index state"
 msgstr "Tidak dapat menyimpan keadaan indeks saat ini"
 
-#: builtin/stash.c:1356
+#: builtin/stash.c:1340
 msgid "Cannot save the untracked files"
 msgstr "Tidak dapat menyimpan berkas tak terlacak"
 
-#: builtin/stash.c:1367 builtin/stash.c:1386
+#: builtin/stash.c:1351 builtin/stash.c:1370
 msgid "Cannot save the current worktree state"
 msgstr "Tidak dapat menyimpang keadaan pohon kerja saat ini"
 
-#: builtin/stash.c:1377
+#: builtin/stash.c:1361
 msgid "Cannot save the current staged state"
 msgstr "Tidak dapat menyimpan keadaan tergelar saat ini"
 
-#: builtin/stash.c:1414
+#: builtin/stash.c:1398
 msgid "Cannot record working tree state"
 msgstr "Tidak dapat merekam keadaan pohon kerja"
 
-#: builtin/stash.c:1463
+#: builtin/stash.c:1447
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Tidak dapat menggunakan --patch dan --include-untracked atau --all pada "
 "waktu yang bersamaan"
 
-#: builtin/stash.c:1474
+#: builtin/stash.c:1458
 msgid "Can't use --staged and --include-untracked or --all at the same time"
 msgstr ""
 "Tidak dapat menggunakan --staged dan --include-untracked atau --all pada "
 "waktu yang bersamaan"
 
-#: builtin/stash.c:1492
+#: builtin/stash.c:1476
 msgid "Did you forget to 'git add'?"
 msgstr "Anda lupa untuk 'git add'?"
 
-#: builtin/stash.c:1507
+#: builtin/stash.c:1491
 msgid "No local changes to save"
 msgstr "Tidak ada perubahan lokal untuk disimpan"
 
-#: builtin/stash.c:1514
+#: builtin/stash.c:1498
 msgid "Cannot initialize stash"
 msgstr "Tidak dapat menginisialisasi stase"
 
-#: builtin/stash.c:1529
+#: builtin/stash.c:1513
 msgid "Cannot save the current status"
 msgstr "Tidak dapat menyimpan status saat ini"
 
-#: builtin/stash.c:1534
+#: builtin/stash.c:1518
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Direktori kerja dan keadaan indeks %s disimpan"
 
-#: builtin/stash.c:1627
+#: builtin/stash.c:1615
 msgid "Cannot remove worktree changes"
 msgstr "Tidak dapat menghapus perubahaan pohon kerja"
 
-#: builtin/stash.c:1667 builtin/stash.c:1739
+#: builtin/stash.c:1656 builtin/stash.c:1728
 msgid "keep index"
 msgstr "jaga indeks"
 
-#: builtin/stash.c:1669 builtin/stash.c:1741
+#: builtin/stash.c:1658 builtin/stash.c:1730
 msgid "stash staged changes only"
 msgstr "hanya stase perubahan tergelar"
 
-#: builtin/stash.c:1671 builtin/stash.c:1743
+#: builtin/stash.c:1660 builtin/stash.c:1732
 msgid "stash in patch mode"
 msgstr "stase dalam mode tambalan"
 
-#: builtin/stash.c:1672 builtin/stash.c:1744
+#: builtin/stash.c:1661 builtin/stash.c:1733
 msgid "quiet mode"
 msgstr "mode hening"
 
-#: builtin/stash.c:1674 builtin/stash.c:1746
+#: builtin/stash.c:1663 builtin/stash.c:1735
 msgid "include untracked files in stash"
 msgstr "masukkan berkas tak terlacak ke dalam stase"
 
-#: builtin/stash.c:1676 builtin/stash.c:1748
+#: builtin/stash.c:1665 builtin/stash.c:1737
 msgid "include ignore files"
 msgstr "masukkan berkas ignore"
-
-#: builtin/stash.c:1783
-msgid ""
-"the stash.useBuiltin support has been removed!\n"
-"See its entry in 'git help config' for details."
-msgstr ""
-"Dukungan untuk stash.useBuiltin sudah dihapus!\n"
-"Lihat entri itu di 'git help config' untuk selengkapnya."
-
-#: builtin/stripspace.c:18
-msgid "git stripspace [-s | --strip-comments]"
-msgstr ""
-
-#: builtin/stripspace.c:19
-msgid "git stripspace [-c | --comment-lines]"
-msgstr ""
 
 #: builtin/stripspace.c:37
 msgid "skip and remove all lines starting with comment character"
@@ -22182,21 +22807,17 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr ""
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2668
+#: builtin/submodule--helper.c:50 builtin/submodule--helper.c:2486
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Mengharapkan nama referensi penuh, dapat %s"
 
-#: builtin/submodule--helper.c:63
-msgid "submodule--helper print-default-remote takes no arguments"
-msgstr "submodule--helper print-default-remote tidak membutuhkan argumen"
-
-#: builtin/submodule--helper.c:101
+#: builtin/submodule--helper.c:103
 #, c-format
 msgid "cannot strip one component off url '%s'"
 msgstr "tidak dapat mencopot satu komponen dari url '%s'"
 
-#: builtin/submodule--helper.c:211
+#: builtin/submodule--helper.c:213
 #, c-format
 msgid ""
 "could not look up configuration '%s'. Assuming this repository is its own "
@@ -22205,26 +22826,26 @@ msgstr ""
 "tidak dapat mencari konfigurasi '%s'. Asumsi bahwa repositori ini adalah "
 "hulu otoritatif tersendiri."
 
-#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1859
+#: builtin/submodule--helper.c:413 builtin/submodule--helper.c:1873
 msgid "alternative anchor for relative paths"
 msgstr "jangkar alternatif untuk jalur relatif"
 
-#: builtin/submodule--helper.c:410
+#: builtin/submodule--helper.c:418
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<jalur>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:468 builtin/submodule--helper.c:605
-#: builtin/submodule--helper.c:628
+#: builtin/submodule--helper.c:476 builtin/submodule--helper.c:617
+#: builtin/submodule--helper.c:640
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Tidak ada url yang ditemukan untuk jalur submodul '%s' di .gitmodules"
 
-#: builtin/submodule--helper.c:520
+#: builtin/submodule--helper.c:528
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Memasuki '%s'\n"
 
-#: builtin/submodule--helper.c:523
+#: builtin/submodule--helper.c:531
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -22233,7 +22854,7 @@ msgstr ""
 "run_command mengembalikan status bukan nol untuk %s\n"
 "."
 
-#: builtin/submodule--helper.c:545
+#: builtin/submodule--helper.c:553
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -22244,68 +22865,68 @@ msgstr ""
 "bersarang %s\n"
 "."
 
-#: builtin/submodule--helper.c:561
+#: builtin/submodule--helper.c:569
 msgid "suppress output of entering each submodule command"
 msgstr "sembunyikan keluaran memasuki setiap perintah submodul"
 
-#: builtin/submodule--helper.c:563 builtin/submodule--helper.c:864
-#: builtin/submodule--helper.c:1453
+#: builtin/submodule--helper.c:571 builtin/submodule--helper.c:876
+#: builtin/submodule--helper.c:1458
 msgid "recurse into nested submodules"
 msgstr "rekursi ke dalam submodul bersarang"
 
-#: builtin/submodule--helper.c:568
+#: builtin/submodule--helper.c:576
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr ""
 "git submodule--helper foreach [--quiet] [--recursive] [--] [<perintah>]"
 
-#: builtin/submodule--helper.c:642
+#: builtin/submodule--helper.c:654
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr "Gagal mendaftarkan url untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:646
+#: builtin/submodule--helper.c:658
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Submodul '%s' (%s) didaftarkan untuk jalur '%s'\n"
 
-#: builtin/submodule--helper.c:656
+#: builtin/submodule--helper.c:668
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "peringatan: perintah mode pembaruan disarankan untuk submodul '%s'\n"
 
-#: builtin/submodule--helper.c:663
+#: builtin/submodule--helper.c:675
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr "Gagal mendaftarkan mode pembaruan untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:685
+#: builtin/submodule--helper.c:697
 msgid "suppress output for initializing a submodule"
 msgstr "sembunyikan keluaran menginisialisasi submodul"
 
-#: builtin/submodule--helper.c:690
+#: builtin/submodule--helper.c:702
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<opsi>] [<jalur>]"
 
-#: builtin/submodule--helper.c:763 builtin/submodule--helper.c:898
+#: builtin/submodule--helper.c:775 builtin/submodule--helper.c:910
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "tidak ada pemetaan submodul ditemukan di .gitmodules untuk jalur '%s'"
 
-#: builtin/submodule--helper.c:811
+#: builtin/submodule--helper.c:823
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "tidak dapat menguraikan referensi HEAD di dalam submodul '%s'"
 
-#: builtin/submodule--helper.c:838 builtin/submodule--helper.c:1423
+#: builtin/submodule--helper.c:850 builtin/submodule--helper.c:1428
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "gagal merekursi ke dalam submodul '%s'"
 
-#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1590
+#: builtin/submodule--helper.c:874 builtin/submodule--helper.c:1595
 msgid "suppress submodule status output"
 msgstr "sembunyikan keluaran status submodul"
 
-#: builtin/submodule--helper.c:863
+#: builtin/submodule--helper.c:875
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -22313,92 +22934,92 @@ msgstr ""
 "gunakan komit yang disimpan di dalam indeks daripada yang disimpan di dalam "
 "HEAD"
 
-#: builtin/submodule--helper.c:869
+#: builtin/submodule--helper.c:881
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quiet] [--cached] [--recursive] [<jalur>...]"
 
-#: builtin/submodule--helper.c:893
+#: builtin/submodule--helper.c:905
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <jalur>"
 
-#: builtin/submodule--helper.c:965
+#: builtin/submodule--helper.c:977
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
 msgstr "* %s %s(blob)->%s(submodul)"
 
-#: builtin/submodule--helper.c:968
+#: builtin/submodule--helper.c:980
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
 msgstr "* %s %s(submodul)->%s(blob)"
 
-#: builtin/submodule--helper.c:981
+#: builtin/submodule--helper.c:993
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: builtin/submodule--helper.c:1031
+#: builtin/submodule--helper.c:1043
 #, c-format
 msgid "couldn't hash object from '%s'"
 msgstr "tidak dapat hash objek dari '%s'"
 
-#: builtin/submodule--helper.c:1035
+#: builtin/submodule--helper.c:1047
 #, c-format
 msgid "unexpected mode %o\n"
 msgstr "mode tidak diharapkan %o\n"
 
-#: builtin/submodule--helper.c:1276
+#: builtin/submodule--helper.c:1288
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr "gunakan komit yang disimpan di dalam indeks daripada HEAD submodul"
 
-#: builtin/submodule--helper.c:1278
+#: builtin/submodule--helper.c:1290
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr "bandingkan komit di dalam indeks dengan yang di dalam HEAD submodul"
 
-#: builtin/submodule--helper.c:1280
+#: builtin/submodule--helper.c:1292
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr "lewatkan submodul dengan nilai 'ignore_config' disetel ke 'all'"
 
-#: builtin/submodule--helper.c:1282
+#: builtin/submodule--helper.c:1294
 msgid "limit the summary size"
 msgstr "batasi ukuran ringkasan"
 
-#: builtin/submodule--helper.c:1287
+#: builtin/submodule--helper.c:1299
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 msgstr "git submodule--helper summary [<opsi>] [<commit>] -- [<jalur>]"
 
-#: builtin/submodule--helper.c:1311
+#: builtin/submodule--helper.c:1323
 msgid "could not fetch a revision for HEAD"
 msgstr "tidak dapat mengambil revisi untuk HEAD"
 
-#: builtin/submodule--helper.c:1373
+#: builtin/submodule--helper.c:1384
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Mensinkronisasi url submodul untuk '%s'\n"
 
-#: builtin/submodule--helper.c:1379
+#: builtin/submodule--helper.c:1390
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "gagal mendaftarkan url untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1393
+#: builtin/submodule--helper.c:1399
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "gagal mendapatkan remote asali untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:1404
+#: builtin/submodule--helper.c:1409
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "gagal memperbarui remote untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:1451
+#: builtin/submodule--helper.c:1456
 msgid "suppress output of synchronizing submodule url"
 msgstr "sembunyikan keluaran mensinkronisasi url submodul"
 
-#: builtin/submodule--helper.c:1458
+#: builtin/submodule--helper.c:1463
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<jalur>]"
 
-#: builtin/submodule--helper.c:1508
+#: builtin/submodule--helper.c:1513
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory. This will be replaced "
@@ -22407,7 +23028,7 @@ msgstr ""
 "Pohon kerja submodul '%s' berisi direktori .git. Ini akan diganti dengan  "
 "berkas .git oleh dengan menggunakan absorbgitdirs."
 
-#: builtin/submodule--helper.c:1525
+#: builtin/submodule--helper.c:1530
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -22416,46 +23037,46 @@ msgstr ""
 "Pohon kerja submodul '%s' berisi modifikasi lokal; gunakan '-f' untuk "
 "menyingkirkan itu"
 
-#: builtin/submodule--helper.c:1533
+#: builtin/submodule--helper.c:1538
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Direktori '%s' dibersihkan\n"
 
-#: builtin/submodule--helper.c:1535
+#: builtin/submodule--helper.c:1540
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Tidak dapat menghapus pohon kerja submodul '%s'\n"
 
-#: builtin/submodule--helper.c:1546
+#: builtin/submodule--helper.c:1551
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "tidak dapat membuat direktori submodul kosong %s"
 
-#: builtin/submodule--helper.c:1562
+#: builtin/submodule--helper.c:1567
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submodul '%s' (%s) tak terdaftar untuk jalur '%s'\n"
 
-#: builtin/submodule--helper.c:1591
+#: builtin/submodule--helper.c:1596
 msgid "remove submodule working trees even if they contain local changes"
 msgstr "hapus pohon kerja submodul bahkan jika itu berisi perubahan lokal"
 
-#: builtin/submodule--helper.c:1592
+#: builtin/submodule--helper.c:1597
 msgid "unregister all submodules"
 msgstr "batal daftar semua submodul"
 
-#: builtin/submodule--helper.c:1597
+#: builtin/submodule--helper.c:1602
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<jalur>...]]"
 
-#: builtin/submodule--helper.c:1611
+#: builtin/submodule--helper.c:1616
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr ""
 "Gunakan '--all' jika Anda benar-benar ingin deinisialisasi semua submodul"
 
-#: builtin/submodule--helper.c:1656
+#: builtin/submodule--helper.c:1665
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -22467,102 +23088,102 @@ msgstr ""
 " itu, setel submodule.alternateErrorStrategy ke 'info' atau yang sama,\n"
 "kloning degan '--reference-if-able' daripada '--reference'."
 
-#: builtin/submodule--helper.c:1701 builtin/submodule--helper.c:1704
+#: builtin/submodule--helper.c:1710 builtin/submodule--helper.c:1713
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "submodul '%s' tidak dapat menambahkan pengganti: %s"
 
-#: builtin/submodule--helper.c:1740
+#: builtin/submodule--helper.c:1749
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Nilai '%s' untuk submodule.alternateErrorStrategy tidak dikenal"
 
-#: builtin/submodule--helper.c:1747
+#: builtin/submodule--helper.c:1756
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Nilai '%s' untuk submodule.alternateLocation tidak dikenal"
 
-#: builtin/submodule--helper.c:1772
+#: builtin/submodule--helper.c:1781
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "menolak membuat/menggunakan '%s' di dalam direktori git submodul yang lain"
 
-#: builtin/submodule--helper.c:1813
+#: builtin/submodule--helper.c:1826
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "gagal mengkloning '%s' ke dalam jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1818
+#: builtin/submodule--helper.c:1831
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "direktori tidak kosong: '%s'"
 
-#: builtin/submodule--helper.c:1830
+#: builtin/submodule--helper.c:1843
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "tidak dapat mendapatkan direktori submodul untuk '%s'"
 
-#: builtin/submodule--helper.c:1862
+#: builtin/submodule--helper.c:1876
 msgid "where the new submodule will be cloned to"
 msgstr "di mana submodul baru akan dikloning"
 
-#: builtin/submodule--helper.c:1865
+#: builtin/submodule--helper.c:1879
 msgid "name of the new submodule"
 msgstr "nama submodul baru"
 
-#: builtin/submodule--helper.c:1868
+#: builtin/submodule--helper.c:1882
 msgid "url where to clone the submodule from"
 msgstr "url di mana submodul dikloning"
 
-#: builtin/submodule--helper.c:1876 builtin/submodule--helper.c:3265
+#: builtin/submodule--helper.c:1890 builtin/submodule--helper.c:3383
 msgid "depth for shallow clones"
 msgstr "kedalaman untuk kloning dangkal"
 
-#: builtin/submodule--helper.c:1879 builtin/submodule--helper.c:2526
-#: builtin/submodule--helper.c:3258
+#: builtin/submodule--helper.c:1893 builtin/submodule--helper.c:2731
+#: builtin/submodule--helper.c:3376
 msgid "force cloning progress"
 msgstr "paksa perkembangan kloning"
 
-#: builtin/submodule--helper.c:1881 builtin/submodule--helper.c:2528
+#: builtin/submodule--helper.c:1895 builtin/submodule--helper.c:2733
 msgid "disallow cloning into non-empty directory"
 msgstr "tak perbolehkan kloning ke dalam direktori bukan kosong"
 
-#: builtin/submodule--helper.c:1888
+#: builtin/submodule--helper.c:1903
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
-"<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
-"<url> --path <path>"
+"<repository>] [--name <name>] [--depth <depth>] [--single-branch] [--filter "
+"<filter-spec>]--url <url> --path <path>"
 msgstr ""
 "git submodule--helper clone [--prefix=<jalur>] [--quiet] [--reference "
-"<repositori>] [--name <nama>] [--depth <kedalaman>] [--single-branch] --url "
-"<url> --path <jalur>"
+"<repositori>] [--name <nama>] [--depth <kedalaman>] [--single-branch] [--"
+"filter <spek filter>] --url <url> --path <jalur>"
 
-#: builtin/submodule--helper.c:1925
+#: builtin/submodule--helper.c:1943
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Mode pembaruan '%s' tidak valid untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:1929
+#: builtin/submodule--helper.c:1947
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr "Mode pembaruan '%s' tidak valid untuk jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:2044
+#: builtin/submodule--helper.c:2041
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Jalur submodul '%s' tidak diinisialisasi"
 
-#: builtin/submodule--helper.c:2048
+#: builtin/submodule--helper.c:2045
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Mungkin Anda ingin menggunakan 'update --init'?"
 
-#: builtin/submodule--helper.c:2078
+#: builtin/submodule--helper.c:2075
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Melewati submodul tak tergabung %s"
 
-#: builtin/submodule--helper.c:2107
+#: builtin/submodule--helper.c:2104
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Melewati submodul '%s'"
@@ -22577,54 +23198,54 @@ msgstr "Gagal mengkloning '%s'. Percobaan ulang dijadwalkan"
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Gagal mengkloning '%s' untuk kedua kalinya, batalkan"
 
-#: builtin/submodule--helper.c:2373
+#: builtin/submodule--helper.c:2371
 #, c-format
 msgid "Unable to checkout '%s' in submodule path '%s'"
 msgstr "Tidak dapat men-checkout '%s' pada jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:2377
+#: builtin/submodule--helper.c:2375
 #, c-format
 msgid "Unable to rebase '%s' in submodule path '%s'"
 msgstr "Gagal mendasarkan ulang '%s' pada jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:2381
+#: builtin/submodule--helper.c:2379
 #, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
 msgstr "Tidak dapat menggabungkan '%s' pada jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:2385
+#: builtin/submodule--helper.c:2383
 #, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
 msgstr "Eksekusi '%s %s' gagal di jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:2409
+#: builtin/submodule--helper.c:2402
 #, c-format
 msgid "Submodule path '%s': checked out '%s'\n"
 msgstr "Jalur submodul '%s': ter-checkout '%s'\n"
 
-#: builtin/submodule--helper.c:2413
+#: builtin/submodule--helper.c:2406
 #, c-format
 msgid "Submodule path '%s': rebased into '%s'\n"
 msgstr "Jalur submodul '%s: terdasarkan ulang ke '%s''\n"
 
-#: builtin/submodule--helper.c:2417
+#: builtin/submodule--helper.c:2410
 #, c-format
 msgid "Submodule path '%s': merged in '%s'\n"
 msgstr "Jalur submodul '%s': tergabung dalam '%s'\n"
 
-#: builtin/submodule--helper.c:2421
+#: builtin/submodule--helper.c:2414
 #, c-format
 msgid "Submodule path '%s': '%s %s'\n"
 msgstr "Jalur submodul '%s': '%s %s'\n"
 
-#: builtin/submodule--helper.c:2445
+#: builtin/submodule--helper.c:2438
 #, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr ""
 "Tidak dapat mengambil di dalam jalur submodul '%s'; mencoba mengambil "
 "langsung %s:"
 
-#: builtin/submodule--helper.c:2454
+#: builtin/submodule--helper.c:2447
 #, c-format
 msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
@@ -22633,85 +23254,7 @@ msgstr ""
 "Terambil di dalam jalur submodul '%s', tetapi itu tidak berisi %s. "
 "Pengambilan langsung komit tersebut gagal."
 
-#: builtin/submodule--helper.c:2505 builtin/submodule--helper.c:2575
-#: builtin/submodule--helper.c:2813
-msgid "path into the working tree"
-msgstr "jalur ke dalam pohon kerja"
-
-#: builtin/submodule--helper.c:2508 builtin/submodule--helper.c:2580
-msgid "path into the working tree, across nested submodule boundaries"
-msgstr "jalur ke dalam pohon kerja, melintasi perbatasan submodul bersarang"
-
-#: builtin/submodule--helper.c:2512 builtin/submodule--helper.c:2578
-msgid "rebase, merge, checkout or none"
-msgstr "dasarkan ulang, gabungkan, checkout atau tidak sama sekali"
-
-#: builtin/submodule--helper.c:2518
-msgid "create a shallow clone truncated to the specified number of revisions"
-msgstr "buat klon dangkal terpotong hingga sejumlah revisi yang disebutkan"
-
-#: builtin/submodule--helper.c:2521
-msgid "parallel jobs"
-msgstr "pekerjaan paralel"
-
-#: builtin/submodule--helper.c:2523
-msgid "whether the initial clone should follow the shallow recommendation"
-msgstr "apakah klon awal seharusnya mengikuti rekomendasi dangkal"
-
-#: builtin/submodule--helper.c:2524
-msgid "don't print cloning progress"
-msgstr "jangan cetak perkembangan pengkloningan"
-
-#: builtin/submodule--helper.c:2535
-msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
-msgstr "git submodule--helper update-clone [--prefix=<jalur>] [<jalur>...]"
-
-#: builtin/submodule--helper.c:2548
-msgid "bad value for update parameter"
-msgstr "nilai jelek untuk parameter pembaruan"
-
-#: builtin/submodule--helper.c:2566
-msgid "suppress output for update by rebase or merge"
-msgstr ""
-"sembunyikan keluaran untuk pembaruan oleh pendasaran ulang atau penggabungan"
-
-#: builtin/submodule--helper.c:2567
-msgid "force checkout updates"
-msgstr "paksa pembaruan checkout"
-
-#: builtin/submodule--helper.c:2569
-msgid "don't fetch new objects from the remote site"
-msgstr "jangan ambil objek baru dari situs remote"
-
-#: builtin/submodule--helper.c:2571
-msgid "overrides update mode in case the repository is a fresh clone"
-msgstr "timpa mode pembaruan jika repositori adalah kloning segar"
-
-#: builtin/submodule--helper.c:2572
-msgid "depth for shallow fetch"
-msgstr "kedalaman untuk pengambilan dangkal"
-
-#: builtin/submodule--helper.c:2582
-msgid "sha1"
-msgstr "sha1"
-
-#: builtin/submodule--helper.c:2583
-msgid "SHA1 expected by superproject"
-msgstr "SHA1 diharapkan oleh proyek super"
-
-#: builtin/submodule--helper.c:2585
-msgid "subsha1"
-msgstr "subsha1"
-
-#: builtin/submodule--helper.c:2586
-msgid "SHA1 of submodule's HEAD"
-msgstr "SHA1 dari HEAD submodul"
-
-#: builtin/submodule--helper.c:2592
-msgid "git submodule--helper run-update-procedure [<options>] <path>"
-msgstr "git submodule--helper run-update-procedure [<opsi>] <jalur>"
-
-#: builtin/submodule--helper.c:2663
+#: builtin/submodule--helper.c:2481
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -22720,90 +23263,191 @@ msgstr ""
 "Cabang submodul (%s) dikonfigurasikan untuk mewarisi cabang dari proyek "
 "super, tapi proyek super tidak pada cabang apapun"
 
-#: builtin/submodule--helper.c:2781
+#: builtin/submodule--helper.c:2499
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "tidak dapat mendapat pegangan repositori untuk submodul '%s'"
 
-#: builtin/submodule--helper.c:2814
+#: builtin/submodule--helper.c:2588
+#, c-format
+msgid "Unable to find current revision in submodule path '%s'"
+msgstr "Tidak dapat menemukan revisi saat ini pada jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:2599
+#, c-format
+msgid "Unable to fetch in submodule path '%s'"
+msgstr "Tidak dapat mengambil pada jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:2604
+#, c-format
+msgid "Unable to find %s revision in submodule path '%s'"
+msgstr "Tidak dapat menemukan revisi %s pada jalur submodul '%s'"
+
+#: builtin/submodule--helper.c:2640
+#, c-format
+msgid "Failed to recurse into submodule path '%s'"
+msgstr "Gagal merekursi ke dalam submodul '%s'"
+
+#: builtin/submodule--helper.c:2699
+msgid "force checkout updates"
+msgstr "paksa pembaruan checkout"
+
+#: builtin/submodule--helper.c:2701
+msgid "initialize uninitialized submodules before update"
+msgstr "inisialisasi submodul yang belum diinisialisasi sebelum pembaruan"
+
+#: builtin/submodule--helper.c:2703
+msgid "use SHA-1 of submodule's remote tracking branch"
+msgstr "gunakan SHA-1 dari cabang pelacak remote submodul"
+
+#: builtin/submodule--helper.c:2705
+msgid "traverse submodules recursively"
+msgstr ""
+
+#: builtin/submodule--helper.c:2707
+msgid "don't fetch new objects from the remote site"
+msgstr "jangan ambil objek baru dari situs remote"
+
+#: builtin/submodule--helper.c:2710 builtin/submodule--helper.c:2892
+msgid "path into the working tree"
+msgstr "jalur ke dalam pohon kerja"
+
+#: builtin/submodule--helper.c:2713
+msgid "path into the working tree, across nested submodule boundaries"
+msgstr "jalur ke dalam pohon kerja, melintasi perbatasan submodul bersarang"
+
+#: builtin/submodule--helper.c:2717
+msgid "rebase, merge, checkout or none"
+msgstr "dasarkan ulang, gabungkan, checkout atau tidak sama sekali"
+
+#: builtin/submodule--helper.c:2723
+msgid "create a shallow clone truncated to the specified number of revisions"
+msgstr "buat klon dangkal terpotong hingga sejumlah revisi yang disebutkan"
+
+#: builtin/submodule--helper.c:2726
+msgid "parallel jobs"
+msgstr "pekerjaan paralel"
+
+#: builtin/submodule--helper.c:2728
+msgid "whether the initial clone should follow the shallow recommendation"
+msgstr "apakah klon awal seharusnya mengikuti rekomendasi dangkal"
+
+#: builtin/submodule--helper.c:2729
+msgid "don't print cloning progress"
+msgstr "jangan cetak perkembangan pengkloningan"
+
+#: builtin/submodule--helper.c:2741
+msgid ""
+"git submodule [--quiet] update [--init [--filter=<filter-spec>]] [--remote] "
+"[-N|--no-fetch] [-f|--force] [--checkout|--merge|--rebase] [--[no-]recommend-"
+"shallow] [--reference <repository>] [--recursive] [--[no-]single-branch] "
+"[--] [<path>...]"
+msgstr ""
+
+#: builtin/submodule--helper.c:2767
+msgid "bad value for update parameter"
+msgstr "nilai jelek untuk parameter pembaruan"
+
+#: builtin/submodule--helper.c:2893
 msgid "recurse into submodules"
 msgstr "rekursi ke dalam submodul"
 
-#: builtin/submodule--helper.c:2820
+#: builtin/submodule--helper.c:2899
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<opsi>] [<jalur>...]"
 
-#: builtin/submodule--helper.c:2876
+#: builtin/submodule--helper.c:2955
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "periksa apakah itu aman untuk menulis ke berkas .gitmodules"
 
-#: builtin/submodule--helper.c:2879
+#: builtin/submodule--helper.c:2958
 msgid "unset the config in the .gitmodules file"
 msgstr "batal setel konfigurasi dalam berkas .gitmodules"
 
-#: builtin/submodule--helper.c:2884
+#: builtin/submodule--helper.c:2963
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <nama> [<nilai>]"
 
-#: builtin/submodule--helper.c:2885
+#: builtin/submodule--helper.c:2964
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <nama>"
 
-#: builtin/submodule--helper.c:2886
-msgid "git submodule--helper config --check-writeable"
-msgstr "git submodule--helper config --check-writeable"
-
-#: builtin/submodule--helper.c:2905 builtin/submodule--helper.c:3121
-#: builtin/submodule--helper.c:3277
+#: builtin/submodule--helper.c:2984 builtin/submodule--helper.c:3238
+#: builtin/submodule--helper.c:3395
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "mohom pastikan berkas .gitmodules di dalam pohon kerja"
 
-#: builtin/submodule--helper.c:2921
+#: builtin/submodule--helper.c:3000
 msgid "suppress output for setting url of a submodule"
 msgstr "sembunyikan keluaran penyetelan url submodule"
 
-#: builtin/submodule--helper.c:2925
+#: builtin/submodule--helper.c:3004
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <jalur> <url baru>"
 
-#: builtin/submodule--helper.c:2958
+#: builtin/submodule--helper.c:3037
 msgid "set the default tracking branch to master"
 msgstr "setel cabang pelacak asali ke master"
 
-#: builtin/submodule--helper.c:2960
+#: builtin/submodule--helper.c:3039
 msgid "set the default tracking branch"
 msgstr "setel cabang pelacak asali"
 
-#: builtin/submodule--helper.c:2964
+#: builtin/submodule--helper.c:3043
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) <jalur>"
 
-#: builtin/submodule--helper.c:2965
+#: builtin/submodule--helper.c:3044
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <cabang> <jalur>"
 
-#: builtin/submodule--helper.c:2972
+#: builtin/submodule--helper.c:3051
 msgid "--branch or --default required"
 msgstr "--branch atau --default dibutuhkan"
 
-#: builtin/submodule--helper.c:3038
+#: builtin/submodule--helper.c:3072 builtin/submodule--helper.c:3375
+msgid "print only error messages"
+msgstr "hanya cetak pesan kesalahan"
+
+#: builtin/submodule--helper.c:3073
+msgid "force creation"
+msgstr "paksa pembuatan"
+
+#: builtin/submodule--helper.c:3081
+msgid "show whether the branch would be created"
+msgstr "perlihatkan apabila cabang akan dibuat"
+
+#: builtin/submodule--helper.c:3085
+msgid ""
+"git submodule--helper create-branch [-f|--force] [--create-reflog] [-q|--"
+"quiet] [-t|--track] [-n|--dry-run] <name> <start_oid> <start_name>"
+msgstr ""
+"git submodule--helper create-branch [-f|--force] [--create-reflog] [-q|--"
+"quiet] [-t|--track] [-n|--dry-run] <nama> <oid awal> <nama awal>"
+
+#: builtin/submodule--helper.c:3097
+#, c-format
+msgid "creating branch '%s'"
+msgstr "membuat cabang '%s'"
+
+#: builtin/submodule--helper.c:3155
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Menambahkan repo yang sudah ada pada '%s' ke indeks\n"
 
-#: builtin/submodule--helper.c:3041
+#: builtin/submodule--helper.c:3158
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "'%s' sudah ada dan bukan repo git valid"
 
-#: builtin/submodule--helper.c:3054
+#: builtin/submodule--helper.c:3171
 #, c-format
 msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr "Sebuah direktori git untuk '%s' ditemukan lokal dengan remote:\n"
 
-#: builtin/submodule--helper.c:3061
+#: builtin/submodule--helper.c:3178
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -22820,84 +23464,80 @@ msgstr ""
 "atau Anda tidak yakin apa maksudnya, pilih nama yang lain dengan opsi '--"
 "name'."
 
-#: builtin/submodule--helper.c:3073
+#: builtin/submodule--helper.c:3190
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Mengaktifkan ulang direktori git lokal untuk submodul '%s'\n"
 
-#: builtin/submodule--helper.c:3110
+#: builtin/submodule--helper.c:3227
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "Tidak dapat men-checkout submodul '%s'"
 
-#: builtin/submodule--helper.c:3149
+#: builtin/submodule--helper.c:3266
 #, c-format
 msgid "Failed to add submodule '%s'"
 msgstr "Tidak dapat menambahkan submodul '%s'"
 
-#: builtin/submodule--helper.c:3153 builtin/submodule--helper.c:3158
-#: builtin/submodule--helper.c:3166
+#: builtin/submodule--helper.c:3270 builtin/submodule--helper.c:3275
+#: builtin/submodule--helper.c:3283
 #, c-format
 msgid "Failed to register submodule '%s'"
 msgstr "Gagal mendaftarkan jalur submodul '%s'"
 
-#: builtin/submodule--helper.c:3222
+#: builtin/submodule--helper.c:3339
 #, c-format
 msgid "'%s' already exists in the index"
 msgstr "'%s' sudah ada di dalam indeks"
 
-#: builtin/submodule--helper.c:3225
+#: builtin/submodule--helper.c:3342
 #, c-format
 msgid "'%s' already exists in the index and is not a submodule"
 msgstr "'%s' sudah ada di dalam indeks dan bukan submodul"
 
-#: builtin/submodule--helper.c:3254
+#: builtin/submodule--helper.c:3372
 msgid "branch of repository to add as submodule"
 msgstr "cabang repositori untuk ditambahkan sebagai submodul"
 
-#: builtin/submodule--helper.c:3255
+#: builtin/submodule--helper.c:3373
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "perbolehkan menambah jalur submodul yang diabaikan"
 
-#: builtin/submodule--helper.c:3257
-msgid "print only error messages"
-msgstr "hanya cetak pesan kesalahan"
-
-#: builtin/submodule--helper.c:3261
+#: builtin/submodule--helper.c:3379
 msgid "borrow the objects from reference repositories"
 msgstr "pinjam objek dari repositori referensi"
 
-#: builtin/submodule--helper.c:3263
+#: builtin/submodule--helper.c:3381
 msgid ""
 "sets the submodule’s name to the given string instead of defaulting to its "
 "path"
 msgstr ""
 "setel nama submodul ke untai yang diberikan daripada diasalkan ke jalurnya"
 
-#: builtin/submodule--helper.c:3270
+#: builtin/submodule--helper.c:3388
 msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
 msgstr "git submodule--helper add [<opsi>] [--] <repositori> [<jalur>]"
 
-#: builtin/submodule--helper.c:3298
+#: builtin/submodule--helper.c:3416
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr "Jalur relatif hanya dapat digunakan dari level atas dari pohon kerja"
 
-#: builtin/submodule--helper.c:3306
+#: builtin/submodule--helper.c:3425
 #, c-format
 msgid "repo URL: '%s' must be absolute or begin with ./|../"
 msgstr "URL repo: '%s' harus absolut atau diawali dengan ./|../"
 
-#: builtin/submodule--helper.c:3341
+#: builtin/submodule--helper.c:3460
 #, c-format
 msgid "'%s' is not a valid submodule name"
 msgstr "'%s' bukan nama submodul yang valid"
 
-#: builtin/submodule--helper.c:3405 git.c:452 git.c:726
+#: builtin/submodule--helper.c:3520 git.c:453 git.c:729
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s tidak mendukung --super-prefix"
 
-#: builtin/submodule--helper.c:3411
+#: builtin/submodule--helper.c:3526
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' bukan subperintah submodule--helper valid"
@@ -22930,7 +23570,7 @@ msgstr "alasan"
 msgid "reason of the update"
 msgstr "alasan pembaruan"
 
-#: builtin/tag.c:25
+#: builtin/tag.c:26
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
 "        <tagname> [<head>]"
@@ -22938,11 +23578,11 @@ msgstr ""
 "git tag [-a | -s | -u <id kunci>] [-f] [-m <pesan | -F <berkas>]\n"
 "        <nama tag> [<kepala>]"
 
-#: builtin/tag.c:27
+#: builtin/tag.c:28
 msgid "git tag -d <tagname>..."
 msgstr "git tag -d <nama tag>..."
 
-#: builtin/tag.c:28
+#: builtin/tag.c:29
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
@@ -22954,21 +23594,21 @@ msgstr ""
 "        [--format=<format>] [--merged <komit>] [--no-merged <komit>] "
 "[<pola>...]"
 
-#: builtin/tag.c:30
+#: builtin/tag.c:31
 msgid "git tag -v [--format=<format>] <tagname>..."
 msgstr "git tag -v [--format]<format>] <nama tag>..."
 
-#: builtin/tag.c:100
+#: builtin/tag.c:101
 #, c-format
 msgid "tag '%s' not found."
 msgstr "tag '%s' tidak ditemukan."
 
-#: builtin/tag.c:135
+#: builtin/tag.c:136
 #, c-format
 msgid "Deleted tag '%s' (was %s)\n"
 msgstr "Tag '%s' (yaitu %s) dihapus\n"
 
-#: builtin/tag.c:170
+#: builtin/tag.c:171
 #, c-format
 msgid ""
 "\n"
@@ -22981,7 +23621,7 @@ msgstr ""
 "  %s\n"
 "Baris yang diawali dengan '%c' akan diabaikan.\n"
 
-#: builtin/tag.c:174
+#: builtin/tag.c:175
 #, c-format
 msgid ""
 "\n"
@@ -22996,11 +23636,11 @@ msgstr ""
 "Baris yang diawali dengan '%c' akan disimpan; Anda dapat menghapus itu bila "
 "Anda mau.\n"
 
-#: builtin/tag.c:240
+#: builtin/tag.c:241
 msgid "unable to sign the tag"
 msgstr "tidak dapat menandatangani tag"
 
-#: builtin/tag.c:258
+#: builtin/tag.c:259
 #, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -23014,118 +23654,122 @@ msgstr ""
 "\n"
 "\tgit tag -f %s %s^{}"
 
-#: builtin/tag.c:274
+#: builtin/tag.c:275
 msgid "bad object type."
 msgstr "tipe objek jelek."
 
-#: builtin/tag.c:325
+#: builtin/tag.c:326
 msgid "no tag message?"
 msgstr "tidak ada pesan tag?"
 
-#: builtin/tag.c:332
+#: builtin/tag.c:333
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Pesan tag dibiarkan di %s\n"
 
-#: builtin/tag.c:444
+#: builtin/tag.c:445
 msgid "list tag names"
 msgstr "daftarkan nama tag"
 
-#: builtin/tag.c:446
+#: builtin/tag.c:447
 msgid "print <n> lines of each tag message"
 msgstr "cetak <n> baris dari setiap pesan tag"
 
-#: builtin/tag.c:448
+#: builtin/tag.c:449
 msgid "delete tags"
 msgstr "hapus tag"
 
-#: builtin/tag.c:449
+#: builtin/tag.c:450
 msgid "verify tags"
 msgstr "verifikasi tag"
 
-#: builtin/tag.c:451
+#: builtin/tag.c:452
 msgid "Tag creation options"
 msgstr "Opsi pembuatan tag"
 
-#: builtin/tag.c:453
+#: builtin/tag.c:454
 msgid "annotated tag, needs a message"
 msgstr "tag bercatat, butuh sebuah pesan"
 
-#: builtin/tag.c:455
+#: builtin/tag.c:456
 msgid "tag message"
 msgstr "pesan tag"
 
-#: builtin/tag.c:457
+#: builtin/tag.c:458
 msgid "force edit of tag message"
 msgstr "paksa sunting pesan tag"
 
-#: builtin/tag.c:458
+#: builtin/tag.c:459
 msgid "annotated and GPG-signed tag"
 msgstr "tag bercatat dan bertandatangan GPG"
 
-#: builtin/tag.c:461
+#: builtin/tag.c:462
 msgid "use another key to sign the tag"
 msgstr "gunakan kunci yang lain untuk menandatangani tag"
 
-#: builtin/tag.c:462
+#: builtin/tag.c:463
 msgid "replace the tag if exists"
 msgstr "ganti tag jika ada"
 
-#: builtin/tag.c:463 builtin/update-ref.c:511
+#: builtin/tag.c:464 builtin/update-ref.c:511
 msgid "create a reflog"
 msgstr "buat log referensi"
 
-#: builtin/tag.c:465
+#: builtin/tag.c:466
 msgid "Tag listing options"
 msgstr "Opsi daftar tag"
 
-#: builtin/tag.c:466
+#: builtin/tag.c:467
 msgid "show tag list in columns"
 msgstr "perlihatkan daftar tag dalam kolom"
 
-#: builtin/tag.c:467 builtin/tag.c:469
+#: builtin/tag.c:468 builtin/tag.c:470
 msgid "print only tags that contain the commit"
 msgstr "hanya cetak tag yang berisi komit"
 
-#: builtin/tag.c:468 builtin/tag.c:470
+#: builtin/tag.c:469 builtin/tag.c:471
 msgid "print only tags that don't contain the commit"
 msgstr "hanya cetak tag yang tidak berisi komit"
 
-#: builtin/tag.c:471
+#: builtin/tag.c:472
 msgid "print only tags that are merged"
 msgstr "hanya cetak tag yang tergabung"
 
-#: builtin/tag.c:472
+#: builtin/tag.c:473
 msgid "print only tags that are not merged"
 msgstr "hanya cetak tag yang tak tergabung"
 
-#: builtin/tag.c:476
+#: builtin/tag.c:477
 msgid "print only tags of the object"
 msgstr "hanya cetak tag dari objek"
 
-#: builtin/tag.c:558
+#: builtin/tag.c:559
 #, c-format
 msgid "the '%s' option is only allowed in list mode"
 msgstr "opsi '%s' hanya diperbolehkan dalam mode daftar"
 
-#: builtin/tag.c:597
+#: builtin/tag.c:598
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "'%s' bukan nama tag yang valid."
 
-#: builtin/tag.c:602
+#: builtin/tag.c:603
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "tag '%s' sudah ada"
 
-#: builtin/tag.c:633
+#: builtin/tag.c:634
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Tag '%s' diperbarui (yaitu %s)\n"
 
+#: builtin/unpack-objects.c:95
+msgid "pack exceeds maximum allowed size"
+msgstr "paket melebihi ukuran maksimum yang diperbolehkan"
+
 #: builtin/unpack-objects.c:504
 msgid "Unpacking objects"
-msgstr ""
+msgstr "Membongkar objek"
 
 #: builtin/update-index.c:84
 #, c-format
@@ -23180,143 +23824,143 @@ msgstr " OK"
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr "git update-index [<opsi>] [--] [<berkas>...]"
 
-#: builtin/update-index.c:974
+#: builtin/update-index.c:993
 msgid "continue refresh even when index needs update"
 msgstr "lanjutkan penyegaran bahkan ketika indeks perlu diperbarui"
 
-#: builtin/update-index.c:977
+#: builtin/update-index.c:996
 msgid "refresh: ignore submodules"
 msgstr "refresh: abaikan submodul"
 
-#: builtin/update-index.c:980
+#: builtin/update-index.c:999
 msgid "do not ignore new files"
 msgstr "jangan abaikan berkas baru"
 
-#: builtin/update-index.c:982
+#: builtin/update-index.c:1001
 msgid "let files replace directories and vice-versa"
 msgstr "biarkan berkas menggantikan direktori dan sebaliknya"
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:1003
 msgid "notice files missing from worktree"
 msgstr "catat berkas hilang dari pohon kerja"
 
-#: builtin/update-index.c:986
+#: builtin/update-index.c:1005
 msgid "refresh even if index contains unmerged entries"
 msgstr "segarkan bahkan jika indeks berisi entri tak tergabung"
 
-#: builtin/update-index.c:989
+#: builtin/update-index.c:1008
 msgid "refresh stat information"
 msgstr "segarkan informasi stat"
 
-#: builtin/update-index.c:993
+#: builtin/update-index.c:1012
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr "seperti --refresh, tapi abaikan setelan assume-unchanged"
 
-#: builtin/update-index.c:997
+#: builtin/update-index.c:1016
 msgid "<mode>,<object>,<path>"
 msgstr "<mode>,<objek>,<jalur>"
 
-#: builtin/update-index.c:998
+#: builtin/update-index.c:1017
 msgid "add the specified entry to the index"
 msgstr "tambahkan entri yang disebutkan ke indeks"
 
-#: builtin/update-index.c:1008
+#: builtin/update-index.c:1027
 msgid "mark files as \"not changing\""
 msgstr "tandai berkas sebagai \"not changing\""
 
-#: builtin/update-index.c:1011
+#: builtin/update-index.c:1030
 msgid "clear assumed-unchanged bit"
 msgstr "bersihkan bita assumed-unchanged"
 
-#: builtin/update-index.c:1014
+#: builtin/update-index.c:1033
 msgid "mark files as \"index-only\""
 msgstr "tandai berkas sebagai \"index-only\""
 
-#: builtin/update-index.c:1017
+#: builtin/update-index.c:1036
 msgid "clear skip-worktree bit"
 msgstr "bersihkan bita skip-worktree"
 
-#: builtin/update-index.c:1020
+#: builtin/update-index.c:1039
 msgid "do not touch index-only entries"
 msgstr "jangan sentuh entri index-only"
 
-#: builtin/update-index.c:1022
+#: builtin/update-index.c:1041
 msgid "add to index only; do not add content to object database"
 msgstr "hanya tambahkan ke indeks; jangan tambahkan konten ke basis data objek"
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1043
 msgid "remove named paths even if present in worktree"
 msgstr "hapus jalur bernama bahkan jika ada dalam pohon kerja"
 
-#: builtin/update-index.c:1026
+#: builtin/update-index.c:1045
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr "dengan --stdin: baris masukan diakhiri dengan bita null"
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1047
 msgid "read list of paths to be updated from standard input"
 msgstr "baca daftar jalur yang akan diperbarui dari masukan standar"
 
-#: builtin/update-index.c:1032
+#: builtin/update-index.c:1051
 msgid "add entries from standard input to the index"
 msgstr "tambahkan entri dari masukan standar ke indeks"
 
-#: builtin/update-index.c:1036
+#: builtin/update-index.c:1055
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr "populasi ulang tahapan #2 dan #3 untuk jalur yang terdaftar"
 
-#: builtin/update-index.c:1040
+#: builtin/update-index.c:1059
 msgid "only update entries that differ from HEAD"
 msgstr "hanya perbarui entri yang berbeda dari HEAD"
 
-#: builtin/update-index.c:1044
+#: builtin/update-index.c:1063
 msgid "ignore files missing from worktree"
 msgstr "abaikan berkas yang hilang dari pohon kerja"
 
-#: builtin/update-index.c:1047
+#: builtin/update-index.c:1066
 msgid "report actions to standard output"
 msgstr "laporkan aksi ke keluaran standar"
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1068
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr "(untuk porselen) lupakan konflik tak terselesaikan yang disimpan"
 
-#: builtin/update-index.c:1053
+#: builtin/update-index.c:1072
 msgid "write index in this format"
 msgstr "tulis indeks dalam format ini"
 
-#: builtin/update-index.c:1055
+#: builtin/update-index.c:1074
 msgid "enable or disable split index"
 msgstr "aktifkan atau nonaktifkan indeks terpisah"
 
-#: builtin/update-index.c:1057
+#: builtin/update-index.c:1076
 msgid "enable/disable untracked cache"
 msgstr "aktifkan/nonaktifkan tembolok tak terlacak"
 
-#: builtin/update-index.c:1059
+#: builtin/update-index.c:1078
 msgid "test if the filesystem supports untracked cache"
 msgstr "uji jika sistem berkas mendukung tembolok tak terlacak"
 
-#: builtin/update-index.c:1061
+#: builtin/update-index.c:1080
 msgid "enable untracked cache without testing the filesystem"
 msgstr "aktifkan tembolok tak terlacak tanpa menguji sistem berkas"
 
-#: builtin/update-index.c:1063
+#: builtin/update-index.c:1082
 msgid "write out the index even if is not flagged as changed"
 msgstr "tulis indeks bahkan jika tidak dianggap berubah"
 
-#: builtin/update-index.c:1065
+#: builtin/update-index.c:1084
 msgid "enable or disable file system monitor"
 msgstr "aktifkan atau nonaktifkan monitor sistem berkas"
 
-#: builtin/update-index.c:1067
+#: builtin/update-index.c:1086
 msgid "mark files as fsmonitor valid"
 msgstr "tandai berkas sebagai fsmonitor valid"
 
-#: builtin/update-index.c:1070
+#: builtin/update-index.c:1089
 msgid "clear fsmonitor valid bit"
 msgstr "bersihkan bita fsmonitor valid"
 
-#: builtin/update-index.c:1173
+#: builtin/update-index.c:1195
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
@@ -23324,7 +23968,7 @@ msgstr ""
 "core.splitIndex disetel ke false; hapus atau ubah, jika Anda benar-benar "
 "ingin mengaktifkan indeks terpisah"
 
-#: builtin/update-index.c:1182
+#: builtin/update-index.c:1204
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
@@ -23332,7 +23976,7 @@ msgstr ""
 "core.splitIndex disetel ke true; hapus atau ubah, jika Anda benar-benar  "
 "ingin menonaktifkan indeks terpisah"
 
-#: builtin/update-index.c:1194
+#: builtin/update-index.c:1216
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
@@ -23340,11 +23984,11 @@ msgstr ""
 "core.untrackedCache disetel ke true; hapus atau ubah, jika Anda benar-benar "
 "ingin menonaktifkan tembolok tak terlacak"
 
-#: builtin/update-index.c:1198
+#: builtin/update-index.c:1220
 msgid "Untracked cache disabled"
 msgstr "Tembolok tak terlacak dinonaktifkan"
 
-#: builtin/update-index.c:1206
+#: builtin/update-index.c:1228
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
@@ -23352,29 +23996,29 @@ msgstr ""
 "core.untrackedCache disetel ke false; hapus atau ubah, jika Anda benar-benar "
 "ingin mengaktifkan tembolok tak terlacak"
 
-#: builtin/update-index.c:1210
+#: builtin/update-index.c:1232
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr "Tembolok tak terlacak diaktifkan untuk '%s'"
 
-#: builtin/update-index.c:1218
+#: builtin/update-index.c:1241
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
 "core.fsmonitor tak disetel; setel jika Anda benar-benar ingin mengaktifkan "
 "fsmonitor"
 
-#: builtin/update-index.c:1222
+#: builtin/update-index.c:1246
 msgid "fsmonitor enabled"
 msgstr "fsmonitor diaktifkan"
 
-#: builtin/update-index.c:1225
+#: builtin/update-index.c:1250
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
 "core.fsmonitor disetel; hapus jika Anda benar-benar ingin menonaktifkan "
 "fsmonitor"
 
-#: builtin/update-index.c:1229
+#: builtin/update-index.c:1254
 msgid "fsmonitor disabled"
 msgstr "fsmonitor dinonaktifkan"
 
@@ -23406,10 +24050,6 @@ msgstr "stdin punya argumen yang diakhiri dengan NUL"
 #: builtin/update-ref.c:510
 msgid "read updates from stdin"
 msgstr "baca pembaruan dari masukan standar"
-
-#: builtin/update-server-info.c:7
-msgid "git update-server-info [--force]"
-msgstr ""
 
 #: builtin/update-server-info.c:15
 msgid "update the info files from scratch"
@@ -23469,258 +24109,300 @@ msgstr "cetak isi tag"
 
 #: builtin/worktree.c:19
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
-msgstr ""
+msgstr "git worktree add [<opsi>] <jalur> [<mirip komit>]"
 
 #: builtin/worktree.c:20
 msgid "git worktree list [<options>]"
-msgstr ""
+msgstr "git worktree list [<opsi>]"
 
 #: builtin/worktree.c:21
 msgid "git worktree lock [<options>] <path>"
-msgstr ""
+msgstr "git worktree lock [<opsi>] <jalur>"
 
 #: builtin/worktree.c:22
 msgid "git worktree move <worktree> <new-path>"
-msgstr ""
+msgstr "git worktree move <pohon kerja> <jalur baru>"
 
 #: builtin/worktree.c:23
 msgid "git worktree prune [<options>]"
-msgstr ""
+msgstr "git worktree prune [<opsi>]"
 
 #: builtin/worktree.c:24
 msgid "git worktree remove [<options>] <worktree>"
-msgstr ""
+msgstr "git worktree remove [<opsi>] <pohon kerja>"
 
 #: builtin/worktree.c:25
-msgid "git worktree unlock <path>"
-msgstr ""
+msgid "git worktree repair [<path>...]"
+msgstr "git worktree repair [<jalur>...]"
 
-#: builtin/worktree.c:75
+#: builtin/worktree.c:26
+msgid "git worktree unlock <path>"
+msgstr "git worktree unlock <jalur>"
+
+#: builtin/worktree.c:76
 #, c-format
 msgid "Removing %s/%s: %s"
-msgstr ""
+msgstr "Menghapus %s/%s: %s"
 
-#: builtin/worktree.c:148
+#: builtin/worktree.c:149
 msgid "report pruned working trees"
-msgstr ""
+msgstr "laporkan pohon kerja terpangkas"
 
-#: builtin/worktree.c:150
+#: builtin/worktree.c:151
 msgid "expire working trees older than <time>"
-msgstr ""
+msgstr "kadaluarsakan pohon kerja yang lebih tua dari <waktu>"
 
-#: builtin/worktree.c:220
+#: builtin/worktree.c:221
 #, c-format
 msgid "'%s' already exists"
-msgstr ""
+msgstr "'%s' sudah ada"
 
-#: builtin/worktree.c:229
+#: builtin/worktree.c:230
 #, c-format
 msgid "unusable worktree destination '%s'"
-msgstr ""
+msgstr "tujuan pohon kerja '%s' tidak dapat diguanakan"
 
-#: builtin/worktree.c:234
+#: builtin/worktree.c:235
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
 "use '%s -f -f' to override, or 'unlock' and 'prune' or 'remove' to clear"
 msgstr ""
+"'%s' adalah pohon kerja hilang tapi terkunci;\n"
+"gunakan '%s -f -f' untuk menimpa, atau 'unlock' dan 'prune' atau 'remove' "
+"untuk membersihkan"
 
-#: builtin/worktree.c:236
+#: builtin/worktree.c:237
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
 "use '%s -f' to override, or 'prune' or 'remove' to clear"
 msgstr ""
+"'%s' adalah pohon kerja hilang tapi telah didaftarkan;\n"
+"gunakan '%s -f' untuk menimpa, atau 'prune' atau 'remove' untuk membersihkan"
 
-#: builtin/worktree.c:287
+#: builtin/worktree.c:248
+#, c-format
+msgid "failed to copy '%s' to '%s'; sparse-checkout may not work correctly"
+msgstr ""
+"gagal menyalin '%s' ke '%s'; checkout tipis mungkin tidak bekerja dengan baik"
+
+#: builtin/worktree.c:268
+#, c-format
+msgid "failed to copy worktree config from '%s' to '%s'"
+msgstr "Gagal menyalin konfigurasi pohon kerja dari '%s' ke '%s'"
+
+#: builtin/worktree.c:280 builtin/worktree.c:285
+#, c-format
+msgid "failed to unset '%s' in '%s'"
+msgstr "gagal menyetel balik '%s' di '%s'"
+
+#: builtin/worktree.c:356
 #, c-format
 msgid "could not create directory of '%s'"
-msgstr ""
+msgstr "tidak dapat membuat direktori '%s'"
 
-#: builtin/worktree.c:309
+#: builtin/worktree.c:378
 msgid "initializing"
-msgstr ""
+msgstr "menginisialisasi"
 
-#: builtin/worktree.c:420 builtin/worktree.c:426
+#: builtin/worktree.c:492 builtin/worktree.c:498
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
-msgstr ""
+msgstr "Menyiapkan pohon kerja (cabang baru '%s')"
 
-#: builtin/worktree.c:422
+#: builtin/worktree.c:494
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr ""
+"Menyiapkan pohon kerja (menyetel ulang cabang '%s'; sebelumnya pada %s)"
 
-#: builtin/worktree.c:431
+#: builtin/worktree.c:503
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
-msgstr ""
+msgstr "Menyiapkan pohon kerja (men-checkout '%s')"
 
-#: builtin/worktree.c:437
+#: builtin/worktree.c:509
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
-msgstr ""
+msgstr "Menyiapkan pohon kerja (HEAD terpisah %s)"
 
-#: builtin/worktree.c:482
+#: builtin/worktree.c:554
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
+"checkout <cabang> bahkan jika sudah di-checkout pada pohon kerja lainnya"
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:557
 msgid "create a new branch"
-msgstr ""
+msgstr "buat sebuah cabang baru"
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:559
 msgid "create or reset a branch"
-msgstr ""
+msgstr "buat atau setel ulang sebuah cabang"
 
-#: builtin/worktree.c:489
+#: builtin/worktree.c:561
 msgid "populate the new working tree"
-msgstr ""
+msgstr "isikan pohon kerja baru"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:562
 msgid "keep the new working tree locked"
-msgstr ""
+msgstr "tetap pohon kerja baru terkunci"
 
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/worktree.c:564 builtin/worktree.c:809
 msgid "reason for locking"
-msgstr ""
+msgstr "alasan penguncian"
 
-#: builtin/worktree.c:495
+#: builtin/worktree.c:567
 msgid "set up tracking mode (see git-branch(1))"
-msgstr ""
+msgstr "pasang mode pelacakan (lihat git-branch(1))"
 
-#: builtin/worktree.c:498
+#: builtin/worktree.c:570
 msgid "try to match the new branch name with a remote-tracking branch"
-msgstr ""
+msgstr "coba cocokkan nama cabang baru dengan sebuah cabang pelacakan remote"
 
-#: builtin/worktree.c:512
+#: builtin/worktree.c:584
 msgid "added with --lock"
-msgstr ""
+msgstr "tambahkan dengan --lock"
 
-#: builtin/worktree.c:574
+#: builtin/worktree.c:646
 msgid "--[no-]track can only be used if a new branch is created"
-msgstr ""
+msgstr "--[no-]track hanya dapat digunakan jika cabang baru dibuat"
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:766
 msgid "show extended annotations and reasons, if available"
 msgstr ""
 
-#: builtin/worktree.c:693
+#: builtin/worktree.c:768
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
+"tambahkan anotasi 'dapat dipangkas' ke pohon kerja lebih tua dari <time>"
 
-#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
-#: builtin/worktree.c:972
+#: builtin/worktree.c:770
+msgid "terminate records with a NUL character"
+msgstr "akhiri rekaman dengan karakter NUL"
+
+#: builtin/worktree.c:821 builtin/worktree.c:854 builtin/worktree.c:928
+#: builtin/worktree.c:1052
 #, c-format
 msgid "'%s' is not a working tree"
-msgstr ""
+msgstr "'%s' bukan sebuah pohon kerja"
 
-#: builtin/worktree.c:743 builtin/worktree.c:776
+#: builtin/worktree.c:823 builtin/worktree.c:856
 msgid "The main working tree cannot be locked or unlocked"
-msgstr ""
+msgstr "Pohon kerja utama tidak dapat dikunci atau dibuka kunci"
 
-#: builtin/worktree.c:748
+#: builtin/worktree.c:828
 #, c-format
 msgid "'%s' is already locked, reason: %s"
-msgstr ""
+msgstr "'%s' sudah terkunci, alasan: %s"
 
-#: builtin/worktree.c:750
+#: builtin/worktree.c:830
 #, c-format
 msgid "'%s' is already locked"
-msgstr ""
+msgstr "'%s' sudah terkunci"
 
-#: builtin/worktree.c:778
+#: builtin/worktree.c:858
 #, c-format
 msgid "'%s' is not locked"
-msgstr ""
+msgstr "'%s' tidak terkunci"
 
-#: builtin/worktree.c:819
+#: builtin/worktree.c:899
 msgid "working trees containing submodules cannot be moved or removed"
-msgstr ""
+msgstr "pohon kerja yang berisi submodul tidak dapat dipindahkan atau dihapus"
 
-#: builtin/worktree.c:827
+#: builtin/worktree.c:907
 msgid "force move even if worktree is dirty or locked"
-msgstr ""
+msgstr "paksa pindah bahkan jika pohon kerja kotor atau terkunci"
 
-#: builtin/worktree.c:850 builtin/worktree.c:974
+#: builtin/worktree.c:930 builtin/worktree.c:1054
 #, c-format
 msgid "'%s' is a main working tree"
-msgstr ""
+msgstr "'%s' adalah pohon kerja utama"
 
-#: builtin/worktree.c:855
+#: builtin/worktree.c:935
 #, c-format
 msgid "could not figure out destination name from '%s'"
-msgstr ""
+msgstr "tidak dapat menebak nama tujuan dari '%s'"
 
-#: builtin/worktree.c:868
+#: builtin/worktree.c:948
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
+"tidak dapat memindahkan pohon kerja terkunci, alasan penguncian: %s\n"
+"gunakan 'move -f -f' untuk memaksakan atau membuka kunci terlebih dahulu"
 
-#: builtin/worktree.c:870
+#: builtin/worktree.c:950
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
+"tidak dapat memindahkan pohon kerja terkunci;\n"
+"gunakan 'move -f -f' untuk memaksakan atau membuka kunci terlebih dahulu"
 
-#: builtin/worktree.c:873
+#: builtin/worktree.c:953
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
-msgstr ""
+msgstr "validasi gagal, tidak dapat memindahkan pohon kerja: %s"
 
-#: builtin/worktree.c:878
+#: builtin/worktree.c:958
 #, c-format
 msgid "failed to move '%s' to '%s'"
-msgstr ""
+msgstr "gagal memindahkan '%s' ke '%s'"
 
-#: builtin/worktree.c:924
+#: builtin/worktree.c:1004
 #, c-format
 msgid "failed to run 'git status' on '%s'"
-msgstr ""
+msgstr "tidak dapat menjalankan 'git status' pada '%s'"
 
-#: builtin/worktree.c:928
+#: builtin/worktree.c:1008
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
+"'%s' berisi berkas termodifikasi atau tak terlacak, gunakan --force untuk "
+"menghapus"
 
-#: builtin/worktree.c:933
+#: builtin/worktree.c:1013
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
-msgstr ""
+msgstr "gagal menjalankan 'git status' pada '%s', kode %d"
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:1036
 msgid "force removal even if worktree is dirty or locked"
-msgstr ""
+msgstr "paksa penghapusan bahkan jika pohon kerja kotor atau terkunci"
 
-#: builtin/worktree.c:979
+#: builtin/worktree.c:1059
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
+"tidak dapat menghapus pohon kerja terkunci, alasan penguncian: %s\n"
+"gunakan 'remove -f -f' untuk memaksakan atau buka kunci terlebih dahulu"
 
-#: builtin/worktree.c:981
+#: builtin/worktree.c:1061
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
+"tidak dapat menghapus pohon kerja terkunci;\n"
+"gunakan 'remove -f -f' untuk memaksakan atau buka kunci terlebih dahulu"
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:1064
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
-msgstr ""
+msgstr "validasi gagal, tidak dapat menghapus pohon kerja: %s"
 
-#: builtin/worktree.c:1008
+#: builtin/worktree.c:1088
 #, c-format
 msgid "repair: %s: %s"
-msgstr ""
+msgstr "perbaikan: %s: %s"
 
-#: builtin/worktree.c:1011
+#: builtin/worktree.c:1091
 #, c-format
 msgid "error: %s: %s"
-msgstr ""
+msgstr "kesalahan: %s: %s"
 
 #: builtin/write-tree.c:15
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
@@ -23823,29 +24505,29 @@ msgstr "alias kosong untuk %s"
 msgid "recursive alias: %s"
 msgstr "alias rekursif: %s"
 
-#: git.c:479
+#: git.c:480
 msgid "write failure on standard output"
 msgstr "kegagalan menulis pada keluaran standar"
 
-#: git.c:481
+#: git.c:482
 msgid "unknown write failure on standard output"
 msgstr "kegagal menulis tidak diketahui pada keluaran standar"
 
-#: git.c:483
+#: git.c:484
 msgid "close failed on standard output"
 msgstr "penutupan gagal pada keluaran standar"
 
-#: git.c:835
+#: git.c:838
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "putaran alias terdeteksi: perluasan '%s' tidak berhenti:%s"
 
-#: git.c:885
+#: git.c:888
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "tidak dapat menangani %s sebagai bawaan"
 
-#: git.c:898
+#: git.c:901
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -23854,12 +24536,12 @@ msgstr ""
 "penggunaan: %s\n"
 "\n"
 
-#: git.c:918
+#: git.c:921
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "perluasan alias '%s' gagal; '%s' bukan sebuah perintah git\n"
 
-#: git.c:930
+#: git.c:933
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "gagal menjalankan perintah '%s': %s\n"
@@ -24008,139 +24690,139 @@ msgid ""
 "   redirect: %s"
 msgstr ""
 
-#: remote-curl.c:183
+#: remote-curl.c:184
 #, c-format
 msgid "invalid quoting in push-option value: '%s'"
 msgstr ""
 
-#: remote-curl.c:304
+#: remote-curl.c:308
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr ""
 
-#: remote-curl.c:405
+#: remote-curl.c:409
 msgid "invalid server response; expected service, got flush packet"
 msgstr ""
 
-#: remote-curl.c:436
+#: remote-curl.c:440
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr ""
 
-#: remote-curl.c:496
+#: remote-curl.c:500
 #, c-format
 msgid "repository '%s' not found"
 msgstr ""
 
-#: remote-curl.c:500
+#: remote-curl.c:504
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr ""
 
-#: remote-curl.c:504
+#: remote-curl.c:508
 #, c-format
 msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
 msgstr ""
 
-#: remote-curl.c:508
+#: remote-curl.c:512
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr ""
 
-#: remote-curl.c:514
+#: remote-curl.c:518
 #, c-format
 msgid "redirecting to %s"
 msgstr ""
 
-#: remote-curl.c:645
+#: remote-curl.c:649
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr ""
 
-#: remote-curl.c:657
+#: remote-curl.c:661
 msgid "remote server sent unexpected response end packet"
 msgstr ""
 
-#: remote-curl.c:726
+#: remote-curl.c:730
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
 
-#: remote-curl.c:755
+#: remote-curl.c:759
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr ""
 
-#: remote-curl.c:757
+#: remote-curl.c:761
 msgid "remote-curl: unexpected response end packet"
 msgstr ""
 
-#: remote-curl.c:833
+#: remote-curl.c:837
 #, c-format
 msgid "RPC failed; %s"
 msgstr ""
 
-#: remote-curl.c:873
+#: remote-curl.c:877
 msgid "cannot handle pushes this big"
-msgstr ""
-
-#: remote-curl.c:986
-#, c-format
-msgid "cannot deflate request; zlib deflate error %d"
 msgstr ""
 
 #: remote-curl.c:990
 #, c-format
+msgid "cannot deflate request; zlib deflate error %d"
+msgstr ""
+
+#: remote-curl.c:994
+#, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr ""
 
-#: remote-curl.c:1040
+#: remote-curl.c:1044
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr ""
 
-#: remote-curl.c:1042
+#: remote-curl.c:1046
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr ""
 
-#: remote-curl.c:1131
+#: remote-curl.c:1135
 msgid "dumb http transport does not support shallow capabilities"
 msgstr ""
 
-#: remote-curl.c:1146
+#: remote-curl.c:1150
 msgid "fetch failed."
 msgstr ""
 
-#: remote-curl.c:1192
+#: remote-curl.c:1198
 msgid "cannot fetch by sha1 over smart http"
 msgstr ""
 
-#: remote-curl.c:1236 remote-curl.c:1242
+#: remote-curl.c:1242 remote-curl.c:1248
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr ""
 
-#: remote-curl.c:1254 remote-curl.c:1372
+#: remote-curl.c:1260 remote-curl.c:1378
 #, c-format
 msgid "http transport does not support %s"
 msgstr ""
 
-#: remote-curl.c:1290
+#: remote-curl.c:1296
 msgid "git-http-push failed"
 msgstr ""
 
-#: remote-curl.c:1478
+#: remote-curl.c:1485
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr ""
 
-#: remote-curl.c:1510
+#: remote-curl.c:1517
 msgid "remote-curl: error reading command stream from git"
 msgstr ""
 
-#: remote-curl.c:1517
+#: remote-curl.c:1524
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr ""
 
-#: remote-curl.c:1558
+#: remote-curl.c:1565
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr ""
@@ -24153,158 +24835,171 @@ msgstr ""
 msgid "could not find enlistment root"
 msgstr ""
 
-#: contrib/scalar/scalar.c:89 contrib/scalar/scalar.c:351
-#: contrib/scalar/scalar.c:436 contrib/scalar/scalar.c:579
+#: contrib/scalar/scalar.c:89 contrib/scalar/scalar.c:350
+#: contrib/scalar/scalar.c:435 contrib/scalar/scalar.c:578
 #, c-format
 msgid "could not switch to '%s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:180
+#: contrib/scalar/scalar.c:179
 #, c-format
 msgid "could not configure %s=%s"
 msgstr ""
 
-#: contrib/scalar/scalar.c:198
+#: contrib/scalar/scalar.c:197
 msgid "could not configure log.excludeDecoration"
 msgstr ""
 
-#: contrib/scalar/scalar.c:219
+#: contrib/scalar/scalar.c:218
 msgid "Scalar enlistments require a worktree"
 msgstr ""
 
-#: contrib/scalar/scalar.c:311
+#: contrib/scalar/scalar.c:310
 #, c-format
 msgid "remote HEAD is not a branch: '%.*s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:317
+#: contrib/scalar/scalar.c:316
 msgid "failed to get default branch name from remote; using local default"
 msgstr ""
 
-#: contrib/scalar/scalar.c:330
+#: contrib/scalar/scalar.c:329
 msgid "failed to get default branch name"
 msgstr ""
 
-#: contrib/scalar/scalar.c:341
+#: contrib/scalar/scalar.c:340
 msgid "failed to unregister repository"
 msgstr ""
 
-#: contrib/scalar/scalar.c:356
+#: contrib/scalar/scalar.c:355
 msgid "failed to delete enlistment directory"
 msgstr ""
 
-#: contrib/scalar/scalar.c:376
+#: contrib/scalar/scalar.c:375
 msgid "branch to checkout after clone"
 msgstr ""
 
-#: contrib/scalar/scalar.c:378
+#: contrib/scalar/scalar.c:377
 msgid "when cloning, create full working directory"
 msgstr ""
 
-#: contrib/scalar/scalar.c:380
+#: contrib/scalar/scalar.c:379
 msgid "only download metadata for the branch that will be checked out"
 msgstr ""
 
-#: contrib/scalar/scalar.c:385
+#: contrib/scalar/scalar.c:384
 msgid "scalar clone [<options>] [--] <repo> [<dir>]"
 msgstr ""
 
-#: contrib/scalar/scalar.c:410
+#: contrib/scalar/scalar.c:409
 #, c-format
 msgid "cannot deduce worktree name from '%s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:419
+#: contrib/scalar/scalar.c:418
 #, c-format
 msgid "directory '%s' exists already"
 msgstr ""
 
-#: contrib/scalar/scalar.c:446
+#: contrib/scalar/scalar.c:445
 #, c-format
 msgid "failed to get default branch for '%s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:457
+#: contrib/scalar/scalar.c:456
 #, c-format
 msgid "could not configure remote in '%s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:466
+#: contrib/scalar/scalar.c:465
 #, c-format
 msgid "could not configure '%s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:469
+#: contrib/scalar/scalar.c:468
 msgid "partial clone failed; attempting full clone"
 msgstr ""
 
-#: contrib/scalar/scalar.c:473
+#: contrib/scalar/scalar.c:472
 msgid "could not configure for full clone"
 msgstr ""
 
-#: contrib/scalar/scalar.c:505
+#: contrib/scalar/scalar.c:504
 msgid "`scalar list` does not take arguments"
 msgstr ""
 
-#: contrib/scalar/scalar.c:518
+#: contrib/scalar/scalar.c:517
 msgid "scalar register [<enlistment>]"
 msgstr ""
 
-#: contrib/scalar/scalar.c:545
+#: contrib/scalar/scalar.c:544
 msgid "reconfigure all registered enlistments"
 msgstr ""
 
-#: contrib/scalar/scalar.c:549
+#: contrib/scalar/scalar.c:548
 msgid "scalar reconfigure [--all | <enlistment>]"
 msgstr ""
 
-#: contrib/scalar/scalar.c:567
+#: contrib/scalar/scalar.c:566
 msgid "--all or <enlistment>, but not both"
 msgstr ""
 
-#: contrib/scalar/scalar.c:582
+#: contrib/scalar/scalar.c:581
 #, c-format
 msgid "git repository gone in '%s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:622
+#: contrib/scalar/scalar.c:621
 msgid ""
 "scalar run <task> [<enlistment>]\n"
 "Tasks:\n"
 msgstr ""
 
-#: contrib/scalar/scalar.c:640
+#: contrib/scalar/scalar.c:639
 #, c-format
 msgid "no such task: '%s'"
 msgstr ""
 
-#: contrib/scalar/scalar.c:690
+#: contrib/scalar/scalar.c:689
 msgid "scalar unregister [<enlistment>]"
 msgstr ""
 
-#: contrib/scalar/scalar.c:737
+#: contrib/scalar/scalar.c:736
 msgid "scalar delete <enlistment>"
 msgstr ""
 
-#: contrib/scalar/scalar.c:752
+#: contrib/scalar/scalar.c:751
 msgid "refusing to delete current working directory"
 msgstr ""
 
-#: contrib/scalar/scalar.c:767
+#: contrib/scalar/scalar.c:766
 msgid "include Git version"
 msgstr ""
 
-#: contrib/scalar/scalar.c:769
+#: contrib/scalar/scalar.c:768
 msgid "include Git's build options"
 msgstr ""
 
-#: contrib/scalar/scalar.c:773
+#: contrib/scalar/scalar.c:772
 msgid "scalar verbose [-v | --verbose] [--build-options]"
 msgstr ""
 
+#: contrib/scalar/scalar.c:813
+msgid "-C requires a <directory>"
+msgstr ""
+
+#: contrib/scalar/scalar.c:815
+#, c-format
+msgid "could not change to '%s'"
+msgstr ""
+
 #: contrib/scalar/scalar.c:821
+msgid "-c requires a <key>=<value> argument"
+msgstr ""
+
+#: contrib/scalar/scalar.c:839
 msgid ""
-"scalar <command> [<options>]\n"
+"scalar [-C <directory>] [-c <key>=<value>] <command> [<options>]\n"
 "\n"
 "Commands:\n"
 msgstr ""
@@ -24317,43 +25012,43 @@ msgstr ""
 msgid "no libc information available\n"
 msgstr ""
 
-#: list-objects-filter-options.h:94
+#: list-objects-filter-options.h:126
 msgid "args"
 msgstr ""
 
-#: list-objects-filter-options.h:95
+#: list-objects-filter-options.h:127
 msgid "object filtering"
 msgstr ""
 
-#: parse-options.h:183
+#: parse-options.h:188
 msgid "expiry-date"
 msgstr ""
 
-#: parse-options.h:197
+#: parse-options.h:202
 msgid "no-op (backward compatibility)"
 msgstr ""
 
-#: parse-options.h:310
+#: parse-options.h:341
 msgid "be more verbose"
 msgstr ""
 
-#: parse-options.h:312
+#: parse-options.h:343
 msgid "be more quiet"
 msgstr ""
 
-#: parse-options.h:318
+#: parse-options.h:349
 msgid "use <n> digits to display object names"
 msgstr ""
 
-#: parse-options.h:337
+#: parse-options.h:368
 msgid "how to strip spaces and #comments from message"
 msgstr ""
 
-#: parse-options.h:338
+#: parse-options.h:369
 msgid "read pathspec from file"
 msgstr ""
 
-#: parse-options.h:339
+#: parse-options.h:370
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
@@ -24603,446 +25298,450 @@ msgid "Display help information about Git"
 msgstr ""
 
 #: command-list.h:108
-msgid "Server side implementation of Git over HTTP"
+msgid "Run git hooks"
 msgstr ""
 
 #: command-list.h:109
-msgid "Download from a remote Git repository via HTTP"
+msgid "Server side implementation of Git over HTTP"
 msgstr ""
 
 #: command-list.h:110
-msgid "Push objects over HTTP/DAV to another repository"
+msgid "Download from a remote Git repository via HTTP"
 msgstr ""
 
 #: command-list.h:111
-msgid "Send a collection of patches from stdin to an IMAP folder"
+msgid "Push objects over HTTP/DAV to another repository"
 msgstr ""
 
 #: command-list.h:112
-msgid "Build pack index file for an existing packed archive"
+msgid "Send a collection of patches from stdin to an IMAP folder"
 msgstr ""
 
 #: command-list.h:113
-msgid "Create an empty Git repository or reinitialize an existing one"
+msgid "Build pack index file for an existing packed archive"
 msgstr ""
 
 #: command-list.h:114
-msgid "Instantly browse your working repository in gitweb"
+msgid "Create an empty Git repository or reinitialize an existing one"
 msgstr ""
 
 #: command-list.h:115
-msgid "Add or parse structured information in commit messages"
+msgid "Instantly browse your working repository in gitweb"
 msgstr ""
 
 #: command-list.h:116
-msgid "Show commit logs"
+msgid "Add or parse structured information in commit messages"
 msgstr ""
 
 #: command-list.h:117
-msgid "Show information about files in the index and the working tree"
+msgid "Show commit logs"
 msgstr ""
 
 #: command-list.h:118
-msgid "List references in a remote repository"
+msgid "Show information about files in the index and the working tree"
 msgstr ""
 
 #: command-list.h:119
-msgid "List the contents of a tree object"
+msgid "List references in a remote repository"
 msgstr ""
 
 #: command-list.h:120
-msgid "Extracts patch and authorship from a single e-mail message"
+msgid "List the contents of a tree object"
 msgstr ""
 
 #: command-list.h:121
-msgid "Simple UNIX mbox splitter program"
+msgid "Extracts patch and authorship from a single e-mail message"
 msgstr ""
 
 #: command-list.h:122
-msgid "Run tasks to optimize Git repository data"
+msgid "Simple UNIX mbox splitter program"
 msgstr ""
 
 #: command-list.h:123
-msgid "Join two or more development histories together"
+msgid "Run tasks to optimize Git repository data"
 msgstr ""
 
 #: command-list.h:124
-msgid "Find as good common ancestors as possible for a merge"
+msgid "Join two or more development histories together"
 msgstr ""
 
 #: command-list.h:125
-msgid "Run a three-way file merge"
+msgid "Find as good common ancestors as possible for a merge"
 msgstr ""
 
 #: command-list.h:126
-msgid "Run a merge for files needing merging"
+msgid "Run a three-way file merge"
 msgstr ""
 
 #: command-list.h:127
-msgid "The standard helper program to use with git-merge-index"
+msgid "Run a merge for files needing merging"
 msgstr ""
 
 #: command-list.h:128
-msgid "Show three-way merge without touching index"
+msgid "The standard helper program to use with git-merge-index"
 msgstr ""
 
 #: command-list.h:129
-msgid "Run merge conflict resolution tools to resolve merge conflicts"
+msgid "Show three-way merge without touching index"
 msgstr ""
 
 #: command-list.h:130
-msgid "Creates a tag object with extra validation"
+msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 
 #: command-list.h:131
-msgid "Build a tree-object from ls-tree formatted text"
+msgid "Creates a tag object with extra validation"
 msgstr ""
 
 #: command-list.h:132
-msgid "Write and verify multi-pack-indexes"
+msgid "Build a tree-object from ls-tree formatted text"
 msgstr ""
 
 #: command-list.h:133
-msgid "Move or rename a file, a directory, or a symlink"
+msgid "Write and verify multi-pack-indexes"
 msgstr ""
 
 #: command-list.h:134
-msgid "Find symbolic names for given revs"
+msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 
 #: command-list.h:135
-msgid "Add or inspect object notes"
+msgid "Find symbolic names for given revs"
 msgstr ""
 
 #: command-list.h:136
-msgid "Import from and submit to Perforce repositories"
+msgid "Add or inspect object notes"
 msgstr ""
 
 #: command-list.h:137
-msgid "Create a packed archive of objects"
+msgid "Import from and submit to Perforce repositories"
 msgstr ""
 
 #: command-list.h:138
-msgid "Find redundant pack files"
+msgid "Create a packed archive of objects"
 msgstr ""
 
 #: command-list.h:139
-msgid "Pack heads and tags for efficient repository access"
+msgid "Find redundant pack files"
 msgstr ""
 
 #: command-list.h:140
-msgid "Compute unique ID for a patch"
+msgid "Pack heads and tags for efficient repository access"
 msgstr ""
 
 #: command-list.h:141
-msgid "Prune all unreachable objects from the object database"
+msgid "Compute unique ID for a patch"
 msgstr ""
 
 #: command-list.h:142
-msgid "Remove extra objects that are already in pack files"
+msgid "Prune all unreachable objects from the object database"
 msgstr ""
 
 #: command-list.h:143
-msgid "Fetch from and integrate with another repository or a local branch"
+msgid "Remove extra objects that are already in pack files"
 msgstr ""
 
 #: command-list.h:144
-msgid "Update remote refs along with associated objects"
+msgid "Fetch from and integrate with another repository or a local branch"
 msgstr ""
 
 #: command-list.h:145
-msgid "Applies a quilt patchset onto the current branch"
+msgid "Update remote refs along with associated objects"
 msgstr ""
 
 #: command-list.h:146
-msgid "Compare two commit ranges (e.g. two versions of a branch)"
+msgid "Applies a quilt patchset onto the current branch"
 msgstr ""
 
 #: command-list.h:147
-msgid "Reads tree information into the index"
+msgid "Compare two commit ranges (e.g. two versions of a branch)"
 msgstr ""
 
 #: command-list.h:148
-msgid "Reapply commits on top of another base tip"
+msgid "Reads tree information into the index"
 msgstr ""
 
 #: command-list.h:149
-msgid "Receive what is pushed into the repository"
+msgid "Reapply commits on top of another base tip"
 msgstr ""
 
 #: command-list.h:150
-msgid "Manage reflog information"
+msgid "Receive what is pushed into the repository"
 msgstr ""
 
 #: command-list.h:151
-msgid "Manage set of tracked repositories"
+msgid "Manage reflog information"
 msgstr ""
 
 #: command-list.h:152
-msgid "Pack unpacked objects in a repository"
+msgid "Manage set of tracked repositories"
 msgstr ""
 
 #: command-list.h:153
-msgid "Create, list, delete refs to replace objects"
+msgid "Pack unpacked objects in a repository"
 msgstr ""
 
 #: command-list.h:154
-msgid "Generates a summary of pending changes"
+msgid "Create, list, delete refs to replace objects"
 msgstr ""
 
 #: command-list.h:155
-msgid "Reuse recorded resolution of conflicted merges"
+msgid "Generates a summary of pending changes"
 msgstr ""
 
 #: command-list.h:156
-msgid "Reset current HEAD to the specified state"
+msgid "Reuse recorded resolution of conflicted merges"
 msgstr ""
 
 #: command-list.h:157
-msgid "Restore working tree files"
+msgid "Reset current HEAD to the specified state"
 msgstr ""
 
 #: command-list.h:158
-msgid "Lists commit objects in reverse chronological order"
+msgid "Restore working tree files"
 msgstr ""
 
 #: command-list.h:159
-msgid "Pick out and massage parameters"
+msgid "Lists commit objects in reverse chronological order"
 msgstr ""
 
 #: command-list.h:160
-msgid "Revert some existing commits"
+msgid "Pick out and massage parameters"
 msgstr ""
 
 #: command-list.h:161
-msgid "Remove files from the working tree and from the index"
+msgid "Revert some existing commits"
 msgstr ""
 
 #: command-list.h:162
-msgid "Send a collection of patches as emails"
+msgid "Remove files from the working tree and from the index"
 msgstr ""
 
 #: command-list.h:163
-msgid "Push objects over Git protocol to another repository"
+msgid "Send a collection of patches as emails"
 msgstr ""
 
 #: command-list.h:164
-msgid "Git's i18n setup code for shell scripts"
+msgid "Push objects over Git protocol to another repository"
 msgstr ""
 
 #: command-list.h:165
-msgid "Common Git shell script setup code"
+msgid "Git's i18n setup code for shell scripts"
 msgstr ""
 
 #: command-list.h:166
-msgid "Restricted login shell for Git-only SSH access"
+msgid "Common Git shell script setup code"
 msgstr ""
 
 #: command-list.h:167
-msgid "Summarize 'git log' output"
+msgid "Restricted login shell for Git-only SSH access"
 msgstr ""
 
 #: command-list.h:168
-msgid "Show various types of objects"
+msgid "Summarize 'git log' output"
 msgstr ""
 
 #: command-list.h:169
-msgid "Show branches and their commits"
+msgid "Show various types of objects"
 msgstr ""
 
 #: command-list.h:170
-msgid "Show packed archive index"
+msgid "Show branches and their commits"
 msgstr ""
 
 #: command-list.h:171
-msgid "List references in a local repository"
+msgid "Show packed archive index"
 msgstr ""
 
 #: command-list.h:172
-msgid "Initialize and modify the sparse-checkout"
+msgid "List references in a local repository"
 msgstr ""
 
 #: command-list.h:173
-msgid "Add file contents to the staging area"
+msgid "Reduce your working tree to a subset of tracked files"
 msgstr ""
 
 #: command-list.h:174
-msgid "Stash the changes in a dirty working directory away"
+msgid "Add file contents to the staging area"
 msgstr ""
 
 #: command-list.h:175
-msgid "Show the working tree status"
+msgid "Stash the changes in a dirty working directory away"
 msgstr ""
 
 #: command-list.h:176
-msgid "Remove unnecessary whitespace"
+msgid "Show the working tree status"
 msgstr ""
 
 #: command-list.h:177
-msgid "Initialize, update or inspect submodules"
+msgid "Remove unnecessary whitespace"
 msgstr ""
 
 #: command-list.h:178
-msgid "Bidirectional operation between a Subversion repository and Git"
+msgid "Initialize, update or inspect submodules"
 msgstr ""
 
 #: command-list.h:179
-msgid "Switch branches"
+msgid "Bidirectional operation between a Subversion repository and Git"
 msgstr ""
 
 #: command-list.h:180
-msgid "Read, modify and delete symbolic refs"
+msgid "Switch branches"
 msgstr ""
 
 #: command-list.h:181
-msgid "Create, list, delete or verify a tag object signed with GPG"
+msgid "Read, modify and delete symbolic refs"
 msgstr ""
 
 #: command-list.h:182
-msgid "Creates a temporary file with a blob's contents"
+msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 
 #: command-list.h:183
-msgid "Unpack objects from a packed archive"
+msgid "Creates a temporary file with a blob's contents"
 msgstr ""
 
 #: command-list.h:184
-msgid "Register file contents in the working tree to the index"
+msgid "Unpack objects from a packed archive"
 msgstr ""
 
 #: command-list.h:185
-msgid "Update the object name stored in a ref safely"
+msgid "Register file contents in the working tree to the index"
 msgstr ""
 
 #: command-list.h:186
-msgid "Update auxiliary info file to help dumb servers"
+msgid "Update the object name stored in a ref safely"
 msgstr ""
 
 #: command-list.h:187
-msgid "Send archive back to git-archive"
+msgid "Update auxiliary info file to help dumb servers"
 msgstr ""
 
 #: command-list.h:188
-msgid "Send objects packed back to git-fetch-pack"
+msgid "Send archive back to git-archive"
 msgstr ""
 
 #: command-list.h:189
-msgid "Show a Git logical variable"
+msgid "Send objects packed back to git-fetch-pack"
 msgstr ""
 
 #: command-list.h:190
-msgid "Check the GPG signature of commits"
+msgid "Show a Git logical variable"
 msgstr ""
 
 #: command-list.h:191
-msgid "Validate packed Git archive files"
+msgid "Check the GPG signature of commits"
 msgstr ""
 
 #: command-list.h:192
-msgid "Check the GPG signature of tags"
+msgid "Validate packed Git archive files"
 msgstr ""
 
 #: command-list.h:193
-msgid "Show logs with difference each commit introduces"
+msgid "Check the GPG signature of tags"
 msgstr ""
 
 #: command-list.h:194
-msgid "Manage multiple working trees"
+msgid "Show logs with difference each commit introduces"
 msgstr ""
 
 #: command-list.h:195
-msgid "Create a tree object from the current index"
+msgid "Manage multiple working trees"
 msgstr ""
 
 #: command-list.h:196
-msgid "Defining attributes per path"
+msgid "Create a tree object from the current index"
 msgstr ""
 
 #: command-list.h:197
-msgid "Git command-line interface and conventions"
+msgid "Defining attributes per path"
 msgstr ""
 
 #: command-list.h:198
-msgid "A Git core tutorial for developers"
+msgid "Git command-line interface and conventions"
 msgstr ""
 
 #: command-list.h:199
-msgid "Providing usernames and passwords to Git"
+msgid "A Git core tutorial for developers"
 msgstr ""
 
 #: command-list.h:200
-msgid "Git for CVS users"
+msgid "Providing usernames and passwords to Git"
 msgstr ""
 
 #: command-list.h:201
-msgid "Tweaking diff output"
+msgid "Git for CVS users"
 msgstr ""
 
 #: command-list.h:202
-msgid "A useful minimum set of commands for Everyday Git"
+msgid "Tweaking diff output"
 msgstr ""
 
 #: command-list.h:203
-msgid "Frequently asked questions about using Git"
+msgid "A useful minimum set of commands for Everyday Git"
 msgstr ""
 
 #: command-list.h:204
-msgid "A Git Glossary"
+msgid "Frequently asked questions about using Git"
 msgstr ""
 
 #: command-list.h:205
-msgid "Hooks used by Git"
+msgid "A Git Glossary"
 msgstr ""
 
 #: command-list.h:206
-msgid "Specifies intentionally untracked files to ignore"
+msgid "Hooks used by Git"
 msgstr ""
 
 #: command-list.h:207
-msgid "The Git repository browser"
+msgid "Specifies intentionally untracked files to ignore"
 msgstr ""
 
 #: command-list.h:208
-msgid "Map author/committer names and/or E-Mail addresses"
+msgid "The Git repository browser"
 msgstr ""
 
 #: command-list.h:209
-msgid "Defining submodule properties"
+msgid "Map author/committer names and/or E-Mail addresses"
 msgstr ""
 
 #: command-list.h:210
-msgid "Git namespaces"
+msgid "Defining submodule properties"
 msgstr ""
 
 #: command-list.h:211
-msgid "Helper programs to interact with remote repositories"
+msgid "Git namespaces"
 msgstr ""
 
 #: command-list.h:212
-msgid "Git Repository Layout"
+msgid "Helper programs to interact with remote repositories"
 msgstr ""
 
 #: command-list.h:213
-msgid "Specifying revisions and ranges for Git"
+msgid "Git Repository Layout"
 msgstr ""
 
 #: command-list.h:214
-msgid "Mounting one repository inside another"
+msgid "Specifying revisions and ranges for Git"
 msgstr ""
 
 #: command-list.h:215
-msgid "A tutorial introduction to Git"
+msgid "Mounting one repository inside another"
 msgstr ""
 
 #: command-list.h:216
-msgid "A tutorial introduction to Git: part two"
+msgid "A tutorial introduction to Git"
 msgstr ""
 
 #: command-list.h:217
-msgid "Git web interface (web frontend to Git repositories)"
+msgid "A tutorial introduction to Git: part two"
 msgstr ""
 
 #: command-list.h:218
+msgid "Git web interface (web frontend to Git repositories)"
+msgstr ""
+
+#: command-list.h:219
 msgid "An overview of recommended workflows with Git"
 msgstr ""
 
@@ -25084,66 +25783,44 @@ msgstr ""
 msgid "Simple merge did not work, trying automatic merge."
 msgstr ""
 
-#: git-submodule.sh:401
-#, sh-format
-msgid "Unable to find current revision in submodule path '$displaypath'"
-msgstr ""
-
-#: git-submodule.sh:411
-#, sh-format
-msgid "Unable to fetch in submodule path '$sm_path'"
-msgstr ""
-
-#: git-submodule.sh:416
-#, sh-format
-msgid ""
-"Unable to find current ${remote_name}/${branch} revision in submodule path "
-"'$sm_path'"
-msgstr ""
-
-#: git-submodule.sh:464
-#, sh-format
-msgid "Failed to recurse into submodule path '$displaypath'"
-msgstr ""
-
 #: git-sh-setup.sh:89 git-sh-setup.sh:94
 #, sh-format
 msgid "usage: $dashless $USAGE"
 msgstr ""
 
-#: git-sh-setup.sh:183
+#: git-sh-setup.sh:182
 #, sh-format
 msgid "Cannot chdir to $cdup, the toplevel of the working tree"
 msgstr ""
 
-#: git-sh-setup.sh:192 git-sh-setup.sh:199
+#: git-sh-setup.sh:191 git-sh-setup.sh:198
 #, sh-format
 msgid "fatal: $program_name cannot be used without a working tree."
 msgstr ""
 
-#: git-sh-setup.sh:213
+#: git-sh-setup.sh:212
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 
-#: git-sh-setup.sh:216
+#: git-sh-setup.sh:215
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr ""
 
-#: git-sh-setup.sh:227
+#: git-sh-setup.sh:226
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 
-#: git-sh-setup.sh:229
+#: git-sh-setup.sh:228
 msgid "Additionally, your index contains uncommitted changes."
 msgstr ""
 
-#: git-sh-setup.sh:349
+#: git-sh-setup.sh:348
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr ""
 
-#: git-sh-setup.sh:354
+#: git-sh-setup.sh:353
 msgid "Unable to determine absolute path of git directory"
 msgstr ""
 
@@ -25755,23 +26432,17 @@ msgstr "tidak dapat mengirim pesan sebagai 7bit"
 msgid "invalid transfer encoding"
 msgstr "pengkodean transfer tidak valid"
 
-#: git-send-email.perl:2095
+#: git-send-email.perl:2099
 #, perl-format
-msgid ""
-"fatal: %s: rejected by sendemail-validate hook\n"
-"%s\n"
-"warning: no patches were sent\n"
+msgid "fatal: %s: rejected by %s hook\n"
 msgstr ""
-"fatal: %s: ditolak oleh kail sendemail-validate\n"
-"%s\n"
-"peringatan: tidak ada tambalan yang dikirimkan\n"
 
-#: git-send-email.perl:2105 git-send-email.perl:2158 git-send-email.perl:2168
+#: git-send-email.perl:2111 git-send-email.perl:2164 git-send-email.perl:2174
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "tidak dapat membuka %s: %s\n"
 
-#: git-send-email.perl:2108
+#: git-send-email.perl:2114
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -25780,13 +26451,211 @@ msgstr ""
 "fatal: %s:%d lebih panjang dari 998 karakter\n"
 "peringatan: tidak ada tambalan yang dikirimkan\n"
 
-#: git-send-email.perl:2126
+#: git-send-email.perl:2132
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Melewati %s dengan akhiran cadangan '%s'.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2130
+#: git-send-email.perl:2136
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Anda benar-benar ingin mengirim %s? [y|N]: "
+
+#~ msgid ""
+#~ "\n"
+#~ "It took %.2f seconds to enumerate unstaged changes after reset.  You can\n"
+#~ "use '--quiet' to avoid this.  Set the config setting reset.quiet to true\n"
+#~ "to make this the default.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Butuh %.2f detik untuk daftar perubahan tak tergelar setelah setel "
+#~ "ulang.\n"
+#~ "Anda dapat menggunakan '--quiet' untuk hindari hal ini. Setel "
+#~ "konfigurasi\n"
+#~ "reset.quiet ke true untuk membuat hal tersebut asali.\n"
+
+#~ msgid "suppress output for update by rebase or merge"
+#~ msgstr ""
+#~ "sembunyikan keluaran untuk pembaruan oleh pendasaran ulang atau "
+#~ "penggabungan"
+
+#~ msgid "overrides update mode in case the repository is a fresh clone"
+#~ msgstr "timpa mode pembaruan jika repositori adalah kloning segar"
+
+#~ msgid "depth for shallow fetch"
+#~ msgstr "kedalaman untuk pengambilan dangkal"
+
+#~ msgid "sha1"
+#~ msgstr "sha1"
+
+#~ msgid "SHA1 expected by superproject"
+#~ msgstr "SHA1 diharapkan oleh proyek super"
+
+#~ msgid "git submodule--helper run-update-procedure [<options>] <path>"
+#~ msgstr "git submodule--helper run-update-procedure [<opsi>] <jalur>"
+
+#~ msgid "set up tracking mode (see git-pull(1))"
+#~ msgstr "pasang mode pelacakan (lihat git-pull(1))"
+
+#~ msgid "submodule--helper print-default-remote takes no arguments"
+#~ msgstr "submodule--helper print-default-remote tidak membutuhkan argumen"
+
+#~ msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
+#~ msgstr "git submodule--helper update-clone [--prefix=<jalur>] [<jalur>...]"
+
+#~ msgid "subsha1"
+#~ msgstr "subsha1"
+
+#~ msgid "SHA1 of submodule's HEAD"
+#~ msgstr "SHA1 dari HEAD submodul"
+
+#~ msgid "git archive --list"
+#~ msgstr "git archive --list"
+
+#~ msgid "backend for `git stash -p`"
+#~ msgstr "tulang belakang untuk `git stash -p`"
+
+#~ msgid "Invalid value for --empty: %s"
+#~ msgstr "Nilai tidak valid untuk --empty: %s"
+
+#~ msgid "Invalid value for --patch-format: %s"
+#~ msgstr "Nilai tidak valid untuk --patch-format: %s"
+
+#~ msgid "Invalid value for --show-current-patch: %s"
+#~ msgstr "Nilai tidak valid untuk --show-current-patch: %s"
+
+#~ msgid ""
+#~ "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad "
+#~ "| --term-new]"
+#~ msgstr ""
+#~ "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad "
+#~ "| --term-new]"
+
+#~ msgid "git bisect--helper --bisect-next"
+#~ msgstr "git bisect--helper --bisect-next"
+
+#~ msgid "git bisect--helper --bisect-visualize"
+#~ msgstr "git bisect--helper --bisect-visualize"
+
+#~ msgid "invalid color '%s' in color.blame.repeatedLines"
+#~ msgstr "warna tidak valid '%s' pada color.blame.repeatedLines"
+
+#~ msgid "invalid value for blame.coloring"
+#~ msgstr "nilai tidak valid untuk blame.coloring"
+
+#~ msgid ""
+#~ "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e "
+#~ "| -p | <type> | --textconv | --filters) [--path=<path>] <object>"
+#~ msgstr ""
+#~ "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e "
+#~ "| -p | <tipe> | --textconv | --filters) [--path=<jalur>] <objek>"
+
+#~ msgid "show object type"
+#~ msgstr "perlihatkan tipe objek"
+
+#~ msgid "exit with zero when there's no error"
+#~ msgstr "keluar dengan nol ketika tidak ada kesalahan"
+
+#~ msgid "show info and content of objects fed from the standard input"
+#~ msgstr "perlihatkan info dan isi objek yang disuap dari masukan standar"
+
+#~ msgid "show info about objects fed from the standard input"
+#~ msgstr "perlihatkan info tentang objek yang disuap dari masukan standar"
+
+#~ msgid "follow in-tree symlinks (used with --batch or --batch-check)"
+#~ msgstr ""
+#~ "ikuti tautan simbolik dalam pohon (digunakan dengan --batch atau --batch-"
+#~ "check)"
+
+#~ msgid "show all objects with --batch or --batch-check"
+#~ msgstr "perlihatkan semua objek dengan --batch atau --batch-check"
+
+#~ msgid "do not order --batch-all-objects output"
+#~ msgstr "jangan urutkan keluaran --batch-all-objects"
+
+#~ msgid "Using both --reset-author and --author does not make sense"
+#~ msgstr "Menggunakan baik --reset-author dan --author tidak masuk akal"
+
+#~ msgid "Options --squash and --fixup cannot be used together"
+#~ msgstr "Opsi --squash dan --fixup tidak dapat digunakan bersamaan"
+
+#~ msgid "Only one of -c/-C/-F/--fixup can be used."
+#~ msgstr "Hanya salah satu dari -c/-C/-F/--fixup yang dapat digunakan."
+
+#~ msgid "Option -m cannot be combined with -c/-C/-F."
+#~ msgstr "Opsi -m tidak dapat digabung dengan -c/-C/-F."
+
+#~ msgid ""
+#~ "Only one of --include/--only/--all/--interactive/--patch can be used."
+#~ msgstr ""
+#~ "Hanya salah satu dari --include/--only/--all/--interactive/--patch yang "
+#~ "dapat digunakan."
+
+#~ msgid "git count-objects [-v] [-H | --human-readable]"
+#~ msgstr "git count-objects [-v] [-H | --human-readable]"
+
+#~ msgid "configuration fetch.output contains invalid value %s"
+#~ msgstr "konfigurasi fetch.output berisi nilai tidak valid %s"
+
+#~ msgid "--cached or --untracked cannot be used with --no-index"
+#~ msgstr "--cached atau --untracked tidak dapat digunakan dengan --no-index"
+
+#~ msgid "--untracked cannot be used with --cached"
+#~ msgstr "--untracked tidak dapat digunakan dengan --cached"
+
+#~ msgid "git hash-object  --stdin-paths"
+#~ msgstr "git hash-object  --stdin-paths"
+
+#~ msgid "Invalid value for %s: %s"
+#~ msgstr "Nilai tidak valid untuk %s: %s"
+
+#~ msgid "Invalid value for pull.ff: %s"
+#~ msgstr "Nilai tidak valid untuk pull.ff: %s"
+
+#~ msgid "git rebase --continue | --abort | --skip | --edit-todo"
+#~ msgstr "git rebase --continue | --abort | --skip | --edit-todo"
+
+#~ msgid "'%s' is not a valid timestamp"
+#~ msgstr "'%s' bukan stempel waktu valid"
+
+#~ msgid "git reflog [ show | expire | delete | exists ]"
+#~ msgstr "git reflog [ show | expire | delete | exists ]"
+
+#~ msgid "git remote [-v | --verbose]"
+#~ msgstr "git remote [-v | --verbose]"
+
+#~ msgid "git sparse-checkout list"
+#~ msgstr "git sparse-checkout list"
+
+#~ msgid "unable to upgrade repository format to enable worktreeConfig"
+#~ msgstr ""
+#~ "gagal mengupgrade format repositori untuk mengaktifkan worktreeConfig"
+
+#~ msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+#~ msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+
+#~ msgid "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+#~ msgstr "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+
+#~ msgid "git sparse-checkout disable"
+#~ msgstr "git sparse-checkout disable"
+
+#~ msgid ""
+#~ "the stash.useBuiltin support has been removed!\n"
+#~ "See its entry in 'git help config' for details."
+#~ msgstr ""
+#~ "Dukungan untuk stash.useBuiltin sudah dihapus!\n"
+#~ "Lihat entri itu di 'git help config' untuk selengkapnya."
+
+#~ msgid "git submodule--helper config --check-writeable"
+#~ msgstr "git submodule--helper config --check-writeable"
+
+#~ msgid ""
+#~ "fatal: %s: rejected by sendemail-validate hook\n"
+#~ "%s\n"
+#~ "warning: no patches were sent\n"
+#~ msgstr ""
+#~ "fatal: %s: ditolak oleh kail sendemail-validate\n"
+#~ "%s\n"
+#~ "peringatan: tidak ada tambalan yang dikirimkan\n"


### PR DESCRIPTION
Update following components:

  * add-interactive.c
  * branch.c
  * config.c
  * help.c
  * merge-ort-wrappers.c
  * builtin/bisect--helper.c
  * builtin/branch.c
  * builtin/cat-file.c
  * builtin/checkout.c
  * builtin/clone.c
  * builtin/config.c
  * builtin/reflog.c
  * builtin/remote.c
  * builtin/sparse-checkout.c
  * builtin/submodule--helper.c
  * builtin/unpack-objects.c

Translate following new components:
  * connect.c
  * connected.c
  * date.c
  * hook.c
  * files-backend.c
  * ident.c
  * merge-ort.c
  * merge-recursive.c
  * refs.c
  * refspec.c
  * revision.c
  * symlinks.c
  * worktree.c
  * builtin/notes.c
  * builtin/multi-pack-index.c
  * builtin/commit.c
  * builtin/merge-base.c

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>
