### PR TITLE
l10n: po-id for 2.39 (round 1)

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-09-28 14:31+0700\n"
-"PO-Revision-Date: 2022-09-28 14:50+0700\n"
+"POT-Creation-Date: 2022-11-30 11:05+0700\n"
+"PO-Revision-Date: 2022-11-30 20:45+0700\n"
 "Last-Translator: Bagas Sanjaya <bagasdotme@gmail.com>\n"
 "Language-Team: Indonesian\n"
 "Language: id\n"
@@ -900,6 +900,11 @@ msgstr "baris perintah diakhiri dengan \\"
 msgid "unclosed quote"
 msgstr "tanda kutip tak ditutup"
 
+#: alias.c builtin/cat-file.c builtin/notes.c builtin/prune-packed.c
+#: builtin/receive-pack.c builtin/tag.c
+msgid "too many arguments"
+msgstr "terlalu banyak argumen"
+
 #: apply.c
 #, c-format
 msgid "unrecognized whitespace option '%s'"
@@ -1364,7 +1369,7 @@ msgid "No valid patches in input (allow with \"--allow-empty\")"
 msgstr ""
 "Tidak ada tambalan valid dalam masukan (perbolehkan dengan \"--allow-empty\")"
 
-#: apply.c
+#: apply.c t/helper/test-cache-tree.c
 msgid "unable to read index file"
 msgstr "tidak dapa membaca berkas indeks"
 
@@ -1599,7 +1604,7 @@ msgstr "tidak ada referensi seperti: %.*s"
 msgid "not a valid object name: %s"
 msgstr "bukan nama objek valid: %s"
 
-#: archive.c
+#: archive.c t/helper/test-cache-tree.c
 #, c-format
 msgid "not a tree object: %s"
 msgstr "bukan objek pohon: %s"
@@ -1650,7 +1655,7 @@ msgid "prepend prefix to each pathname in the archive"
 msgstr "tambahkan prefiks di depan setiap nama jalur dalam arsip"
 
 #: archive.c builtin/blame.c builtin/commit-tree.c builtin/config.c
-#: builtin/fast-export.c builtin/grep.c builtin/hash-object.c
+#: builtin/fast-export.c builtin/gc.c builtin/grep.c builtin/hash-object.c
 #: builtin/ls-files.c builtin/notes.c builtin/read-tree.c parse-options.h
 msgid "file"
 msgstr "berkas"
@@ -3116,54 +3121,6 @@ msgstr ""
 "keluar %d"
 
 #: builtin/bisect--helper.c
-msgid "reset the bisection state"
-msgstr "setel ulang keadaan pembagian dua"
-
-#: builtin/bisect--helper.c
-msgid "check whether bad or good terms exist"
-msgstr "periksa apakah ada istilah jelek atau bagus"
-
-#: builtin/bisect--helper.c
-msgid "print out the bisect terms"
-msgstr "cetak istilah pembagian dua"
-
-#: builtin/bisect--helper.c
-msgid "start the bisect session"
-msgstr "mulai sesi pembagian dua"
-
-#: builtin/bisect--helper.c
-msgid "find the next bisection commit"
-msgstr "temukan komit pembagian dua berikutnya"
-
-#: builtin/bisect--helper.c
-msgid "mark the state of ref (or refs)"
-msgstr "tandai keadaan referensi"
-
-#: builtin/bisect--helper.c
-msgid "list the bisection steps so far"
-msgstr "daftar langkah pembagian dua sejauh ini"
-
-#: builtin/bisect--helper.c
-msgid "replay the bisection process from the given file"
-msgstr "mainkan ulang proses pembagian dua dari berkas yang diberikan"
-
-#: builtin/bisect--helper.c
-msgid "skip some commits for checkout"
-msgstr "lewati beberapa komit untuk checkout"
-
-#: builtin/bisect--helper.c
-msgid "visualize the bisection"
-msgstr "visualisasikan pembagian dua"
-
-#: builtin/bisect--helper.c
-msgid "use <cmd>... to automatically bisect"
-msgstr "gunakan <cmd>... untuk bagi dua otomatis."
-
-#: builtin/bisect--helper.c
-msgid "no log for BISECT_WRITE"
-msgstr "tidak ada log untuk BISECT_WRITE"
-
-#: builtin/bisect--helper.c
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset butuh baik tanpa argumen atau sebuah komit"
 
@@ -3186,6 +3143,10 @@ msgstr "tidak ada berkas log yang diberikan"
 #: builtin/blame.c
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
 msgstr "git blame [<opsi>] [<opsi revisi>] [<revisi>] [--] <berkas>"
+
+#: builtin/blame.c
+msgid "git annotate [<options>] [<rev-opts>] [<rev>] [--] <file>"
+msgstr "git annotate [<opsi>] [<opsi revisi>] [<revisi>] [--] <berkas>"
 
 #: builtin/blame.c
 msgid "<rev-opts> are documented in git-rev-list(1)"
@@ -3427,10 +3388,6 @@ msgid "cannot use -a with -d"
 msgstr "tidak dapat gunakan -a dengan -d"
 
 #: builtin/branch.c
-msgid "Couldn't look up commit object for HEAD"
-msgstr "Tidak dapat mencari objek komit untuk HEAD"
-
-#: builtin/branch.c
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
 msgstr "Tidak dapat menghapus cabang '%s' yang ter-checkout pada '%s'"
@@ -3479,17 +3436,19 @@ msgid "Branch %s is being bisected at %s"
 msgstr "Cabang %s sedang dibagi dua pada %s"
 
 #: builtin/branch.c
-msgid "cannot copy the current branch while not on any."
-msgstr "tidak dapat menyalin cabang saat ini ketika tidak ada."
-
-#: builtin/branch.c
-msgid "cannot rename the current branch while not on any."
-msgstr "tidak dapat mengganti nama cabang saat ini ketika tidak ada."
-
-#: builtin/branch.c
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Nama cabang tidak valid: '%s'"
+
+#: builtin/branch.c
+#, c-format
+msgid "No commit on branch '%s' yet."
+msgstr "Belum ada komit pada cabang '%s'."
+
+#: builtin/branch.c
+#, c-format
+msgid "No branch named '%s'."
+msgstr "Tidak ada cabang bernama '%s'."
 
 #: builtin/branch.c
 msgid "Branch rename failed"
@@ -3699,14 +3658,12 @@ msgid "cannot edit description of more than one branch"
 msgstr "tidak dapat menyunting deskripsi lebih dari satu cabang"
 
 #: builtin/branch.c
-#, c-format
-msgid "No commit on branch '%s' yet."
-msgstr "Belum ada komit pada cabang '%s'."
+msgid "cannot copy the current branch while not on any."
+msgstr "tidak dapat menyalin cabang saat ini ketika tidak ada."
 
 #: builtin/branch.c
-#, c-format
-msgid "No branch named '%s'."
-msgstr "Tidak ada cabang bernama '%s'."
+msgid "cannot rename the current branch while not on any."
+msgstr "tidak dapat mengganti nama cabang saat ini ketika tidak ada."
 
 #: builtin/branch.c
 msgid "too many branches for a copy operation"
@@ -3794,11 +3751,12 @@ msgstr ""
 
 #: builtin/bugreport.c
 msgid ""
-"git bugreport [-o|--output-directory <file>] [-s|--suffix <format>] [--"
-"diagnose[=<mode>]"
+"git bugreport [(-o | --output-directory) <path>] [(-s | --suffix) <format>]\n"
+"              [--diagnose[=<mode>]]"
 msgstr ""
-"git bugreport [-o|--output-directory <berkas>] [-s|--suffix <format>] [--"
-"diagnose[=<mode>]]"
+"git bugreport [(-o | --output-directory) <berkas>] [(-s |-- suffix) "
+"<format>]\n"
+"              [--diagnose[=<mode>]]"
 
 #: builtin/bugreport.c
 msgid ""
@@ -3881,20 +3839,26 @@ msgid "Created new report at '%s'.\n"
 msgstr "Laporan baru dibuat pada '%s'.\n"
 
 #: builtin/bundle.c
-msgid "git bundle create [<options>] <file> <git-rev-list args>"
-msgstr "git bundle create [<opsi>] <berkas> <argumen git-rev-list>"
+msgid ""
+"git bundle create [-q | --quiet | --progress | --all-progress] [--all-"
+"progress-implied]\n"
+"                  [--version=<version>] <file> <git-rev-list-args>"
+msgstr ""
+"git bundle create [-q | --quiet | --progress | --all-progress] [-all-"
+"progress-implied]\n"
+"                  [--version=<versi>] <berkas> <argumen git-rev-list>"
 
 #: builtin/bundle.c
-msgid "git bundle verify [<options>] <file>"
-msgstr "git bundle verify [<opsi>] <berkas>"
+msgid "git bundle verify [-q | --quiet] <file>"
+msgstr "git bundle verify [-q | --quiet] <berkas>"
 
 #: builtin/bundle.c
 msgid "git bundle list-heads <file> [<refname>...]"
 msgstr "git bundle list-heads <berkas> [<nama referensi>...]"
 
 #: builtin/bundle.c
-msgid "git bundle unbundle <file> [<refname>...]"
-msgstr "git bundle unbundle <berkas> [<nama referensi>...]"
+msgid "git bundle unbundle [--progress] <file> [<refname>...]"
+msgstr "git bundle unbundle [--progress] <berkas> [<nama referensi>...]"
 
 #: builtin/bundle.c builtin/pack-objects.c
 msgid "do not show progress meter"
@@ -3991,12 +3955,12 @@ msgid ""
 "git cat-file (--batch | --batch-check | --batch-command) [--batch-all-"
 "objects]\n"
 "             [--buffer] [--follow-symlinks] [--unordered]\n"
-"             [--textconv | --filters]"
+"             [--textconv | --filters] [-z]"
 msgstr ""
 "git cat-file (--batch | --batch-check | --batch-command) [--batch-all-"
 "objects]\n"
 "             [--buffer] [--follow-symlinks] [--unordered]\n"
