### PR TITLE
l10n: ci: suppress warnings introduced when bumping Actions versions in l10n.yml

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -1,6 +1,6 @@
 name: git-l10n
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 # Avoid unnecessary builds. Unlike the main CI jobs, these are not
 # ci-configurable (but could be).
@@ -21,7 +21,7 @@ jobs:
       - name: Setup base and head objects
         id: setup-tips
         run: |
-          if test "${{ github.event_name }}" = "pull_request_target"
+          if test "${{ github.event_name }}" = "pull_request"
           then
             base=${{ github.event.pull_request.base.sha }}
             head=${{ github.event.pull_request.head.sha }}
@@ -95,7 +95,7 @@ jobs:
         uses: mshick/add-pr-comment@v2
         if: >-
           always() &&
-          github.event_name == 'pull_request_target' &&
+          github.event_name == 'pull_request' &&
           env.COMMENT_BODY != ''
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8173,7 +8173,7 @@ msgstr "'git multi-pack-index repack' 失败"
 #: builtin/gc.c
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
-msgstr "跳过增量重新打包任务，因为 core.multiPackIndex 被禁用"
+msgstr "跳过增量重新打包任务，因为 core.index 被禁用"
 
 #: builtin/gc.c
 #, c-format


### PR DESCRIPTION
Suppress warnings introduced when bumping Actions versions in l10n.yml

* l10n: ci: disable cache for setup-go to suppress warnings
* l10n: ci: remove unused param for add-pr-comment@v2