### PR TITLE
ci(l10n): bump Actions versions to avoid Node.js 16 deprecation warnings

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -63,7 +63,7 @@ jobs:
             origin \
             ${{ github.ref }} \
             $args
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.16'
       - name: Install git-po-helper
@@ -91,7 +91,7 @@ jobs:
           cat git-po-helper.out
           exit $exit_code
       - name: Create comment in pull request for report
-        uses: mshick/add-pr-comment@v1
+        uses: mshick/add-pr-comment@v2
         if: >-
           always() &&
           github.event_name == 'pull_request_target' &&


### PR DESCRIPTION
This avoids the "Node.js 16 Actions are deprecated" warnings.

Since this workflow only runs in the l10n forks of `git/git`, it would be inappropriate to submit this patch to the Git mailing list for review, and I deem this the correct place to offer my contribution.