-"             [--textconv | --filters]"
+"             [--textconv | --filters] [-z]"
 
 #: builtin/cat-file.c
 msgid ""
@@ -4137,11 +4101,6 @@ msgstr "<revisi> diperlukan dengan '%s'"
 #, c-format
 msgid "<object> required with '-%c'"
 msgstr "<objek> diperlukan dengan '-%c'"
-
-#: builtin/cat-file.c builtin/notes.c builtin/prune-packed.c
-#: builtin/receive-pack.c builtin/tag.c
-msgid "too many arguments"
-msgstr "terlalu banyak argumen"
 
 #: builtin/cat-file.c
 #, c-format
@@ -4810,9 +4769,11 @@ msgstr "gunakan mode hamparan"
 
 #: builtin/clean.c
 msgid ""
-"git clean [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <paths>..."
+"git clean [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] "
+"[<pathspec>...]"
 msgstr ""
-"git clean [-d] [-f] [-i] [-n] [-q] [-e <pola>] [-x | -X] [--] <jalur>..."
+"git clean [-d] [-f] [-i] [-n] [-q] [-e <pola>] [-x | -X] [--] [<spek "
+"jalur>...]"
 
 #: builtin/clean.c
 #, c-format
@@ -5181,6 +5142,11 @@ msgstr "%s ada dan bukan direktori"
 msgid "failed to start iterator over '%s'"
 msgstr "gagal memulai iterator pada '%s'"
 
+#: builtin/clone.c
+#, c-format
+msgid "symlink '%s' exists, refusing to clone with --local"
+msgstr "tautan simbolik '%s' ada, menolak mengkloning dengan --local"
+
 #: builtin/clone.c compat/precompose_utf8.c
 #, c-format
 msgid "failed to unlink '%s'"
@@ -5261,11 +5227,6 @@ msgstr "Terlalu banyak argumen."
 #: builtin/clone.c scalar.c
 msgid "You must specify a repository to clone."
 msgstr "Anda harus sebutkan repositori untuk diklon."
-
-#: builtin/clone.c
-#, c-format
-msgid "options '%s' and '%s %s' cannot be used together"
-msgstr "opsi '%s' dan '%s %s' tidak dapat digunakan bersamaan"
 
 #: builtin/clone.c
 msgid ""
@@ -5423,22 +5384,28 @@ msgstr "--command harus menjadi argumen pertama"
 
 #: builtin/commit-graph.c
 msgid ""
-"git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
+"git commit-graph verify [--object-dir <dir>] [--shallow] [--[no-]progress]"
 msgstr ""
-"git commit-graph verify [--object-dir <direktori objek>] [--shallow] [--"
+"git commit-graph verify [--object-dir <direktori>] [--shallow] [--"
 "[no-]progress]"
 
 #: builtin/commit-graph.c
 msgid ""
-"git commit-graph write [--object-dir <objdir>] [--append] [--"
-"split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
-"paths] [--[no-]max-new-filters <n>] [--[no-]progress] <split options>"
+"git commit-graph write [--object-dir <dir>] [--append]\n"
+"                       [--split[=<strategy>]] [--reachable | --stdin-packs | "
+"--stdin-commits]\n"
+"                       [--changed-paths] [--[no-]max-new-filters <n>] [--"
+"[no-]progress]\n"
+"                       <split options>"
 msgstr ""
-"git commit-graph write [--object-dir <direktori objek>] [--append] [--"
-"split[=<strategi>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
-"paths] [--[no-]max-new-filters <n>] [--[-no-]progrss] <opsi pemisah>"
+"git commit-graph write [--object-dir <direktori>] [--append]\n"
+"                       [--split[=<strategi>]] [--reachable | --stdin-packs | "
+"--stdin-commits]\n"
+"                       [--changed-paths] [--[no-]max-new-filters <n>] [--[-"
+"no-]progress]\n"
+"                       <opsi pemisahan>"
 
-#: builtin/commit-graph.c builtin/fetch.c builtin/log.c
+#: builtin/commit-graph.c builtin/fetch.c builtin/log.c builtin/repack.c
 msgid "dir"
 msgstr "direktori"
 
@@ -5526,12 +5493,16 @@ msgid "Collecting commits from input"
 msgstr "Mengumpulkan komit dari masukan"
 
 #: builtin/commit-tree.c
+msgid "git commit-tree <tree> [(-p <parent>)...]"
+msgstr "git commit-tree <pohon> [(-p <induk>)...]"
+
+#: builtin/commit-tree.c
 msgid ""
-"git commit-tree [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...] [(-F "
-"<file>)...] <tree>"
+"git commit-tree [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
+"                [(-F <file>)...] <tree>"
 msgstr ""
-"git commit-tree [(-p <induk>)...] [-S[<id kunci>]] [(-m <pesan>)...] [(-F "
-"<berkas>)...] <pohon>"
+"git commit-tree [(-p <induk>)...] [-S[<id kunci>]] [(-m <pesan>)...]\n"
+"                [(-F <berkas>)...] <pohon>"
 
 #: builtin/commit-tree.c
 #, c-format
@@ -5588,12 +5559,31 @@ msgid "git commit-tree: failed to read"
 msgstr "git commit-tree: gagal membaca"
 
 #: builtin/commit.c
-msgid "git commit [<options>] [--] <pathspec>..."
-msgstr "git commit [<opsi>] [--] <spek jalur>..."
+msgid ""
+"git commit [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
+"           [--dry-run] [(-c | -C | --squash) <commit> | --fixup [(amend|"
+"reword):]<commit>)]\n"
+"           [-F <file> | -m <msg>] [--reset-author] [--allow-empty]\n"
+"           [--allow-empty-message] [--no-verify] [-e] [--author=<author>]\n"
+"           [--date=<date>] [--cleanup=<mode>] [--[no-]status]\n"
+"           [-i | -o] [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"           [(--trailer <token>[(=|:)<value>])...] [-S[<keyid>]]\n"
+"           [--] [<pathspec>...]"
+msgstr ""
+"git commit [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
+"           [--dry-run] [(-c | -C | --squash) <komit> | --fixup [(amend|"
+"reword):]<komit>)]\n"
+"           [-F <berkas> | -m <pesan>] [--reset-author] [--allow-empty]\n"
+"           [--allow-empty-message] [--no-verify] [-e] [--"
+"author=<pengarang>]\n"
+"           [--date=<tanggal>] [--cleanup=<mode>] [--[no-]status]\n"
+"           [-i | -o] [--pathspec-from-file=<berkas> [--pathspec-file-nul]]\n"
+"           [(--trailer <token>[(=|:)<nilai>])...] [-S[<id kunci>]]\n"
+"           [--] [<spek jalur>...]"
 
 #: builtin/commit.c
-msgid "git status [<options>] [--] <pathspec>..."
-msgstr "git status [<opsi>] [--] <spek jalur>..."
+msgid "git status [<options>] [--] [<pathspec>...]"
+msgstr "git status [<opsi>] [--] [<spek jalur>...]"
 
 #: builtin/commit.c
 msgid ""
@@ -6215,7 +6205,7 @@ msgstr "gunakan berkas konfigurasi repositori"
 msgid "use per-worktree config file"
 msgstr "gunakan berkas konfigurasi per pohon kerja"
 
-#: builtin/config.c
+#: builtin/config.c builtin/gc.c
 msgid "use given config file"
 msgstr "gunakan berkas konfigurasi yang diberikan"
 
@@ -6439,7 +6429,7 @@ msgstr "--blob hanya dapat digunakan di dalam repositori git"
 msgid "--worktree can only be used inside a git repository"
 msgstr "--worktree hanya dapat digunakan di dalam repositori git"
 
-#: builtin/config.c
+#: builtin/config.c builtin/gc.c
 msgid "$HOME not set"
 msgstr "$HOME tak disetel"
 
@@ -6553,12 +6543,20 @@ msgstr ""
 "tidak dapat mendapatkan kunci penyimpanan kredensial dalam %d milidetik"
 
 #: builtin/describe.c
-msgid "git describe [<options>] [<commit-ish>...]"
-msgstr "git describe [<opsi>] [<mirip-komit>...]"
+msgid ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]"
+msgstr ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] [<mirip-komit>...]"
 
 #: builtin/describe.c
-msgid "git describe [<options>] --dirty"
-msgstr "git describe [<opsi>] --dirty"
+msgid ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]"
+msgstr ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<penanda>]"
+
+#: builtin/describe.c
+msgid "git describe <blob>"
+msgstr "git describe <blob>"
 
 #: builtin/describe.c
 msgid "head"
@@ -6713,11 +6711,11 @@ msgstr "opsi '%s' dan mirip-komit tidak dapat digunakan bersamaan"
 
 #: builtin/diagnose.c
 msgid ""
-"git diagnose [-o|--output-directory <path>] [-s|--suffix <format>] [--"
-"mode=<mode>]"
+"git diagnose [(-o | --output-directory) <path>] [(-s | --suffix) <format>]\n"
+"             [--mode=<mode>]"
 msgstr ""
-"git diagnose [-o|--output-directory <jalur>] [-s|--suffix <format>] [--"
-"mode=<mode>]"
+"git diagnose [(-o | --output-directory) <jalur>] [(-s | --suffix) <format>]\n"
+"             [--mode=<mode>]"
 
 #: builtin/diagnose.c
 msgid "specify a destination for the diagnostics archive"
@@ -6739,6 +6737,10 @@ msgstr "--merge-base hanya bekerja dengan dua komit"
 #, c-format
 msgid "'%s': not a regular file or symlink"
 msgstr "'%s': bukan berkas reguler atau tautan simbolik"
+
+#: builtin/diff.c
+msgid "no merge given, only parents."
+msgstr "tidak ada penggabungan yang diberikan, hanya induk."
 
 #: builtin/diff.c
 #, c-format
@@ -7552,8 +7554,8 @@ msgid "print only refs which don't contain the commit"
 msgstr "hanya cetak referensi yang tidak berisi komit"
 
 #: builtin/for-each-repo.c
-msgid "git for-each-repo --config=<config> <command-args>"
-msgstr "git for-each-repo --config=<konfigurasi> <argumen perintah>"
+msgid "git for-each-repo --config=<config> [--] <arguments>"
+msgstr "git for-each-repo --config=<konfigurasi> [--] <argumen perintah>"
 
 #: builtin/for-each-repo.c
 msgid "config"
@@ -7770,8 +7772,16 @@ msgid "%s: invalid sha1 pointer in resolve-undo"
 msgstr "%s: penunjuk sha1 tidak valid di resolve-undo"
 
 #: builtin/fsck.c
-msgid "git fsck [<options>] [<object>...]"
-msgstr "git fsck [<opsi>] [<objek>...]"
+msgid ""
+"git fsck [--tags] [--root] [--unreachable] [--cache] [--no-reflogs]\n"
+"         [--[no-]full] [--strict] [--verbose] [--lost-found]\n"
+"         [--[no-]dangling] [--[no-]progress] [--connectivity-only]\n"
+"         [--[no-]name-objects] [<object>...]"
+msgstr ""
+"git fsck [--tags] [--root] [--unreachable] [--cache] [--no-reflogs]\n"
+"         [--[no-]full] [--strict] [--verbose] [--lost-found]\n"
+"         [--[no-]dangling] [--[no-]progress] [--connectivity-only]\n"
+"         [--[no-]name-objects] [<objek>...]"
 
 #: builtin/fsck.c
 msgid "show unreachable objects"
@@ -7842,14 +7852,6 @@ msgstr "git fsmonitor--daemon start [<opsi>]"
 #: builtin/fsmonitor--daemon.c
 msgid "git fsmonitor--daemon run [<options>]"
 msgstr "git fsmonitor--daemon run [<opsi>]"
-
-#: builtin/fsmonitor--daemon.c
-msgid "git fsmonitor--daemon stop"
-msgstr "git fsmonitor--daemon stop"
-
-#: builtin/fsmonitor--daemon.c
-msgid "git fsmonitor--daemon status"
-msgstr "git fsmonitor--daemon status"
 
 #: builtin/fsmonitor--daemon.c
 #, c-format
@@ -7952,7 +7954,7 @@ msgstr ""
 msgid "invalid 'ipc-threads' value (%d)"
 msgstr "nilai 'ipc-threads' tidak valid (%d)"
 
-#: builtin/fsmonitor--daemon.c
+#: builtin/fsmonitor--daemon.c t/helper/test-cache-tree.c
 #, c-format
 msgid "Unhandled subcommand '%s'"
 msgstr "Subperintah tidak tertangani '%s'"
@@ -8157,8 +8159,23 @@ msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr "gunakan paling banyak satu dari --auto dan --schedule=<frekuensi>"
 
 #: builtin/gc.c
-msgid "failed to run 'git config'"
-msgstr "gagal menjalankan 'git config'"
+#, c-format
+msgid "unable to add '%s' value of '%s'"
+msgstr "tidak dapat menambahkan nilai '%s' dari '%s'"
+
+#: builtin/gc.c
+msgid "return success even if repository was not registered"
+msgstr "kembalikan sukses bahkan jika repositori tidak terdaftar"
+
+#: builtin/gc.c
+#, c-format
+msgid "unable to unset '%s' value of '%s'"
+msgstr "tidak dapat membatal-setel nilai '%s' dari '%s'"
+
+#: builtin/gc.c
+#, c-format
+msgid "repository '%s' is not registered"
+msgstr "repositori '%s' tidak terdaftar"
 
 #: builtin/gc.c
 #, c-format
@@ -8537,11 +8554,15 @@ msgstr "baik --cached dan pohon diberikan"
 
 #: builtin/hash-object.c
 msgid ""
-"git hash-object [-t <type>] [-w] [--path=<file> | --no-filters] [--stdin] "
-"[--] <file>..."
+"git hash-object [-t <type>] [-w] [--path=<file> | --no-filters]\n"
+"                [--stdin [--literally]] [--] <file>..."
 msgstr ""
-"git hash-object [-t <tipe>] [-w] [--path=<berkas> | --no-filters] [--stdin] "
-"[--] <berkas>..."
+"git hash-object [-t <tipe>] [-w] [--path=<berkas> | --no-filters]\n"
+"                [--stdin [--literally]] [--] <berkas>..."
+
+#: builtin/hash-object.c
+msgid "git hash-object [-t <type>] [-w] --stdin-paths [--no-filters]"
+msgstr "git hash-object [-t <tipe>] [-w] --stdin-paths [--no-filters]"
 
 #: builtin/hash-object.c
 msgid "object type"
@@ -9080,11 +9101,15 @@ msgstr "Repositori Git kosong dinisialisasi di %s%s\n"
 
 #: builtin/init-db.c
 msgid ""
-"git init [-q | --quiet] [--bare] [--template=<template-directory>] [--"
-"shared[=<permissions>]] [<directory>]"
+"git init [-q | --quiet] [--bare] [--template=<template-directory>]\n"
+"         [--separate-git-dir <git-dir>] [--object-format=<format>]\n"
+"         [-b <branch-name> | --initial-branch=<branch-name>]\n"
+"         [--shared[=<permissions>]] [<directory>]"
 msgstr ""
-"git init [-q | --quiet] [--bare] [--template=<direktori-templat>][--"
-"shared[=<perizinan>]] [<direktori>]"
+"git init [-q | --quiet] [--bare] [--template=<direktori templat>]\n"
+"         [--separate-git-dir <direktori git>] [--object-format=<format>]\n"
+"         [-b <nama cabang> | --initial-branch=<nama cabang>]\n"
+"         [--shared[=<perizinan>]] [<direktori>]"
 
 #: builtin/init-db.c
 msgid "permissions"
@@ -9137,11 +9162,13 @@ msgstr "--separate-git-dir tidak kompatibel dengan repositori bare"
 
 #: builtin/interpret-trailers.c
 msgid ""
-"git interpret-trailers [--in-place] [--trim-empty] [(--trailer "
-"<token>[(=|:)<value>])...] [<file>...]"
+"git interpret-trailers [--in-place] [--trim-empty]\n"
+"                       [(--trailer <token>[(=|:)<value>])...]\n"
+"                       [--parse] [<file>...]"
 msgstr ""
-"git interpret-trailers [--in-place] [--trim-empty] [(--trailer "
-"<token>[(=|:)<nilai>])...] [<berkas>...]"
+"git interpret-trailers [--in-place] [--trim-empty]\n"
+"                       [(--trailer <token>[(=|:)<nilai>])...]\n"
+"                       [--parse] [<berkas>...]"
 
 #: builtin/interpret-trailers.c
 msgid "edit files in place"
@@ -9771,11 +9798,11 @@ msgstr ""
 #: builtin/ls-remote.c
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
 "              [--symref] [<repository> [<refs>...]]"
 msgstr ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [-q | --quiet] [--exit-code] [--get-url] [--sort=<kunci>]\n"
 "              [--symref] [<repositori> [<referensi>...]]"
 
 #: builtin/ls-remote.c
@@ -9948,12 +9975,12 @@ msgid "git merge-base [-a | --all] --octopus <commit>..."
 msgstr "git merge-base [-a | --all] --octopus <komit>..."
 
 #: builtin/merge-base.c
-msgid "git merge-base --independent <commit>..."
-msgstr "git merge-base --independent <komit>..."
-
-#: builtin/merge-base.c
 msgid "git merge-base --is-ancestor <commit> <commit>"
 msgstr "git merge-base --is-ancestor <komit> <komit>"
+
+#: builtin/merge-base.c
+msgid "git merge-base --independent <commit>..."
+msgstr "git merge-base --independent <komit>..."
 
 #: builtin/merge-base.c
 msgid "git merge-base --fork-point <ref> [<commit>]"
@@ -10095,8 +10122,22 @@ msgid "allow merging unrelated histories"
 msgstr "perbolehkan penggabungan riwayat yang tak terkait"
 
 #: builtin/merge-tree.c
+msgid "perform multiple merges, one per line of input"
+msgstr "lakukan banyak penggabungan, satu per baris masukan"
+
+#: builtin/merge-tree.c
 msgid "--trivial-merge is incompatible with all other options"
 msgstr "--trivial-merge tidak kompatibel dengan semua opsi lainnya"
+
+#: builtin/merge-tree.c builtin/notes.c
+#, c-format
+msgid "malformed input line: '%s'."
+msgstr "baris masukan jelek: '%s'."
+
+#: builtin/merge-tree.c
+#, c-format
+msgid "merging cannot continue; got unclean result of %d"
+msgstr "penggabungan tidak dapat berlanjut; dapat hasil kotor dari %d"
 
 #: builtin/merge.c
 msgid "git merge [<options>] [<commit>...]"
@@ -10680,7 +10721,7 @@ msgstr "%s, source=%s, destination=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Mengganti nama %s ke %s\n"
 
-#: builtin/mv.c builtin/remote.c builtin/repack.c
+#: builtin/mv.c builtin/remote.c
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "gagal mengganti nama '%s'"
@@ -10883,11 +10924,6 @@ msgstr "gagal membaca objek '%s'."
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
 msgstr "gagal membaca data catatan dari objek bukan blob '%s'."
-
-#: builtin/notes.c
-#, c-format
-msgid "malformed input line: '%s'."
-msgstr "baris masukan jelek: '%s'."
 
 #: builtin/notes.c
 #, c-format
@@ -11130,15 +11166,14 @@ msgid "unknown subcommand: `%s'"
 msgstr "subperintah tidak dikenal: `%s'"
 
 #: builtin/pack-objects.c
-msgid ""
-"git pack-objects --stdout [<options>...] [< <ref-list> | < <object-list>]"
+msgid "git pack-objects --stdout [<options>] [< <ref-list> | < <object-list>]"
 msgstr ""
-"git pack-objects --stdout [<opsi>...] [< <daftar referensi>| < <daftar-"
+"git pack-objects --stdout [<opsi>...] [< <daftar referensi> | < <daftar-"
 "objek>]"
 
 #: builtin/pack-objects.c
 msgid ""
-"git pack-objects [<options>...] <base-name> [< <ref-list> | < <object-list>]"
+"git pack-objects [<options>] <base-name> [< <ref-list> | < <object-list>]"
 msgstr ""
 "git pack-objects [<opsi>...] <nama dasar> [< <daftar referensi> | < <daftar-"
 "objek>]"
@@ -11620,8 +11655,8 @@ msgstr ""
 "<git@vger.kernel.org>. Terima kasih.\n"
 
 #: builtin/pack-refs.c
-msgid "git pack-refs [<options>]"
-msgstr "git pack-refs [<opsi>]"
+msgid "git pack-refs [--all] [--no-prune]"
+msgstr "git pack-refs [--all] [--no-prune]"
 
 #: builtin/pack-refs.c
 msgid "pack everything"
@@ -11630,6 +11665,22 @@ msgstr "pak semuanya"
 #: builtin/pack-refs.c
 msgid "prune loose refs (default)"
 msgstr "pangkas referensi longgar (asali)"
+
+#: builtin/patch-id.c
+msgid "git patch-id [--stable | --unstable | --verbatim]"
+msgstr "git patch-id [--stable | --unstable | --verbatim]"
+
+#: builtin/patch-id.c
+msgid "use the unstable patch-id algorithm"
+msgstr "gunakan algoritma id tambalan tidak stabil"
+
+#: builtin/patch-id.c
+msgid "use the stable patch-id algorithm"
+msgstr "gunakan algoritma id tambalan stabil"
+
+#: builtin/patch-id.c
+msgid "don't strip whitespace from the patch"
+msgstr "jangan kupas spasi dari tambalan"
 
 #: builtin/prune.c
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
@@ -11895,14 +11946,13 @@ msgstr ""
 #: builtin/push.c
 msgid ""
 "\n"
-"To avoid automatically configuring upstream branches when their name\n"
-"doesn't match the local branch, see option 'simple' of branch."
-"autoSetupMerge\n"
+"To avoid automatically configuring an upstream branch when its name\n"
+"won't match the local branch, see option 'simple' of branch.autoSetupMerge\n"
 "in 'git help config'.\n"
 msgstr ""
 "\n"
 "Untuk menghindari konfigurasi cabang hulu otomatis ketika namanya\n"
-"tidak cocok dengan cabang lokal, lihat opsi 'simple' dari branch."
+"tidak akan cocok dengan cabang lokal, lihat opsi 'simple' dari branch."
 "autoSetupMerge\n"
 "di 'git help config'.\n"
 
@@ -12067,6 +12117,14 @@ msgstr "Mendorong ke %s\n"
 #, c-format
 msgid "failed to push some refs to '%s'"
 msgstr "gagal dorong beberapa referensi ke '%s'"
+
+#: builtin/push.c
+msgid ""
+"recursing into submodule with push.recurseSubmodules=only; using on-demand "
+"instead"
+msgstr ""
+"mengulangi ke dalam submodul dengan push.recurseSubmodules=only; menggunakan "
+"on-demand sebagai gantinya"
 
 #: builtin/push.c builtin/send-pack.c submodule-config.c
 #, c-format
@@ -12242,14 +12300,15 @@ msgstr "butuh dua rentang komit"
 
 #: builtin/read-tree.c
 msgid ""
-"git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
-"[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
-"ish1> [<tree-ish2> [<tree-ish3>]])"
+"git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
+"prefix=<prefix>)\n"
+"              [-u | -i]] [--index-output=<file>] [--no-sparse-checkout]\n"
+"              (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
-"prefix=<prefiks>) [-u | -i]] [--no-sparse-checkout] [--index-"
-"output=<berkas>] (--empty | <mirip-pohon 1> [<mirip-pohon 2> <mirip-pohon "
-"3>])"
+"prefix=<awalan>)\n"
+"              [-u | -i]] [--index-output=<berkas>] [--no-sparse-checkout]\n"
+"              (--empty | <mirip pohon 1> [<mirip pohon 2> [mirip pohon 3]])"
 
 #: builtin/read-tree.c
 msgid "write resulting index to <file>"
@@ -12368,8 +12427,8 @@ msgstr "%s butuh tulang belakang penggabungan"
 
 #: builtin/rebase.c
 #, c-format
-msgid "could not get 'onto': '%s'"
-msgstr "tidak dapat mendapatkan 'ke': '%s'"
+msgid "invalid onto: '%s'"
+msgstr "kepada tidak valid: '%s'"
 
 #: builtin/rebase.c
 #, c-format
@@ -12742,8 +12801,8 @@ msgid "No such ref: %s"
 msgstr "Tidak ada referensi seperti: %s"
 
 #: builtin/rebase.c
-msgid "Could not resolve HEAD to a revision"
-msgstr "Tidak dapat menguraikan HEAD ke sebuah revisi"
+msgid "Could not resolve HEAD to a commit"
+msgstr "tidak dapat menguraikan komit HEAD ke sebuah komit"
 
 #: builtin/rebase.c
 #, c-format
@@ -13558,6 +13617,11 @@ msgid "could not close refs snapshot tempfile"
 msgstr "tidak dapat menutup berkas sementara jepretan referensi"
 
 #: builtin/repack.c
+#, c-format
+msgid "could not remove stale bitmap: %s"
+msgstr "tidak dapt memindahkan bitmap basi: %s"
+
+#: builtin/repack.c
 msgid "pack everything in a single pack"
 msgstr "pak semuanya dalam satu pak"
 
@@ -13656,6 +13720,10 @@ msgid "write a multi-pack index of the resulting packs"
 msgstr "tulis indeks multipak dari pak yang dihasilkan"
 
 #: builtin/repack.c
+msgid "pack prefix to store a pack containing pruned objects"
+msgstr "awalan pak untuk menyimpan pak berisi objek terpangkas"
+
+#: builtin/repack.c
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "tidak dapat menghapus pak dalam repositori objek berharga"
 
@@ -13670,10 +13738,15 @@ msgstr "nama berkas paket %s tidak diawali dengan %s"
 
 #: builtin/repack.c
 #, c-format
-msgid "missing required file: %s"
-msgstr "berkas yang diperlukan hilang: %s"
+msgid "renaming pack to '%s' failed"
+msgstr "gagal mengganti nama pak ke '%s'"
 
 #: builtin/repack.c
+#, c-format
+msgid "pack-objects did not write a '%s' file for pack %s-%s"
+msgstr "pack-objects tidak menulis berkas '%s' untuk pak %s-%s"
+
+#: builtin/repack.c sequencer.c
 #, c-format
 msgid "could not unlink: %s"
 msgstr "tidak dapat membatal taut: %s"
@@ -13917,8 +13990,10 @@ msgid "only one pattern can be given with -l"
 msgstr "hanya satu pola yang dapat diberikan dengan -l"
 
 #: builtin/rerere.c
-msgid "git rerere [clear | forget <path>... | status | remaining | diff | gc]"
-msgstr "git rerere [clear | forge <jalur>... | status | remaining | diff | gc]"
+msgid ""
+"git rerere [clear | forget <pathspec>... | diff | status | remaining | gc]"
+msgstr ""
+"git rerere [clear | forget <spek jalur>... | diff | status | remaining | gc]"
 
 #: builtin/rerere.c
 msgid "register clean resolutions in index"
@@ -14176,6 +14251,18 @@ msgstr "--prefix butuh sebuah argumen"
 msgid "unknown mode for --abbrev-ref: %s"
 msgstr "mode untuk --abbrev-ref tidak dikenal: %s"
 
+#: builtin/rev-parse.c revision.c
+msgid "--exclude-hidden cannot be used together with --branches"
+msgstr "--exclude-hidden tidak dapat digunakan bersamaan dengan --branches"
+
+#: builtin/rev-parse.c revision.c
+msgid "--exclude-hidden cannot be used together with --tags"
+msgstr "--exclude-hidden tidak dapat digunakan bersamaan dengan --tags"
+
+#: builtin/rev-parse.c revision.c
+msgid "--exclude-hidden cannot be used together with --remotes"
+msgstr "--exclude-hidden tidak dapat digunakan dengan --remotes"
+
 #: builtin/rev-parse.c setup.c
 msgid "this operation must be run in a work tree"
 msgstr "operasi ini harus dijalankan di dalam pohon kerja"
@@ -14186,20 +14273,28 @@ msgid "unknown mode for --show-object-format: %s"
 msgstr "mode untuk --show-object-format tidak dikenal: %s"
 
 #: builtin/revert.c
-msgid "git revert [<options>] <commit-ish>..."
-msgstr "git revert [<opsi>] <mirip-komit>..."
+msgid ""
+"git revert [--[no-]edit] [-n] [-m <parent-number>] [-s] [-S[<keyid>]] "
+"<commit>..."
+msgstr ""
+"git revert [--[no-]edit] [-n] [-m <nomor induk>] [-s] [-S[<id kunci>]] "
+"<komit>..."
 
 #: builtin/revert.c
-msgid "git revert <subcommand>"
-msgstr "git revert <subperintah>"
+msgid "git revert (--continue | --skip | --abort | --quit)"
+msgstr "git revert (--continue | --skip | --abort | --quit)"
 
 #: builtin/revert.c
-msgid "git cherry-pick [<options>] <commit-ish>..."
-msgstr "git cherry-pick [<opsi>] <mirip-komit>..."
+msgid ""
+"git cherry-pick [--edit] [-n] [-m <parent-number>] [-s] [-x] [--ff]\n"
+"                [-S[<keyid>]] <commit>..."
+msgstr ""
+"git cherry-pick [--edit] [-n] [-m <nomor induk>] [-s] [-x] [--ff]\n"
+"                [-S[<id kunci>]] <komit>..."
 
 #: builtin/revert.c
-msgid "git cherry-pick <subcommand>"
-msgstr "git cherry-pick <subperintah>"
+msgid "git cherry-pick (--continue | --skip | --abort | --quit)"
+msgstr "git cherry-pick (--continue | --skip | --abort | --quit)"
 
 #: builtin/revert.c
 #, c-format
@@ -14280,8 +14375,14 @@ msgid "cherry-pick failed"
 msgstr "pemetikan ceri gagal"
 
 #: builtin/rm.c
-msgid "git rm [<options>] [--] <file>..."
-msgstr "git rm [<opsi>] [--] <berkas>..."
+msgid ""
+"git rm [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch]\n"
+"       [--quiet] [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"       [--] [<pathspec>...]"
+msgstr ""
+"git rm [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch]\n"
+"       [--quiet] [--pathspec-from-file=<berkas> [--pathspec-file-nul]]\n"
+"       [--] [<spek jalur>...]"
 
 #: builtin/rm.c
 msgid ""
@@ -14369,11 +14470,13 @@ msgid ""
 "git send-pack [--mirror] [--dry-run] [--force]\n"
 "              [--receive-pack=<git-receive-pack>]\n"
 "              [--verbose] [--thin] [--atomic]\n"
+"              [--[no-]signed | --signed=(true|false|if-asked)]\n"
 "              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
 "git send-pack [--mirror] [--dry-run] [--force]\n"
 "              [--receive-pack=<git-receive-pack>\n"
-"]              [--verbose] [--thin] [--atomic]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [--[no-]signed | --signed=(true|false|if-asked)]\n"
 "              [<tuan rumah>:]<direktori> (--all | <referensi>...)"
 
 #: builtin/send-pack.c
@@ -14405,8 +14508,9 @@ msgid "using multiple --group options with stdin is not supported"
 msgstr "menggunakan banyak opsi --group dengan masukan standar tidak didukung"
 
 #: builtin/shortlog.c
-msgid "using --group=trailer with stdin is not supported"
-msgstr "mengguanakn --group=trailer dengan stdin tidak didukung"
+#, c-format
+msgid "using %s with stdin is not supported"
+msgstr "menggunakan %s dengan masukan standar tidak didukung"
 
 #: builtin/shortlog.c
 #, c-format
@@ -14454,12 +14558,14 @@ msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
 "                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
 "                [--more=<n> | --list | --independent | --merge-base]\n"
-"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
+"                [--no-name | --sha1-name] [--topics]\n"
+"                [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
 "                [--current] [--color[=<kapan>] | --no-color] [--sparse]\n"
 "                [--more=<n> | --list | --independent | --merge-base]\n"
-"                [--no-name | --sha1-name] [--topics] [(<revisi> | <glob>)...]"
+"                [--no-name | --sha1-name] [--topics]\n"
+"                [(<revisi> | <glob>)...]"
 
 #: builtin/show-branch.c
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -14589,11 +14695,13 @@ msgstr "algoritma hash tidak dikenal"
 
 #: builtin/show-ref.c
 msgid ""
-"git show-ref [-q | --quiet] [--verify] [--head] [-d | --dereference] [-s | --"
-"hash[=<n>]] [--abbrev[=<n>]] [--tags] [--heads] [--] [<pattern>...]"
+"git show-ref [-q | --quiet] [--verify] [--head] [-d | --dereference]\n"
+"             [-s | --hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
+"             [--heads] [--] [<pattern>...]"
 msgstr ""
-"git show-ref [-q | --quiet] [--verify] [--head] [-d | --dereference] [-s | --"
-"hash[=<n>]] [--abbrev[=<n>]] [--tags] [--heads] [--] [<pola>...]"
+"git show-ref [-q | --quiet] [--verify] [--head] [-d | --dereference]\n"
+"             [-s | --hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
+"             [--heads] [--] [<pola>...]"
 
 #: builtin/show-ref.c
 msgid "git show-ref --exclude-existing[=<pattern>]"
@@ -14634,8 +14742,10 @@ msgstr ""
 "lokal"
 
 #: builtin/sparse-checkout.c
-msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
-msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <opsi>"
+msgid ""
+"git sparse-checkout (init | list | set | add | reapply | disable) [<options>]"
+msgstr ""
+"git sparse-checkout (init | list | set | add | reapply | disable) [<opsi>]"
 
 #: builtin/sparse-checkout.c
 msgid "this worktree is not sparse"
@@ -14787,76 +14897,66 @@ msgid "error while refreshing working directory"
 msgstr "kesalahan saat menyegarkan direktori kerja"
 
 #: builtin/stash.c
-msgid "git stash list [<options>]"
-msgstr "git stash list [<opsi>]"
+msgid "git stash list [<log-options>]"
+msgstr "git stash list [<opsi log>]"
 
 #: builtin/stash.c
-msgid "git stash show [<options>] [<stash>]"
-msgstr "git stash show [<opsi>] [<stase>]"
+msgid ""
+"git stash show [-u | --include-untracked | --only-untracked] [<diff-"
+"options>] [<stash>]"
+msgstr ""
+"git stash show [-u | --include-untracked | --only-untracked] [<opsi diff>] "
+"[<stase>]"
 
 #: builtin/stash.c
-msgid "git stash drop [-q|--quiet] [<stash>]"
-msgstr "git stash drop [-q|--quiet] [<stase>]"
+msgid "git stash drop [-q | --quiet] [<stash>]"
+msgstr "git stash drop [-q | --quiet] [<stase>]"
 
 #: builtin/stash.c
-msgid "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
-msgstr "git stash ( pop | apply ) [--index] [-q|--quiet] [<stase>]"
+msgid "git stash pop [--index] [-q | --quiet] [<stash>]"
+msgstr "git stash pop [--index] [-q | --quiet] [<stase>]"
+
+#: builtin/stash.c
+msgid "git stash apply [--index] [-q | --quiet] [<stash>]"
+msgstr "git stash apply [--index] [-q | --quiet] [<stase>]"
 
 #: builtin/stash.c
 msgid "git stash branch <branchname> [<stash>]"
 msgstr "git stash branch <nama cabang> [<stase>]"
 
 #: builtin/stash.c
+msgid "git stash store [(-m | --message) <message>] [-q | --quiet] <commit>"
+msgstr "git stash store [(-m | --message) <pesan>] [-q|--quiet] <komit>"
+
+#: builtin/stash.c
 msgid ""
-"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
-"quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
+"git stash [push [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q "
+"| --quiet]\n"
+"          [-u | --include-untracked] [-a | --all] [(-m | --message) "
+"<message>]\n"
 "          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
-"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index]\n"
-"          [-q|--quiet] [-u|--include-untracked] [-a|--all]\n"
-"          [-m|--message <pesan>] [--pathspec-from-file=<berkas>\n"
-"          [--pathspec-file-nul]] [--] [<spek jalur>...]]"
+"git stash [push [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q "
+"| --quiet]\n"
+"          [-u | --include-untracked] [-a | --all] [(-m | --message) "
+"<pesan>]\n"
+"          [--pathspec-from-file=<berkas> [--pathspec-file-nul]]\n"
+"          [--] [<spek jalur>...]]"
 
 #: builtin/stash.c
 msgid ""
-"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
-"quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [<message>]"
+"git stash save [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q | "
+"--quiet]\n"
+"          [-u | --include-untracked] [-a | --all] [<message>]"
 msgstr ""
-"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index]\n"
-"          [-q|--quiet] [-u|--include-untracked] [-a|--all] [<pesan>]"
+"git stash save [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q | "
+"--quiet]\n"
+"          [-u | --include-untracked] [-a | --all] [<pesan>]"
 
 #: builtin/stash.c
-msgid "git stash pop [--index] [-q|--quiet] [<stash>]"
-msgstr "git stash pop [--index] [-q|--quiet] [<stase>]"
-
-#: builtin/stash.c
-msgid "git stash apply [--index] [-q|--quiet] [<stash>]"
-msgstr "git stash apply [--index] [-q|--quiet] [<stase>]"
-
-#: builtin/stash.c
-msgid "git stash store [-m|--message <message>] [-q|--quiet] <commit>"
-msgstr "git stash store [-m|--message <pesan>] [-q|--quiet] <komit>"
-
-#: builtin/stash.c
-msgid ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
-"          [--] [<pathspec>...]]"
-msgstr ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [-m|--message <pesan>]\n"
-"          [--] [<spek jalur>...]"
-
-#: builtin/stash.c
-msgid ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"               [-u|--include-untracked] [-a|--all] [<message>]"
-msgstr ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"               [-u|--include-untracked] [-a|--all] [<pesan>]"
+msgid "git stash create [<message>]"
+msgstr "git stash create [<pesan>]"
 
 #: builtin/stash.c
 #, c-format
@@ -15565,10 +15665,6 @@ msgid "don't fetch new objects from the remote site"
 msgstr "jangan ambil objek baru dari situs remote"
 
 #: builtin/submodule--helper.c
-msgid "path into the working tree"
-msgstr "jalur ke dalam pohon kerja"
-
-#: builtin/submodule--helper.c
 msgid "use the 'checkout' update strategy (default)"
 msgstr "gunakan strategi pembaruan 'checkout' (asali)"
 
@@ -15614,32 +15710,8 @@ msgstr ""
 "[--] [<jalur>...]"
 
 #: builtin/submodule--helper.c
-msgid "recurse into submodules"
-msgstr "rekursi ke dalam submodul"
-
-#: builtin/submodule--helper.c
 msgid "git submodule absorbgitdirs [<options>] [<path>...]"
 msgstr "git submodule absorbgitdirs [<opsi>] [<jalur>...]"
-
-#: builtin/submodule--helper.c
-msgid "check if it is safe to write to the .gitmodules file"
-msgstr "periksa apakah itu aman untuk menulis ke berkas .gitmodules"
-
-#: builtin/submodule--helper.c
-msgid "unset the config in the .gitmodules file"
-msgstr "batal setel konfigurasi dalam berkas .gitmodules"
-
-#: builtin/submodule--helper.c
-msgid "git submodule--helper config <name> [<value>]"
-msgstr "git submodule--helper config <nama> [<nilai>]"
-
-#: builtin/submodule--helper.c
-msgid "git submodule--helper config --unset <name>"
-msgstr "git submodule--helper config --unset <nama>"
-
-#: builtin/submodule--helper.c
-msgid "please make sure that the .gitmodules file is in the working tree"
-msgstr "mohom pastikan berkas .gitmodules di dalam pohon kerja"
 
 #: builtin/submodule--helper.c
 msgid "suppress output for setting url of a submodule"
@@ -15737,6 +15809,10 @@ msgid "unable to checkout submodule '%s'"
 msgstr "Tidak dapat men-checkout submodul '%s'"
 
 #: builtin/submodule--helper.c
+msgid "please make sure that the .gitmodules file is in the working tree"
+msgstr "mohom pastikan berkas .gitmodules di dalam pohon kerja"
+
+#: builtin/submodule--helper.c
 #, c-format
 msgid "Failed to add submodule '%s'"
 msgstr "Tidak dapat menambahkan submodul '%s'"
@@ -15798,23 +15874,26 @@ msgstr "URL repo: '%s' harus absolut atau diawali dengan ./|../"
 msgid "'%s' is not a valid submodule name"
 msgstr "'%s' bukan nama submodul yang valid"
 
+#: builtin/submodule--helper.c
+msgid "git submodule--helper <command>"
+msgstr "git submodule--helper <nama>"
+
 #: builtin/submodule--helper.c git.c
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s tidak mendukung --super-prefix"
 
-#: builtin/submodule--helper.c
-#, c-format
-msgid "'%s' is not a valid submodule--helper subcommand"
-msgstr "'%s' bukan subperintah submodule--helper valid"
+#: builtin/symbolic-ref.c
+msgid "git symbolic-ref [-m <reason>] <name> <ref>"
+msgstr "git symbolic-ref [-m <alasan>] <nama> <referensi>"
 
 #: builtin/symbolic-ref.c
-msgid "git symbolic-ref [<options>] <name> [<ref>]"
-msgstr "git symbolic-ref [<opsi>] <nama> [<referensi>]"
+msgid "git symbolic-ref [-q] [--short] [--no-recurse] <name>"
+msgstr "git symbolic-ref [-q] [--short] [--no-recurse] <nama>"
 
 #: builtin/symbolic-ref.c
-msgid "git symbolic-ref -d [-q] <name>"
-msgstr "git symbolic-ref -d [-q] <nama>"
+msgid "git symbolic-ref --delete [-q] <name>"
+msgstr "git symbolic-ref --delete [-q] <nama>"
 
 #: builtin/symbolic-ref.c
 msgid "suppress error message for non-symbolic (detached) refs"
@@ -15828,6 +15907,10 @@ msgstr "hapus referensi simbolik"
 msgid "shorten ref output"
 msgstr "pendekkan keluaran referensi"
 
+#: builtin/symbolic-ref.c
+msgid "recursively dereference (default)"
+msgstr "derefensi secara rekursif (asali)"
+
 #: builtin/symbolic-ref.c builtin/update-ref.c
 msgid "reason"
 msgstr "alasan"
@@ -15838,11 +15921,11 @@ msgstr "alasan pembaruan"
 
 #: builtin/tag.c
 msgid ""
-"git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
-"        <tagname> [<head>]"
+"git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>] [-e]\n"
+"        <tagname> [<commit> | <object>]"
 msgstr ""
-"git tag [-a | -s | -u <id kunci>] [-f] [-m <pesan | -F <berkas>]\n"
-"        <nama tag> [<kepala>]"
+"git tag [-a | -s | -u <id kunci>] [-f] [-m <pesan> | -F <berkas>] [-e]\n"
+"        <nama tag> [<komit> | <objek>]"
 
 #: builtin/tag.c
 msgid "git tag -d <tagname>..."
@@ -15850,15 +15933,15 @@ msgstr "git tag -d <nama tag>..."
 
 #: builtin/tag.c
 msgid ""
-"git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
-"points-at <object>]\n"
-"        [--format=<format>] [--merged <commit>] [--no-merged <commit>] "
-"[<pattern>...]"
+"git tag [-n[<num>]] -l [--contains <commit>] [--no-contains <commit>]\n"
+"        [--points-at <object>] [--column[=<options>] | --no-column]\n"
+"        [--create-reflog] [--sort=<key>] [--format=<format>]\n"
+"        [--merged <commit>] [--no-merged <commit>] [<pattern>...]"
 msgstr ""
-"git tag -l [-n[<angka>]] [--contains <komit>] [--no-contains <komit>] [--"
-"points-at <objek>]\n"
-"        [--format=<format>] [--merged <komit>] [--no-merged <komit>] "
-"[<pola>...]"
+"git tag [-n[<angka>]] -l [--contains <komit>] [--no-contains <komit>]\n"
+"        [--points-at <objeck>] [--column[=<opsi>] | --no-column]\n"
+"        [--create-reflog] [--sort=<kunci>] [--format=<format>]\n"
+"        [--merged <komit>] [--no-merged <komit>] [<pola>...]"
 
 #: builtin/tag.c
 msgid "git tag -v [--format=<format>] <tagname>..."
@@ -16340,8 +16423,12 @@ msgid "update the info files from scratch"
 msgstr "perbarui berkas info dari awal"
 
 #: builtin/upload-pack.c
-msgid "git upload-pack [<options>] <dir>"
-msgstr "git upload-pack [<opsi>] <direktori>"
+msgid ""
+"git-upload-pack [--[no-]strict] [--timeout=<n>] [--stateless-rpc]\n"
+"                [--advertise-refs] <directory>"
+msgstr ""
+"git-upload-pack [--[no-]strict] [--timeout=<n>] [--stateless-rpc]\n"
+"                [--advertise-refs] <direktori>"
 
 #: builtin/upload-pack.c t/helper/test-serve-v2.c
 msgid "quit after a single request/response exchange"
@@ -16360,8 +16447,8 @@ msgid "interrupt transfer after <n> seconds of inactivity"
 msgstr "interupsi transfer setelah <n> detik niraktivitas"
 
 #: builtin/verify-commit.c
-msgid "git verify-commit [-v | --verbose] <commit>..."
-msgstr "git verify-commit [-v | --verbose] <komit>..."
+msgid "git verify-commit [-v | --verbose] [--raw] <commit>..."
+msgstr "git verify-commit [-v | --verbose] [--raw] <komit>..."
 
 #: builtin/verify-commit.c
 msgid "print commit contents"
@@ -16372,8 +16459,8 @@ msgid "print raw gpg status output"
 msgstr "cetak keluaran status gpg mentah"
 
 #: builtin/verify-pack.c
-msgid "git verify-pack [-v | --verbose] [-s | --stat-only] <pack>..."
-msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] <pak>..."
+msgid "git verify-pack [-v | --verbose] [-s | --stat-only] [--] <pack>.idx..."
+msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] [--] <pak>.idx..."
 
 #: builtin/verify-pack.c
 msgid "verbose"
@@ -16384,44 +16471,48 @@ msgid "show statistics only"
 msgstr "hanya perlihatkan statistik"
 
 #: builtin/verify-tag.c
-msgid "git verify-tag [-v | --verbose] [--format=<format>] <tag>..."
-msgstr "git verify-tag [-v | --verbose] [--format=<format>] <tag>..."
+msgid "git verify-tag [-v | --verbose] [--format=<format>] [--raw] <tag>..."
+msgstr "git verify-tag [-v | --verbose] [--format=<format>] [--raw] <tag>..."
 
 #: builtin/verify-tag.c
 msgid "print tag contents"
 msgstr "cetak isi tag"
 
 #: builtin/worktree.c
-msgid "git worktree add [<options>] <path> [<commit-ish>]"
-msgstr "git worktree add [<opsi>] <jalur> [<mirip komit>]"
+msgid ""
+"git worktree add [-f] [--detach] [--checkout] [--lock [--reason <string>]]\n"
+"                 [-b <new-branch>] <path> [<commit-ish>]"
+msgstr ""
+"git worktree add [-f] [--detach] [--checkout] [--lock [--reason <untai>]]\n"
+"                 [-b <cabang baru>] <jalur> [<mirip komit>]"
 
 #: builtin/worktree.c
-msgid "git worktree list [<options>]"
-msgstr "git worktree list [<opsi>]"
+msgid "git worktree list [-v | --porcelain [-z]]"
+msgstr "git worktree list [-v | --porcelain [-z]"
 
 #: builtin/worktree.c
-msgid "git worktree lock [<options>] <path>"
-msgstr "git worktree lock [<opsi>] <jalur>"
+msgid "git worktree lock [--reason <string>] <worktree>"
+msgstr "git worktree lock [--reason <untai>] <pohon kerja>"
 
 #: builtin/worktree.c
 msgid "git worktree move <worktree> <new-path>"
 msgstr "git worktree move <pohon kerja> <jalur baru>"
 
 #: builtin/worktree.c
-msgid "git worktree prune [<options>]"
-msgstr "git worktree prune [<opsi>]"
+msgid "git worktree prune [-n] [-v] [--expire <expire>]"
+msgstr "git worktree prune [-n] [-v] [--expire <kadaluarsa>]"
 
 #: builtin/worktree.c
-msgid "git worktree remove [<options>] <worktree>"
-msgstr "git worktree remove [<opsi>] <pohon kerja>"
+msgid "git worktree remove [-f] <worktree>"
+msgstr "git worktree remove [-f] <pohon kerja>"
 
 #: builtin/worktree.c
 msgid "git worktree repair [<path>...]"
 msgstr "git worktree repair [<jalur>...]"
 
 #: builtin/worktree.c
-msgid "git worktree unlock <path>"
-msgstr "git worktree unlock <jalur>"
+msgid "git worktree unlock <worktree>"
+msgstr "git worktree unlock <worktree>"
 
 #: builtin/worktree.c
 #, c-format
@@ -16713,6 +16804,11 @@ msgid "core.fsyncMethod = batch is unsupported on this platform"
 msgstr "core.fsyncMethod = batch tidak didukung pada platform ini"
 
 #: bundle-uri.c
+#, c-format
+msgid "bundle list at '%s' has no mode"
+msgstr "daftar bundel pada '%s' tidak punya mode"
+
+#: bundle-uri.c
 msgid "failed to create temporary file"
 msgstr "tidak dapat membuat berkas sementara"
 
@@ -16722,18 +16818,35 @@ msgstr "tidak cukup kemampuan"
 
 #: bundle-uri.c
 #, c-format
+msgid "unrecognized bundle mode from URI '%s'"
+msgstr "mode bundel tidak dikenal dari URI '%s'"
+
+#: bundle-uri.c
+#, c-format
+msgid "exceeded bundle URI recursion limit (%d)"
+msgstr "batas rekursi URI bundel (%d) terlewati"
+
+#: bundle-uri.c
+#, c-format
 msgid "failed to download bundle from URI '%s'"
 msgstr "gagal mengunduh bundel dari URI '%s'"
 
 #: bundle-uri.c
 #, c-format
-msgid "file at URI '%s' is not a bundle"
-msgstr "berkas pada URI '%s' bukan sebuah bundle"
+msgid "file at URI '%s' is not a bundle or bundle list"
+msgstr "berkas pada URI '%s' bukan sebuah bundel atau daftar bundel"
 
 #: bundle-uri.c
-#, c-format
-msgid "failed to unbundle bundle from URI '%s'"
-msgstr "gagal membongkar bundel dari URI '%s'"
+msgid "bundle-uri: got an empty line"
+msgstr "bundle-uri: dapat satu baris kosong"
+
+#: bundle-uri.c
+msgid "bundle-uri: line is not of the form 'key=value'"
+msgstr "bundle-uri: baris bukan berbentuk 'kunci=nilai'"
+
+#: bundle-uri.c
+msgid "bundle-uri: line has empty key or value"
+msgstr "bundle-uri: baris berisi kunci atau nilai kosong"
 
 #: bundle.c
 #, c-format
@@ -17496,7 +17609,7 @@ msgid "Chunk-based file formats"
 msgstr "Berkas format berbasis bingkah"
 
 #: command-list.h
-msgid "Git commit graph format"
+msgid "Git commit-graph format"
 msgstr "Format grafik komit Git"
 
 #: command-list.h
@@ -17929,6 +18042,11 @@ msgstr "kasus tak tertangani di 'has_worktree_moved': %d"
 msgid "health thread wait failed [GLE %ld]"
 msgstr "antri utas kesehatan gagal [GLE %ld]"
 
+#: compat/fsmonitor/fsm-ipc-darwin.c
+#, c-format
+msgid "Invalid path: %s"
+msgstr "Jalur tidak valid: %s"
+
 #: compat/fsmonitor/fsm-listen-darwin.c
 msgid "Unable to create FSEventStream."
 msgstr "tidak dapat membuat FSEventStream."
@@ -17967,12 +18085,32 @@ msgstr "GetOverlappedResult gagal pada '%s' [GLE %ld]"
 msgid "could not read directory changes [GLE %ld]"
 msgstr "tidak dapat membaca perubahan direktori [GLE %ld]"
 
-#: compat/fsmonitor/fsm-settings-win32.c
+#: compat/fsmonitor/fsm-path-utils-darwin.c
+#, c-format
+msgid "opendir('%s') failed"
+msgstr "opendir('%s') gagal"
+
+#: compat/fsmonitor/fsm-path-utils-darwin.c
+#, c-format
+msgid "lstat('%s') failed"
+msgstr "lstat('%s') gagal"
+
+#: compat/fsmonitor/fsm-path-utils-darwin.c
+#, c-format
+msgid "strbuf_readlink('%s') failed"
+msgstr "strbuf_readlink('%s') gagal"
+
+#: compat/fsmonitor/fsm-path-utils-darwin.c
+#, c-format
+msgid "closedir('%s') failed"
+msgstr "closedir('%s') gagal"
+
+#: compat/fsmonitor/fsm-path-utils-win32.c
 #, c-format
 msgid "[GLE %ld] unable to open for read '%ls'"
 msgstr "[GLE %ld] tidak dapat membuka untuk dibaca '%ls'"
 
-#: compat/fsmonitor/fsm-settings-win32.c
+#: compat/fsmonitor/fsm-path-utils-win32.c
 #, c-format
 msgid "[GLE %ld] unable to get protocol information for '%ls'"
 msgstr "[GLE %ld] tidak dapat mendapatkan informasi protokol untuk '%ls'"
@@ -19983,10 +20121,11 @@ msgstr "repositori virtual '%s' tidka kompatibel dengan fsmonitor"
 #: fsmonitor-settings.c
 #, c-format
 msgid ""
-"repository '%s' is incompatible with fsmonitor due to lack of Unix sockets"
+"socket directory '%s' is incompatible with fsmonitor due to lack of Unix "
+"sockets support"
 msgstr ""
-"repositori '%s' tidak kompatibel dengan fsmonitor karena kekurangan soket "
-"Unix"
+"direktori soket '%s' tidak kompatibel dengan fsmonitor karena kekurangan "
+"dukungan soket Unix"
 
 #: git.c
 msgid ""
@@ -20380,8 +20519,8 @@ msgstr[1] ""
 "Perintah paling mirip adalah"
 
 #: help.c
-msgid "git version [<options>]"
-msgstr "git version [<opsi>]"
+msgid "git version [--build-options]"
+msgstr "git version [--build-options]"
 
 #: help.c
 #, c-format
@@ -21493,11 +21632,6 @@ msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: mengabaikan penyimpanan objek alternatif, bersarang terlalu dalam"
 
 #: object-file.c
-#, c-format
-msgid "unable to normalize object directory: %s"
-msgstr "tidak dapat menormalisasikan direktori objek: %s"
-
-#: object-file.c
 msgid "unable to fdopen alternates lockfile"
 msgstr "tidak dapat men-fdopen berkas kunci alternatif"
 
@@ -22519,6 +22653,11 @@ msgstr ""
 #, c-format
 msgid "promisor remote name cannot begin with '/': %s"
 msgstr "nama remote penjanji tidak dapat diawali dengan '/': %s"
+
+#: promisor-remote.c
+#, c-format
+msgid "could not fetch %s from promisor remote"
+msgstr "tidak dapat mengambil %s dari remote penjanji"
 
 #: protocol-caps.c
 msgid "object-info: expected flush after arguments"
@@ -23821,6 +23960,15 @@ msgstr "gagal menemukan pohon %s"
 
 #: revision.c
 #, c-format
+msgid "unsupported section for hidden refs: %s"
+msgstr "seksi tidak didukung untuk referensi tersembunyi: %s"
+
+#: revision.c
+msgid "--exclude-hidden= passed more than once"
+msgstr "--exclude-hidden= dilewatkan lebih dari sekali"
+
+#: revision.c
+#, c-format
 msgid "resolve-undo records `%s` which is missing"
 msgstr "resolve-undo merekam `%s` yang dimana hilang"
 
@@ -24004,6 +24152,16 @@ msgstr "scalar reconfigure [--all | <pendaftaran>]"
 #: scalar.c
 msgid "--all or <enlistment>, but not both"
 msgstr "--all atau <pendaftaran>, tetapi bukan kedua-duanya"
+
+#: scalar.c
+#, c-format
+msgid "could not remove stale scalar.repo '%s'"
+msgstr "tidak dapat menghapus scalar.repo basi '%s'"
+
+#: scalar.c
+#, c-format
+msgid "removing stale scalar.repo '%s'"
+msgstr "menghapus scalar.repo basi '%s'"
 
 #: scalar.c
 #, c-format
@@ -24763,17 +24921,17 @@ msgid "illegal label name: '%.*s'"
 msgstr "nama label ilegal: '%.*s'"
 
 #: sequencer.c
+#, c-format
+msgid "could not resolve '%s'"
+msgstr "tidak dapat menguraikan '%s'"
+
+#: sequencer.c
 msgid "writing fake root commit"
 msgstr "menulis komit akar palsu"
 
 #: sequencer.c
 msgid "writing squash-onto"
 msgstr "menulis squash-onto"
-
-#: sequencer.c
-#, c-format
-msgid "could not resolve '%s'"
-msgstr "tidak dapat menguraikan '%s'"
 
 #: sequencer.c
 msgid "cannot merge without a current revision"
@@ -25502,100 +25660,116 @@ msgstr "ls-tree kembalikan kode kembali %d yang tak diharapkan"
 msgid "failed to lstat '%s'"
 msgstr "gagal men-lstat '%s'"
 
+#: t/helper/test-cache-tree.c
+msgid "test-tool cache-tree <options> (control|prime|update)"
+msgstr "test-tool cache-tree <opsi> (control|prime|update)"
+
+#: t/helper/test-cache-tree.c
+msgid "clear the cache tree before each iteration"
+msgstr "bersihkan pohon tembolok sebelum setiap iterasi"
+
+#: t/helper/test-cache-tree.c
+msgid "number of entries in the cache tree to invalidate (default 0)"
+msgstr "jumlah entri di dalam pohon tembolok untuk dinirvalidasi (asali 0)"
+
 #: t/helper/test-fast-rebase.c
 msgid "unhandled options"
-msgstr ""
+msgstr "opsi tak tertangani"
 
 #: t/helper/test-fast-rebase.c
 msgid "error preparing revisions"
-msgstr ""
+msgstr "kesalahan menyiapkan revisi"
 
 #: t/helper/test-reach.c
 #, c-format
 msgid "commit %s is not marked reachable"
-msgstr ""
+msgstr "komit %s tidak ditandai sebagai dapat dicapai"
 
 #: t/helper/test-reach.c
 msgid "too many commits marked reachable"
-msgstr ""
+msgstr "terlalu banyak komit yang ditandai sebagai dapat dicapai"
 
 #: t/helper/test-serve-v2.c
 msgid "test-tool serve-v2 [<options>]"
-msgstr ""
+msgstr "test-tool serve-v2 [<opsi>]"
 
 #: t/helper/test-serve-v2.c
 msgid "exit immediately after advertising capabilities"
-msgstr ""
+msgstr "langsung keluar setelah mengiklankan kemampuan"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
-msgstr ""
+msgstr "test-helper simple-ipc is-active    [<nama>] [<opsi>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
-msgstr ""
+msgstr "test-helper simple-ipc run-daemon   [<nama>] [<utas>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
 msgstr ""
+"test-helper simple-ipc start-daemon [<nama>] [<utas>] [<tunggu maksimum>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
-msgstr ""
+msgstr "test-helper simple-ipc stop-daemon  [<nama> [<tunggu maksimum>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
-msgstr ""
+msgstr "test-helper simple-ipc send         [<nama>] [<token>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
 msgstr ""
+"test-helper simple-ipc sendbytes    [<nama>] [<hitungan bita>] [<bita>]"
 
 #: t/helper/test-simple-ipc.c
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
 msgstr ""
+"test-helper simple-ipc multiple     [<nama>] [<utas>] [<hitungan bita>] "
+"[<ukuran batch>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "name or pathname of unix domain socket"
-msgstr ""
+msgstr "nama atau nama jalur soket domain unix"
 
 #: t/helper/test-simple-ipc.c
 msgid "named-pipe name"
-msgstr ""
+msgstr "nama pipa bernama"
 
 #: t/helper/test-simple-ipc.c
 msgid "number of threads in server thread pool"
-msgstr ""
+msgstr "jumlah utas pada kolam utas peladen"
 
 #: t/helper/test-simple-ipc.c
 msgid "seconds to wait for daemon to start or stop"
-msgstr ""
+msgstr "waktu menunggu daemon dimulai atau dihentikan (dalam detik)"
 
 #: t/helper/test-simple-ipc.c
 msgid "number of bytes"
-msgstr ""
+msgstr "jumlah bita"
 
 #: t/helper/test-simple-ipc.c
 msgid "number of requests per thread"
-msgstr ""
+msgstr "jumlah permintaan tiap utas"
 
 #: t/helper/test-simple-ipc.c
 msgid "byte"
-msgstr ""
+msgstr "bita"
 
 #: t/helper/test-simple-ipc.c
 msgid "ballast character"
-msgstr ""
+msgstr "karakter pemberat"
 
 #: t/helper/test-simple-ipc.c
 msgid "token"
-msgstr ""
+msgstr "token"
 
 #: t/helper/test-simple-ipc.c
 msgid "command token to send to the server"
-msgstr ""
+msgstr "token perintah untuk dikirim ke peladen"
 
 #: trailer.c
 #, c-format
@@ -27634,3 +27808,147 @@ msgstr "Melewati %s dengan akhiran cadangan '%s'.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Anda benar-benar ingin mengirim %s? [y|N]: "
+
+#, c-format
+#~ msgid "unable to normalize object directory: %s"
+#~ msgstr "tidak dapat menormalisasikan direktori objek: %s"
+
+#~ msgid "reset the bisection state"
+#~ msgstr "setel ulang keadaan pembagian dua"
+
+#~ msgid "check whether bad or good terms exist"
+#~ msgstr "periksa apakah ada istilah jelek atau bagus"
+
+#~ msgid "print out the bisect terms"
+#~ msgstr "cetak istilah pembagian dua"
+
+#~ msgid "start the bisect session"
+#~ msgstr "mulai sesi pembagian dua"
+
+#~ msgid "find the next bisection commit"
+#~ msgstr "temukan komit pembagian dua berikutnya"
+
+#~ msgid "mark the state of ref (or refs)"
+#~ msgstr "tandai keadaan referensi"
+
+#~ msgid "list the bisection steps so far"
+#~ msgstr "daftar langkah pembagian dua sejauh ini"
+
+#~ msgid "replay the bisection process from the given file"
+#~ msgstr "mainkan ulang proses pembagian dua dari berkas yang diberikan"
+
+#~ msgid "skip some commits for checkout"
+#~ msgstr "lewati beberapa komit untuk checkout"
+
+#~ msgid "visualize the bisection"
+#~ msgstr "visualisasikan pembagian dua"
+
+#~ msgid "use <cmd>... to automatically bisect"
+#~ msgstr "gunakan <cmd>... untuk bagi dua otomatis."
+
+#~ msgid "no log for BISECT_WRITE"
+#~ msgstr "tidak ada log untuk BISECT_WRITE"
+
+#~ msgid "Couldn't look up commit object for HEAD"
+#~ msgstr "Tidak dapat mencari objek komit untuk HEAD"
+
+#~ msgid "git bundle create [<options>] <file> <git-rev-list args>"
+#~ msgstr "git bundle create [<opsi>] <berkas> <argumen git-rev-list>"
+
+#, c-format
+#~ msgid "options '%s' and '%s %s' cannot be used together"
+#~ msgstr "opsi '%s' dan '%s %s' tidak dapat digunakan bersamaan"
+
+#~ msgid "git commit [<options>] [--] <pathspec>..."
+#~ msgstr "git commit [<opsi>] [--] <spek jalur>..."
+
+#~ msgid "git fsck [<options>] [<object>...]"
+#~ msgstr "git fsck [<opsi>] [<objek>...]"
+
+#~ msgid "git fsmonitor--daemon stop"
+#~ msgstr "git fsmonitor--daemon stop"
+
+#~ msgid "git fsmonitor--daemon status"
+#~ msgstr "git fsmonitor--daemon status"
+
+#~ msgid "failed to run 'git config'"
+#~ msgstr "gagal menjalankan 'git config'"
+
+#, c-format
+#~ msgid "could not get 'onto': '%s'"
+#~ msgstr "tidak dapat mendapatkan 'ke': '%s'"
+
+#~ msgid "Could not resolve HEAD to a revision"
+#~ msgstr "Tidak dapat menguraikan HEAD ke sebuah revisi"
+
+#, c-format
+#~ msgid "missing required file: %s"
+#~ msgstr "berkas yang diperlukan hilang: %s"
+
+#~ msgid "git revert [<options>] <commit-ish>..."
+#~ msgstr "git revert [<opsi>] <mirip-komit>..."
+
+#~ msgid "git revert <subcommand>"
+#~ msgstr "git revert <subperintah>"
+
+#~ msgid "git cherry-pick [<options>] <commit-ish>..."
+#~ msgstr "git cherry-pick [<opsi>] <mirip-komit>..."
+
+#~ msgid "git cherry-pick <subcommand>"
+#~ msgstr "git cherry-pick <subperintah>"
+
+#~ msgid "git rm [<options>] [--] <file>..."
+#~ msgstr "git rm [<opsi>] [--] <berkas>..."
+
+#~ msgid "using --group=trailer with stdin is not supported"
+#~ msgstr "mengguanakn --group=trailer dengan stdin tidak didukung"
+
+#~ msgid "git stash show [<options>] [<stash>]"
+#~ msgstr "git stash show [<opsi>] [<stase>]"
+
+#~ msgid "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
+#~ msgstr "git stash ( pop | apply ) [--index] [-q|--quiet] [<stase>]"
+
+#~ msgid ""
+#~ "git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+#~ "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
+#~ "          [--] [<pathspec>...]]"
+#~ msgstr ""
+#~ "git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+#~ "          [-u|--include-untracked] [-a|--all] [-m|--message <pesan>]\n"
+#~ "          [--] [<spek jalur>...]"
+
+#~ msgid ""
+#~ "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+#~ "               [-u|--include-untracked] [-a|--all] [<message>]"
+#~ msgstr ""
+#~ "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+#~ "               [-u|--include-untracked] [-a|--all] [<pesan>]"
+
+#~ msgid "path into the working tree"
+#~ msgstr "jalur ke dalam pohon kerja"
+
+#~ msgid "recurse into submodules"
+#~ msgstr "rekursi ke dalam submodul"
+
+#~ msgid "check if it is safe to write to the .gitmodules file"
+#~ msgstr "periksa apakah itu aman untuk menulis ke berkas .gitmodules"
+
+#~ msgid "unset the config in the .gitmodules file"
+#~ msgstr "batal setel konfigurasi dalam berkas .gitmodules"
+
+#~ msgid "git submodule--helper config --unset <name>"
+#~ msgstr "git submodule--helper config --unset <nama>"
+
+#, c-format
+#~ msgid "'%s' is not a valid submodule--helper subcommand"
+#~ msgstr "'%s' bukan subperintah submodule--helper valid"
+
+#~ msgid "git upload-pack [<options>] <dir>"
+#~ msgstr "git upload-pack [<opsi>] <direktori>"
+
+#~ msgid "git worktree add [<options>] <path> [<commit-ish>]"
+#~ msgstr "git worktree add [<opsi>] <jalur> [<mirip komit>]"
+
+#~ msgid "git worktree lock [<options>] <path>"
+#~ msgstr "git worktree lock [<opsi>] <jalur>"


### PR DESCRIPTION
All of updates are new strings translation.

Update following components:

  * builtin/bundle.c
  * builtin/clone.c
  * builtin/commit.c
  * builtin/describe.c
  * builtin/diff.c
  * builtin/fsck.c
  * builtin/gc.c
  * builtin/merge-tree.c
  * builtin/repack.c
  * builtin/revert.c
  * builtin/stash.c
  * builtin/upload-pack.c
  * builtin/worktree.c
  * bundle-uri.c
  * push.c
  * revision.c
  * scalar.c

Translate following new components:

  * builtin/patch-id.c
  * t/helper/test-cache-tree.c
  * t/helper/test-fast-rebase.c
  * t/helper/test-reach.c
  * t/helper/test-serve-v2.c
  * t/helper/test-simple-ipc.c

Signed-off-by: Bagas Sanjaya <bagasdotme@gmail.com>
