### PR TITLE
l10n: Add initial Irish translation (ga.po)

### DIFF
--- a/po/ga.po
+++ b/po/ga.po
@@ -7,16 +7,3312 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2025-05-14 08:56+0100\n"
+"POT-Creation-Date: 2025-05-12 22:57+0000\n"
 "PO-Revision-Date: 2025-05-14 13:12+0100\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: none\n"
 "Language: ga\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
 "X-Generator: Poedit 3.4.4\n"
+
+#, c-format
+msgid "Huh (%s)?"
+msgstr ""
+
+#, fuzzy
+msgid "could not read index"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+msgid "binary"
+msgstr ""
+
+msgid "nothing"
+msgstr ""
+
+#, fuzzy
+msgid "unchanged"
+msgstr "Gan aon athruithe"
+
+msgid "Update"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not stage '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "could not write index"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "updated %d path\n"
+msgid_plural "updated %d paths\n"
+msgstr[0] "Nuashonraíodh %d cosán ó %s"
+msgstr[1] "Nuashonraíodh %d cosán ó %s"
+msgstr[2] "Nuashonraíodh %d cosán ó %s"
+
+#, c-format
+msgid "note: %s is untracked now.\n"
+msgstr ""
+
+#, c-format
+msgid "make_cache_entry failed for path '%s'"
+msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
+
+msgid "Revert"
+msgstr ""
+
+#, fuzzy
+msgid "Could not parse HEAD^{tree}"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "reverted %d path\n"
+msgid_plural "reverted %d paths\n"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy, c-format
+msgid "No untracked files.\n"
+msgstr "Comhaid neamhrianaithe"
+
+msgid "Add untracked"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "added %d path\n"
+msgid_plural "added %d paths\n"
+msgstr[0] "a chuir siad leis:"
+msgstr[1] "a chuir siad leis:"
+msgstr[2] "a chuir siad leis:"
+
+#, fuzzy, c-format
+msgid "ignoring unmerged: %s"
+msgstr "neamhaird a dhéanamh ar iontrálacha"
+
+#, c-format
+msgid "Only binary files changed.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "No changes.\n"
+msgstr "Gan aon athruithe"
+
+#, fuzzy
+msgid "Patch update"
+msgstr "nuashonruithe fórsa"
+
+msgid "Review diff"
+msgstr ""
+
+msgid "show paths with changes"
+msgstr ""
+
+msgid "add working tree state to the staged set of changes"
+msgstr ""
+
+msgid "revert staged set of changes back to the HEAD version"
+msgstr ""
+
+#, fuzzy
+msgid "pick hunks and update selectively"
+msgstr "roghnaigh hunks idirghníomhach"
+
+#, fuzzy
+msgid "view diff between HEAD and index"
+msgstr "athshocraigh HEAD agus innéacs"
+
+msgid "add contents of untracked files to the staged set of changes"
+msgstr ""
+
+msgid "Prompt help:"
+msgstr ""
+
+msgid "select a single item"
+msgstr ""
+
+msgid "select a range of items"
+msgstr ""
+
+msgid "select multiple ranges"
+msgstr ""
+
+msgid "select item based on unique prefix"
+msgstr ""
+
+msgid "unselect specified items"
+msgstr ""
+
+msgid "choose all items"
+msgstr ""
+
+msgid "(empty) finish selecting"
+msgstr ""
+
+msgid "select a numbered item"
+msgstr ""
+
+msgid "(empty) select nothing"
+msgstr ""
+
+msgid "*** Commands ***"
+msgstr ""
+
+msgid "What now"
+msgstr ""
+
+msgid "staged"
+msgstr ""
+
+msgid "unstaged"
+msgstr ""
+
+msgid "path"
+msgstr "cosán"
+
+#, fuzzy
+msgid "could not refresh index"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, c-format
+msgid "Bye.\n"
+msgstr ""
+
+#, c-format
+msgid "Stage mode change [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Stage deletion [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Stage addition [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Stage this hunk [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"staging."
+msgstr ""
+
+msgid ""
+"y - stage this hunk\n"
+"n - do not stage this hunk\n"
+"q - quit; do not stage this hunk or any of the remaining ones\n"
+"a - stage this hunk and all later hunks in the file\n"
+"d - do not stage this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, c-format
+msgid "Stash mode change [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Stash deletion [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Stash addition [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Stash this hunk [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"stashing."
+msgstr ""
+
+msgid ""
+"y - stash this hunk\n"
+"n - do not stash this hunk\n"
+"q - quit; do not stash this hunk or any of the remaining ones\n"
+"a - stash this hunk and all later hunks in the file\n"
+"d - do not stash this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, c-format
+msgid "Unstage mode change [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Unstage deletion [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Unstage addition [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"unstaging."
+msgstr ""
+
+msgid ""
+"y - unstage this hunk\n"
+"n - do not unstage this hunk\n"
+"q - quit; do not unstage this hunk or any of the remaining ones\n"
+"a - unstage this hunk and all later hunks in the file\n"
+"d - do not unstage this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, c-format
+msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply addition to index [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"applying."
+msgstr ""
+
+msgid ""
+"y - apply this hunk to index\n"
+"n - do not apply this hunk to index\n"
+"q - quit; do not apply this hunk or any of the remaining ones\n"
+"a - apply this hunk and all later hunks in the file\n"
+"d - do not apply this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, c-format
+msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"If the patch applies cleanly, the edited hunk will immediately be marked for "
+"discarding."
+msgstr ""
+
+msgid ""
+"y - discard this hunk from worktree\n"
+"n - do not discard this hunk from worktree\n"
+"q - quit; do not discard this hunk or any of the remaining ones\n"
+"a - discard this hunk and all later hunks in the file\n"
+"d - do not discard this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, c-format
+msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"y - discard this hunk from index and worktree\n"
+"n - do not discard this hunk from index and worktree\n"
+"q - quit; do not discard this hunk or any of the remaining ones\n"
+"a - discard this hunk and all later hunks in the file\n"
+"d - do not discard this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, c-format
+msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"y - apply this hunk to index and worktree\n"
+"n - do not apply this hunk to index and worktree\n"
+"q - quit; do not apply this hunk or any of the remaining ones\n"
+"a - apply this hunk and all later hunks in the file\n"
+"d - do not apply this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, c-format
+msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+#, c-format
+msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
+msgstr ""
+
+msgid ""
+"y - apply this hunk to worktree\n"
+"n - do not apply this hunk to worktree\n"
+"q - quit; do not apply this hunk or any of the remaining ones\n"
+"a - apply this hunk and all later hunks in the file\n"
+"d - do not apply this hunk or any of the later hunks in the file\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse hunk header '%.*s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy
+msgid "could not parse diff"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "could not parse colored diff"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "failed to run '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+msgid "mismatched output from interactive.diffFilter"
+msgstr ""
+
+msgid ""
+"Your filter must maintain a one-to-one correspondence\n"
+"between its input and output lines."
+msgstr ""
+
+#, c-format
+msgid ""
+"expected context line #%d in\n"
+"%.*s"
+msgstr ""
+
+#, c-format
+msgid ""
+"hunks do not overlap:\n"
+"%.*s\n"
+"\tdoes not end with:\n"
+"%.*s"
+msgstr ""
+
+msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"---\n"
+"To remove '%c' lines, make them ' ' lines (context).\n"
+"To remove '%c' lines, delete them.\n"
+"Lines starting with %s will be removed.\n"
+msgstr ""
+
+msgid ""
+"If it does not apply cleanly, you will be given an opportunity to\n"
+"edit again.  If all lines of the hunk are removed, then the edit is\n"
+"aborted and the hunk is left unchanged.\n"
+msgstr ""
+
+msgid "could not parse hunk header"
+msgstr ""
+
+msgid "'git apply --cached' failed"
+msgstr ""
+
+#. TRANSLATORS: do not translate [y/n]
+#. The program will only accept that input at this point.
+#. Consider translating (saying "no" discards!) as
+#. (saying "n" for "no" discards!) if the translation
+#. of the word "no" does not start with n.
+#.
+msgid ""
+"Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
+msgstr ""
+
+msgid "The selected hunks do not apply to the index!"
+msgstr ""
+
+msgid "Apply them to the worktree anyway? "
+msgstr ""
+
+msgid "Nothing was applied.\n"
+msgstr ""
+
+msgid ""
+"j - leave this hunk undecided, see next undecided hunk\n"
+"J - leave this hunk undecided, see next hunk\n"
+"k - leave this hunk undecided, see previous undecided hunk\n"
+"K - leave this hunk undecided, see previous hunk\n"
+"g - select a hunk to go to\n"
+"/ - search for a hunk matching the given regex\n"
+"s - split the current hunk into smaller hunks\n"
+"e - manually edit the current hunk\n"
+"p - print the current hunk, 'P' to use the pager\n"
+"? - print help\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Only one letter is expected, got '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+msgid "No previous hunk"
+msgstr ""
+
+msgid "No next hunk"
+msgstr ""
+
+msgid "No other hunks to goto"
+msgstr ""
+
+msgid "go to which hunk (<ret> to see more)? "
+msgstr ""
+
+msgid "go to which hunk? "
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Invalid number: '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "Sorry, only %d hunk available."
+msgid_plural "Sorry, only %d hunks available."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "No other hunks to search"
+msgstr ""
+
+msgid "search for regex? "
+msgstr ""
+
+#, c-format
+msgid "Malformed search regexp %s: %s"
+msgstr ""
+
+msgid "No hunk matches the given pattern"
+msgstr ""
+
+msgid "Sorry, cannot split this hunk"
+msgstr ""
+
+#, c-format
+msgid "Split into %d hunks."
+msgstr ""
+
+msgid "Sorry, cannot edit this hunk"
+msgstr ""
+
+#, c-format
+msgid "Unknown command '%s' (use '?' for help)"
+msgstr ""
+
+msgid "'git apply' failed"
+msgstr ""
+
+#, fuzzy
+msgid "No changes."
+msgstr "Gan aon athruithe"
+
+msgid "Only binary files changed."
+msgstr ""
+
+#, c-format
+msgid ""
+"\n"
+"Disable this message with \"git config set advice.%s false\""
+msgstr ""
+
+#, c-format
+msgid "%shint:%s%.*s%s\n"
+msgstr ""
+
+msgid "Cherry-picking is not possible because you have unmerged files."
+msgstr ""
+
+msgid "Committing is not possible because you have unmerged files."
+msgstr ""
+
+msgid "Merging is not possible because you have unmerged files."
+msgstr ""
+
+msgid "Pulling is not possible because you have unmerged files."
+msgstr ""
+
+msgid "Reverting is not possible because you have unmerged files."
+msgstr ""
+
+msgid "Rebasing is not possible because you have unmerged files."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"Fix them up in the work tree, and then use 'git add/rm <file>'\n"
+"as appropriate to mark resolution and make a commit."
+msgstr ""
+" (bain úsáid \"git add/rm <comhad>...\" de réir mar is cuí chun réiteach a "
+"mharcáil)"
+
+msgid "Exiting because of an unresolved conflict."
+msgstr ""
+
+msgid "You have not concluded your merge (MERGE_HEAD exists)."
+msgstr ""
+
+msgid "Please, commit your changes before merging."
+msgstr ""
+
+msgid "Exiting because of unfinished merge."
+msgstr ""
+
+msgid ""
+"Diverging branches can't be fast-forwarded, you need to either:\n"
+"\n"
+"\tgit merge --no-ff\n"
+"\n"
+"or:\n"
+"\n"
+"\tgit rebase\n"
+msgstr ""
+
+msgid "Not possible to fast-forward, aborting."
+msgstr ""
+
+#, c-format
+msgid ""
+"The following paths and/or pathspecs matched paths that exist\n"
+"outside of your sparse-checkout definition, so will not be\n"
+"updated in the index:\n"
+msgstr ""
+
+msgid ""
+"If you intend to update such entries, try one of the following:\n"
+"* Use the --sparse option.\n"
+"* Disable or modify the sparsity rules."
+msgstr ""
+
+#, c-format
+msgid ""
+"Note: switching to '%s'.\n"
+"\n"
+"You are in 'detached HEAD' state. You can look around, make experimental\n"
+"changes and commit them, and you can discard any commits you make in this\n"
+"state without impacting any branches by switching back to a branch.\n"
+"\n"
+"If you want to create a new branch to retain commits you create, you may\n"
+"do so (now or later) by using -c with the switch command. Example:\n"
+"\n"
+"  git switch -c <new-branch-name>\n"
+"\n"
+"Or undo this operation with:\n"
+"\n"
+"  git switch -\n"
+"\n"
+"Turn off this advice by setting config variable advice.detachedHead to "
+"false\n"
+"\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following paths have been moved outside the\n"
+"sparse-checkout definition but are not sparse due to local\n"
+"modifications.\n"
+msgstr ""
+
+msgid ""
+"To correct the sparsity of these paths, do the following:\n"
+"* Use \"git add --sparse <paths>\" to update the index\n"
+"* Use \"git sparse-checkout reapply\" to apply the sparsity rules"
+msgstr ""
+
+msgid "cmdline ends with \\"
+msgstr ""
+
+msgid "unclosed quote"
+msgstr ""
+
+#, fuzzy
+msgid "too many arguments"
+msgstr "An iomarca argóintí."
+
+#, c-format
+msgid "unrecognized whitespace option '%s'"
+msgstr ""
+
+#, c-format
+msgid "unrecognized whitespace ignore option '%s'"
+msgstr ""
+
+#, c-format
+msgid "options '%s' and '%s' cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+#, fuzzy, c-format
+msgid "'%s' outside a repository"
+msgstr "socrú mar stór roinnte"
+
+#, fuzzy
+msgid "failed to read patch"
+msgstr "nach féidir %s a léamh"
+
+msgid "patch too large"
+msgstr ""
+
+#, c-format
+msgid "Cannot prepare timestamp regexp %s"
+msgstr ""
+
+#, c-format
+msgid "regexec returned %d for input: %s"
+msgstr ""
+
+#, c-format
+msgid "unable to find filename in patch at line %d"
+msgstr ""
+
+#, c-format
+msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
+msgstr ""
+
+#, c-format
+msgid "git apply: bad git-diff - inconsistent new filename on line %d"
+msgstr ""
+
+#, c-format
+msgid "git apply: bad git-diff - inconsistent old filename on line %d"
+msgstr ""
+
+#, c-format
+msgid "git apply: bad git-diff - expected /dev/null on line %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid mode on line %d: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "inconsistent header lines %d and %d"
+msgstr ""
+
+#, c-format
+msgid ""
+"git diff header lacks filename information when removing %d leading pathname "
+"component (line %d)"
+msgid_plural ""
+"git diff header lacks filename information when removing %d leading pathname "
+"components (line %d)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "git diff header lacks filename information (line %d)"
+msgstr ""
+
+#, c-format
+msgid "recount: unexpected line: %.*s"
+msgstr ""
+
+#, c-format
+msgid "patch fragment without header at line %d: %.*s"
+msgstr ""
+
+msgid "new file depends on old contents"
+msgstr ""
+
+msgid "deleted file still has contents"
+msgstr ""
+
+#, c-format
+msgid "corrupt patch at line %d"
+msgstr ""
+
+#, c-format
+msgid "new file %s depends on old contents"
+msgstr ""
+
+#, c-format
+msgid "deleted file %s still has contents"
+msgstr ""
+
+#, c-format
+msgid "** warning: file %s becomes empty but is not deleted"
+msgstr ""
+
+#, c-format
+msgid "corrupt binary patch at line %d: %.*s"
+msgstr ""
+
+#, c-format
+msgid "unrecognized binary patch at line %d"
+msgstr ""
+
+#, c-format
+msgid "patch with only garbage at line %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to read symlink %s"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "unable to open or read %s"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "invalid start of line: '%c'"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "Hunk #%d succeeded at %d (offset %d line)."
+msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
+msgstr ""
+
+#, c-format
+msgid ""
+"while searching for:\n"
+"%.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "missing binary patch data for '%s'"
+msgstr "ainm brainse ar iarraidh; iarracht -%c"
+
+#, c-format
+msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
+msgstr ""
+
+#, c-format
+msgid "cannot apply binary patch to '%s' without full index line"
+msgstr ""
+
+#, c-format
+msgid ""
+"the patch applies to '%s' (%s), which does not match the current contents."
+msgstr ""
+
+#, c-format
+msgid "the patch applies to an empty '%s' but it is not empty"
+msgstr ""
+
+#, c-format
+msgid "the necessary postimage %s for '%s' cannot be read"
+msgstr ""
+
+#, c-format
+msgid "binary patch does not apply to '%s'"
+msgstr ""
+
+#, c-format
+msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
+msgstr ""
+
+#, c-format
+msgid "patch failed: %s:%ld"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot checkout %s"
+msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
+
+#, fuzzy, c-format
+msgid "failed to read %s"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "reading from '%s' beyond a symbolic link"
+msgstr ""
+
+#, c-format
+msgid "path %s has been renamed/deleted"
+msgstr ""
+
+#, c-format
+msgid "%s: does not exist in index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s: does not match index"
+msgstr "src refspec %s ní mheaitseálann aon"
+
+msgid "repository lacks the necessary blob to perform 3-way merge."
+msgstr ""
+
+#, c-format
+msgid "Performing three-way merge...\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot read the current contents of '%s'"
+msgstr "ní féidir comhpháirt amháin a bhaint as url '%s'"
+
+#, c-format
+msgid "Failed to perform three-way merge...\n"
+msgstr ""
+
+#, c-format
+msgid "Applied patch to '%s' with conflicts.\n"
+msgstr ""
+
+#, c-format
+msgid "Applied patch to '%s' cleanly.\n"
+msgstr ""
+
+#, c-format
+msgid "Falling back to direct application...\n"
+msgstr ""
+
+msgid "removal patch leaves file contents"
+msgstr ""
+
+#, c-format
+msgid "%s: wrong type"
+msgstr ""
+
+#, c-format
+msgid "%s has type %o, expected %o"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid path '%s'"
+msgstr "%s neamhbhailí"
+
+#, c-format
+msgid "%s: already exists in index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s: already exists in working directory"
+msgstr "Tá %s ann agus ní eolaire é"
+
+#, c-format
+msgid "new mode (%o) of %s does not match old mode (%o)"
+msgstr ""
+
+#, c-format
+msgid "new mode (%o) of %s does not match old mode (%o) of %s"
+msgstr ""
+
+#, c-format
+msgid "affected file '%s' is beyond a symbolic link"
+msgstr ""
+
+#, c-format
+msgid "%s: patch does not apply"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Checking patch %s..."
+msgstr "Rud a sheiceáil"
+
+#, c-format
+msgid "sha1 information is lacking or useless for submodule %s"
+msgstr ""
+
+#, c-format
+msgid "mode change for %s, which is not in current HEAD"
+msgstr ""
+
+#, c-format
+msgid "sha1 information is lacking or useless (%s)."
+msgstr ""
+
+#, c-format
+msgid "could not add %s to temporary index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not write temporary index to %s"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "unable to remove %s from index"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "corrupt patch for submodule %s"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+#, fuzzy, c-format
+msgid "unable to stat newly created file '%s'"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "unable to create backing store for newly created file %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "unable to add cache entry for %s"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+#, fuzzy, c-format
+msgid "failed to write to '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy, c-format
+msgid "closing file '%s'"
+msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
+
+#, fuzzy, c-format
+msgid "unable to write file '%s' mode %o"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "Applied patch %s cleanly."
+msgstr ""
+
+#, fuzzy
+msgid "internal error"
+msgstr "earráid inmheánach i dsiúlóid"
+
+#, c-format
+msgid "Applying patch %%s with %d reject..."
+msgid_plural "Applying patch %%s with %d rejects..."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "cannot open %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot unlink '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, c-format
+msgid "Hunk #%d applied cleanly."
+msgstr ""
+
+#, c-format
+msgid "Rejected hunk #%d."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Skipped patch '%s'."
+msgstr "Aistrithe go brainse '%s'\n"
+
+msgid "No valid patches in input (allow with \"--allow-empty\")"
+msgstr ""
+
+#, fuzzy
+msgid "unable to read index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "can't open patch '%s': %s"
+msgstr ""
+
+#, c-format
+msgid "squelched %d whitespace error"
+msgid_plural "squelched %d whitespace errors"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%d line adds whitespace errors."
+msgid_plural "%d lines add whitespace errors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%d line applied after fixing whitespace errors."
+msgid_plural "%d lines applied after fixing whitespace errors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy
+msgid "Unable to write new index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+msgid "don't apply changes matching the given path"
+msgstr ""
+
+msgid "apply changes matching the given path"
+msgstr ""
+
+msgid "num"
+msgstr ""
+
+msgid "remove <num> leading slashes from traditional diff paths"
+msgstr ""
+
+msgid "ignore additions made by the patch"
+msgstr ""
+
+msgid "instead of applying the patch, output diffstat for the input"
+msgstr ""
+
+msgid "show number of added and deleted lines in decimal notation"
+msgstr ""
+
+msgid "instead of applying the patch, output a summary for the input"
+msgstr ""
+
+msgid "instead of applying the patch, see if the patch is applicable"
+msgstr ""
+
+msgid "make sure the patch is applicable to the current index"
+msgstr ""
+
+msgid "mark new files with `git add --intent-to-add`"
+msgstr ""
+
+msgid "apply a patch without touching the working tree"
+msgstr ""
+
+msgid "accept a patch that touches outside the working area"
+msgstr ""
+
+msgid "also apply the patch (use with --stat/--summary/--check)"
+msgstr ""
+
+msgid "attempt three-way merge, fall back on normal patch if that fails"
+msgstr ""
+
+msgid "for conflicts, use our version"
+msgstr ""
+
+msgid "for conflicts, use their version"
+msgstr ""
+
+msgid "for conflicts, use a union version"
+msgstr ""
+
+msgid "build a temporary index based on embedded index information"
+msgstr ""
+
+msgid "paths are separated with NUL character"
+msgstr ""
+
+msgid "ensure at least <n> lines of context match"
+msgstr ""
+
+msgid "action"
+msgstr ""
+
+msgid "detect new or modified lines that have whitespace errors"
+msgstr ""
+
+msgid "ignore changes in whitespace when finding context"
+msgstr ""
+
+msgid "apply the patch in reverse"
+msgstr ""
+
+msgid "don't expect at least one line of context"
+msgstr ""
+
+msgid "leave the rejected hunks in corresponding *.rej files"
+msgstr ""
+
+msgid "allow overlapping hunks"
+msgstr ""
+
+msgid "tolerate incorrectly detected missing new-line at the end of file"
+msgstr ""
+
+msgid "do not trust the line counts in the hunk headers"
+msgstr ""
+
+msgid "root"
+msgstr ""
+
+msgid "prepend <root> to all filenames"
+msgstr ""
+
+msgid "don't return error for empty patches"
+msgstr ""
+
+msgid "--ours, --theirs, and --union require --3way"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot stream blob %s"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+#, c-format
+msgid "unsupported file mode: 0%o (SHA1: %s)"
+msgstr ""
+
+#, c-format
+msgid "deflate error (%d)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to start '%s' filter"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy
+msgid "unable to redirect descriptor"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "'%s' filter reported error"
+msgstr "earráid tuairiscithe ar iompar"
+
+#, c-format
+msgid "path is not valid UTF-8: %s"
+msgstr ""
+
+#, c-format
+msgid "path too long (%d chars, SHA1: %s): %s"
+msgstr ""
+
+#, c-format
+msgid "timestamp too large for this system: %<PRIuMAX>"
+msgstr ""
+
+#, fuzzy
+msgid "git archive [<options>] <tree-ish> [<path>...]"
+msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+
+msgid ""
+"git archive --remote <repo> [--exec <cmd>] [<options>] <tree-ish> [<path>...]"
+msgstr ""
+
+msgid "git archive --remote <repo> [--exec <cmd>] --list"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot read '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, c-format
+msgid "pathspec '%s' matches files outside the current directory"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "pathspec '%s' did not match any files"
+msgstr "src refspec %s ní mheaitseálann aon"
+
+#, fuzzy, c-format
+msgid "no such ref: %.*s"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy, c-format
+msgid "not a valid object name: %s"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#, fuzzy, c-format
+msgid "not a tree object: %s"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "failed to unpack tree object %s"
+msgstr "Theip ar chrann %s a aimsiú."
+
+#, c-format
+msgid "File not found: %s"
+msgstr ""
+
+#, c-format
+msgid "Not a regular file: %s"
+msgstr ""
+
+#, c-format
+msgid "unclosed quote: '%s'"
+msgstr ""
+
+#, c-format
+msgid "missing colon: '%s'"
+msgstr ""
+
+#, c-format
+msgid "empty file name: '%s'"
+msgstr ""
+
+#, fuzzy
+msgid "fmt"
+msgstr "formáid"
+
+#, fuzzy
+msgid "archive format"
+msgstr "formáid"
+
+msgid "prefix"
+msgstr ""
+
+msgid "prepend prefix to each pathname in the archive"
+msgstr ""
+
+#, fuzzy
+msgid "file"
+msgstr "comhad nua:"
+
+#, fuzzy
+msgid "add untracked file to archive"
+msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+
+msgid "path:content"
+msgstr ""
+
+msgid "write the archive to this file"
+msgstr ""
+
+msgid "read .gitattributes in working directory"
+msgstr ""
+
+msgid "report archived files on stderr"
+msgstr ""
+
+msgid "time"
+msgstr "am"
+
+msgid "set modification time of archive entries"
+msgstr ""
+
+msgid "set compression level"
+msgstr ""
+
+msgid "list supported archive formats"
+msgstr ""
+
+msgid "repo"
+msgstr "stóras"
+
+msgid "retrieve the archive from remote repository <repo>"
+msgstr ""
+
+msgid "command"
+msgstr ""
+
+#, fuzzy
+msgid "path to the remote git-upload-archive command"
+msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
+
+msgid "Unexpected option --remote"
+msgstr ""
+
+#, c-format
+msgid "the option '%s' requires '%s'"
+msgstr "tá %s ag teastáil don rogha '%s'"
+
+msgid "Unexpected option --output"
+msgstr ""
+
+#, c-format
+msgid "extra command line parameter '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Unknown archive format '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "Argument not supported for format '%s': -%d"
+msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+
+#, fuzzy, c-format
+msgid "%.*s is not a valid attribute name"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+msgid "unable to add additional attribute"
+msgstr ""
+
+#, c-format
+msgid "ignoring overly long attributes line %d"
+msgstr ""
+
+#, c-format
+msgid "%s not allowed: %s:%d"
+msgstr ""
+
+msgid ""
+"Negative patterns are ignored in git attributes\n"
+"Use '\\!' for literal leading exclamation."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot fstat gitattributes file '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, c-format
+msgid "ignoring overly large gitattributes file '%s'"
+msgstr ""
+
+#, c-format
+msgid "ignoring overly large gitattributes blob '%s'"
+msgstr ""
+
+msgid "cannot use --attr-source or GIT_ATTR_SOURCE without repo"
+msgstr ""
+
+msgid "bad --attr-source or GIT_ATTR_SOURCE"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to stat '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid "unable to read %s"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "Badly quoted content in file '%s': %s"
+msgstr ""
+
+#, c-format
+msgid "We cannot bisect more!\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Not a valid commit name %s"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid ""
+"The merge base %s is bad.\n"
+"This means the bug has been fixed between %s and [%s].\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"The merge base %s is new.\n"
+"The property has changed between %s and [%s].\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"The merge base %s is %s.\n"
+"This means the first '%s' commit is between %s and [%s].\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Some %s revs are not ancestors of the %s rev.\n"
+"git bisect cannot work properly in this case.\n"
+"Maybe you mistook %s and %s revs?\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"the merge base between %s and [%s] must be skipped.\n"
+"So we cannot be sure the first %s commit is between %s and %s.\n"
+"We continue anyway."
+msgstr ""
+
+#, c-format
+msgid "Bisecting: a merge base must be tested\n"
+msgstr ""
+
+#, c-format
+msgid "a %s revision is needed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not create file '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "unable to start 'show' for object '%s'"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+#, fuzzy, c-format
+msgid "could not read file '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "reading bisect refs failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s was both %s and %s\n"
+msgstr "Rianann %s %s agus %s araon"
+
+#, c-format
+msgid ""
+"No testable commit found.\n"
+"Maybe you started with bad path arguments?\n"
+msgstr ""
+
+#, c-format
+msgid "(roughly %d step)"
+msgid_plural "(roughly %d steps)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#. TRANSLATORS: the last %s will be replaced with "(roughly %d
+#. steps)" translation.
+#.
+#, c-format
+msgid "Bisecting: %d revision left to test after this %s\n"
+msgid_plural "Bisecting: %d revisions left to test after this %s\n"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "--contents and --reverse do not blend well."
+msgstr ""
+
+msgid "--reverse and --first-parent together require specified latest commit"
+msgstr ""
+
+msgid "revision walk setup failed"
+msgstr "theip ar socrú siúlóid ath"
+
+msgid ""
+"--reverse --first-parent together require range along first-parent chain"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "no such path %s in %s"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy, c-format
+msgid "cannot read blob %s for path %s"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+msgid ""
+"cannot inherit upstream tracking configuration of multiple refs when "
+"rebasing is requested"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not setting branch '%s' as its own upstream"
+msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+
+#, c-format
+msgid "branch '%s' set up to track '%s' by rebasing."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "branch '%s' set up to track '%s'."
+msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
+
+#, c-format
+msgid "branch '%s' set up to track:"
+msgstr ""
+
+#, fuzzy
+msgid "unable to write upstream branch configuration"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+msgid ""
+"\n"
+"After fixing the error cause you may try to fix up\n"
+"the remote tracking information by invoking:"
+msgstr ""
+
+#, c-format
+msgid "asked to inherit tracking from '%s', but no remote is set"
+msgstr ""
+
+#, c-format
+msgid "asked to inherit tracking from '%s', but no merge configuration is set"
+msgstr ""
+
+#, c-format
+msgid "not tracking: ambiguous information for ref '%s'"
+msgstr ""
+
+#. #-#-#-#-#  branch.c.po  #-#-#-#-#
+#. TRANSLATORS: This is a line listing a remote with duplicate
+#. refspecs in the advice message below. For RTL languages you'll
+#. probably want to swap the "%s" and leading "  " space around.
+#.
+#. #-#-#-#-#  object-name.c.po  #-#-#-#-#
+#. TRANSLATORS: This is line item of ambiguous object output
+#. from describe_ambiguous_object() above. For RTL languages
+#. you'll probably want to swap the "%s" and leading " " space
+#. around.
+#.
+#, c-format
+msgid "  %s\n"
+msgstr ""
+
+#. TRANSLATORS: The second argument is a \n-delimited list of
+#. duplicate refspecs, composed above.
+#.
+#, c-format
+msgid ""
+"There are multiple remotes whose fetch refspecs map to the remote\n"
+"tracking ref '%s':\n"
+"%s\n"
+"This is typically a configuration error.\n"
+"\n"
+"To support setting up tracking branches, ensure that\n"
+"different remotes' fetch refspecs map into different\n"
+"tracking namespaces."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid branch name"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+msgid "See `man git check-ref-format`"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "a branch named '%s' already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, c-format
+msgid "cannot force update the branch '%s' used by worktree at '%s'"
+msgstr ""
+
+#, c-format
+msgid "cannot set up tracking information; starting point '%s' is not a branch"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "the requested upstream branch '%s' does not exist"
+msgstr "níl an stóras '%s' ann"
+
+msgid ""
+"\n"
+"If you are planning on basing your work on an upstream\n"
+"branch that already exists at the remote, you may need to\n"
+"run \"git fetch\" to retrieve it.\n"
+"\n"
+"If you are planning to push out a new local branch that\n"
+"will track its remote counterpart, you may want to use\n"
+"\"git push -u\" to set the upstream config as you push."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not a valid object name: '%s'"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#, fuzzy, c-format
+msgid "ambiguous object name: '%s'"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#, fuzzy, c-format
+msgid "not a valid branch point: '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, c-format
+msgid "submodule '%s': unable to find submodule"
+msgstr ""
+
+#, c-format
+msgid ""
+"You may try updating the submodules using 'git checkout --no-recurse-"
+"submodules %s && git submodule update --init'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "submodule '%s': cannot create branch '%s'"
+msgstr "Ní féidir '%s' a úsáid le '%s'"
+
+#, c-format
+msgid "'%s' is already used by worktree at '%s'"
+msgstr ""
+
+#, fuzzy
+msgid "git add [<options>] [--] <pathspec>..."
+msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+
+#, fuzzy, c-format
+msgid "cannot chmod %cx '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy
+msgid "Unstaged changes after refreshing the index:"
+msgstr "Athruithe gan stáitse tar éis athshocrú:"
+
+#, fuzzy
+msgid "could not read the index"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy
+msgid "editing patch failed"
+msgstr "theip ar socrú siúlóid ath"
+
+#, fuzzy, c-format
+msgid "could not stat '%s'"
+msgstr "theip ar '%s' a stáil"
+
+msgid "empty patch. aborted"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not apply '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "The following paths are ignored by one of your .gitignore files:\n"
+msgstr ""
+
+msgid "dry run"
+msgstr "rith tirim"
+
+msgid "be verbose"
+msgstr ""
+
+msgid "interactive picking"
+msgstr ""
+
+msgid "select hunks interactively"
+msgstr "roghnaigh hunks idirghníomhach"
+
+msgid "edit current diff and apply"
+msgstr ""
+
+msgid "allow adding otherwise ignored files"
+msgstr ""
+
+#, fuzzy
+msgid "update tracked files"
+msgstr "Comhaid neamhrianaithe"
+
+msgid "renormalize EOL of tracked files (implies -u)"
+msgstr ""
+
+#, fuzzy
+msgid "record only the fact that the path will be added later"
+msgstr ""
+"ní thaifeadadh ach an fíric go gcuirfear cosáin bainte leis níos déanaí"
+
+msgid "add changes from all tracked and untracked files"
+msgstr ""
+
+#, fuzzy
+msgid "ignore paths removed in the working tree (same as --no-all)"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+msgid "don't add, only refresh the index"
+msgstr ""
+
+msgid "just skip files which cannot be added because of errors"
+msgstr ""
+
+msgid "check if - even missing - files are ignored in dry run"
+msgstr ""
+
+msgid "allow updating entries outside of the sparse-checkout cone"
+msgstr ""
+
+msgid "override the executable bit of the listed files"
+msgstr ""
+
+#, fuzzy
+msgid "warn when adding an embedded repository"
+msgstr "stóras lom a chruthú"
+
+#, c-format
+msgid ""
+"You've added another git repository inside your current repository.\n"
+"Clones of the outer repository will not contain the contents of\n"
+"the embedded repository and will not know how to obtain it.\n"
+"If you meant to add a submodule, use:\n"
+"\n"
+"\tgit submodule add <url> %s\n"
+"\n"
+"If you added this path by mistake, you can remove it from the\n"
+"index with:\n"
+"\n"
+"\tgit rm --cached %s\n"
+"\n"
+"See \"git help submodule\" for more information."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "adding embedded git repository: %s"
+msgstr "--stdin teastaíonn stórlann git"
+
+msgid "Use -f if you really want to add them."
+msgstr ""
+
+msgid "adding files failed"
+msgstr ""
+
+#, c-format
+msgid "--chmod param '%s' must be either -x or +x"
+msgstr ""
+
+#, c-format
+msgid "'%s' and pathspec arguments cannot be used together"
+msgstr "Ní féidir argóintí '%s' agus pathspec a úsáid le chéile"
+
+#, c-format
+msgid "Nothing specified, nothing added.\n"
+msgstr ""
+
+msgid "Maybe you wanted to say 'git add .'?"
+msgstr ""
+
+msgid "index file corrupt"
+msgstr "comhad innéacs truaillithe"
+
+msgid "unable to write new index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "bad action '%s' for '%s'"
+msgstr "tá %s ag teastáil don rogha '%s'"
+
+#, fuzzy, c-format
+msgid "invalid value for '%s': '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "could not read '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "could not parse author script"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "could not parse %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "'%s' was deleted by the applypatch-msg hook"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Malformed input line: '%s'."
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy, c-format
+msgid "Failed to copy notes from '%s' to '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+msgid "fseek failed"
+msgstr ""
+
+#, c-format
+msgid "could not open '%s' for reading"
+msgstr ""
+
+#, c-format
+msgid "could not open '%s' for writing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse patch '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+msgid "Only one StGIT patch series can be applied at once"
+msgstr ""
+
+#, fuzzy
+msgid "invalid timestamp"
+msgstr "%s neamhbhailí"
+
+#, fuzzy
+msgid "invalid Date line"
+msgstr "sonraíocht cosáin nebhail"
+
+msgid "invalid timezone offset"
+msgstr ""
+
+msgid "Patch format detection failed."
+msgstr ""
+
+#, c-format
+msgid "failed to create directory '%s'"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy
+msgid "Failed to split patches."
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid "When you have resolved this problem, run \"%s --continue\".\n"
+msgstr ""
+
+#, c-format
+msgid "If you prefer to skip this patch, run \"%s --skip\" instead.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"To record the empty patch as an empty commit, run \"%s --allow-empty\".\n"
+msgstr ""
+
+#, c-format
+msgid "To restore the original branch and stop patching, run \"%s --abort\"."
+msgstr ""
+
+msgid "Patch sent with format=flowed; space at the end of lines might be lost."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "missing author line in commit %s"
+msgstr "brainse ar iarraidh nó argóint a dhéanamh"
+
+#, fuzzy, c-format
+msgid "invalid ident line: %.*s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "unable to parse commit %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+msgid "Repository lacks necessary blobs to fall back on 3-way merge."
+msgstr ""
+
+msgid "Using index info to reconstruct a base tree..."
+msgstr ""
+
+msgid ""
+"Did you hand edit your patch?\n"
+"It does not apply to blobs recorded in its index."
+msgstr ""
+
+msgid "Falling back to patching base and 3-way merge..."
+msgstr ""
+
+#, fuzzy
+msgid "Failed to merge in the changes."
+msgstr "Theip ar chrann %s a aimsiú."
+
+msgid "git write-tree failed to write a tree"
+msgstr ""
+
+msgid "applying to an empty history"
+msgstr ""
+
+#, fuzzy
+msgid "failed to write commit object"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "cannot resume: %s does not exist."
+msgstr "níl an stóras '%s' ann"
+
+msgid "Commit Body is:"
+msgstr ""
+
+#. TRANSLATORS: Make sure to include [y], [n], [e], [v] and [a]
+#. in your translation. The program will only accept English
+#. input at this point.
+#.
+#, c-format
+msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
+msgstr ""
+
+#, fuzzy
+msgid "unable to write index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "Dirty index: cannot apply patches (dirty: %s)"
+msgstr ""
+
+#, c-format
+msgid "Skipping: %.*s"
+msgstr ""
+
+#, c-format
+msgid "Creating an empty commit: %.*s"
+msgstr ""
+
+#, fuzzy
+msgid "Patch is empty."
+msgstr "Tá an paiste reatha folamh."
+
+#, c-format
+msgid "Applying: %.*s"
+msgstr ""
+
+msgid "No changes -- Patch already applied."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Patch failed at %s %.*s"
+msgstr "theip ar '%s' a stáil"
+
+msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
+msgstr ""
+
+#, fuzzy
+msgid "No changes - recorded it as an empty commit."
+msgstr "níl aon athruithe curtha le tiomantas\n"
+
+msgid ""
+"No changes - did you forget to use 'git add'?\n"
+"If there is nothing left to stage, chances are that something else\n"
+"already introduced the same changes; you might want to skip this patch."
+msgstr ""
+
+msgid ""
+"You still have unmerged paths in your index.\n"
+"You should 'git add' each file with resolved conflicts to mark them as "
+"such.\n"
+"You might run `git rm` on a file to accept \"deleted by them\" for it."
+msgstr ""
+
+#, c-format
+msgid "Could not parse object '%s'."
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy
+msgid "failed to clean index"
+msgstr "theip ar nasc '%s' a chruthú"
+
+msgid ""
+"You seem to have moved HEAD since the last 'am' failure.\n"
+"Not rewinding to ORIG_HEAD"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to read '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy
+msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+msgid "git am [<options>] (--continue | --skip | --abort)"
+msgstr ""
+
+#, fuzzy
+msgid "run interactively"
+msgstr "roghnaigh hunks idirghníomhach"
+
+msgid "bypass pre-applypatch and applypatch-msg hooks"
+msgstr ""
+
+msgid "historical option -- no-op"
+msgstr ""
+
+msgid "allow fall back on 3way merging if needed"
+msgstr ""
+
+msgid "be quiet"
+msgstr ""
+
+msgid "add a Signed-off-by trailer to the commit message"
+msgstr ""
+
+#, fuzzy
+msgid "recode into utf8 (default)"
+msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
+
+msgid "pass -k flag to git-mailinfo"
+msgstr ""
+
+msgid "pass -b flag to git-mailinfo"
+msgstr ""
+
+msgid "pass -m flag to git-mailinfo"
+msgstr ""
+
+msgid "pass --keep-cr flag to git-mailsplit for mbox format"
+msgstr ""
+
+msgid "strip everything before a scissors line"
+msgstr ""
+
+msgid "pass it through git-mailinfo"
+msgstr ""
+
+msgid "pass it through git-apply"
+msgstr ""
+
+msgid "n"
+msgstr ""
+
+msgid "format"
+msgstr "formáid"
+
+msgid "format the patch(es) are in"
+msgstr ""
+
+msgid "override error message when patch failure occurs"
+msgstr ""
+
+msgid "continue applying patches after resolving a conflict"
+msgstr ""
+
+msgid "synonyms for --continue"
+msgstr ""
+
+#, fuzzy
+msgid "skip the current patch"
+msgstr "Tá an paiste reatha folamh."
+
+msgid "restore the original branch and abort the patching operation"
+msgstr ""
+
+msgid "abort the patching operation but keep HEAD where it is"
+msgstr ""
+
+msgid "show the patch being applied"
+msgstr ""
+
+msgid "try to apply current patch again"
+msgstr ""
+
+#, fuzzy
+msgid "record the empty patch as an empty commit"
+msgstr ""
+" (bain úsáid as “git am --allow-empty” chun an paiste seo a thaifeadadh mar "
+"thiomantas folamh)"
+
+msgid "lie about committer date"
+msgstr ""
+
+msgid "use current timestamp for author date"
+msgstr ""
+
+msgid "key-id"
+msgstr ""
+
+#, fuzzy
+msgid "GPG-sign commits"
+msgstr "tiomantais nua, "
+
+msgid "how to handle empty patches"
+msgstr ""
+
+msgid "(internal use for git-rebase)"
+msgstr ""
+
+msgid ""
+"The -b/--binary option has been a no-op for long time, and\n"
+"it will be removed. Please do not use it anymore."
+msgstr ""
+
+#, fuzzy
+msgid "failed to read the index"
+msgstr "an t-innéacs a chur ar ais"
+
+#, c-format
+msgid "previous rebase directory %s still exists but mbox given."
+msgstr ""
+
+#, c-format
+msgid ""
+"Stray %s directory found.\n"
+"Use \"git am --abort\" to remove it."
+msgstr ""
+
+msgid "Resolve operation not in progress, we are not resuming."
+msgstr ""
+
+msgid "interactive mode requires patches on the command line"
+msgstr ""
+
+#, fuzzy
+msgid "git apply [<options>] [<patch>...]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+#, fuzzy
+msgid "could not redirect output"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "git archive: expected ACK/NAK, got a flush packet"
+msgstr ""
+
+#, c-format
+msgid "git archive: NACK %s"
+msgstr ""
+
+msgid "git archive: protocol error"
+msgstr ""
+
+#, fuzzy
+msgid "git archive: expected a flush"
+msgstr "nár bhfuair sé réad ag súil leis %s"
+
+msgid "git backfill [--min-batch-size=<n>] [--[no-]sparse]"
+msgstr ""
+
+#, fuzzy
+msgid "problem loading sparse-checkout"
+msgstr "Tá tú i seiceáil neamhchoitianta."
+
+msgid "Minimum number of objects to request at a time"
+msgstr ""
+
+msgid "Restrict the missing objects to the current sparse-checkout"
+msgstr ""
+
+msgid ""
+"git bisect start [--term-(new|bad)=<term> --term-(old|good)=<term>]    [--no-"
+"checkout] [--first-parent] [<bad> [<good>...]] [--]    [<pathspec>...]"
+msgstr ""
+
+msgid "git bisect (good|bad) [<rev>...]"
+msgstr ""
+
+msgid "git bisect skip [(<rev>|<range>)...]"
+msgstr ""
+
+msgid "git bisect reset [<commit>]"
+msgstr ""
+
+msgid "git bisect replay <logfile>"
+msgstr ""
+
+msgid "git bisect run <cmd> [<arg>...]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot open file '%s' in mode '%s'"
+msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
+
+#, fuzzy, c-format
+msgid "could not write to file '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy, c-format
+msgid "cannot open file '%s' for reading"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid term"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid "can't use the builtin command '%s' as a term"
+msgstr ""
+
+#, c-format
+msgid "can't change the meaning of the term '%s'"
+msgstr ""
+
+msgid "please use two different terms"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "We are not bisecting.\n"
+msgstr "Tá tú ag déileáil faoi láthair."
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid commit"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid ""
+"could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
+msgstr ""
+
+#, c-format
+msgid "Bad bisect_write argument: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "couldn't get the oid of the rev '%s'"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+#, fuzzy, c-format
+msgid "couldn't open the file '%s'"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+#, c-format
+msgid "Invalid command: you're currently in a %s/%s bisect"
+msgstr ""
+
+#, c-format
+msgid ""
+"You need to give me at least one %s and %s revision.\n"
+"You can use \"git bisect %s\" and \"git bisect %s\" for that."
+msgstr ""
+
+#, c-format
+msgid ""
+"You need to start by \"git bisect start\".\n"
+"You then need to give me at least one %s and %s revision.\n"
+"You can use \"git bisect %s\" and \"git bisect %s\" for that."
+msgstr ""
+
+#, c-format
+msgid "bisecting only with a %s commit"
+msgstr ""
+
+#. TRANSLATORS: Make sure to include [Y] and [n] in your
+#. translation. The program will only accept English input
+#. at this point.
+#.
+msgid "Are you sure [Y/n]? "
+msgstr ""
+
+msgid "status: waiting for both good and bad commits\n"
+msgstr ""
+
+#, c-format
+msgid "status: waiting for bad commit, %d good commit known\n"
+msgid_plural "status: waiting for bad commit, %d good commits known\n"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "status: waiting for good commit(s), bad commit known\n"
+msgstr ""
+
+msgid "no terms defined"
+msgstr ""
+
+#, c-format
+msgid ""
+"Your current terms are %s for the old state\n"
+"and %s for the new state.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"invalid argument %s for 'git bisect terms'.\n"
+"Supported options are: --term-good|--term-old and --term-bad|--term-new."
+msgstr ""
+
+#, c-format
+msgid "could not open '%s' for appending"
+msgstr ""
+
+#, fuzzy
+msgid "'' is not a valid term"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid "unrecognized option: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' does not appear to be a valid revision"
+msgstr "níl a leagan ag cosán '%s'"
+
+msgid "bad HEAD - I need a HEAD"
+msgstr ""
+
+#, c-format
+msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
+msgstr ""
+
+msgid "bad HEAD - strange symbolic ref"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid ref: '%s'"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "You need to start by \"git bisect start\"\n"
+msgstr ""
+
+#. TRANSLATORS: Make sure to include [Y] and [n] in your
+#. translation. The program will only accept English input
+#. at this point.
+#.
+msgid "Do you want me to do it for you [Y/n]? "
+msgstr ""
+
+msgid "Please call `--bisect-state` with at least one argument"
+msgstr ""
+
+#, c-format
+msgid "'git bisect %s' can take only one argument."
+msgstr ""
+
+#, c-format
+msgid "Bad rev input: %s"
+msgstr ""
+
+#, c-format
+msgid "Bad rev input (not a commit): %s"
+msgstr ""
+
+#, fuzzy
+msgid "We are not bisecting."
+msgstr "Tá tú ag déileáil faoi láthair."
+
+#, c-format
+msgid "'%s'?? what are you talking about?"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot read file '%s' for replaying"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy, c-format
+msgid "running %s\n"
+msgstr "Ag brú chuig %s\n"
+
+msgid "bisect run failed: no command provided."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to verify %s on good revision"
+msgstr "Theip ar '%s' a réiteach mar athbhreithniú bailí."
+
+#, c-format
+msgid "bogus exit code %d for good revision"
+msgstr ""
+
+#, c-format
+msgid "bisect run failed: exit code %d from %s is < 0 or >= 128"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot open file '%s' for writing"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+msgid "bisect run cannot continue any more"
+msgstr ""
+
+msgid "bisect run success"
+msgstr ""
+
+msgid "bisect found first bad commit"
+msgstr ""
+
+#, c-format
+msgid "bisect run failed: 'git bisect %s' exited with error code %d"
+msgstr ""
+
+#, c-format
+msgid "'%s' requires either no argument or a commit"
+msgstr ""
+
+#, c-format
+msgid "'%s' requires 0 or 1 argument"
+msgstr ""
+
+#, c-format
+msgid "'%s' requires 0 arguments"
+msgstr ""
+
+msgid "no logfile given"
+msgstr ""
+
+#, c-format
+msgid "'%s' failed: no command provided."
+msgstr ""
+
+msgid "need a command"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown command: '%s'"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+#, fuzzy
+msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+#, fuzzy
+msgid "git annotate [<options>] [<rev-opts>] [<rev>] [--] <file>"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+msgid "<rev-opts> are documented in git-rev-list(1)"
+msgstr ""
+
+#, c-format
+msgid "expecting a color: %s"
+msgstr ""
+
+msgid "must end with a color"
+msgstr ""
+
+#, c-format
+msgid "cannot find revision %s to ignore"
+msgstr ""
+
+msgid "show blame entries as we find them, incrementally"
+msgstr ""
+
+msgid "do not show object names of boundary commits (Default: off)"
+msgstr ""
+
+msgid "do not treat root commits as boundaries (Default: off)"
+msgstr ""
+
+msgid "show work cost statistics"
+msgstr ""
+
+msgid "force progress reporting"
+msgstr "tuairisciú dul chun cinn"
+
+msgid "show output score for blame entries"
+msgstr ""
+
+msgid "show original filename (Default: auto)"
+msgstr ""
+
+msgid "show original linenumber (Default: off)"
+msgstr ""
+
+msgid "show in a format designed for machine consumption"
+msgstr ""
+
+msgid "show porcelain format with per-line commit information"
+msgstr ""
+
+msgid "use the same output mode as git-annotate (Default: off)"
+msgstr ""
+
+msgid "show raw timestamp (Default: off)"
+msgstr ""
+
+msgid "show long commit SHA1 (Default: off)"
+msgstr ""
+
+msgid "suppress author name and timestamp (Default: off)"
+msgstr ""
+
+msgid "show author email instead of name (Default: off)"
+msgstr ""
+
+msgid "ignore whitespace differences"
+msgstr ""
+
+msgid "rev"
+msgstr "rev"
+
+msgid "ignore <rev> when blaming"
+msgstr ""
+
+msgid "ignore revisions from <file>"
+msgstr ""
+
+msgid "color redundant metadata from previous line differently"
+msgstr ""
+
+msgid "color lines by age"
+msgstr ""
+
+msgid "spend extra cycles to find better match"
+msgstr ""
+
+msgid "use revisions from <file> instead of calling git-rev-list"
+msgstr ""
+
+msgid "use <file>'s contents as the final image"
+msgstr ""
+
+msgid "score"
+msgstr ""
+
+msgid "find line copies within and across files"
+msgstr ""
+
+msgid "find line movements within and across files"
+msgstr ""
+
+msgid "range"
+msgstr ""
+
+msgid "process only line range <start>,<end> or function :<funcname>"
+msgstr ""
+
+#, fuzzy
+msgid "--progress can't be used with --incremental or porcelain formats"
+msgstr ""
+"clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
+
+#. TRANSLATORS: This string is used to tell us the
+#. maximum display width for a relative timestamp in
+#. "git blame" output.  For C locale, "4 years, 11
+#. months ago", which takes 22 places, is the longest
+#. among various forms of relative timestamps, but
+#. your language may need more or fewer display
+#. columns.
+#.
+msgid "4 years, 11 months ago"
+msgstr ""
+
+#, c-format
+msgid "file %s has only %lu line"
+msgid_plural "file %s has only %lu lines"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "Blaming lines"
+msgstr ""
+
+msgid "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
+msgstr ""
+
+msgid ""
+"git branch [<options>] [-f] [--recurse-submodules] <branch-name> [<start-"
+"point>]"
+msgstr ""
+
+#, fuzzy
+msgid "git branch [<options>] [-l] [<pattern>...]"
+msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+
+#, fuzzy
+msgid "git branch [<options>] [-r] (-d | -D) <branch-name>..."
+msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+
+#, fuzzy
+msgid "git branch [<options>] (-m | -M) [<old-branch>] <new-branch>"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+#, fuzzy
+msgid "git branch [<options>] (-c | -C) [<old-branch>] <new-branch>"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+#, fuzzy
+msgid "git branch [<options>] [-r | -a] [--points-at]"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+#, fuzzy
+msgid "git branch [<options>] [-r | -a] [--format]"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+#, c-format
+msgid ""
+"deleting branch '%s' that has been merged to\n"
+"         '%s', but not yet merged to HEAD"
+msgstr ""
+
+#, c-format
+msgid ""
+"not deleting branch '%s' that is not yet merged to\n"
+"         '%s', even though it is merged to HEAD"
+msgstr ""
+
+#, c-format
+msgid "couldn't look up commit object for '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "the branch '%s' is not fully merged"
+msgstr "tá cosán '%s' neamh-chomhcheangailte"
+
+#, c-format
+msgid "If you are sure you want to delete it, run 'git branch -D %s'"
+msgstr ""
+
+msgid "update of config-file failed"
+msgstr ""
+
+#, fuzzy
+msgid "cannot use -a with -d"
+msgstr "Ní féidir '%s' a úsáid le '%s'"
+
+#, c-format
+msgid "cannot delete branch '%s' used by worktree at '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "remote-tracking branch '%s' not found"
+msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+
+#, c-format
+msgid ""
+"branch '%s' not found.\n"
+"Did you forget --remote?"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "branch '%s' not found"
+msgstr "níl aon iargúlta ag brainse '%s' chun brú"
+
+#, c-format
+msgid "Deleted remote-tracking branch %s (was %s).\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Deleted branch %s (was %s).\n"
+msgstr "Athshocraigh brainse '%s'\n"
+
+#, fuzzy
+msgid "unable to parse format string"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy
+msgid "could not resolve HEAD"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "HEAD (%s) points outside of refs/heads/"
+msgstr "Ní fhaightear CEAD thíos na refs/heads!"
+
+#, fuzzy, c-format
+msgid "branch %s is being rebased at %s"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, fuzzy, c-format
+msgid "branch %s is being bisected at %s"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, c-format
+msgid "HEAD of working tree %s is not updated"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid branch name: '%s'"
+msgstr "tagairt neamhbhailí: %s"
+
+#, fuzzy, c-format
+msgid "no commit on branch '%s' yet"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy, c-format
+msgid "no branch named '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+msgid "branch rename failed"
+msgstr ""
+
+msgid "branch copy failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "created a copy of a misnamed branch '%s'"
+msgstr "cruthú agus aistrigh go brainse nua"
+
+#, c-format
+msgid "renamed a misnamed branch '%s' away"
+msgstr ""
+
+#, c-format
+msgid "branch renamed to %s, but HEAD is not updated"
+msgstr ""
+
+msgid "branch is renamed, but update of config-file failed"
+msgstr ""
+
+msgid "branch is copied, but update of config-file failed"
+msgstr ""
+
+#, c-format
+msgid ""
+"Please edit the description for the branch\n"
+"  %s\n"
+"Lines starting with '%s' will be stripped.\n"
+msgstr ""
+
+msgid "Generic options"
+msgstr ""
+
+msgid "show hash and subject, give twice for upstream branch"
+msgstr ""
+
+msgid "suppress informational messages"
+msgstr ""
+
+msgid "set branch tracking configuration"
+msgstr "cumraíocht rianaithe brainse a shoc"
+
+msgid "do not use"
+msgstr ""
+
+msgid "upstream"
+msgstr ""
+
+msgid "change the upstream info"
+msgstr ""
+
+msgid "unset the upstream info"
+msgstr ""
+
+msgid "use colored output"
+msgstr ""
+
+#, fuzzy
+msgid "act on remote-tracking branches"
+msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
+
+msgid "print only branches that contain the commit"
+msgstr ""
+
+msgid "print only branches that don't contain the commit"
+msgstr ""
+
+msgid "Specific git-branch actions:"
+msgstr ""
+
+msgid "list both remote-tracking and local branches"
+msgstr ""
+
+msgid "delete fully merged branch"
+msgstr ""
+
+msgid "delete branch (even if not merged)"
+msgstr ""
+
+msgid "move/rename a branch and its reflog"
+msgstr ""
+
+msgid "move/rename a branch, even if target exists"
+msgstr ""
+
+msgid "do not output a newline after empty formatted refs"
+msgstr ""
+
+msgid "copy a branch and its reflog"
+msgstr ""
+
+msgid "copy a branch, even if target exists"
+msgstr ""
+
+#, fuzzy
+msgid "list branch names"
+msgstr "Athshocraigh brainse '%s'\n"
+
+#, fuzzy
+msgid "show current branch name"
+msgstr "Níl sé ar aon bhrainse faoi láthair."
+
+msgid "create the branch's reflog"
+msgstr ""
+
+#, fuzzy
+msgid "edit the description for the branch"
+msgstr "cruthú reflog do bhrainse nua"
+
+msgid "force creation, move/rename, deletion"
+msgstr ""
+
+msgid "print only branches that are merged"
+msgstr ""
+
+msgid "print only branches that are not merged"
+msgstr ""
+
+msgid "list branches in columns"
+msgstr ""
+
+msgid "object"
+msgstr ""
+
+msgid "print only branches of the object"
+msgstr ""
+
+msgid "sorting and filtering are case insensitive"
+msgstr ""
+
+#, fuzzy
+msgid "recurse through submodules"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+msgid "format to use for the output"
+msgstr ""
+
+#, fuzzy
+msgid "failed to resolve HEAD as a valid ref"
+msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+
+msgid "HEAD not found below refs/heads!"
+msgstr "Ní fhaightear CEAD thíos na refs/heads!"
+
+msgid ""
+"branch with --recurse-submodules can only be used if "
+"submodule.propagateBranches is enabled"
+msgstr ""
+
+msgid "--recurse-submodules can only be used to create branches"
+msgstr ""
+
+msgid "branch name required"
+msgstr ""
+
+msgid "cannot give description to detached HEAD"
+msgstr ""
+
+msgid "cannot edit description of more than one branch"
+msgstr ""
+
+msgid "cannot copy the current branch while not on any"
+msgstr ""
+
+msgid "cannot rename the current branch while not on any"
+msgstr ""
+
+msgid "too many branches for a copy operation"
+msgstr ""
+
+msgid "too many arguments for a rename operation"
+msgstr ""
+
+msgid "too many arguments to set new upstream"
+msgstr ""
+
+#, c-format
+msgid ""
+"could not set upstream of HEAD to %s when it does not point to any branch"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "no such branch '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy, c-format
+msgid "branch '%s' does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy
+msgid "too many arguments to unset upstream"
+msgstr "An iomarca argóintí."
+
+#, fuzzy
+msgid "could not unset upstream of HEAD when it does not point to any branch"
+msgstr "Ní chuireann HEAD in iúl do bhrainse"
+
+#, fuzzy, c-format
+msgid "branch '%s' has no upstream information"
+msgstr "níl aon iargúlta ag brainse '%s' chun brú"
+
+msgid ""
+"the -a, and -r, options to 'git branch' do not take a branch name.\n"
+"Did you mean to use: -a|-r --list <pattern>?"
+msgstr ""
+
+msgid ""
+"the '--set-upstream' option is no longer supported. Please use '--track' or "
+"'--set-upstream-to' instead"
+msgstr ""
+
+msgid "git version:\n"
+msgstr ""
+
+msgid "compiler info: "
+msgstr ""
+
+msgid "libc info: "
+msgstr ""
+
+msgid "not run from a git repository - no hooks to show\n"
+msgstr ""
+
+msgid ""
+"git bugreport [(-o | --output-directory) <path>]\n"
+"              [(-s | --suffix) <format> | --no-suffix]\n"
+"              [--diagnose[=<mode>]]"
+msgstr ""
+
+msgid ""
+"Thank you for filling out a Git bug report!\n"
+"Please answer the following questions to help us understand your issue.\n"
+"\n"
+"What did you do before the bug happened? (Steps to reproduce your issue)\n"
+"\n"
+"What did you expect to happen? (Expected behavior)\n"
+"\n"
+"What happened instead? (Actual behavior)\n"
+"\n"
+"What's different between what you expected and what actually happened?\n"
+"\n"
+"Anything else you want to add:\n"
+"\n"
+"Please review the rest of the bug report below.\n"
+"You can delete any lines you don't wish to share.\n"
+msgstr ""
+
+msgid "mode"
+msgstr ""
+
+msgid ""
+"create an additional zip archive of detailed diagnostics (default 'stats')"
+msgstr ""
+
+msgid "specify a destination for the bugreport file(s)"
+msgstr ""
+
+msgid "specify a strftime format suffix for the filename(s)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown argument `%s'"
+msgstr "algartam hais anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "could not create leading directories for '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "unable to create diagnostics archive %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+msgid "System Info"
+msgstr ""
+
+msgid "Enabled Hooks"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to write to %s"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "Created new report at '%s'.\n"
+msgstr ""
+
+msgid ""
+"git bundle create [-q | --quiet | --progress]\n"
+"                  [--version=<version>] <file> <git-rev-list-args>"
+msgstr ""
+
+msgid "git bundle verify [-q | --quiet] <file>"
+msgstr ""
+
+msgid "git bundle list-heads <file> [<refname>...]"
+msgstr ""
+
+msgid "git bundle unbundle [--progress] <file> [<refname>...]"
+msgstr ""
+
+msgid "need a <file> argument"
+msgstr ""
+
+msgid "do not show progress meter"
+msgstr ""
+
+#, fuzzy
+msgid "show progress meter"
+msgstr "tuairisciú dul chun cinn"
+
+msgid "historical; same as --progress"
+msgstr ""
+
+msgid "historical; does nothing"
+msgstr ""
+
+msgid "specify bundle format version"
+msgstr ""
+
+msgid "Need a repository to create a bundle."
+msgstr ""
+
+msgid "do not show bundle details"
+msgstr ""
+
+msgid "need a repository to verify a bundle"
+msgstr ""
+
+#, c-format
+msgid "%s is okay\n"
+msgstr ""
+
+#, fuzzy
+msgid "Need a repository to unbundle."
+msgstr "Ní mór duit stór a shonrú le clónú."
+
+#, fuzzy
+msgid "Unbundling objects"
+msgstr "Rudaí innéacsála"
+
+#, fuzzy, c-format
+msgid "cannot read object %s '%s'"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+msgid "flush is only for --buffer mode"
+msgstr ""
+
+msgid "empty command in input"
+msgstr ""
+
+#, c-format
+msgid "whitespace before command: '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s requires arguments"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s takes no arguments"
+msgstr "An iomarca argóintí."
+
+msgid "only one batch option may be specified"
+msgstr ""
+
+msgid "git cat-file <type> <object>"
+msgstr ""
+
+msgid "git cat-file (-e | -p) <object>"
+msgstr ""
+
+msgid "git cat-file (-t | -s) [--allow-unknown-type] <object>"
+msgstr ""
+
+msgid ""
+"git cat-file (--textconv | --filters)\n"
+"             [<rev>:<path|tree-ish> | --path=<path|tree-ish> <rev>]"
+msgstr ""
+
+msgid ""
+"git cat-file (--batch | --batch-check | --batch-command) [--batch-all-"
+"objects]\n"
+"             [--buffer] [--follow-symlinks] [--unordered]\n"
+"             [--textconv | --filters] [-Z]"
+msgstr ""
+
+msgid "Check object existence or emit object contents"
+msgstr ""
+
+#, fuzzy
+msgid "check if <object> exists"
+msgstr "Rud a sheiceáil"
+
+msgid "pretty-print <object> content"
+msgstr ""
+
+msgid "Emit [broken] object attributes"
+msgstr ""
+
+msgid "show object type (one of 'blob', 'tree', 'commit', 'tag', ...)"
+msgstr ""
+
+msgid "show object size"
+msgstr ""
+
+msgid "allow -s and -t to work with broken/corrupt objects"
+msgstr ""
+
+msgid "use mail map file"
+msgstr ""
+
+msgid "Batch objects requested on stdin (or --batch-all-objects)"
+msgstr ""
+
+msgid "show full <object> or <rev> contents"
+msgstr ""
+
+msgid "like --batch, but don't emit <contents>"
+msgstr ""
+
+msgid "stdin is NUL-terminated"
+msgstr ""
+
+msgid "stdin and stdout is NUL-terminated"
+msgstr ""
+
+#, fuzzy
+msgid "read commands from stdin"
+msgstr "Níl aon orduithe fágtha."
+
+msgid "with --batch[-check]: ignores stdin, batches all known objects"
+msgstr ""
+
+msgid "Change or optimize batch output"
+msgstr ""
+
+msgid "buffer --batch output"
+msgstr ""
+
+msgid "follow in-tree symlinks"
+msgstr ""
+
+msgid "do not order objects before emitting them"
+msgstr ""
+
+msgid ""
+"Emit object (blob or tree) with conversion or filter (stand-alone, or with "
+"batch)"
+msgstr ""
+
+msgid "run textconv on object's content"
+msgstr ""
+
+msgid "run filters on object's content"
+msgstr ""
+
+msgid "blob|tree"
+msgstr ""
+
+msgid "use a <path> for (--textconv | --filters); Not with 'batch'"
+msgstr ""
+
+msgid "objects filter only supported in batch mode"
+msgstr ""
+
+#, c-format
+msgid "objects filter not supported: '%s'"
+msgstr ""
+
+#, c-format
+msgid "'%s=<%s>' needs '%s' or '%s'"
+msgstr ""
+
+msgid "path|tree-ish"
+msgstr ""
+
+#, c-format
+msgid "'%s' requires a batch mode"
+msgstr ""
+
+#, c-format
+msgid "'-%c' is incompatible with batch mode"
+msgstr ""
+
+msgid "batch modes take no arguments"
+msgstr ""
+
+#, c-format
+msgid "<rev> required with '%s'"
+msgstr ""
+
+#, c-format
+msgid "<object> required with '-%c'"
+msgstr ""
+
+#, c-format
+msgid "only two arguments allowed in <type> <object> mode, not %d"
+msgstr ""
+
+msgid ""
+"git check-attr [--source <tree-ish>] [-a | --all | <attr>...] [--] "
+"<pathname>..."
+msgstr ""
+
+#, fuzzy
+msgid ""
+"git check-attr --stdin [-z] [--source <tree-ish>] [-a | --all | <attr>...]"
+msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+
+msgid "report all attributes set on file"
+msgstr ""
+
+msgid "use .gitattributes only from the index"
+msgstr ""
+
+msgid "read file names from stdin"
+msgstr ""
+
+msgid "terminate input and output records by a NUL character"
+msgstr ""
+
+msgid "<tree-ish>"
+msgstr ""
+
+#, fuzzy
+msgid "which tree-ish to check attributes at"
+msgstr "cén crainn le seiceáil uaidh"
+
+msgid "suppress progress reporting"
+msgstr "cur chun cinn tuairiscithe"
+
+msgid "show non-matching input paths"
+msgstr ""
+
+msgid "ignore index when checking"
+msgstr ""
+
+msgid "cannot specify pathnames with --stdin"
+msgstr ""
+
+msgid "-z only makes sense with --stdin"
+msgstr ""
+
+#, fuzzy
+msgid "no path specified"
+msgstr "sonraíocht cosáin nebhail"
+
+msgid "--quiet is only valid with a single pathname"
+msgstr ""
+
+msgid "cannot have both --quiet and --verbose"
+msgstr ""
+
+msgid "--non-matching is only valid with --verbose"
+msgstr ""
+
+#, fuzzy
+msgid "git check-mailmap [<options>] <contact>..."
+msgstr "git checkout [<roghanna>] <brainse>"
+
+msgid "also read contacts from stdin"
+msgstr ""
+
+msgid "read additional mailmap entries from file"
+msgstr ""
+
+msgid "blob"
+msgstr ""
+
+msgid "read additional mailmap entries from blob"
+msgstr ""
+
+msgid "no contacts specified"
+msgstr ""
+
+#, fuzzy
+msgid "git checkout--worker [<options>]"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+msgid "string"
+msgstr ""
+
+msgid "when creating files, prepend <string>"
+msgstr ""
+
+#, fuzzy
+msgid "git checkout-index [<options>] [--] [<file>...]"
+msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+
+msgid "stage should be between 1 and 3 or all"
+msgstr ""
+
+msgid "check out all files in the index"
+msgstr ""
+
+msgid "do not skip files with skip-worktree set"
+msgstr ""
+
+msgid "force overwrite of existing files"
+msgstr ""
+
+msgid "no warning for existing files and files not in index"
+msgstr ""
+
+msgid "don't checkout new files"
+msgstr ""
+
+#, fuzzy
+msgid "update stat information in the index file"
+msgstr "Nuashonraíodh %d cosán ón innéacs"
+
+msgid "read list of paths from the standard input"
+msgstr ""
+
+msgid "write the content to temporary files"
+msgstr ""
+
+msgid "copy out the files from named stage"
+msgstr ""
 
 msgid "git checkout [<options>] <branch>"
 msgstr "git checkout [<roghanna>] <brainse>"
@@ -55,10 +3351,6 @@ msgid "Unable to add merge result for '%s'"
 msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
 
 #, c-format
-msgid "make_cache_entry failed for path '%s'"
-msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
-
-#, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Athchruthaíodh %d coimhlint chumasc"
@@ -84,10 +3376,6 @@ msgid "'%s' cannot be used with updating paths"
 msgstr "Ní féidir '%s' a úsáid le cosáin a nuashonrú"
 
 #, c-format
-msgid "options '%s' and '%s' cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
-
-#, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
@@ -109,15 +3397,9 @@ msgid "'%s', '%s', or '%s' cannot be used when checking out of a tree"
 msgstr ""
 "Ní féidir '%s', '%s', nó '%s' a úsáid agus tú ag seiceáil amach as crann"
 
-msgid "index file corrupt"
-msgstr "comhad innéacs truaillithe"
-
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "tá cosán '%s' neamh-chomhcheangailte"
-
-msgid "unable to write new index file"
-msgstr "in ann comhad innéacs nua a scríobh"
 
 #, c-format
 msgid "unable to read tree (%s)"
@@ -125,10 +3407,6 @@ msgstr "nach féidir crann a léamh (%s)"
 
 msgid "you need to resolve your current index first"
 msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
-
-#, c-format
-msgid "unable to parse commit %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
 
 #, c-format
 msgid ""
@@ -256,8 +3534,8 @@ msgid ""
 "one remote, e.g. the 'origin' remote, consider setting\n"
 "checkout.defaultRemote=origin in your config."
 msgstr ""
-"Má bhí sé i gceist agat brainse cianrianaithe a sheiceáil ar, e.eg. "
-"'tionscnamh',\n"
+"Má bhí sé i gceist agat brainse cianrianaithe a sheiceáil ar, e.g. "
+"'origin',\n"
 "is féidir leat é sin a dhéanamh tríd an ainm a cháiliú go hiomlán leis an "
 "rogha --track:\n"
 "\n"
@@ -265,7 +3543,7 @@ msgstr ""
 "\n"
 "<name>Más mian leat seiceálacha débhríoch a bheith agat i gcónaí is fearr "
 "leat\n"
-"iargúlta amháin, e.g. an iargúlta 'bunús', smaoinigh ar shocrú\n"
+"iargúlta amháin, e.g. an iargúlta 'origin', smaoinigh ar shocrú\n"
 "checkout.defaultRemote=origin i do chumraíocht."
 
 #, c-format
@@ -377,12 +3655,6 @@ msgstr "brainse ar iarraidh nó argóint a dhéanamh"
 msgid "unknown conflict style '%s'"
 msgstr "stíl choimhlinte anaithnid '%s'"
 
-msgid "suppress progress reporting"
-msgstr "cur chun cinn tuairiscithe"
-
-msgid "force progress reporting"
-msgstr "tuairisciú dul chun cinn"
-
 msgid "perform a 3-way merge with the new branch"
 msgstr "cumasc 3 bhealach a dhéanamh leis an mbrainse nua"
 
@@ -394,9 +3666,6 @@ msgstr "stíl choimhlinte (cumaisc, diff3, nó zdiff3)"
 
 msgid "detach HEAD at named commit"
 msgstr "dícheangail HEAD ag an tiomnú ainmnithe"
-
-msgid "set branch tracking configuration"
-msgstr "cumraíocht rianaithe brainse a shoc"
 
 msgid "force checkout (throw away local modifications)"
 msgstr "seiceáil fórsa (caith modhnuithe áitiúla)"
@@ -411,7 +3680,8 @@ msgid "update ignored files (default)"
 msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
 
 msgid "do not check if another worktree is using this branch"
-msgstr "ná seiceáil an bhfuil crann oibre eile á úsáid ag baint úsáide as an "
+msgstr ""
+"ná seiceáil an bhfuil crann oibre eile á úsáid ag baint úsáide as an "
 "mbrainse seo"
 
 msgid "checkout our version for unmerged files"
@@ -419,9 +3689,6 @@ msgstr "seiceáil ár leagan le haghaidh comhaid neamh-chumasaithe"
 
 msgid "checkout their version for unmerged files"
 msgstr "seiceáil a leagan le haghaidh comhaid neamh-chumasaithe"
-
-msgid "select hunks interactively"
-msgstr "roghnaigh hunks idirghníomhach"
 
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "ná teorainn le speisiúintí cosáin le hiontrálacha neamhchoitianta"
@@ -452,20 +3719,11 @@ msgstr "Ní tiomantas é '%s' agus ní féidir brainse '%s' a chruthú uaidh"
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach ní ghlacann argóint cosáin '%s'"
 
-#, c-format
-msgid "'%s' and pathspec arguments cannot be used together"
-msgstr "Ní féidir argóintí '%s' agus pathspec a úsáid le chéile"
-
-#, c-format
-msgid "the option '%s' requires '%s'"
-msgstr "tá %s ag teastáil don rogha '%s'"
-
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
 msgstr ""
-"git checkout: --ours/--theirs, --force agus --merge neamhoiriúnach "
-"nuair\n"
+"git checkout: --ours/--theirs, --force agus --merge neamhoiriúnach nuair\n"
 "seiceáil amach as an innéacs."
 
 msgid "you must specify path(s) to restore"
@@ -516,13 +3774,133 @@ msgstr "neamhaird a dhéanamh ar iontrálacha"
 msgid "use overlay mode"
 msgstr "úsáid modh forleagtha"
 
+msgid ""
+"git clean [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] "
+"[<pathspec>...]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Removing %s\n"
+msgstr "Deltas a réiteach"
+
+#, fuzzy, c-format
+msgid "Would remove %s\n"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "Skipping repository %s\n"
+msgstr "droch-stóras '%s'"
+
+#, fuzzy, c-format
+msgid "Would skip repository %s\n"
+msgstr "droch-stóras '%s'"
+
+#, fuzzy, c-format
+msgid "failed to remove %s"
+msgstr "theip ar athrá thar '%s'"
+
+#, fuzzy, c-format
+msgid "could not lstat %s\n"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "Refusing to remove current working directory\n"
+msgstr ""
+
+#, fuzzy
+msgid "Would refuse to remove current working directory\n"
+msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
+
+#, c-format
+msgid ""
+"Prompt help:\n"
+"1          - select a numbered item\n"
+"foo        - select item based on unique prefix\n"
+"           - (empty) select nothing\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Prompt help:\n"
+"1          - select a single item\n"
+"3-5        - select a range of items\n"
+"2-3,6-9    - select multiple ranges\n"
+"foo        - select item based on unique prefix\n"
+"-...       - unselect specified items\n"
+"*          - choose all items\n"
+"           - (empty) finish selecting\n"
+msgstr ""
+
+#, c-format
+msgid "Huh (%s)?\n"
+msgstr ""
+
+#, c-format
+msgid "Input ignore patterns>> "
+msgstr ""
+
+#, c-format
+msgid "WARNING: Cannot find items matched by: %s"
+msgstr ""
+
+msgid "Select items to delete"
+msgstr ""
+
+#. TRANSLATORS: Make sure to keep [y/N] as is
+#, c-format
+msgid "Remove %s [y/N]? "
+msgstr ""
+
+msgid ""
+"clean               - start cleaning\n"
+"filter by pattern   - exclude items from deletion\n"
+"select by numbers   - select items to be deleted by numbers\n"
+"ask each            - confirm each deletion (like \"rm -i\")\n"
+"quit                - stop cleaning\n"
+"help                - this screen\n"
+"?                   - help for prompt selection"
+msgstr ""
+
+msgid "Would remove the following item:"
+msgid_plural "Would remove the following items:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "No more files to clean, exiting."
+msgstr ""
+
+msgid "do not print names of files removed"
+msgstr ""
+
+msgid "force"
+msgstr ""
+
+msgid "interactive cleaning"
+msgstr ""
+
+msgid "remove whole directories"
+msgstr ""
+
+msgid "pattern"
+msgstr ""
+
+msgid "add <pattern> to ignore rules"
+msgstr ""
+
+#, fuzzy
+msgid "remove ignored files, too"
+msgstr "Comhaid neamhaird"
+
+#, fuzzy
+msgid "remove only ignored files"
+msgstr "Comhaid neamhaird"
+
+msgid "clean.requireForce is true and -f not given: refusing to clean"
+msgstr ""
+
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "eolas: Ní féidir malartach a chur le haghaidh '%s': %s\n"
-
-#, c-format
-msgid "failed to create directory '%s'"
-msgstr "theip ar eolaire '%s' a chruthú"
 
 #, c-format
 msgid "failed to stat '%s'"
@@ -596,9 +3974,6 @@ msgid "remote HEAD refers to nonexistent ref, unable to checkout"
 msgstr ""
 "tagraíonn iargúlta HEAD do thagartha nach bhfuil ann, nach féidir a sheiceáil"
 
-msgid "HEAD not found below refs/heads!"
-msgstr "Ní fhaightear CEAD thíos na refs/heads!"
-
 msgid "unable to checkout working tree"
 msgstr "in ann crann oibre a sheiceáil"
 
@@ -647,9 +4022,6 @@ msgstr "eolaire teimpléad"
 msgid "directory from which templates will be used"
 msgstr "eolaire as a n-úsáidfear teimpléid"
 
-msgid "repo"
-msgstr "stóras"
-
 msgid "reference repository"
 msgstr "stór tagartha"
 
@@ -660,19 +4032,13 @@ msgid "name"
 msgstr "ainm"
 
 msgid "use <name> instead of 'origin' to track upstream"
-msgstr "úsáid in <name> ionad 'tionscnamh' chun suas an sruth a rianú"
+msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
 
 msgid "checkout <branch> instead of the remote's HEAD"
 msgstr "seiceáil <brainse> in ionad CEAD an iargúlta"
 
-msgid "rev"
-msgstr "rev"
-
 msgid "clone single revision <rev> and check out"
 msgstr "clónáil athbhreithniú aonair <rev> agus seiceáil amach"
-
-msgid "path"
-msgstr "cosán"
 
 msgid "path to git-upload-pack on the remote"
 msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
@@ -682,9 +4048,6 @@ msgstr "doimhneacht"
 
 msgid "create a shallow clone of that depth"
 msgstr "clón éadomhain den doimhneacht sin a chruthú"
-
-msgid "time"
-msgstr "am"
 
 msgid "create a shallow clone since a specific time"
 msgstr "clón éadrom a chruthú ó am ar leith"
@@ -709,9 +4072,6 @@ msgstr "gitdir"
 
 msgid "separate git dir from working tree"
 msgstr "git dir ar leithligh ó chrann oibre"
-
-msgid "format"
-msgstr "formáid"
 
 msgid "specify the reference format to use"
 msgstr "sonraigh an fhormáid tagartha le húsáid"
@@ -801,22 +4161,29 @@ msgid ""
 msgstr ""
 "níl clón --recursive comhoiriúnach le --reference agus --reference-if-able"
 
-
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "Ní ainm iargúlta bailí é '%s'"
 
 msgid "--depth is ignored in local clones; use file:// instead."
-msgstr "--depth déantar neamhaird de i gclóin áitiúla; bain úsáid as comhad:// ina ionad."
+msgstr ""
+"--depth déantar neamhaird de i gclóin áitiúla; bain úsáid as comhad:// ina "
+"ionad."
 
 msgid "--shallow-since is ignored in local clones; use file:// instead."
-msgstr "--shallow-since déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// ina ionad."
+msgstr ""
+"--shallow-since déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// "
+"ina ionad."
 
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
-msgstr "--shallow-exclude déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// ina ionad."
+msgstr ""
+"--shallow-exclude déantar neamhaird de i gclóin áitiúla; bain úsáid as "
+"file:// ina ionad."
 
 msgid "--filter is ignored in local clones; use file:// instead."
-msgstr "--filter déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// ina ionad."
+msgstr ""
+"--filter déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// ina "
+"ionad."
 
 msgid "source repository is shallow, reject to clone."
 msgstr "tá stóras foinse éadrom, diúltaigh clóin."
@@ -854,6 +4221,2812 @@ msgstr "Ní aimsíodh athbhreithniú iargúlta %s i suas sruth %s"
 msgid "You appear to have cloned an empty repository."
 msgstr "Is cosúil gur chlónaigh tú stór folamh."
 
+#, fuzzy
+msgid "git column [<options>]"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+msgid "lookup config vars"
+msgstr ""
+
+msgid "layout to use"
+msgstr ""
+
+msgid "maximum width"
+msgstr ""
+
+msgid "padding space on left border"
+msgstr ""
+
+msgid "padding space on right border"
+msgstr ""
+
+msgid "padding space between columns"
+msgstr ""
+
+#, c-format
+msgid "%s must be non-negative"
+msgstr ""
+
+msgid "--command must be the first argument"
+msgstr ""
+
+msgid ""
+"git commit-graph verify [--object-dir <dir>] [--shallow] [--[no-]progress]"
+msgstr ""
+
+msgid ""
+"git commit-graph write [--object-dir <dir>] [--append]\n"
+"                       [--split[=<strategy>]] [--reachable | --stdin-packs | "
+"--stdin-commits]\n"
+"                       [--changed-paths] [--[no-]max-new-filters <n>] [--"
+"[no-]progress]\n"
+"                       <split-options>"
+msgstr ""
+
+#, fuzzy
+msgid "dir"
+msgstr "gitdir"
+
+msgid "the object directory to store the graph"
+msgstr ""
+
+msgid "if the commit-graph is split, only verify the tip file"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not open commit-graph '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "could not open commit-graph chain '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "unrecognized --split argument, %s"
+msgstr ""
+
+#, c-format
+msgid "unexpected non-hex object ID: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid object: %s"
+msgstr "réad blob neamhbhailí %s"
+
+#, c-format
+msgid "option `%s' expects a numerical value"
+msgstr ""
+
+msgid "start walk at all refs"
+msgstr ""
+
+msgid "scan pack-indexes listed by stdin for commits"
+msgstr ""
+
+msgid "start walk at commits listed by stdin"
+msgstr ""
+
+msgid "include all commits already in the commit-graph file"
+msgstr ""
+
+msgid "enable computation for changed paths"
+msgstr ""
+
+msgid "allow writing an incremental commit-graph file"
+msgstr ""
+
+msgid "maximum number of commits in a non-base split commit-graph"
+msgstr ""
+
+msgid "maximum ratio between two levels of a split commit-graph"
+msgstr ""
+
+msgid "only expire files older than a given date-time"
+msgstr ""
+
+msgid "maximum number of changed-path Bloom filters to compute"
+msgstr ""
+
+msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
+msgstr ""
+
+msgid "Collecting commits from input"
+msgstr ""
+
+msgid "git commit-tree <tree> [(-p <parent>)...]"
+msgstr ""
+
+msgid ""
+"git commit-tree [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
+"                [(-F <file>)...] <tree>"
+msgstr ""
+
+#, c-format
+msgid "duplicate parent %s ignored"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not a valid object name %s"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#, c-format
+msgid "git commit-tree: failed to read '%s'"
+msgstr ""
+
+#, c-format
+msgid "git commit-tree: failed to close '%s'"
+msgstr ""
+
+msgid "parent"
+msgstr ""
+
+msgid "id of a parent commit object"
+msgstr ""
+
+msgid "message"
+msgstr ""
+
+msgid "commit message"
+msgstr ""
+
+msgid "read commit log message from file"
+msgstr ""
+
+#, fuzzy
+msgid "GPG sign commit"
+msgstr "Síníonn GPG an brú"
+
+msgid "must give exactly one tree"
+msgstr ""
+
+msgid "git commit-tree: failed to read"
+msgstr ""
+
+msgid ""
+"git commit [-a | --interactive | --patch] [-s] [-v] [-u[<mode>]] [--amend]\n"
+"           [--dry-run] [(-c | -C | --squash) <commit> | --fixup [(amend|"
+"reword):]<commit>]\n"
+"           [-F <file> | -m <msg>] [--reset-author] [--allow-empty]\n"
+"           [--allow-empty-message] [--no-verify] [-e] [--author=<author>]\n"
+"           [--date=<date>] [--cleanup=<mode>] [--[no-]status]\n"
+"           [-i | -o] [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"           [(--trailer <token>[(=|:)<value>])...] [-S[<keyid>]]\n"
+"           [--] [<pathspec>...]"
+msgstr ""
+
+#, fuzzy
+msgid "git status [<options>] [--] [<pathspec>...]"
+msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+
+msgid ""
+"You asked to amend the most recent commit, but doing so would make\n"
+"it empty. You can repeat your command with --allow-empty, or you can\n"
+"remove the commit entirely with \"git reset HEAD^\".\n"
+msgstr ""
+
+msgid ""
+"The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
+"If you wish to commit it anyway, use:\n"
+"\n"
+"    git commit --allow-empty\n"
+"\n"
+msgstr ""
+
+msgid "Otherwise, please use 'git rebase --skip'\n"
+msgstr ""
+
+msgid "Otherwise, please use 'git cherry-pick --skip'\n"
+msgstr ""
+
+msgid ""
+"and then use:\n"
+"\n"
+"    git cherry-pick --continue\n"
+"\n"
+"to resume cherry-picking the remaining commits.\n"
+"If you wish to skip this commit, use:\n"
+"\n"
+"    git cherry-pick --skip\n"
+"\n"
+msgstr ""
+
+#, fuzzy
+msgid "updating files failed"
+msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
+
+msgid "failed to unpack HEAD tree object"
+msgstr ""
+
+msgid "No paths with --include/--only does not make sense."
+msgstr ""
+
+#, fuzzy
+msgid "unable to create temporary index"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+msgid "interactive add failed"
+msgstr ""
+
+#, fuzzy
+msgid "unable to update temporary index"
+msgstr "nach féidir %s a nuashonrú"
+
+msgid "Failed to update main cache tree"
+msgstr ""
+
+#, fuzzy
+msgid "cannot do a partial commit during a merge."
+msgstr "Ní féidir athshocrú %s a dhéanamh i lár cumaisc."
+
+msgid "cannot do a partial commit during a cherry-pick."
+msgstr ""
+
+#, fuzzy
+msgid "cannot do a partial commit during a rebase."
+msgstr "Tá tú ag eagarthóireacht tiomanta faoi láthair le linn athbhunaithe."
+
+#, fuzzy
+msgid "cannot read the index"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+#, fuzzy
+msgid "unable to write temporary index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "commit '%s' lacks author header"
+msgstr ""
+
+#, c-format
+msgid "commit '%s' has malformed author line"
+msgstr ""
+
+msgid "malformed --author parameter"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid date format: %s"
+msgstr "luach neamhbhailí do '%s'"
+
+msgid ""
+"unable to select a comment character that is not used\n"
+"in the current commit message"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not lookup commit '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "(reading log message from standard input)\n"
+msgstr ""
+
+msgid "could not read log from standard input"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read log file '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "options '%s' and '%s:%s' cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+msgid "could not read SQUASH_MSG"
+msgstr ""
+
+msgid "could not read MERGE_MSG"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not open '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "could not write commit template"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, c-format
+msgid ""
+"Please enter the commit message for your changes. Lines starting\n"
+"with '%s' will be ignored.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Please enter the commit message for your changes. Lines starting\n"
+"with '%s' will be ignored, and an empty message aborts the commit.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Please enter the commit message for your changes. Lines starting\n"
+"with '%s' will be kept; you may remove them yourself if you want to.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Please enter the commit message for your changes. Lines starting\n"
+"with '%s' will be kept; you may remove them yourself if you want to.\n"
+"An empty message aborts the commit.\n"
+msgstr ""
+
+msgid ""
+"\n"
+"It looks like you may be committing a merge.\n"
+"If this is not correct, please run\n"
+"\tgit update-ref -d MERGE_HEAD\n"
+"and try again.\n"
+msgstr ""
+
+msgid ""
+"\n"
+"It looks like you may be committing a cherry-pick.\n"
+"If this is not correct, please run\n"
+"\tgit update-ref -d CHERRY_PICK_HEAD\n"
+"and try again.\n"
+msgstr ""
+
+#, c-format
+msgid "%sAuthor:    %.*s <%.*s>"
+msgstr ""
+
+#, c-format
+msgid "%sDate:      %s"
+msgstr ""
+
+#, c-format
+msgid "%sCommitter: %.*s <%.*s>"
+msgstr ""
+
+#, fuzzy
+msgid "Cannot read index"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+#, fuzzy
+msgid "unable to pass trailers to --trailers"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+msgid "Error building trees"
+msgstr ""
+
+#, c-format
+msgid "Please supply the message using either -m or -F option.\n"
+msgstr ""
+
+#, c-format
+msgid "--author '%s' is not 'Name <email>' and matches no existing author"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Invalid ignored mode '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "Invalid untracked files mode '%s'"
+msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+
+#, fuzzy
+msgid "You are in the middle of a merge -- cannot reword."
+msgstr "Tá tú i lár seisiún am."
+
+#, fuzzy
+msgid "You are in the middle of a cherry-pick -- cannot reword."
+msgstr "Tá tú i lár seisiún am."
+
+#, fuzzy, c-format
+msgid "reword option of '%s' and path '%s' cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+#, fuzzy, c-format
+msgid "reword option of '%s' and '%s' cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+msgid "You have nothing to amend."
+msgstr ""
+
+#, fuzzy
+msgid "You are in the middle of a merge -- cannot amend."
+msgstr "Tá tú i lár seisiún am."
+
+#, fuzzy
+msgid "You are in the middle of a cherry-pick -- cannot amend."
+msgstr "Tá tú i lár seisiún am."
+
+#, fuzzy
+msgid "You are in the middle of a rebase -- cannot amend."
+msgstr "Tá tú i lár seisiún am."
+
+#, fuzzy
+msgid "--reset-author can be used only with -C, -c or --amend."
+msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+
+#, c-format
+msgid "unknown option: --fixup=%s:%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "paths '%s ...' with -a does not make sense"
+msgstr "níl ár leagan ag cosán '%s'"
+
+msgid "show status concisely"
+msgstr ""
+
+#, fuzzy
+msgid "show branch information"
+msgstr "cumraíocht rianaithe brainse a shoc"
+
+msgid "show stash information"
+msgstr ""
+
+msgid "compute full ahead/behind values"
+msgstr ""
+
+msgid "version"
+msgstr ""
+
+msgid "machine-readable output"
+msgstr "aschur inléite meaisín"
+
+msgid "show status in long format (default)"
+msgstr ""
+
+msgid "terminate entries with NUL"
+msgstr ""
+
+msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
+msgstr ""
+
+msgid ""
+"show ignored files, optional modes: traditional, matching, no. (Default: "
+"traditional)"
+msgstr ""
+
+msgid "when"
+msgstr ""
+
+msgid ""
+"ignore changes to submodules, optional when: all, dirty, untracked. "
+"(Default: all)"
+msgstr ""
+
+#, fuzzy
+msgid "list untracked files in columns"
+msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+
+msgid "do not detect renames"
+msgstr ""
+
+msgid "detect renames, optionally set similarity index"
+msgstr ""
+
+msgid "Unsupported combination of ignored and untracked-files arguments"
+msgstr ""
+
+msgid "suppress summary after successful commit"
+msgstr ""
+
+msgid "show diff in commit message template"
+msgstr ""
+
+msgid "Commit message options"
+msgstr ""
+
+msgid "read message from file"
+msgstr ""
+
+msgid "author"
+msgstr ""
+
+msgid "override author for commit"
+msgstr ""
+
+msgid "date"
+msgstr ""
+
+msgid "override date for commit"
+msgstr ""
+
+#, fuzzy
+msgid "commit"
+msgstr "tiomantais nua, "
+
+msgid "reuse and edit message from specified commit"
+msgstr ""
+
+msgid "reuse message from specified commit"
+msgstr ""
+
+#. TRANSLATORS: Leave "[(amend|reword):]" as-is,
+#. and only translate <commit>.
+#.
+msgid "[(amend|reword):]commit"
+msgstr ""
+
+msgid ""
+"use autosquash formatted message to fixup or amend/reword specified commit"
+msgstr ""
+
+msgid "use autosquash formatted message to squash specified commit"
+msgstr ""
+
+msgid "the commit is authored by me now (used with -C/-c/--amend)"
+msgstr ""
+
+msgid "trailer"
+msgstr ""
+
+msgid "add custom trailer(s)"
+msgstr ""
+
+msgid "add a Signed-off-by trailer"
+msgstr ""
+
+msgid "use specified template file"
+msgstr ""
+
+#, fuzzy
+msgid "force edit of commit"
+msgstr "níl aon athruithe curtha le tiomantas\n"
+
+msgid "include status in commit message template"
+msgstr ""
+
+msgid "Commit contents options"
+msgstr ""
+
+msgid "commit all changed files"
+msgstr ""
+
+msgid "add specified files to index for commit"
+msgstr ""
+
+#, fuzzy
+msgid "interactively add files"
+msgstr "Comhaid neamhrianaithe"
+
+msgid "interactively add changes"
+msgstr ""
+
+msgid "commit only specified files"
+msgstr ""
+
+msgid "bypass pre-commit and commit-msg hooks"
+msgstr ""
+
+#, fuzzy
+msgid "show what would be committed"
+msgstr "Athruithe atá le déanamh:"
+
+msgid "amend previous commit"
+msgstr ""
+
+#, fuzzy
+msgid "bypass post-rewrite hook"
+msgstr "seachbhóthar crúca réamh"
+
+msgid "ok to record an empty change"
+msgstr ""
+
+msgid "ok to record a change with an empty message"
+msgstr ""
+
+#, fuzzy
+msgid "could not parse HEAD commit"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "Corrupt MERGE_HEAD file (%s)"
+msgstr ""
+
+msgid "could not read MERGE_MODE"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read commit message: %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "Aborting commit due to empty commit message.\n"
+msgstr ""
+
+#, c-format
+msgid "Aborting commit; you did not edit the message.\n"
+msgstr ""
+
+#, c-format
+msgid "Aborting commit due to empty commit message body.\n"
+msgstr ""
+
+msgid ""
+"repository has been updated, but unable to write\n"
+"new index file. Check that disk is not full and quota is\n"
+"not exceeded, and then \"git restore --staged :/\" to recover."
+msgstr ""
+
+msgid "git config list [<file-option>] [<display-option>] [--includes]"
+msgstr ""
+
+msgid ""
+"git config get [<file-option>] [<display-option>] [--includes] [--all] [--"
+"regexp] [--value=<value>] [--fixed-value] [--default=<default>] <name>"
+msgstr ""
+
+msgid ""
+"git config set [<file-option>] [--type=<type>] [--all] [--value=<value>] [--"
+"fixed-value] <name> <value>"
+msgstr ""
+
+msgid ""
+"git config unset [<file-option>] [--all] [--value=<value>] [--fixed-value] "
+"<name>"
+msgstr ""
+
+msgid "git config rename-section [<file-option>] <old-name> <new-name>"
+msgstr ""
+
+msgid "git config remove-section [<file-option>] <name>"
+msgstr ""
+
+msgid "git config edit [<file-option>]"
+msgstr ""
+
+msgid "git config [<file-option>] --get-colorbool <name> [<stdout-is-tty>]"
+msgstr ""
+
+msgid ""
+"git config get [<file-option>] [<display-option>] [--includes] [--all] [--"
+"regexp=<regexp>] [--value=<value>] [--fixed-value] [--default=<default>] "
+"<name>"
+msgstr ""
+
+msgid ""
+"git config set [<file-option>] [--type=<type>] [--comment=<message>] [--all] "
+"[--value=<value>] [--fixed-value] <name> <value>"
+msgstr ""
+
+msgid "Config file location"
+msgstr ""
+
+msgid "use global config file"
+msgstr ""
+
+msgid "use system config file"
+msgstr ""
+
+#, fuzzy
+msgid "use repository config file"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+#, fuzzy
+msgid "use per-worktree config file"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+msgid "use given config file"
+msgstr ""
+
+msgid "blob-id"
+msgstr ""
+
+msgid "read config from given blob object"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "type"
+msgstr ""
+
+msgid "value is given this type"
+msgstr ""
+
+msgid "value is \"true\" or \"false\""
+msgstr ""
+
+msgid "value is decimal number"
+msgstr ""
+
+msgid "value is --bool or --int"
+msgstr ""
+
+msgid "value is --bool or string"
+msgstr ""
+
+msgid "value is a path (file or directory name)"
+msgstr ""
+
+msgid "value is an expiry date"
+msgstr ""
+
+msgid "Display options"
+msgstr ""
+
+msgid "terminate values with NUL byte"
+msgstr ""
+
+msgid "show variable names only"
+msgstr ""
+
+msgid "show origin of config (file, standard input, blob, command line)"
+msgstr ""
+
+msgid "show scope of config (worktree, local, global, system, command)"
+msgstr ""
+
+msgid "show config keys in addition to their values"
+msgstr ""
+
+#, c-format
+msgid "unrecognized --type argument, %s"
+msgstr ""
+
+msgid "only one type at a time"
+msgstr ""
+
+#, c-format
+msgid "wrong number of arguments, should be %d"
+msgstr ""
+
+#, c-format
+msgid "wrong number of arguments, should be from %d to %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid key pattern: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, fuzzy, c-format
+msgid "invalid pattern: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, fuzzy, c-format
+msgid "failed to format default config value: %s"
+msgstr "theip ar athrá thar '%s'"
+
+#, fuzzy, c-format
+msgid "cannot parse color '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy
+msgid "unable to parse default color value"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy
+msgid "not in a git directory"
+msgstr "Tá %s ann agus ní eolaire é"
+
+msgid "writing to stdin is not supported"
+msgstr ""
+
+msgid "writing config blobs is not supported"
+msgstr ""
+
+#, c-format
+msgid ""
+"# This is Git's per-user configuration file.\n"
+"[user]\n"
+"# Please adapt and uncomment the following lines:\n"
+"#\tname = %s\n"
+"#\temail = %s\n"
+msgstr ""
+
+msgid "only one config file at a time"
+msgstr ""
+
+#, fuzzy
+msgid "--local can only be used inside a git repository"
+msgstr "--stdin teastaíonn stórlann git"
+
+#, fuzzy
+msgid "--blob can only be used inside a git repository"
+msgstr "--stdin teastaíonn stórlann git"
+
+#, fuzzy
+msgid "--worktree can only be used inside a git repository"
+msgstr "--stdin teastaíonn stórlann git"
+
+msgid "$HOME not set"
+msgstr ""
+
+msgid ""
+"--worktree cannot be used with multiple working trees unless the config\n"
+"extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
+"section in \"git help worktree\" for details"
+msgstr ""
+
+msgid "Other"
+msgstr ""
+
+msgid "respect include directives on lookup"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to read config file '%s'"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy
+msgid "error processing config file(s)"
+msgstr "earráid agus comhad pacáiste á dúnadh"
+
+msgid "Filter options"
+msgstr ""
+
+msgid "return all values for multi-valued config options"
+msgstr ""
+
+msgid "interpret the name as a regular expression"
+msgstr ""
+
+msgid "show config with values matching the pattern"
+msgstr ""
+
+msgid "use string equality when comparing values to value pattern"
+msgstr ""
+
+msgid "URL"
+msgstr ""
+
+msgid "show config matching the given URL"
+msgstr ""
+
+#, fuzzy
+msgid "value"
+msgstr "eochair=luach"
+
+msgid "use default value when missing entry"
+msgstr ""
+
+msgid "--fixed-value only applies with 'value-pattern'"
+msgstr ""
+
+#, fuzzy
+msgid "--default= cannot be used with --all or --url="
+msgstr ""
+"clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
+
+#, fuzzy
+msgid "--url= cannot be used with --all, --regexp or --value"
+msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+
+msgid "Filter"
+msgstr ""
+
+msgid "replace multi-valued config option with new value"
+msgstr ""
+
+msgid "human-readable comment string (# will be prepended as needed)"
+msgstr ""
+
+msgid "add a new line without altering any existing values"
+msgstr ""
+
+msgid "--fixed-value only applies with --value=<pattern>"
+msgstr ""
+
+#, fuzzy
+msgid "--append cannot be used with --value=<pattern>"
+msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+
+#, c-format
+msgid ""
+"cannot overwrite multiple values with a single value\n"
+"       Use a regexp, --add or --replace-all to change %s."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "no such section: %s"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+msgid "editing stdin is not supported"
+msgstr ""
+
+msgid "editing blobs is not supported"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot create configuration file %s"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+msgid "Action"
+msgstr ""
+
+msgid "get value: name [<value-pattern>]"
+msgstr ""
+
+msgid "get all values: key [<value-pattern>]"
+msgstr ""
+
+msgid "get values for regexp: name-regex [<value-pattern>]"
+msgstr ""
+
+msgid "get value specific for the URL: section[.var] URL"
+msgstr ""
+
+msgid "replace all matching variables: name value [<value-pattern>]"
+msgstr ""
+
+msgid "add a new variable: name value"
+msgstr ""
+
+msgid "remove a variable: name [<value-pattern>]"
+msgstr ""
+
+msgid "remove all matches: name [<value-pattern>]"
+msgstr ""
+
+msgid "rename section: old-name new-name"
+msgstr ""
+
+msgid "remove a section: name"
+msgstr ""
+
+msgid "list all"
+msgstr ""
+
+msgid "open an editor"
+msgstr ""
+
+msgid "find the color configured: slot [<default>]"
+msgstr ""
+
+msgid "find the color setting: slot [<stdout-is-tty>]"
+msgstr ""
+
+msgid "with --get, use default value when missing entry"
+msgstr ""
+
+msgid "--get-color and variable type are incoherent"
+msgstr ""
+
+msgid "no action specified"
+msgstr ""
+
+msgid "--name-only is only applicable to --list or --get-regexp"
+msgstr ""
+
+msgid ""
+"--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
+"list"
+msgstr ""
+
+msgid "--default is only applicable to --get"
+msgstr ""
+
+msgid "--comment is only applicable to add/set/replace operations"
+msgstr ""
+
+msgid "print sizes in human readable format"
+msgstr ""
+
+#, c-format
+msgid ""
+"The permissions on your socket directory are too loose; other\n"
+"users may be able to read your cached credentials. Consider running:\n"
+"\n"
+"\tchmod 0700 %s"
+msgstr ""
+
+msgid "print debugging messages to stderr"
+msgstr ""
+
+msgid "credential-cache--daemon unavailable; no unix socket support"
+msgstr ""
+
+msgid "credential-cache unavailable; no unix socket support"
+msgstr ""
+
+#, c-format
+msgid "unable to get credential storage lock in %d ms"
+msgstr ""
+
+msgid ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]"
+msgstr ""
+
+msgid ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]"
+msgstr ""
+
+msgid "git describe <blob>"
+msgstr ""
+
+#, fuzzy
+msgid "head"
+msgstr "chun tosaigh "
+
+msgid "lightweight"
+msgstr ""
+
+msgid "annotated"
+msgstr ""
+
+#, c-format
+msgid "annotated tag %s not available"
+msgstr ""
+
+#, c-format
+msgid "tag '%s' is externally known as '%s'"
+msgstr ""
+
+#, c-format
+msgid "no tag exactly matches '%s'"
+msgstr ""
+
+#, c-format
+msgid "No exact match on refs or tags, searching to describe\n"
+msgstr ""
+
+#, c-format
+msgid "finished search at %s\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"No annotated tags can describe '%s'.\n"
+"However, there were unannotated tags: try --tags."
+msgstr ""
+
+#, c-format
+msgid ""
+"No tags can describe '%s'.\n"
+"Try --always, or create some tags."
+msgstr ""
+
+#, c-format
+msgid "traversed %lu commits\n"
+msgstr ""
+
+#, c-format
+msgid "found %i tags; gave up search at %s\n"
+msgstr ""
+
+#, c-format
+msgid "describe %s\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Not a valid object name %s"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#, c-format
+msgid "%s is neither a commit nor blob"
+msgstr ""
+
+msgid "find the tag that comes after the commit"
+msgstr ""
+
+msgid "debug search strategy on stderr"
+msgstr ""
+
+msgid "use any ref"
+msgstr ""
+
+msgid "use any tag, even unannotated"
+msgstr ""
+
+msgid "always use long format"
+msgstr ""
+
+msgid "only follow first parent"
+msgstr ""
+
+msgid "only output exact matches"
+msgstr ""
+
+msgid "consider <n> most recent tags (default: 10)"
+msgstr ""
+
+msgid "only consider tags matching <pattern>"
+msgstr ""
+
+msgid "do not consider tags matching <pattern>"
+msgstr ""
+
+msgid "show abbreviated commit object as fallback"
+msgstr ""
+
+msgid "mark"
+msgstr ""
+
+#, fuzzy
+msgid "append <mark> on dirty working tree (default: \"-dirty\")"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+msgid "append <mark> on broken working tree (default: \"-broken\")"
+msgstr ""
+
+msgid "No names found, cannot describe anything."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "option '%s' and commit-ishes cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+msgid ""
+"git diagnose [(-o | --output-directory) <path>] [(-s | --suffix) <format>]\n"
+"             [--mode=<mode>]"
+msgstr ""
+
+msgid "specify a destination for the diagnostics archive"
+msgstr ""
+
+msgid "specify a strftime format suffix for the filename"
+msgstr ""
+
+msgid "specify the content of the diagnostic archive"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to parse mode: %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unable to parse object id: %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+msgid "git diff-pairs -z [<diff-options>]"
+msgstr ""
+
+#, c-format
+msgid "unrecognized argument: %s"
+msgstr ""
+
+msgid "working without -z is not supported"
+msgstr ""
+
+#, fuzzy
+msgid "pathspec arguments not supported"
+msgstr "Ní féidir argóintí '%s' agus pathspec a úsáid le chéile"
+
+#, fuzzy
+msgid "revision arguments not allowed"
+msgstr "theip ar socrú siúlóid ath"
+
+msgid "invalid raw diff input"
+msgstr ""
+
+msgid "tree objects not supported"
+msgstr ""
+
+msgid "got EOF while reading path"
+msgstr ""
+
+msgid "got EOF while reading destination path"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to parse rename/copy score: %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "unknown diff status: %c"
+msgstr ""
+
+msgid "--merge-base only works with two commits"
+msgstr ""
+
+#, c-format
+msgid "'%s': not a regular file or symlink"
+msgstr ""
+
+msgid "no merge given, only parents."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid option: %s"
+msgstr "%s neamhbhailí"
+
+#, c-format
+msgid "%s...%s: no merge base"
+msgstr ""
+
+#, fuzzy
+msgid "Not a git repository"
+msgstr "stóras lom a chruthú"
+
+#, fuzzy, c-format
+msgid "invalid object '%s' given."
+msgstr "réad blob neamhbhailí %s"
+
+#, c-format
+msgid "more than two blobs given: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unhandled object '%s' given."
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "%s...%s: multiple merge bases, using %s"
+msgstr ""
+
+msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read symlink %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not read symlink file %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not read object %s for symlink %s"
+msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+
+msgid ""
+"combined diff formats ('-c' and '--cc') are not supported in\n"
+"directory diff mode ('-d' and '--dir-diff')."
+msgstr ""
+
+#, c-format
+msgid "both files modified: '%s' and '%s'."
+msgstr ""
+
+#, fuzzy
+msgid "working tree file has been left."
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, fuzzy, c-format
+msgid "could not copy '%s' to '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, c-format
+msgid "temporary files exist in '%s'."
+msgstr ""
+
+msgid "you may want to cleanup or recover these."
+msgstr ""
+
+#, c-format
+msgid "failed: %d"
+msgstr ""
+
+msgid "use `diff.guitool` instead of `diff.tool`"
+msgstr ""
+
+msgid "perform a full-directory diff"
+msgstr ""
+
+msgid "do not prompt before launching a diff tool"
+msgstr ""
+
+msgid "use symlinks in dir-diff mode"
+msgstr ""
+
+msgid "tool"
+msgstr ""
+
+msgid "use the specified diff tool"
+msgstr ""
+
+msgid "print a list of diff tools that may be used with `--tool`"
+msgstr ""
+
+msgid ""
+"make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
+"code"
+msgstr ""
+
+msgid "specify a custom command for viewing diffs"
+msgstr ""
+
+msgid "passed to `diff`"
+msgstr ""
+
+msgid "difftool requires worktree or --no-index"
+msgstr ""
+
+msgid "no <tool> given for --tool=<tool>"
+msgstr ""
+
+msgid "no <cmd> given for --extcmd=<cmd>"
+msgstr ""
+
+msgid "git fast-export [<rev-list-opts>]"
+msgstr ""
+
+msgid "Error: Cannot export nested tags unless --mark-tags is specified."
+msgstr ""
+
+msgid "--anonymize-map token cannot be empty"
+msgstr ""
+
+msgid "show progress after <n> objects"
+msgstr ""
+
+msgid "select handling of signed tags"
+msgstr ""
+
+msgid "select handling of signed commits"
+msgstr ""
+
+msgid "select handling of tags that tag filtered objects"
+msgstr ""
+
+msgid "select handling of commit messages in an alternate encoding"
+msgstr ""
+
+msgid "dump marks to this file"
+msgstr ""
+
+msgid "import marks from this file"
+msgstr ""
+
+msgid "import marks from this file if it exists"
+msgstr ""
+
+msgid "fake a tagger when tags lack one"
+msgstr ""
+
+msgid "output full tree for each commit"
+msgstr ""
+
+msgid "use the done feature to terminate the stream"
+msgstr ""
+
+msgid "skip output of blob data"
+msgstr ""
+
+msgid "refspec"
+msgstr ""
+
+msgid "apply refspec to exported refs"
+msgstr ""
+
+msgid "anonymize output"
+msgstr ""
+
+msgid "from:to"
+msgstr ""
+
+msgid "convert <from> to <to> in anonymized output"
+msgstr ""
+
+msgid "reference parents which are not in fast-export stream by object id"
+msgstr ""
+
+msgid "show original object ids of blobs/commits"
+msgstr ""
+
+msgid "label tags with mark ids"
+msgstr ""
+
+#, c-format
+msgid "Missing from marks for submodule '%s'"
+msgstr ""
+
+#, c-format
+msgid "Missing to marks for submodule '%s'"
+msgstr ""
+
+#, c-format
+msgid "Expected 'mark' command, got %s"
+msgstr ""
+
+#, c-format
+msgid "Expected 'to' command, got %s"
+msgstr ""
+
+msgid "Expected format name:filename for submodule rewrite option"
+msgstr ""
+
+#, c-format
+msgid "feature '%s' forbidden in input without --allow-unsafe-features"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Lockfile created but not reported: %s"
+msgstr "Fo-mhodúil athraithe ach gan nuashonrú:"
+
+#, fuzzy
+msgid "git fetch [<options>] [<repository> [<refspec>...]]"
+msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+
+#, fuzzy
+msgid "git fetch [<options>] <group>"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+#, fuzzy
+msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
+msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+
+#, fuzzy
+msgid "git fetch --all [<options>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "fetch.parallel cannot be negative"
+msgstr ""
+
+#, fuzzy
+msgid "couldn't find remote ref HEAD"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+#, c-format
+msgid "From %.*s\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "object %s not found"
+msgstr "réad %s: súil leis an gcineál %s, aimsíodh %s"
+
+msgid "[up to date]"
+msgstr ""
+
+msgid "[rejected]"
+msgstr ""
+
+#, fuzzy
+msgid "can't fetch into checked-out branch"
+msgstr "cruthaigh/athshocraigh agus seiceáil amach brainse"
+
+msgid "[tag update]"
+msgstr ""
+
+#, fuzzy
+msgid "unable to update local ref"
+msgstr "nach féidir %s a nuashonrú"
+
+msgid "would clobber existing tag"
+msgstr ""
+
+msgid "[new tag]"
+msgstr ""
+
+#, fuzzy
+msgid "[new branch]"
+msgstr "brainse-nua"
+
+msgid "[new ref]"
+msgstr ""
+
+#, fuzzy
+msgid "forced update"
+msgstr "nuashonruithe fórsa"
+
+msgid "non-fast-forward"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot open '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+msgid ""
+"fetch normally indicates which branches had a forced update,\n"
+"but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
+"flag or run 'git config fetch.showForcedUpdates true'"
+msgstr ""
+
+#, c-format
+msgid ""
+"it took %.2f seconds to check forced updates; you can use\n"
+"'--no-show-forced-updates' or run 'git config fetch.showForcedUpdates "
+"false'\n"
+"to avoid this check\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s did not send all necessary objects"
+msgstr "níor sheol iargúlta gach rud riachtanach"
+
+#, c-format
+msgid "rejected %s because shallow roots are not allowed to be updated"
+msgstr ""
+
+#, c-format
+msgid ""
+"some local refs could not be updated; try running\n"
+" 'git remote prune %s' to remove any old, conflicting branches"
+msgstr ""
+
+#, c-format
+msgid "   (%s will become dangling)"
+msgstr ""
+
+#, c-format
+msgid "   (%s has become dangling)"
+msgstr ""
+
+#, fuzzy
+msgid "[deleted]"
+msgstr "scriosta:"
+
+msgid "(none)"
+msgstr ""
+
+#, c-format
+msgid "refusing to fetch into branch '%s' checked out at '%s'"
+msgstr ""
+
+#, c-format
+msgid "option \"%s\" value \"%s\" is not valid for %s"
+msgstr ""
+
+#, c-format
+msgid "option \"%s\" is ignored for %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s is not a valid object"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, fuzzy, c-format
+msgid "the object %s does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#, c-format
+msgid ""
+"Run 'git remote set-head %s %s' to follow the change, or set\n"
+"'remote.%s.followRemoteHEAD' configuration option to a different value\n"
+"if you do not want to see this message. Specifically running\n"
+"'git config set remote.%s.followRemoteHEAD warn-if-not-branch-%s'\n"
+"will disable the warning until the remote changes HEAD to something else."
+msgstr ""
+
+msgid "multiple branches detected, incompatible with --set-upstream"
+msgstr ""
+
+#, c-format
+msgid ""
+"could not set upstream of HEAD to '%s' from '%s' when it does not point to "
+"any branch."
+msgstr ""
+
+#, fuzzy
+msgid "not setting upstream for a remote remote-tracking branch"
+msgstr "brainse suas srutha '%s' nach stóráiltear mar bhrainse cianrianaithe"
+
+#, fuzzy
+msgid "not setting upstream for a remote tag"
+msgstr "socraigh suas sruth le haghaidh tarraing/stádas git"
+
+#, fuzzy
+msgid "unknown branch type"
+msgstr "cineál réad anaithnid %d"
+
+msgid ""
+"no source branch found;\n"
+"you need to specify exactly one branch with the --set-upstream option"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Fetching %s\n"
+msgstr "Ag brú chuig %s\n"
+
+#, fuzzy, c-format
+msgid "could not fetch %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "could not fetch '%s' (exit code: %d)\n"
+msgstr ""
+
+msgid ""
+"no remote repository specified; please specify either a URL or a\n"
+"remote name from which new revisions should be fetched"
+msgstr ""
+
+msgid "you need to specify a tag name"
+msgstr ""
+
+msgid "fetch from all remotes"
+msgstr ""
+
+#, fuzzy
+msgid "set upstream for git pull/fetch"
+msgstr "socraigh suas sruth le haghaidh tarraing/stádas git"
+
+msgid "append to .git/FETCH_HEAD instead of overwriting"
+msgstr ""
+
+#, fuzzy
+msgid "use atomic transaction to update references"
+msgstr "iarraidh idirbheart adamach ar an taobh iargúl"
+
+#, fuzzy
+msgid "path to upload pack on remote end"
+msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
+
+msgid "force overwrite of local reference"
+msgstr ""
+
+msgid "fetch from multiple remotes"
+msgstr ""
+
+msgid "fetch all tags and associated objects"
+msgstr ""
+
+msgid "do not fetch all tags (--no-tags)"
+msgstr ""
+
+#, fuzzy
+msgid "number of submodules fetched in parallel"
+msgstr "líon na bhfo-mhodúil atá clónaithe go comhthreomhar"
+
+msgid "modify the refspec to place all refs within refs/prefetch/"
+msgstr ""
+
+msgid "prune remote-tracking branches no longer on remote"
+msgstr ""
+
+msgid "prune local tags no longer on remote and clobber changed tags"
+msgstr ""
+
+msgid "on-demand"
+msgstr ""
+
+#, fuzzy
+msgid "control recursive fetching of submodules"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+msgid "write fetched references to the FETCH_HEAD file"
+msgstr ""
+
+msgid "keep downloaded pack"
+msgstr ""
+
+msgid "allow updating of HEAD ref"
+msgstr ""
+
+#, fuzzy
+msgid "deepen history of shallow clone"
+msgstr "stair an chlóin éadomhain a dhoimhniú, gan tagairt"
+
+#, fuzzy
+msgid "deepen history of shallow repository based on time"
+msgstr "stair an chlóin éadomhain a dhoimhniú, gan tagairt"
+
+#, fuzzy
+msgid "convert to a complete repository"
+msgstr "a chlónú ó stór áitiúil"
+
+msgid "re-fetch without negotiating common commits"
+msgstr ""
+
+msgid "prepend this to submodule path output"
+msgstr ""
+
+msgid ""
+"default for recursive fetching of submodules (lower priority than config "
+"files)"
+msgstr ""
+
+msgid "accept refs that update .git/shallow"
+msgstr ""
+
+msgid "refmap"
+msgstr ""
+
+msgid "specify fetch refmap"
+msgstr ""
+
+msgid "revision"
+msgstr ""
+
+msgid "report that we have only objects reachable from this object"
+msgstr ""
+
+msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
+msgstr ""
+
+msgid "run 'maintenance --auto' after fetching"
+msgstr ""
+
+msgid "check for forced-updates on all updated branches"
+msgstr ""
+
+msgid "write the commit-graph after fetching"
+msgstr ""
+
+msgid "accept refspecs from stdin"
+msgstr ""
+
+msgid "--negotiate-only needs one or more --negotiation-tip=*"
+msgstr ""
+
+msgid "negative depth in --deepen is not supported"
+msgstr ""
+
+msgid "--unshallow on a complete repository does not make sense"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to fetch bundles from '%s'"
+msgstr "theip ar rudaí a fháil ó URI '%s'"
+
+#, fuzzy
+msgid "fetch --all does not take a repository argument"
+msgstr "git checkout: --detach ní ghlacann argóint cosáin '%s'"
+
+#, fuzzy
+msgid "fetch --all does not make sense with refspecs"
+msgstr "--delete níl ciall leis gan aon réiteoirí"
+
+#, c-format
+msgid "no such remote or remote group: %s"
+msgstr ""
+
+msgid "fetching a group and specifying refspecs does not make sense"
+msgstr ""
+
+msgid "must supply remote when using --negotiate-only"
+msgstr ""
+
+msgid "protocol does not support --negotiate-only, exiting"
+msgstr ""
+
+msgid ""
+"--filter can only be used with the remote configured in "
+"extensions.partialclone"
+msgstr ""
+
+#, fuzzy
+msgid "--atomic can only be used when fetching from one remote"
+msgstr ""
+"a URI chun cuachtaí a íoslódáil sula n-iarrtar iad ó chianchéim tionscnaimh"
+
+msgid "--stdin can only be used when fetching from one remote"
+msgstr ""
+
+msgid ""
+"git fmt-merge-msg [-m <message>] [--log[=<n>] | --no-log] [--file <file>]"
+msgstr ""
+
+msgid "populate log with at most <n> entries from shortlog"
+msgstr ""
+
+msgid "alias for --log (deprecated)"
+msgstr ""
+
+msgid "text"
+msgstr ""
+
+msgid "use <text> as start of message"
+msgstr ""
+
+#, fuzzy
+msgid "use <name> instead of the real target branch"
+msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+
+#, fuzzy
+msgid "file to read from"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy
+msgid "git for-each-ref [<options>] [<pattern>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "git for-each-ref [--points-at <object>]"
+msgstr ""
+
+msgid "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
+msgstr ""
+
+msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
+msgstr ""
+
+msgid "quote placeholders suitably for shells"
+msgstr ""
+
+msgid "quote placeholders suitably for perl"
+msgstr ""
+
+msgid "quote placeholders suitably for python"
+msgstr ""
+
+msgid "quote placeholders suitably for Tcl"
+msgstr ""
+
+msgid "show only <n> matched refs"
+msgstr ""
+
+msgid "respect format colors"
+msgstr ""
+
+msgid "print only refs which points at the given object"
+msgstr ""
+
+msgid "print only refs that are merged"
+msgstr ""
+
+msgid "print only refs that are not merged"
+msgstr ""
+
+msgid "print only refs which contain the commit"
+msgstr ""
+
+msgid "print only refs which don't contain the commit"
+msgstr ""
+
+msgid "read reference patterns from stdin"
+msgstr ""
+
+msgid "also include HEAD ref and pseudorefs"
+msgstr ""
+
+msgid "unknown arguments supplied with --stdin"
+msgstr ""
+
+msgid "git for-each-repo --config=<config> [--] <arguments>"
+msgstr ""
+
+msgid "config"
+msgstr ""
+
+msgid "config key storing a list of repository paths"
+msgstr ""
+
+msgid "keep going even if command fails in a repository"
+msgstr ""
+
+msgid "missing --config=<config>"
+msgstr ""
+
+#, c-format
+msgid "got bad config --config=%s"
+msgstr ""
+
+#, fuzzy
+msgid "unknown"
+msgstr "anaithnid:"
+
+#. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
+#, c-format
+msgid "error in %s %s: %s"
+msgstr ""
+
+#. TRANSLATORS: e.g. warning in tree 01bfda: <more explanation>
+#, c-format
+msgid "warning in %s %s: %s"
+msgstr ""
+
+#, c-format
+msgid "broken link from %7s %s"
+msgstr ""
+
+#, fuzzy
+msgid "wrong object type in link"
+msgstr "cineál réad anaithnid %d"
+
+#, c-format
+msgid ""
+"broken link from %7s %s\n"
+"              to %7s %s"
+msgstr ""
+
+#, fuzzy
+msgid "Checking connectivity"
+msgstr "Rud a sheiceáil"
+
+#, c-format
+msgid "missing %s %s"
+msgstr ""
+
+#, c-format
+msgid "unreachable %s %s"
+msgstr ""
+
+#, c-format
+msgid "dangling %s %s"
+msgstr ""
+
+#, fuzzy
+msgid "could not create lost-found"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not write '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not finish '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "Checking %s"
+msgstr "Rud a sheiceáil"
+
+#, fuzzy, c-format
+msgid "Checking connectivity (%d objects)"
+msgstr "Rud a sheiceáil"
+
+#, fuzzy, c-format
+msgid "Checking %s %s"
+msgstr "Rud a sheiceáil"
+
+msgid "broken links"
+msgstr ""
+
+#, c-format
+msgid "root %s"
+msgstr ""
+
+#, c-format
+msgid "tagged %s %s (%s) in %s"
+msgstr ""
+
+#, c-format
+msgid "%s: object corrupt or missing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s: invalid reflog entry %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "Checking reflog %s->%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s: invalid sha1 pointer %s"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "%s: not a commit"
+msgstr "Tiomantas tosaigh"
+
+msgid "notice: No default references"
+msgstr ""
+
+#, c-format
+msgid "%s: hash-path mismatch, found at: %s"
+msgstr ""
+
+#, c-format
+msgid "%s: object corrupt or missing: %s"
+msgstr ""
+
+#, c-format
+msgid "%s: object is of unknown type '%s': %s"
+msgstr ""
+
+#, c-format
+msgid "%s: object could not be parsed: %s"
+msgstr ""
+
+#, c-format
+msgid "bad sha1 file: %s"
+msgstr ""
+
+#, fuzzy
+msgid "Checking object directory"
+msgstr "Rud a sheiceáil"
+
+#, fuzzy
+msgid "Checking object directories"
+msgstr "Rud a sheiceáil"
+
+#, fuzzy, c-format
+msgid "Checking %s link"
+msgstr "Rud a sheiceáil"
+
+#, c-format
+msgid "invalid %s"
+msgstr "%s neamhbhailí"
+
+#, c-format
+msgid "%s points to something strange (%s)"
+msgstr ""
+
+#, c-format
+msgid "%s: detached HEAD points at nothing"
+msgstr ""
+
+#, c-format
+msgid "notice: %s points to an unborn branch (%s)"
+msgstr ""
+
+#, c-format
+msgid "Checking cache tree of %s"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid sha1 pointer in cache-tree of %s"
+msgstr ""
+
+msgid "non-tree in cache-tree"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid sha1 pointer in resolve-undo of %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to load rev-index for pack '%s'"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+#, fuzzy, c-format
+msgid "invalid rev-index for pack '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy
+msgid "Checking ref database"
+msgstr "Rud a sheiceáil"
+
+msgid ""
+"git fsck [--tags] [--root] [--unreachable] [--cache] [--no-reflogs]\n"
+"         [--[no-]full] [--strict] [--verbose] [--lost-found]\n"
+"         [--[no-]dangling] [--[no-]progress] [--connectivity-only]\n"
+"         [--[no-]name-objects] [--[no-]references] [<object>...]"
+msgstr ""
+
+msgid "show unreachable objects"
+msgstr ""
+
+#, fuzzy
+msgid "show dangling objects"
+msgstr "Rud a sheiceáil"
+
+msgid "report tags"
+msgstr ""
+
+msgid "report root nodes"
+msgstr ""
+
+msgid "make index objects head nodes"
+msgstr ""
+
+#, fuzzy
+msgid "make reflogs head nodes (default)"
+msgstr "úsáid modh forleagtha (réamhshocraithe)"
+
+msgid "also consider packs and alternate objects"
+msgstr ""
+
+msgid "check only connectivity"
+msgstr ""
+
+msgid "enable more strict checking"
+msgstr ""
+
+msgid "write dangling objects in .git/lost-found"
+msgstr ""
+
+msgid "show progress"
+msgstr ""
+
+msgid "show verbose names for reachable objects"
+msgstr ""
+
+msgid "check reference database consistency"
+msgstr ""
+
+msgid "Checking objects"
+msgstr "Rud a sheiceáil"
+
+#, c-format
+msgid "%s: object missing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid parameter: expected sha1, got '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+msgid "git fsmonitor--daemon start [<options>]"
+msgstr ""
+
+msgid "git fsmonitor--daemon run [<options>]"
+msgstr ""
+
+#, c-format
+msgid "value of '%s' out of range: %d"
+msgstr ""
+
+#, c-format
+msgid "value of '%s' not bool or int: %d"
+msgstr ""
+
+#, c-format
+msgid "fsmonitor-daemon is watching '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "fsmonitor-daemon is not watching '%s'\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not create fsmonitor cookie '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "fsmonitor: cookie_result '%d' != SEEN"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not start IPC thread pool on '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+msgid "could not start fsmonitor listener thread"
+msgstr ""
+
+msgid "could not start fsmonitor health thread"
+msgstr ""
+
+msgid "could not initialize listener thread"
+msgstr ""
+
+msgid "could not initialize health thread"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not cd home '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "fsmonitor--daemon is already running '%s'"
+msgstr ""
+
+#, c-format
+msgid "running fsmonitor-daemon in '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "starting fsmonitor-daemon in '%s'\n"
+msgstr ""
+
+#, fuzzy
+msgid "daemon failed to start"
+msgstr "theip ar '%s' a stáil"
+
+msgid "daemon not online yet"
+msgstr ""
+
+msgid "daemon terminated"
+msgstr ""
+
+#, fuzzy
+msgid "detach from console"
+msgstr "CEANN scartha ó "
+
+msgid "use <n> ipc worker threads"
+msgstr ""
+
+msgid "max seconds to wait for background daemon startup"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid 'ipc-threads' value (%d)"
+msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
+
+#, c-format
+msgid "Unhandled subcommand '%s'"
+msgstr ""
+
+msgid "fsmonitor--daemon not supported on this platform"
+msgstr ""
+
+#, fuzzy
+msgid "git gc [<options>]"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+#, fuzzy, c-format
+msgid "Failed to fstat %s: %s"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy, c-format
+msgid "failed to parse '%s' value '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+#, fuzzy, c-format
+msgid "cannot stat '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid ""
+"The last gc run reported the following. Please correct the root cause\n"
+"and remove %s\n"
+"Automatic cleanup will not be performed until the file is removed.\n"
+"\n"
+"%s"
+msgstr ""
+
+#, fuzzy
+msgid "prune unreferenced objects"
+msgstr "níl ach tagairt amháin ag súil leis"
+
+msgid "pack unreferenced objects separately"
+msgstr ""
+
+msgid "with --cruft, limit the size of new cruft packs"
+msgstr ""
+
+msgid "be more thorough (increased runtime)"
+msgstr ""
+
+msgid "enable auto-gc mode"
+msgstr ""
+
+msgid "perform garbage collection in the background"
+msgstr ""
+
+msgid "force running gc even if there may be another gc running"
+msgstr ""
+
+msgid "repack all other packs except the largest pack"
+msgstr ""
+
+msgid "pack prefix to store a pack containing pruned objects"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to parse gc.logExpiry value %s"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, c-format
+msgid "failed to parse prune expiry value %s"
+msgstr ""
+
+#, c-format
+msgid "Auto packing the repository in background for optimum performance.\n"
+msgstr ""
+
+#, c-format
+msgid "Auto packing the repository for optimum performance.\n"
+msgstr ""
+
+#, c-format
+msgid "See \"git help gc\" for manual housekeeping.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
+msgstr ""
+
+msgid ""
+"There are too many unreachable loose objects; run 'git prune' to remove them."
+msgstr ""
+
+msgid ""
+"git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
+msgstr ""
+
+msgid "--no-schedule is not allowed"
+msgstr ""
+
+#, c-format
+msgid "unrecognized --schedule argument '%s'"
+msgstr ""
+
+#, fuzzy
+msgid "failed to write commit-graph"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy
+msgid "failed to prefetch remotes"
+msgstr "theip orthu beartáin fógraithe a fháil"
+
+#, fuzzy
+msgid "failed to start 'git pack-objects' process"
+msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+
+#, fuzzy
+msgid "failed to finish 'git pack-objects' process"
+msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+
+msgid "failed to write multi-pack-index"
+msgstr ""
+
+msgid "'git multi-pack-index expire' failed"
+msgstr ""
+
+msgid "'git multi-pack-index repack' failed"
+msgstr ""
+
+msgid ""
+"skipping incremental-repack task because core.multiPackIndex is disabled"
+msgstr ""
+
+#, c-format
+msgid "lock file '%s' exists, skipping maintenance"
+msgstr ""
+
+#, c-format
+msgid "task '%s' failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid task"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, fuzzy, c-format
+msgid "task '%s' cannot be selected multiple times"
+msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
+
+msgid "run tasks based on the state of the repository"
+msgstr ""
+
+msgid "perform maintenance in the background"
+msgstr ""
+
+msgid "frequency"
+msgstr ""
+
+msgid "run tasks based on frequency"
+msgstr ""
+
+msgid "do not report progress or other information over stderr"
+msgstr ""
+
+msgid "task"
+msgstr ""
+
+msgid "run a specific task"
+msgstr ""
+
+msgid "use at most one of --auto and --schedule=<frequency>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to add '%s' value of '%s'"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+msgid "return success even if repository was not registered"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to unset '%s' value of '%s'"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, fuzzy, c-format
+msgid "repository '%s' is not registered"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy, c-format
+msgid "failed to expand path '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy
+msgid "failed to start launchctl"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy, c-format
+msgid "failed to create directories for '%s'"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "failed to bootstrap service %s"
+msgstr "theip ar athrá thar '%s'"
+
+#, fuzzy
+msgid "failed to create temp xml file"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, fuzzy
+msgid "failed to start schtasks"
+msgstr "theip ar '%s' a stáil"
+
+msgid "failed to run 'crontab -l'; your system might not support 'cron'"
+msgstr ""
+
+#, fuzzy
+msgid "failed to create crontab temporary file"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy
+msgid "failed to open temporary file"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+msgid "failed to run 'crontab'; your system might not support 'cron'"
+msgstr ""
+
+msgid "'crontab' died"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to delete '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy, c-format
+msgid "failed to flush '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy
+msgid "failed to start systemctl"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy
+msgid "failed to run systemctl"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, c-format
+msgid "unrecognized --scheduler argument '%s'"
+msgstr ""
+
+msgid "neither systemd timers nor crontab are available"
+msgstr ""
+
+#, c-format
+msgid "%s scheduler is not available"
+msgstr ""
+
+#, c-format
+msgid ""
+"unable to create '%s.lock': %s.\n"
+"\n"
+"Another scheduled git-maintenance(1) process seems to be running in this\n"
+"repository. Please make sure no other maintenance processes are running and\n"
+"then try again. If it still fails, a git-maintenance(1) process may have\n"
+"crashed in this repository earlier: remove the file manually to continue."
+msgstr ""
+
+msgid "cannot acquire lock for scheduled background maintenance"
+msgstr ""
+
+msgid "git maintenance start [--scheduler=<scheduler>]"
+msgstr ""
+
+msgid "scheduler"
+msgstr ""
+
+msgid "scheduler to trigger git maintenance run"
+msgstr ""
+
+msgid "failed to set up maintenance schedule"
+msgstr ""
+
+msgid "failed to add repo to global config"
+msgstr ""
+
+msgid "git maintenance <subcommand> [<options>]"
+msgstr ""
+
+#, fuzzy
+msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
+msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+
+#, fuzzy, c-format
+msgid "grep: failed to create thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "invalid number of threads specified (%d) for %s"
+msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
+
+#. #-#-#-#-#  grep.c.po  #-#-#-#-#
+#. TRANSLATORS: %s is the configuration
+#. variable for tweaking threads, currently
+#. grep.threads
+#.
+#, c-format
+msgid "no threads support, ignoring %s"
+msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
+
+#, fuzzy, c-format
+msgid "unable to read tree %s"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, fuzzy, c-format
+msgid "unable to grep from object of type %s"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, c-format
+msgid "switch `%c' expects a numerical value"
+msgstr ""
+
+#, fuzzy
+msgid "search in index instead of in the work tree"
+msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+
+msgid "find in contents not managed by git"
+msgstr ""
+
+#, fuzzy
+msgid "search in both tracked and untracked files"
+msgstr " (bain úsáid as an rogha -u chun comhaid neamhrianaithe a thaispeáint)"
+
+msgid "ignore files specified via '.gitignore'"
+msgstr ""
+
+#, fuzzy
+msgid "recursively search in each submodule"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+msgid "show non-matching lines"
+msgstr ""
+
+msgid "case insensitive matching"
+msgstr ""
+
+msgid "match patterns only at word boundaries"
+msgstr ""
+
+msgid "process binary files as text"
+msgstr ""
+
+msgid "don't match patterns in binary files"
+msgstr ""
+
+msgid "process binary files with textconv filters"
+msgstr ""
+
+msgid "search in subdirectories (default)"
+msgstr ""
+
+msgid "descend at most <n> levels"
+msgstr ""
+
+msgid "use extended POSIX regular expressions"
+msgstr ""
+
+msgid "use basic POSIX regular expressions (default)"
+msgstr ""
+
+msgid "interpret patterns as fixed strings"
+msgstr ""
+
+msgid "use Perl-compatible regular expressions"
+msgstr ""
+
+msgid "show line numbers"
+msgstr ""
+
+msgid "show column number of first match"
+msgstr ""
+
+msgid "don't show filenames"
+msgstr ""
+
+msgid "show filenames"
+msgstr ""
+
+msgid "show filenames relative to top directory"
+msgstr ""
+
+msgid "show only filenames instead of matching lines"
+msgstr ""
+
+msgid "synonym for --files-with-matches"
+msgstr ""
+
+msgid "show only the names of files without match"
+msgstr ""
+
+msgid "print NUL after filenames"
+msgstr ""
+
+msgid "show only matching parts of a line"
+msgstr ""
+
+msgid "show the number of matches instead of matching lines"
+msgstr ""
+
+msgid "highlight matches"
+msgstr ""
+
+msgid "print empty line between matches from different files"
+msgstr ""
+
+msgid "show filename only once above matches from same file"
+msgstr ""
+
+msgid "show <n> context lines before and after matches"
+msgstr ""
+
+msgid "show <n> context lines before matches"
+msgstr ""
+
+msgid "show <n> context lines after matches"
+msgstr ""
+
+msgid "use <n> worker threads"
+msgstr ""
+
+msgid "shortcut for -C NUM"
+msgstr ""
+
+msgid "show a line with the function name before matches"
+msgstr ""
+
+msgid "show the surrounding function"
+msgstr ""
+
+msgid "read patterns from file"
+msgstr ""
+
+msgid "match <pattern>"
+msgstr ""
+
+msgid "combine patterns specified with -e"
+msgstr ""
+
+msgid "indicate hit with exit status without output"
+msgstr ""
+
+msgid "show only matches from files that match all patterns"
+msgstr ""
+
+msgid "pager"
+msgstr ""
+
+msgid "show matching files in the pager"
+msgstr ""
+
+msgid "allow calling of grep(1) (ignored by this build)"
+msgstr ""
+
+msgid "maximum number of results per file"
+msgstr ""
+
+msgid "no pattern given"
+msgstr ""
+
+#, fuzzy
+msgid "--no-index or --untracked cannot be used with revs"
+msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
+
+#, fuzzy, c-format
+msgid "unable to resolve revision: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+msgid "--untracked not supported with --recurse-submodules"
+msgstr ""
+
+msgid "invalid option combination, ignoring --threads"
+msgstr ""
+
+#, fuzzy
+msgid "no threads support, ignoring --threads"
+msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
+
+#, c-format
+msgid "invalid number of threads specified (%d)"
+msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
+
+msgid "--open-files-in-pager only works on the worktree"
+msgstr ""
+
+msgid "--[no-]exclude-standard cannot be used for tracked contents"
+msgstr ""
+
+msgid "both --cached and trees are given"
+msgstr ""
+
+msgid ""
+"git hash-object [-t <type>] [-w] [--path=<file> | --no-filters]\n"
+"                [--stdin [--literally]] [--] <file>..."
+msgstr ""
+
+msgid "git hash-object [-t <type>] [-w] --stdin-paths [--no-filters]"
+msgstr ""
+
+#, fuzzy
+msgid "object type"
+msgstr "cineál réad anaithnid %d"
+
+msgid "write the object into the object database"
+msgstr ""
+
+msgid "read the object from stdin"
+msgstr ""
+
+msgid "store file as is without filters"
+msgstr ""
+
+msgid ""
+"just hash any random garbage to create corrupt objects for debugging Git"
+msgstr ""
+
+msgid "process file as it were from this path"
+msgstr ""
+
+msgid "print all available commands"
+msgstr ""
+
+msgid "show external commands in --all"
+msgstr ""
+
+msgid "show aliases in --all"
+msgstr ""
+
+msgid "exclude guides"
+msgstr ""
+
+msgid "show man page"
+msgstr ""
+
+msgid "show manual in web browser"
+msgstr ""
+
+msgid "show info page"
+msgstr ""
+
+msgid "print command description"
+msgstr ""
+
+msgid "print list of useful guides"
+msgstr ""
+
+msgid "print list of user-facing repository, command and file interfaces"
+msgstr ""
+
+msgid "print list of file formats, protocols and other developer interfaces"
+msgstr ""
+
+msgid "print all configuration variable names"
+msgstr ""
+
+msgid "git help [[-i|--info] [-m|--man] [-w|--web]] [<command>|<doc>]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unrecognized help format '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, fuzzy
+msgid "Failed to start emacsclient."
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy
+msgid "Failed to parse emacsclient version."
+msgstr "Theip ar '%s' a réiteach mar athbhreithniú bailí."
+
+#, c-format
+msgid "emacsclient version '%d' too old (< 22)."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to exec '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid ""
+"'%s': path for unsupported man viewer.\n"
+"Please consider using 'man.<tool>.cmd' instead."
+msgstr ""
+
+#, c-format
+msgid ""
+"'%s': cmd for supported man viewer.\n"
+"Please consider using 'man.<tool>.path' instead."
+msgstr ""
+
+#, c-format
+msgid "'%s': unknown man viewer."
+msgstr ""
+
+msgid "no man viewer handled the request"
+msgstr ""
+
+msgid "no info viewer handled the request"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is aliased to '%s'"
+msgstr "Ní féidir '%s' a úsáid le '%s'"
+
+#, c-format
+msgid "bad alias.%s string: %s"
+msgstr ""
+
+#, c-format
+msgid "the '%s' option doesn't take any non-option arguments"
+msgstr ""
+
+msgid ""
+"the '--no-[external-commands|aliases]' options can only be used with '--all'"
+msgstr ""
+
+#, c-format
+msgid "usage: %s%s"
+msgstr ""
+
+msgid "'git help config' for more information"
+msgstr ""
+
+msgid ""
+"git hook run [--ignore-missing] [--to-stdin=<path>] <hook-name> [-- <hook-"
+"args>]"
+msgstr ""
+
+msgid "silently ignore missing requested <hook-name>"
+msgstr ""
+
+#, fuzzy
+msgid "file to read into hooks' stdin"
+msgstr "theip ar nasc '%s' a chruthú"
+
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "mímheaitseáil cineál réad ag %s"
@@ -865,9 +7038,6 @@ msgstr "nár bhfuair sé réad ag súil leis %s"
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "réad %s: súil leis an gcineál %s, aimsíodh %s"
-
-msgid "Checking objects"
-msgstr "Rud a sheiceáil"
 
 #, c-format
 msgid "cannot fill %d byte"
@@ -935,10 +7105,6 @@ msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "FUARTHAS IMBHALL SHA1 LE %s!"
 
 #, c-format
-msgid "unable to read %s"
-msgstr "nach féidir %s a léamh"
-
-#, c-format
 msgid "cannot read existing object info %s"
 msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
 
@@ -952,10 +7118,6 @@ msgstr "réad blob neamhbhailí %s"
 
 msgid "fsck error in packed object"
 msgstr "earráid fsck i réad pacáilte"
-
-#, c-format
-msgid "invalid %s"
-msgstr "%s neamhbhailí"
 
 #, c-format
 msgid "Not all child objects of %s are reachable"
@@ -1042,14 +7204,6 @@ msgid "bad pack.indexVersion=%<PRIu32>"
 msgstr "droch-pack.indexVersion=%<PRIu32>"
 
 #, c-format
-msgid "invalid number of threads specified (%d)"
-msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
-
-#, c-format
-msgid "no threads support, ignoring %s"
-msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
-
-#, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Ní féidir comhad pacáiste atá ann cheana '%s' a oscailt"
 
@@ -1111,6 +7265,2264 @@ msgstr "--verify gan ainm comhaid pacáiste tugtha"
 
 msgid "fsck error in pack objects"
 msgstr "fsck earráid i rudaí pacáiste"
+
+msgid ""
+"git init [-q | --quiet] [--bare] [--template=<template-directory>]\n"
+"         [--separate-git-dir <git-dir>] [--object-format=<format>]\n"
+"         [--ref-format=<format>]\n"
+"         [-b <branch-name> | --initial-branch=<branch-name>]\n"
+"         [--shared[=<permissions>]] [<directory>]"
+msgstr ""
+
+msgid "permissions"
+msgstr ""
+
+msgid "specify that the git repository is to be shared amongst several users"
+msgstr ""
+
+msgid "override the name of the initial branch"
+msgstr ""
+
+msgid "hash"
+msgstr ""
+
+#, fuzzy
+msgid "specify the hash algorithm to use"
+msgstr "sonraigh an fhormáid tagartha le húsáid"
+
+#, c-format
+msgid "cannot mkdir %s"
+msgstr ""
+
+#, c-format
+msgid "cannot chdir to %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
+"dir=<directory>)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Cannot access work tree '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy
+msgid "--separate-git-dir incompatible with bare repository"
+msgstr "Ní cheadaítear athshocrú %s i stóras lom"
+
+msgid ""
+"git interpret-trailers [--in-place] [--trim-empty]\n"
+"                       [(--trailer (<key>|<key-alias>)[(=|:)<value>])...]\n"
+"                       [--parse] [<file>...]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not stat %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "file %s is not a regular file"
+msgstr ""
+
+#, c-format
+msgid "file %s is not writable by user"
+msgstr ""
+
+#, fuzzy
+msgid "could not open temporary file"
+msgstr "ní féidir le comhad malartacha sealadacha a dhínascadh"
+
+#, fuzzy, c-format
+msgid "could not read input file '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "could not read from stdin"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not rename temporary file to %s"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+msgid "edit files in place"
+msgstr ""
+
+msgid "trim empty trailers"
+msgstr ""
+
+msgid "placement"
+msgstr ""
+
+msgid "where to place the new trailer"
+msgstr ""
+
+#, fuzzy
+msgid "action if trailer already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+msgid "action if trailer is missing"
+msgstr ""
+
+msgid "output only the trailers"
+msgstr ""
+
+msgid "do not apply trailer.* configuration variables"
+msgstr ""
+
+msgid "reformat multiline trailer values as single-line values"
+msgstr ""
+
+msgid "alias for --only-trailers --only-input --unfold"
+msgstr ""
+
+msgid "do not treat \"---\" as the end of input"
+msgstr ""
+
+msgid "trailer(s) to add"
+msgstr ""
+
+msgid "--trailer with --only-input does not make sense"
+msgstr ""
+
+msgid "no input file given for in-place editing"
+msgstr ""
+
+#, fuzzy
+msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
+msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+
+#, fuzzy
+msgid "git show [<options>] <object>..."
+msgstr "git checkout [<roghanna>] <brainse>"
+
+#, fuzzy, c-format
+msgid "invalid --decorate option: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "suppress diff output"
+msgstr ""
+
+msgid "show source"
+msgstr ""
+
+msgid "clear all previously-defined decoration filters"
+msgstr ""
+
+msgid "only decorate refs that match <pattern>"
+msgstr ""
+
+msgid "do not decorate refs that match <pattern>"
+msgstr ""
+
+msgid "decorate options"
+msgstr ""
+
+msgid ""
+"trace the evolution of line range <start>,<end> or function :<funcname> in "
+"<file>"
+msgstr ""
+
+#, fuzzy
+msgid "-L<range>:<file> cannot be used with pathspec"
+msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+
+#, c-format
+msgid "Final output: %d %s\n"
+msgstr ""
+
+#, c-format
+msgid "git show %s: bad file"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read object %s"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "unknown type: %d"
+msgstr "cineál réad anaithnid %d"
+
+#, c-format
+msgid "%s: invalid cover from description mode"
+msgstr ""
+
+msgid "format.headers without value"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot open patch file %s"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+msgid "need exactly one range"
+msgstr ""
+
+msgid "not a range"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to read branch description file '%s'"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+msgid "cover letter needs email format"
+msgstr ""
+
+#, fuzzy
+msgid "failed to create cover-letter file"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, c-format
+msgid "insane in-reply-to: %s"
+msgstr ""
+
+#, fuzzy
+msgid "git format-patch [<options>] [<since> | <revision-range>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "two output directories?"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown commit %s"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "failed to resolve '%s' as a valid ref"
+msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+
+#, fuzzy
+msgid "could not find exact merge base"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+msgid ""
+"failed to get upstream, if you want to record base commit automatically,\n"
+"please use git branch --set-upstream-to to track a remote branch.\n"
+"Or you could specify base commit by --base=<base-commit-id> manually"
+msgstr ""
+
+#, fuzzy
+msgid "failed to find exact merge base"
+msgstr "Theip ar chrann %s a aimsiú."
+
+msgid "base commit should be the ancestor of revision list"
+msgstr ""
+
+msgid "base commit shouldn't be in revision list"
+msgstr ""
+
+#, fuzzy
+msgid "cannot get patch id"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+msgid "failed to infer range-diff origin of current series"
+msgstr ""
+
+#, c-format
+msgid "using '%s' as range-diff origin of current series"
+msgstr ""
+
+msgid "use [PATCH n/m] even with a single patch"
+msgstr ""
+
+msgid "use [PATCH] even with multiple patches"
+msgstr ""
+
+msgid "print patches to standard out"
+msgstr ""
+
+msgid "generate a cover letter"
+msgstr ""
+
+msgid "use simple number sequence for output file names"
+msgstr ""
+
+msgid "sfx"
+msgstr ""
+
+msgid "use <sfx> instead of '.patch'"
+msgstr ""
+
+msgid "start numbering patches at <n> instead of 1"
+msgstr ""
+
+msgid "reroll-count"
+msgstr ""
+
+msgid "mark the series as Nth re-roll"
+msgstr ""
+
+msgid "max length of output filename"
+msgstr ""
+
+#, fuzzy
+msgid "rfc"
+msgstr "tagairt"
+
+msgid "add <rfc> (default 'RFC') before 'PATCH'"
+msgstr ""
+
+msgid "cover-from-description-mode"
+msgstr ""
+
+msgid "generate parts of a cover letter based on a branch's description"
+msgstr ""
+
+msgid "use branch description from file"
+msgstr ""
+
+msgid "use [<prefix>] instead of [PATCH]"
+msgstr ""
+
+msgid "store resulting files in <dir>"
+msgstr ""
+
+msgid "don't strip/add [PATCH]"
+msgstr ""
+
+msgid "don't output binary diffs"
+msgstr ""
+
+msgid "output all-zero hash in From header"
+msgstr ""
+
+msgid "don't include a patch matching a commit upstream"
+msgstr ""
+
+msgid "show patch format instead of default (patch + stat)"
+msgstr ""
+
+msgid "Messaging"
+msgstr ""
+
+#, fuzzy
+msgid "header"
+msgstr "chun tosaigh "
+
+msgid "add email header"
+msgstr ""
+
+msgid "email"
+msgstr ""
+
+msgid "add To: header"
+msgstr ""
+
+msgid "add Cc: header"
+msgstr ""
+
+msgid "ident"
+msgstr ""
+
+msgid "set From address to <ident> (or committer ident if absent)"
+msgstr ""
+
+msgid "message-id"
+msgstr ""
+
+msgid "make first mail a reply to <message-id>"
+msgstr ""
+
+msgid "boundary"
+msgstr ""
+
+msgid "attach the patch"
+msgstr ""
+
+msgid "inline the patch"
+msgstr ""
+
+msgid "enable message threading, styles: shallow, deep"
+msgstr ""
+
+msgid "signature"
+msgstr ""
+
+msgid "add a signature"
+msgstr ""
+
+msgid "base-commit"
+msgstr ""
+
+msgid "add prerequisite tree info to the patch series"
+msgstr ""
+
+msgid "add a signature from a file"
+msgstr ""
+
+msgid "don't print the patch filenames"
+msgstr ""
+
+msgid "show progress while generating patches"
+msgstr ""
+
+msgid "show changes against <rev> in cover letter or single patch"
+msgstr ""
+
+msgid "show changes against <refspec> in cover letter or single patch"
+msgstr ""
+
+msgid "percentage by which creation is weighted"
+msgstr ""
+
+msgid "show in-body From: even if identical to the e-mail header"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid ident line: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "--name-only does not make sense"
+msgstr ""
+
+msgid "--name-status does not make sense"
+msgstr ""
+
+msgid "--check does not make sense"
+msgstr ""
+
+msgid "--remerge-diff does not make sense"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not create directory '%s'"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+msgid "--interdiff requires --cover-letter or single patch"
+msgstr ""
+
+msgid "Interdiff:"
+msgstr ""
+
+#, c-format
+msgid "Interdiff against v%d:"
+msgstr ""
+
+msgid "--range-diff requires --cover-letter or single patch"
+msgstr ""
+
+msgid "Range-diff:"
+msgstr ""
+
+#, c-format
+msgid "Range-diff against v%d:"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to read signature file '%s'"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, fuzzy
+msgid "Generating patches"
+msgstr "Cosáin neamh-chumasaithe:"
+
+#, fuzzy
+msgid "failed to create output files"
+msgstr "theip ar nasc '%s' a chruthú"
+
+msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
+msgstr ""
+
+#, c-format
+msgid ""
+"Could not find a tracked remote branch, please specify <upstream> manually.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not get object info about '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy
+msgid "git ls-files [<options>] [<file>...]"
+msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+
+msgid "separate paths with the NUL character"
+msgstr ""
+
+msgid "identify the file status with tags"
+msgstr ""
+
+msgid "use lowercase letters for 'assume unchanged' files"
+msgstr ""
+
+msgid "use lowercase letters for 'fsmonitor clean' files"
+msgstr ""
+
+msgid "show cached files in the output (default)"
+msgstr ""
+
+msgid "show deleted files in the output"
+msgstr ""
+
+msgid "show modified files in the output"
+msgstr ""
+
+msgid "show other files in the output"
+msgstr ""
+
+msgid "show ignored files in the output"
+msgstr ""
+
+msgid "show staged contents' object name in the output"
+msgstr ""
+
+msgid "show files on the filesystem that need to be removed"
+msgstr ""
+
+msgid "show 'other' directories' names only"
+msgstr ""
+
+msgid "show line endings of files"
+msgstr ""
+
+msgid "don't show empty directories"
+msgstr ""
+
+msgid "show unmerged files in the output"
+msgstr ""
+
+msgid "show resolve-undo information"
+msgstr ""
+
+msgid "skip files matching pattern"
+msgstr ""
+
+msgid "read exclude patterns from <file>"
+msgstr ""
+
+msgid "read additional per-directory exclude patterns in <file>"
+msgstr ""
+
+msgid "add the standard git exclusions"
+msgstr ""
+
+msgid "make the output relative to the project top directory"
+msgstr ""
+
+msgid "if any <file> is not in the index, treat this as an error"
+msgstr ""
+
+msgid "tree-ish"
+msgstr ""
+
+msgid "pretend that paths removed since <tree-ish> are still present"
+msgstr ""
+
+msgid "show debugging data"
+msgstr ""
+
+msgid "suppress duplicate entries"
+msgstr ""
+
+msgid "show sparse directories in the presence of a sparse index"
+msgstr ""
+
+msgid ""
+"--format cannot be used with -s, -o, -k, -t, --resolve-undo, --deduplicate, "
+"--eol"
+msgstr ""
+
+msgid ""
+"git ls-remote [--branches] [--tags] [--refs] [--upload-pack=<exec>]\n"
+"              [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
+"              [--symref] [<repository> [<patterns>...]]"
+msgstr ""
+
+msgid "do not print remote URL"
+msgstr ""
+
+msgid "exec"
+msgstr ""
+
+#, fuzzy
+msgid "path of git-upload-pack on the remote host"
+msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
+
+msgid "limit to tags"
+msgstr ""
+
+#, fuzzy
+msgid "limit to branches"
+msgstr "Aistrithe go brainse '%s'\n"
+
+msgid "deprecated synonym for --branches"
+msgstr ""
+
+msgid "do not show peeled tags"
+msgstr ""
+
+msgid "take url.<base>.insteadOf into account"
+msgstr ""
+
+msgid "exit with exit code 2 if no matching refs are found"
+msgstr ""
+
+msgid "show underlying ref in addition to the object pointed by it"
+msgstr ""
+
+#, fuzzy
+msgid "git ls-tree [<options>] <tree-ish> [<path>...]"
+msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+
+msgid "only show trees"
+msgstr ""
+
+msgid "recurse into subtrees"
+msgstr ""
+
+msgid "show trees when recursing"
+msgstr ""
+
+msgid "terminate entries with NUL byte"
+msgstr ""
+
+#, fuzzy
+msgid "include object size"
+msgstr "réad blob neamhbhailí %s"
+
+msgid "list only filenames"
+msgstr ""
+
+#, fuzzy
+msgid "list only objects"
+msgstr "réad blob neamhbhailí %s"
+
+msgid "use full path names"
+msgstr ""
+
+msgid "list entire tree; not just current directory (implies --full-name)"
+msgstr ""
+
+#, fuzzy
+msgid "--format can't be combined with other format-altering options"
+msgstr "--mirror ní féidir é a chomhcheangal le refspecs"
+
+#. TRANSLATORS: keep <> in "<" mail ">" info.
+msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
+msgstr ""
+
+msgid "keep subject"
+msgstr ""
+
+msgid "keep non patch brackets in subject"
+msgstr ""
+
+msgid "copy Message-ID to the end of commit message"
+msgstr ""
+
+msgid "re-code metadata to i18n.commitEncoding"
+msgstr ""
+
+msgid "disable charset re-coding of metadata"
+msgstr ""
+
+msgid "encoding"
+msgstr ""
+
+msgid "re-code metadata to this encoding"
+msgstr ""
+
+msgid "use scissors"
+msgstr ""
+
+msgid "<action>"
+msgstr ""
+
+msgid "action when quoted CR is found"
+msgstr ""
+
+msgid "use headers in message's body"
+msgstr ""
+
+msgid "reading patches from stdin/tty..."
+msgstr ""
+
+#, c-format
+msgid "empty mbox: '%s'"
+msgstr ""
+
+msgid "git merge-base [-a | --all] <commit> <commit>..."
+msgstr ""
+
+msgid "git merge-base [-a | --all] --octopus <commit>..."
+msgstr ""
+
+msgid "git merge-base --is-ancestor <commit> <commit>"
+msgstr ""
+
+msgid "git merge-base --independent <commit>..."
+msgstr ""
+
+msgid "git merge-base --fork-point <ref> [<commit>]"
+msgstr ""
+
+msgid "output all common ancestors"
+msgstr ""
+
+msgid "find ancestors for a single n-way merge"
+msgstr ""
+
+msgid "list revs not reachable from others"
+msgstr ""
+
+msgid "is the first one ancestor of the other?"
+msgstr ""
+
+msgid "find where <commit> forked from reflog of <ref>"
+msgstr ""
+
+msgid ""
+"git merge-file [<options>] [-L <name1> [-L <orig> [-L <name2>]]] <file1> "
+"<orig-file> <file2>"
+msgstr ""
+
+msgid ""
+"option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
+"\"histogram\""
+msgstr ""
+
+msgid "send results to standard output"
+msgstr ""
+
+msgid "use object IDs instead of filenames"
+msgstr ""
+
+msgid "use a diff3 based merge"
+msgstr ""
+
+msgid "use a zealous diff3 based merge"
+msgstr ""
+
+msgid "<algorithm>"
+msgstr ""
+
+msgid "choose a diff algorithm"
+msgstr ""
+
+msgid "for conflicts, use this marker size"
+msgstr ""
+
+msgid "do not warn about conflicts"
+msgstr ""
+
+msgid "set labels for file1/orig-file/file2"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "object '%s' does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy
+msgid "Could not write object file"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "unknown option %s"
+msgstr "cineál réad anaithnid %d"
+
+#, fuzzy, c-format
+msgid "could not parse object '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "cannot handle more than %d base. Ignoring %s."
+msgid_plural "cannot handle more than %d bases. Ignoring %s."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "not handling anything other than two heads merge."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not resolve ref '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "Merging %s with %s\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse as tree '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+msgid "not something we can merge"
+msgstr ""
+
+msgid "refusing to merge unrelated histories"
+msgstr ""
+
+msgid "failure to merge"
+msgstr ""
+
+msgid "git merge-tree [--write-tree] [<options>] <branch1> <branch2>"
+msgstr ""
+
+msgid "git merge-tree [--trivial-merge] <base-tree> <branch1> <branch2>"
+msgstr ""
+
+msgid "do a real merge instead of a trivial merge"
+msgstr ""
+
+msgid "do a trivial merge only"
+msgstr ""
+
+msgid "also show informational/conflict messages"
+msgstr ""
+
+msgid "list filenames without modes/oids/stages"
+msgstr ""
+
+msgid "allow merging unrelated histories"
+msgstr ""
+
+msgid "perform multiple merges, one per line of input"
+msgstr ""
+
+#, fuzzy
+msgid "specify a merge-base for the merge"
+msgstr "sonraigh an fhormáid tagartha le húsáid"
+
+msgid "option=value"
+msgstr ""
+
+msgid "option for selected merge strategy"
+msgstr ""
+
+msgid "--trivial-merge is incompatible with all other options"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown strategy option: -X%s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "malformed input line: '%s'."
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy
+msgid "git merge [<options>] [<commit>...]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "switch `m' requires a value"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "option `%s' requires a value"
+msgstr "tá %s ag teastáil don rogha '%s'"
+
+#, fuzzy, c-format
+msgid "Could not find merge strategy '%s'.\n"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+#, c-format
+msgid "Available strategies are:"
+msgstr ""
+
+#, c-format
+msgid "Available custom strategies are:"
+msgstr ""
+
+msgid "do not show a diffstat at the end of the merge"
+msgstr ""
+
+msgid "show a diffstat at the end of the merge"
+msgstr ""
+
+msgid "(synonym to --stat)"
+msgstr ""
+
+msgid "add (at most <n>) entries from shortlog to merge commit message"
+msgstr ""
+
+msgid "create a single commit instead of doing a merge"
+msgstr ""
+
+msgid "perform a commit if the merge succeeds (default)"
+msgstr ""
+
+#, fuzzy
+msgid "edit message before committing"
+msgstr "Athruithe nach ndearnadh a chur ar stáitse le haghaidh tiomantais:"
+
+msgid "allow fast-forward (default)"
+msgstr ""
+
+msgid "abort if fast-forward is not possible"
+msgstr ""
+
+msgid "verify that the named commit has a valid GPG signature"
+msgstr ""
+
+msgid "strategy"
+msgstr ""
+
+msgid "merge strategy to use"
+msgstr ""
+
+msgid "merge commit message (for a non-fast-forward merge)"
+msgstr ""
+
+#, fuzzy
+msgid "use <name> instead of the real target"
+msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+
+#, fuzzy
+msgid "abort the current in-progress merge"
+msgstr "Ar ais atá ar siúl faoi láthair."
+
+#, fuzzy
+msgid "--abort but leave index and working tree alone"
+msgstr "athshocraigh HEAD, innéacs agus crann oibre"
+
+#, fuzzy
+msgid "continue the current in-progress merge"
+msgstr "Ar ais atá ar siúl faoi láthair."
+
+msgid "bypass pre-merge-commit and commit-msg hooks"
+msgstr ""
+
+#, fuzzy
+msgid "could not run stash."
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "stash failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not a valid object: %s"
+msgstr "réad blob neamhbhailí %s"
+
+msgid "read-tree failed"
+msgstr ""
+
+msgid "Already up to date. (nothing to squash)"
+msgstr ""
+
+msgid "Already up to date."
+msgstr ""
+
+#, c-format
+msgid "Squash commit -- not updating HEAD\n"
+msgstr ""
+
+#, c-format
+msgid "No merge message -- not updating HEAD\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' does not point to a commit"
+msgstr "Ní chuireann HEAD in iúl do bhrainse"
+
+#, c-format
+msgid "Bad branch.%s.mergeoptions string: %s"
+msgstr ""
+
+#, fuzzy
+msgid "Unable to write index."
+msgstr "in ann comhad innéacs nua a scríobh"
+
+msgid "Not handling anything other than two heads merge."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to write %s"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "Could not read from '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "Not committing merge; use 'git commit' to complete the merge.\n"
+msgstr "  (bain úsáid as “git commit” chun cumasc a thabhairt i gcrích)"
+
+msgid ""
+"Please enter a commit message to explain why this merge is necessary,\n"
+"especially if it merges an updated upstream into a topic branch.\n"
+"\n"
+msgstr ""
+
+msgid "An empty message aborts the commit.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Lines starting with '%s' will be ignored, and an empty message aborts\n"
+"the commit.\n"
+msgstr ""
+
+msgid "Empty commit message."
+msgstr ""
+
+#, c-format
+msgid "Wonderful.\n"
+msgstr ""
+
+#, c-format
+msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
+msgstr ""
+
+#, fuzzy
+msgid "No current branch."
+msgstr "Níl sé ar aon bhrainse faoi láthair."
+
+#, fuzzy
+msgid "No remote for the current branch."
+msgstr "Níl sé ar aon bhrainse faoi láthair."
+
+msgid "No default upstream defined for the current branch."
+msgstr ""
+
+#, c-format
+msgid "No remote-tracking branch for %s from %s"
+msgstr ""
+
+#, c-format
+msgid "Bad value '%s' in environment '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not close '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "not something we can merge in %s: %s"
+msgstr ""
+
+msgid "--abort expects no arguments"
+msgstr ""
+
+msgid "There is no merge to abort (MERGE_HEAD missing)."
+msgstr ""
+
+msgid "--quit expects no arguments"
+msgstr ""
+
+msgid "--continue expects no arguments"
+msgstr ""
+
+msgid "There is no merge in progress (MERGE_HEAD missing)."
+msgstr ""
+
+msgid ""
+"You have not concluded your merge (MERGE_HEAD exists).\n"
+"Please, commit your changes before you merge."
+msgstr ""
+
+msgid ""
+"You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
+"Please, commit your changes before you merge."
+msgstr ""
+
+msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
+msgstr ""
+
+msgid "No commit specified and merge.defaultToUpstream not set."
+msgstr ""
+
+msgid "Squash commit into empty head not supported yet"
+msgstr ""
+
+#, fuzzy
+msgid "Non-fast-forward commit does not make sense into an empty head"
+msgstr "--delete níl ciall leis gan aon réiteoirí"
+
+#, c-format
+msgid "%s - not something we can merge"
+msgstr ""
+
+msgid "Can merge only exactly one commit into empty head"
+msgstr ""
+
+#, c-format
+msgid "Updating %s..%s\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by merge:\n"
+"  %s"
+msgstr ""
+
+#, c-format
+msgid "Trying really trivial in-index merge...\n"
+msgstr ""
+
+#, c-format
+msgid "Nope.\n"
+msgstr ""
+
+#, c-format
+msgid "Rewinding the tree to pristine...\n"
+msgstr ""
+
+#, c-format
+msgid "Trying merge strategy %s...\n"
+msgstr ""
+
+#, c-format
+msgid "No merge strategy handled the merge.\n"
+msgstr ""
+
+#, c-format
+msgid "Merge with strategy %s failed.\n"
+msgstr ""
+
+#, c-format
+msgid "Using the %s strategy to prepare resolving by hand.\n"
+msgstr ""
+
+#, c-format
+msgid "Automatic merge went well; stopped before committing as requested\n"
+msgstr ""
+
+#, c-format
+msgid "When finished, apply stashed changes with `git stash pop`\n"
+msgstr ""
+
+#, c-format
+msgid "warning: tag input does not pass fsck: %s"
+msgstr ""
+
+#, c-format
+msgid "error: tag input does not pass fsck: %s"
+msgstr ""
+
+#, c-format
+msgid "%d (FSCK_IGNORE?) should never trigger this callback"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read tagged object '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "object '%s' tagged as '%s', but is a '%s' type"
+msgstr ""
+
+msgid "tag on stdin did not pass our strict fsck check"
+msgstr ""
+
+msgid "tag on stdin did not refer to a valid object"
+msgstr ""
+
+#, fuzzy
+msgid "unable to write tag file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+msgid "input is NUL terminated"
+msgstr ""
+
+#, fuzzy
+msgid "allow missing objects"
+msgstr "Rudaí a fháil"
+
+msgid "allow creation of more than one tree"
+msgstr ""
+
+msgid ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
+msgstr ""
+
+msgid "git multi-pack-index [<options>] verify"
+msgstr ""
+
+#, fuzzy
+msgid "git multi-pack-index [<options>] expire"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
+msgstr ""
+
+#, fuzzy
+msgid "directory"
+msgstr "eolaire teimpléad"
+
+msgid "object directory containing set of packfile and pack-index pairs"
+msgstr ""
+
+msgid "preferred-pack"
+msgstr ""
+
+msgid "pack for reuse when computing a multi-pack bitmap"
+msgstr ""
+
+msgid "write multi-pack bitmap"
+msgstr ""
+
+msgid "write a new incremental MIDX"
+msgstr ""
+
+msgid "write multi-pack index containing only given indexes"
+msgstr ""
+
+msgid "refs snapshot for selecting bitmap commits"
+msgstr ""
+
+msgid ""
+"during repack, collect pack-files of smaller size into a batch that is "
+"larger than this size"
+msgstr ""
+
+msgid "git mv [-v] [-f] [-n] [-k] <source> <destination>"
+msgstr ""
+
+msgid "git mv [-v] [-f] [-n] [-k] <source>... <destination-directory>"
+msgstr ""
+
+#, c-format
+msgid "Directory %s is in index and no submodule?"
+msgstr ""
+
+msgid "Please stage your changes to .gitmodules or stash them to proceed"
+msgstr ""
+
+#, c-format
+msgid "%.*s is in index"
+msgstr ""
+
+msgid "force move/rename even if target exists"
+msgstr ""
+
+msgid "skip move/rename errors"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "destination '%s' is not a directory"
+msgstr "Tá %s ann agus ní eolaire é"
+
+#, c-format
+msgid "Checking rename of '%s' to '%s'\n"
+msgstr ""
+
+#, fuzzy
+msgid "bad source"
+msgstr "droch %s"
+
+msgid "destination exists"
+msgstr ""
+
+msgid "can not move directory into itself"
+msgstr ""
+
+#, fuzzy
+msgid "destination already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+msgid "source directory is empty"
+msgstr ""
+
+msgid "not under version control"
+msgstr ""
+
+msgid "conflicted"
+msgstr ""
+
+#, c-format
+msgid "overwriting '%s'"
+msgstr ""
+
+msgid "Cannot overwrite"
+msgstr ""
+
+msgid "multiple sources for the same target"
+msgstr ""
+
+#, fuzzy
+msgid "destination directory does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy
+msgid "destination exists in the index"
+msgstr "an t-innéacs a chur ar ais"
+
+#, c-format
+msgid "%s, source=%s, destination=%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot move both '%s' and its parent directory '%s'"
+msgstr "Ní féidir %s agus %s a fháil chuig %s"
+
+#, fuzzy, c-format
+msgid "Renaming %s to %s\n"
+msgstr "Ag brú chuig %s\n"
+
+#, c-format
+msgid "renaming '%s' failed"
+msgstr ""
+
+#, fuzzy
+msgid "git name-rev [<options>] <commit>..."
+msgstr "git checkout [<roghanna>] <brainse>"
+
+#, fuzzy
+msgid "git name-rev [<options>] --all"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+msgid "git name-rev [<options>] --annotate-stdin"
+msgstr ""
+
+msgid "print only ref-based names (no object names)"
+msgstr ""
+
+msgid "only use tags to name the commits"
+msgstr ""
+
+msgid "only use refs matching <pattern>"
+msgstr ""
+
+msgid "ignore refs matching <pattern>"
+msgstr ""
+
+msgid "list all commits reachable from all refs"
+msgstr ""
+
+msgid "deprecated: use --annotate-stdin instead"
+msgstr ""
+
+msgid "annotate text from stdin"
+msgstr ""
+
+msgid "allow to print `undefined` names (default)"
+msgstr ""
+
+msgid "dereference tags in the input (internal use)"
+msgstr ""
+
+msgid "git notes [--ref <notes-ref>] [list [<object>]]"
+msgstr ""
+
+msgid ""
+"git notes [--ref <notes-ref>] add [-f] [--allow-empty] [--[no-]separator|--"
+"separator=<paragraph-break>] [--[no-]stripspace] [-m <msg> | -F <file> | (-c "
+"| -C) <object>] [<object>] [-e]"
+msgstr ""
+
+msgid "git notes [--ref <notes-ref>] copy [-f] <from-object> <to-object>"
+msgstr ""
+
+msgid ""
+"git notes [--ref <notes-ref>] append [--allow-empty] [--[no-]separator|--"
+"separator=<paragraph-break>] [--[no-]stripspace] [-m <msg> | -F <file> | (-c "
+"| -C) <object>] [<object>] [-e]"
+msgstr ""
+
+msgid "git notes [--ref <notes-ref>] edit [--allow-empty] [<object>]"
+msgstr ""
+
+msgid "git notes [--ref <notes-ref>] show [<object>]"
+msgstr ""
+
+msgid ""
+"git notes [--ref <notes-ref>] merge [-v | -q] [-s <strategy>] <notes-ref>"
+msgstr ""
+
+msgid "git notes [--ref <notes-ref>] remove [<object>...]"
+msgstr ""
+
+msgid "git notes [--ref <notes-ref>] prune [-n] [-v]"
+msgstr ""
+
+msgid "git notes [--ref <notes-ref>] get-ref"
+msgstr ""
+
+msgid "git notes [list [<object>]]"
+msgstr ""
+
+#, fuzzy
+msgid "git notes add [<options>] [<object>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "git notes copy [<options>] <from-object> <to-object>"
+msgstr ""
+
+msgid "git notes copy --stdin [<from-object> <to-object>]..."
+msgstr ""
+
+#, fuzzy
+msgid "git notes append [<options>] [<object>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "git notes edit [<object>]"
+msgstr ""
+
+msgid "git notes show [<object>]"
+msgstr ""
+
+#, fuzzy
+msgid "git notes merge [<options>] <notes-ref>"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+msgid "git notes merge --commit [<options>]"
+msgstr ""
+
+msgid "git notes merge --abort [<options>]"
+msgstr ""
+
+msgid "git notes remove [<object>]"
+msgstr ""
+
+#, fuzzy
+msgid "git notes prune [<options>]"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+msgid "Write/edit the notes for the following object:"
+msgstr ""
+
+#, fuzzy
+msgid "could not read 'show' output"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "failed to finish 'show' for object '%s'"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+msgid "please supply the note contents using either -m or -F option"
+msgstr ""
+
+#, fuzzy
+msgid "unable to write note object"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "the note contents have been left in %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not open or read '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "failed to resolve '%s' as a valid ref."
+msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+
+#, fuzzy, c-format
+msgid "failed to read object '%s'."
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "cannot read note data from non-blob object '%s'."
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+#, fuzzy, c-format
+msgid "failed to copy notes from '%s' to '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#. TRANSLATORS: the first %s will be replaced by a git
+#. notes command: 'add', 'merge', 'remove', etc.
+#.
+#, c-format
+msgid "refusing to %s notes in %s (outside of refs/notes/)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "no note found for object %s."
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+msgid "note contents as a string"
+msgstr ""
+
+msgid "note contents in a file"
+msgstr ""
+
+msgid "reuse and edit specified note object"
+msgstr ""
+
+msgid "edit note message in editor"
+msgstr ""
+
+msgid "reuse specified note object"
+msgstr ""
+
+msgid "allow storing empty note"
+msgstr ""
+
+#, fuzzy
+msgid "replace existing notes"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+msgid "<paragraph-break>"
+msgstr ""
+
+msgid "insert <paragraph-break> between paragraphs"
+msgstr ""
+
+msgid "remove unnecessary whitespace"
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
+"existing notes"
+msgstr ""
+
+#, c-format
+msgid "Overwriting existing notes for object %s\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Removing note for object %s\n"
+msgstr "Rudaí a fháil"
+
+msgid "read objects from stdin"
+msgstr ""
+
+msgid "load rewriting config for <command> (implies --stdin)"
+msgstr ""
+
+#, fuzzy
+msgid "too few arguments"
+msgstr "An iomarca argóintí."
+
+#, c-format
+msgid ""
+"Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
+"existing notes"
+msgstr ""
+
+#, c-format
+msgid "missing notes on source object %s. Cannot copy."
+msgstr ""
+
+#, c-format
+msgid ""
+"The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
+"Please use 'git notes add -f -m/-F/-c/-C' instead.\n"
+msgstr ""
+
+msgid "failed to delete ref NOTES_MERGE_PARTIAL"
+msgstr ""
+
+msgid "failed to delete ref NOTES_MERGE_REF"
+msgstr ""
+
+msgid "failed to remove 'git notes merge' worktree"
+msgstr ""
+
+msgid "failed to read ref NOTES_MERGE_PARTIAL"
+msgstr ""
+
+msgid "could not find commit from NOTES_MERGE_PARTIAL."
+msgstr ""
+
+msgid "could not parse commit from NOTES_MERGE_PARTIAL."
+msgstr ""
+
+msgid "failed to resolve NOTES_MERGE_REF"
+msgstr ""
+
+#, fuzzy
+msgid "failed to finalize notes merge"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+#, fuzzy, c-format
+msgid "unknown notes merge strategy %s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+msgid "General options"
+msgstr ""
+
+msgid "Merge options"
+msgstr ""
+
+msgid ""
+"resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
+"cat_sort_uniq)"
+msgstr ""
+
+#, fuzzy
+msgid "Committing unmerged notes"
+msgstr "neamhaird a dhéanamh ar iontrálacha"
+
+msgid "finalize notes merge by committing unmerged notes"
+msgstr ""
+
+msgid "Aborting notes merge resolution"
+msgstr ""
+
+#, fuzzy
+msgid "abort notes merge"
+msgstr "cosán '%s': ní féidir a chumasc"
+
+msgid "cannot mix --commit, --abort or -s/--strategy"
+msgstr ""
+
+#, fuzzy
+msgid "must specify a notes ref to merge"
+msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
+
+#, c-format
+msgid "unknown -s/--strategy: %s"
+msgstr ""
+
+#, c-format
+msgid "a notes merge into %s is already in-progress at %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to store link to current notes ref (%s)"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+#, c-format
+msgid ""
+"Automatic notes merge failed. Fix conflicts in %s and commit the result with "
+"'git notes merge --commit', or abort the merge with 'git notes merge --"
+"abort'.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Failed to resolve '%s' as a valid ref."
+msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+
+#, c-format
+msgid "Object %s has no note\n"
+msgstr ""
+
+msgid "attempt to remove non-existent note is not an error"
+msgstr ""
+
+msgid "read object names from the standard input"
+msgstr ""
+
+msgid "do not remove, show only"
+msgstr ""
+
+msgid "report pruned notes"
+msgstr ""
+
+msgid "notes-ref"
+msgstr ""
+
+msgid "use notes from <notes-ref>"
+msgstr ""
+
+#, c-format
+msgid "unknown subcommand: `%s'"
+msgstr ""
+
+msgid "git pack-objects --stdout [<options>] [< <ref-list> | < <object-list>]"
+msgstr ""
+
+msgid ""
+"git pack-objects [<options>] <base-name> [< <ref-list> | < <object-list>]"
+msgstr ""
+
+#, c-format
+msgid "invalid --name-hash-version option: %d"
+msgstr ""
+
+msgid "currently, --write-bitmap-index requires --name-hash-version=1"
+msgstr ""
+
+#, c-format
+msgid ""
+"write_reuse_object: could not locate %s, expected at offset %<PRIuMAX> in "
+"pack %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bad packed object CRC for %s"
+msgstr "droch --pack_header: %s"
+
+#, fuzzy, c-format
+msgid "corrupt packed object for %s"
+msgstr "earráid fsck i réad pacáilte"
+
+#, fuzzy, c-format
+msgid "recursive delta detected for object %s"
+msgstr "nár bhfuair sé réad ag súil leis %s"
+
+#, c-format
+msgid "ordered %u objects, expected %<PRIu32>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "expected object at offset %<PRIuMAX> in pack %s"
+msgstr "tá réad lochtach sa phacáiste ag an bhfritháireamh %<PRIuMAX>: %s"
+
+msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
+msgstr ""
+
+#, fuzzy
+msgid "Writing objects"
+msgstr "Rudaí a fháil"
+
+#, fuzzy, c-format
+msgid "failed to stat %s"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy, c-format
+msgid "failed utime() on %s"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, fuzzy
+msgid "failed to write bitmap index"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
+msgstr ""
+
+msgid "disabling bitmap writing, as some objects are not being packed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "delta base offset overflow in pack for %s"
+msgstr "tá fhritháireamh bonn delta as ceangailte"
+
+#, fuzzy, c-format
+msgid "delta base offset out of bound for %s"
+msgstr "tá fhritháireamh bonn delta as ceangailte"
+
+#, fuzzy
+msgid "Counting objects"
+msgstr "Rud a sheiceáil"
+
+#, fuzzy, c-format
+msgid "unable to get size of %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy, c-format
+msgid "unable to parse object header of %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "object %s cannot be read"
+msgstr "cosán '%s': ní féidir a chumasc"
+
+#, c-format
+msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
+msgstr ""
+
+msgid "suboptimal pack - out of memory"
+msgstr ""
+
+#, c-format
+msgid "Delta compression using up to %d threads"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to pack objects reachable from tag %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unable to get type of object %s"
+msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+
+#, fuzzy
+msgid "Compressing objects"
+msgstr "Rud a sheiceáil"
+
+msgid "inconsistency with delta count"
+msgstr ""
+
+#, c-format
+msgid "invalid pack.allowPackReuse value: '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
+"hash> <uri>' (got '%s')"
+msgstr ""
+
+#, c-format
+msgid ""
+"object already configured in another uploadpack.blobpackfileuri (got '%s')"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not get type of object %s in pack %s"
+msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+
+#, fuzzy, c-format
+msgid "could not find pack '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "packfile %s cannot be accessed"
+msgstr ""
+
+#, fuzzy
+msgid "Enumerating cruft objects"
+msgstr "Rudaí innéacsála"
+
+#, fuzzy
+msgid "unable to add cruft objects"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy
+msgid "Traversing cruft objects"
+msgstr "Rud a sheiceáil"
+
+#, c-format
+msgid ""
+"expected edge object ID, got garbage:\n"
+" %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"expected object ID, got garbage:\n"
+" %s"
+msgstr ""
+
+msgid "could not load cruft pack .mtimes"
+msgstr ""
+
+#, fuzzy
+msgid "cannot open pack index"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+#, c-format
+msgid "loose object at %s could not be examined"
+msgstr ""
+
+#, fuzzy
+msgid "unable to force loose object"
+msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+
+#, c-format
+msgid "not a rev '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bad revision '%s'"
+msgstr "droch-stóras '%s'"
+
+#, fuzzy
+msgid "unable to add recent objects"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, c-format
+msgid "unsupported index version %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bad index version '%s'"
+msgstr "droch-stóras '%s'"
+
+msgid "show progress meter during object writing phase"
+msgstr ""
+
+msgid "similar to --all-progress when progress meter is shown"
+msgstr ""
+
+msgid "<version>[,<offset>]"
+msgstr ""
+
+msgid "write the pack index file in the specified idx format version"
+msgstr ""
+
+msgid "maximum size of each output pack file"
+msgstr ""
+
+msgid "ignore borrowed objects from alternate object store"
+msgstr ""
+
+#, fuzzy
+msgid "ignore packed objects"
+msgstr "earráid fsck i réad pacáilte"
+
+msgid "limit pack window by objects"
+msgstr ""
+
+msgid "limit pack window by memory in addition to object limit"
+msgstr ""
+
+msgid "maximum length of delta chain allowed in the resulting pack"
+msgstr ""
+
+#, fuzzy
+msgid "reuse existing deltas"
+msgstr "Deltas a réiteach"
+
+#, fuzzy
+msgid "reuse existing objects"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+msgid "use OFS_DELTA objects"
+msgstr ""
+
+msgid "use threads when searching for best delta matches"
+msgstr ""
+
+#, fuzzy
+msgid "do not create an empty pack output"
+msgstr "ná cruthaigh seiceáil"
+
+msgid "read revision arguments from standard input"
+msgstr ""
+
+msgid "limit the objects to those that are not yet packed"
+msgstr ""
+
+msgid "include objects reachable from any reference"
+msgstr ""
+
+msgid "include objects referred by reflog entries"
+msgstr ""
+
+msgid "include objects referred to by the index"
+msgstr ""
+
+msgid "read packs from stdin"
+msgstr ""
+
+msgid "output pack to stdout"
+msgstr ""
+
+msgid "include tag objects that refer to objects to be packed"
+msgstr ""
+
+msgid "keep unreachable objects"
+msgstr ""
+
+msgid "pack loose unreachable objects"
+msgstr ""
+
+msgid "unpack unreachable objects newer than <time>"
+msgstr ""
+
+msgid "create a cruft pack"
+msgstr ""
+
+msgid "expire cruft objects older than <time>"
+msgstr ""
+
+msgid "use the sparse reachability algorithm"
+msgstr ""
+
+#, fuzzy
+msgid "create thin packs"
+msgstr "bain úsáid as pacáiste tanaí"
+
+msgid "create packs suitable for shallow fetches"
+msgstr ""
+
+msgid "ignore packs that have companion .keep file"
+msgstr ""
+
+#, fuzzy
+msgid "ignore this pack"
+msgstr "bain úsáid as pacáiste tanaí"
+
+msgid "pack compression level"
+msgstr ""
+
+msgid "do not hide commits by grafts"
+msgstr ""
+
+msgid "use a bitmap index if available to speed up counting objects"
+msgstr ""
+
+msgid "write a bitmap index together with the pack index"
+msgstr ""
+
+msgid "write a bitmap index if possible"
+msgstr ""
+
+#, fuzzy
+msgid "handling for missing objects"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+msgid "do not pack objects in promisor packfiles"
+msgstr ""
+
+msgid "implies --missing=allow-any"
+msgstr ""
+
+msgid "respect islands during delta compression"
+msgstr ""
+
+msgid "protocol"
+msgstr ""
+
+msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
+msgstr ""
+
+msgid "use the specified name-hash function to group similar objects"
+msgstr ""
+
+#, c-format
+msgid "delta chain depth %d is too deep, forcing %d"
+msgstr ""
+
+#, c-format
+msgid "pack.deltaCacheLimit is too high, forcing %d"
+msgstr ""
+
+#, c-format
+msgid "bad pack compression level %d"
+msgstr ""
+
+#, fuzzy
+msgid "--max-pack-size cannot be used to build a pack for transfer"
+msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+
+msgid "minimum pack size limit is 1 MiB"
+msgstr ""
+
+#, fuzzy
+msgid "--thin cannot be used to build an indexable pack"
+msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+
+msgid "cannot use --filter with --stdin-packs"
+msgstr ""
+
+msgid "cannot use internal rev list with --stdin-packs"
+msgstr ""
+
+msgid "cannot use internal rev list with --cruft"
+msgstr ""
+
+msgid "cannot use --stdin-packs with --cruft"
+msgstr ""
+
+#, fuzzy
+msgid "Enumerating objects"
+msgstr "Rudaí innéacsála"
+
+#, c-format
+msgid ""
+"Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
+"reused %<PRIu32> (from %<PRIuMAX>)"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"'git pack-redundant' is nominated for removal.\n"
+"If you still use this command, please add an extra\n"
+"option, '--i-still-use-this', on the command line\n"
+"and let us know you still use it by sending an e-mail\n"
+"to <git@vger.kernel.org>.  Thanks.\n"
+msgstr ""
+"léamh iargúlta ó \"%s/%s\", atá ainmnithe lena bhaint.\n"
+"\n"
+"Má úsáideann tú an eolaire “iargúlta/” fós moltar\n"
+"aistriú chuig iargúlta bunaithe ar chumraíocht:\n"
+"\n"
+" git iargúlta a athainmniú %s %s\n"
+"\n"
+"Mura féidir leat, cuir in iúl dúinn le do thoil cén fáth a gcaithfidh tú\n"
+"é a úsáid fós trí ríomhphost a sheoladh chuig <git@vger.kernel.org>."
+
+msgid "refusing to run without --i-still-use-this"
+msgstr ""
+
+msgid ""
+"git pack-refs [--all] [--no-prune] [--auto] [--include <pattern>] [--exclude "
+"<pattern>]"
+msgstr ""
+
+msgid "pack everything"
+msgstr ""
+
+#, fuzzy
+msgid "prune loose refs (default)"
+msgstr "úsáid modh forleagtha (réamhshocraithe)"
+
+msgid "auto-pack refs as needed"
+msgstr ""
+
+msgid "references to include"
+msgstr ""
+
+#, fuzzy
+msgid "references to exclude"
+msgstr "ní crann é tagairt: %s"
+
+msgid "git patch-id [--stable | --unstable | --verbatim]"
+msgstr ""
+
+msgid "use the unstable patch-id algorithm"
+msgstr ""
+
+msgid "use the stable patch-id algorithm"
+msgstr ""
+
+msgid "don't strip whitespace from the patch"
+msgstr ""
+
+msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
+msgstr ""
+
+msgid "report pruned objects"
+msgstr ""
+
+msgid "expire objects older than <time>"
+msgstr ""
+
+msgid "limit traversal to objects outside promisor packfiles"
+msgstr ""
+
+#, fuzzy
+msgid "cannot prune in a precious-objects repo"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+#, fuzzy
+msgid "git pull [<options>] [<repository> [<refspec>...]]"
+msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+
+#, fuzzy
+msgid "control for recursive fetching of submodules"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+msgid "Options related to merging"
+msgstr ""
+
+msgid "incorporate changes by rebasing rather than merging"
+msgstr ""
+
+msgid "allow fast-forward"
+msgstr ""
+
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr ""
+
+msgid "automatically stash/stash pop before and after"
+msgstr ""
+
+msgid "Options related to fetching"
+msgstr ""
+
+msgid "force overwrite of local branch"
+msgstr ""
+
+#, fuzzy
+msgid "number of submodules pulled in parallel"
+msgstr "líon na bhfo-mhodúil atá clónaithe go comhthreomhar"
+
+msgid "use IPv4 addresses only"
+msgstr ""
+
+msgid "use IPv6 addresses only"
+msgstr ""
+
+msgid ""
+"There is no candidate for rebasing against among the refs that you just "
+"fetched."
+msgstr ""
+
+msgid ""
+"There are no candidates for merging among the refs that you just fetched."
+msgstr ""
+
+msgid ""
+"Generally this means that you provided a wildcard refspec which had no\n"
+"matches on the remote end."
+msgstr ""
+
+#, c-format
+msgid ""
+"You asked to pull from the remote '%s', but did not specify\n"
+"a branch. Because this is not the default configured remote\n"
+"for your current branch, you must specify a branch on the command line."
+msgstr ""
+
+#, fuzzy
+msgid "You are not currently on a branch."
+msgstr "Níl sé ar aon bhrainse faoi láthair."
+
+msgid "Please specify which branch you want to rebase against."
+msgstr ""
+
+msgid "Please specify which branch you want to merge with."
+msgstr ""
+
+msgid "See git-pull(1) for details."
+msgstr ""
+
+msgid "<remote>"
+msgstr ""
+
+#, fuzzy
+msgid "<branch>"
+msgstr "brainse"
+
+msgid "There is no tracking information for the current branch."
+msgstr ""
+
+msgid ""
+"If you wish to set tracking information for this branch you can do so with:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Your configuration specifies to merge with the ref '%s'\n"
+"from the remote, but no such ref was fetched."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to access commit %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "invalid refspec '%s'"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "ignoring --verify-signatures for rebase"
+msgstr ""
+
+msgid ""
+"You have divergent branches and need to specify how to reconcile them.\n"
+"You can do so by running one of the following commands sometime before\n"
+"your next pull:\n"
+"\n"
+"  git config pull.rebase false  # merge\n"
+"  git config pull.rebase true   # rebase\n"
+"  git config pull.ff only       # fast-forward only\n"
+"\n"
+"You can replace \"git config\" with \"git config --global\" to set a "
+"default\n"
+"preference for all repositories. You can also pass --rebase, --no-rebase,\n"
+"or --ff-only on the command line to override the configured default per\n"
+"invocation.\n"
+msgstr ""
+
+msgid "Updating an unborn branch with changes added to the index."
+msgstr ""
+
+msgid "pull with rebase"
+msgstr ""
+
+msgid "Please commit or stash them."
+msgstr ""
+
+#, c-format
+msgid ""
+"fetch updated the current branch head.\n"
+"fast-forwarding your working tree from\n"
+"commit %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot fast-forward your working tree.\n"
+"After making sure that you saved anything precious from\n"
+"$ git diff %s\n"
+"output, run\n"
+"$ git reset --hard\n"
+"to recover."
+msgstr ""
+
+msgid "Cannot merge multiple branches into empty head."
+msgstr ""
+
+msgid "Cannot rebase onto multiple branches."
+msgstr ""
+
+msgid "Cannot fast-forward to multiple branches."
+msgstr ""
+
+msgid "Need to specify how to reconcile divergent branches."
+msgstr ""
+
+msgid "cannot rebase with locally recorded submodule modifications"
+msgstr ""
 
 msgid "git push [<options>] [<repository> [<refspec>...]]"
 msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
@@ -1301,8 +9713,8 @@ msgid ""
 "recursing into submodule with push.recurseSubmodules=only; using on-demand "
 "instead"
 msgstr ""
-"athfhillteach isteach i bhfo-mhodúl le push.RecursesubModules=only; ag "
-"baint úsáide as ar-éileamh ina ionad"
+"athfhillteach isteach i bhfo-mhodúl le push.recurseSubmodules=only; ag baint "
+"úsáide as ar-éileamh ina ionad"
 
 #, c-format
 msgid "invalid value for '%s'"
@@ -1321,13 +9733,8 @@ msgid "delete refs"
 msgstr "scrios réimsí"
 
 msgid "push tags (can't be used with --all or --branches or --mirror)"
-msgstr "clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
-
-msgid "dry run"
-msgstr "rith tirim"
-
-msgid "machine-readable output"
-msgstr "aschur inléite meaisín"
+msgstr ""
+"clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
 
 msgid "force updates"
 msgstr "nuashonruithe fórsa"
@@ -1405,6 +9812,1510 @@ msgstr "--mirror ní féidir é a chomhcheangal le refspecs"
 msgid "push options must not have new line characters"
 msgstr "ní chóir go mbeadh carachtair líne nua ag roghanna brú"
 
+msgid "git range-diff [<options>] <old-base>..<old-tip> <new-base>..<new-tip>"
+msgstr ""
+
+msgid "git range-diff [<options>] <old-tip>...<new-tip>"
+msgstr ""
+
+msgid "git range-diff [<options>] <base> <old-tip> <new-tip>"
+msgstr ""
+
+msgid "use simple diff colors"
+msgstr ""
+
+msgid "notes"
+msgstr ""
+
+msgid "passed to 'git log'"
+msgstr ""
+
+msgid "only emit output related to the first range"
+msgstr ""
+
+msgid "only emit output related to the second range"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not a revision: '%s'"
+msgstr "droch-stóras '%s'"
+
+#, fuzzy, c-format
+msgid "not a commit range: '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy, c-format
+msgid "not a symmetric range: '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy
+msgid "need two commit ranges"
+msgstr "tiomantais nua, "
+
+msgid ""
+"git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
+"prefix=<prefix>)\n"
+"              [-u | -i]] [--index-output=<file>] [--no-sparse-checkout]\n"
+"              (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
+msgstr ""
+
+msgid "write resulting index to <file>"
+msgstr ""
+
+#, fuzzy
+msgid "only empty the index"
+msgstr "an t-innéacs a chur ar ais"
+
+msgid "Merging"
+msgstr ""
+
+#, fuzzy
+msgid "perform a merge in addition to a read"
+msgstr "cumasc 3 bhealach a dhéanamh leis an mbrainse nua"
+
+msgid "3-way merge if no file level merging required"
+msgstr ""
+
+msgid "3-way merge in presence of adds and removes"
+msgstr ""
+
+#, fuzzy
+msgid "same as -m, but discard unmerged entries"
+msgstr "neamhaird a dhéanamh ar iontrálacha"
+
+msgid "<subdirectory>/"
+msgstr ""
+
+msgid "read the tree into the index under <subdirectory>/"
+msgstr ""
+
+msgid "update working tree with merge result"
+msgstr ""
+
+msgid "gitignore"
+msgstr ""
+
+msgid "allow explicitly ignored files to be overwritten"
+msgstr ""
+
+#, fuzzy
+msgid "don't check the working tree after merging"
+msgstr "in ann crann oibre a sheiceáil"
+
+msgid "don't update the index or the work tree"
+msgstr ""
+
+#, fuzzy
+msgid "skip applying sparse checkout filter"
+msgstr "Tá tú i seiceáil neamhchoitianta."
+
+msgid "debug unpack-trees"
+msgstr ""
+
+msgid "suppress feedback messages"
+msgstr ""
+
+#, fuzzy
+msgid "You need to resolve your current index first"
+msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
+
+msgid ""
+"git rebase [-i] [options] [--exec <cmd>] [--onto <newbase> | --keep-base] "
+"[<upstream> [<branch>]]"
+msgstr ""
+
+msgid ""
+"git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] --root [<branch>]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read '%s'."
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not create temporary %s"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy
+msgid "could not mark as interactive"
+msgstr "roghnaigh hunks idirghníomhach"
+
+#, fuzzy
+msgid "could not generate todo list"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "a base commit must be provided with --upstream or --onto"
+msgstr ""
+
+#, c-format
+msgid "%s requires the merge backend"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid onto: '%s'"
+msgstr "%s neamhbhailí"
+
+#, fuzzy, c-format
+msgid "invalid orig-head: '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not remove '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid ""
+"\n"
+"git encountered an error while preparing the patches to replay\n"
+"these revisions:\n"
+"\n"
+"    %s\n"
+"\n"
+"As a result, git cannot rebase them."
+msgstr ""
+
+#, c-format
+msgid "Unknown rebase-merges mode: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not switch to %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "apply options and merge options cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+#, fuzzy
+msgid "--empty=ask is deprecated; use '--empty=stop' instead."
+msgstr ""
+"--mixed le cosáin imithe i léig; bain úsáid as 'git reset -- <cosáin>' ina "
+"ionad."
+
+#, c-format
+msgid ""
+"unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and "
+"\"stop\"."
+msgstr ""
+
+msgid ""
+"--rebase-merges with an empty string argument is deprecated and will stop "
+"working in a future version of Git. Use --rebase-merges without an argument "
+"instead, which does the same thing."
+msgstr ""
+
+#, c-format
+msgid ""
+"%s\n"
+"Please specify which branch you want to rebase against.\n"
+"See git-rebase(1) for details.\n"
+"\n"
+"    git rebase '<branch>'\n"
+"\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"If you wish to set tracking information for this branch you can do so with:\n"
+"\n"
+"    git branch --set-upstream-to=%s/<branch> %s\n"
+"\n"
+msgstr ""
+"Más mian leat é a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-"
+"am é seo chun é sin a dhéanamh le:\n"
+"\n"
+"git branch <ainm-brainse-nua> %s\n"
+
+msgid "exec commands cannot contain newlines"
+msgstr ""
+
+msgid "empty exec command"
+msgstr ""
+
+msgid "rebase onto given branch instead of upstream"
+msgstr ""
+
+msgid "use the merge-base of upstream and branch as the current base"
+msgstr ""
+
+msgid "allow pre-rebase hook to run"
+msgstr ""
+
+msgid "be quiet. implies --no-stat"
+msgstr ""
+
+msgid "display a diffstat of what changed upstream"
+msgstr ""
+
+msgid "do not show diffstat of what changed upstream"
+msgstr ""
+
+msgid "add a Signed-off-by trailer to each commit"
+msgstr ""
+
+msgid "make committer date match author date"
+msgstr ""
+
+msgid "ignore author date and use current date"
+msgstr ""
+
+msgid "synonym of --reset-author-date"
+msgstr ""
+
+msgid "passed to 'git apply'"
+msgstr ""
+
+msgid "ignore changes in whitespace"
+msgstr ""
+
+msgid "cherry-pick all commits, even if unchanged"
+msgstr ""
+
+msgid "continue"
+msgstr ""
+
+msgid "skip current patch and continue"
+msgstr ""
+
+#, fuzzy
+msgid "abort and check out the original branch"
+msgstr ""
+" (bain úsáid as “git rebase --abort” chun an bhrainse bunaidh a sheiceáil)"
+
+msgid "abort but keep HEAD where it is"
+msgstr ""
+
+msgid "edit the todo list during an interactive rebase"
+msgstr ""
+
+msgid "show the patch file being applied or merged"
+msgstr ""
+
+msgid "use apply strategies to rebase"
+msgstr ""
+
+msgid "use merging strategies to rebase"
+msgstr ""
+
+msgid "let the user edit the list of commits to rebase"
+msgstr ""
+
+msgid "(REMOVED) was: try to recreate merges instead of ignoring them"
+msgstr ""
+
+msgid "how to handle commits that become empty"
+msgstr ""
+
+msgid "keep commits which start empty"
+msgstr ""
+
+msgid "move commits that begin with squash!/fixup! under -i"
+msgstr ""
+
+msgid "update branches that point to commits that are being rebased"
+msgstr ""
+
+msgid "add exec lines after each commit of the editable list"
+msgstr ""
+
+msgid "allow rebasing commits with empty messages"
+msgstr ""
+
+msgid "try to rebase merges instead of skipping them"
+msgstr ""
+
+#, fuzzy
+msgid "use 'merge-base --fork-point' to refine upstream"
+msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+
+msgid "use the given merge strategy"
+msgstr ""
+
+msgid "option"
+msgstr ""
+
+msgid "pass the argument through to the merge strategy"
+msgstr ""
+
+msgid "rebase all reachable commits up to the root(s)"
+msgstr ""
+
+msgid "automatically re-schedule any `exec` that fails"
+msgstr ""
+
+msgid "apply all changes, even those already present upstream"
+msgstr ""
+
+msgid "It looks like 'git am' is in progress. Cannot rebase."
+msgstr ""
+
+msgid ""
+"`rebase --preserve-merges` (-p) is no longer supported.\n"
+"Use `git rebase --abort` to terminate current rebase.\n"
+"Or downgrade to v2.33, or earlier, to complete the rebase."
+msgstr ""
+
+msgid ""
+"--preserve-merges was replaced by --rebase-merges\n"
+"Note: Your `pull.rebase` configuration may also be set to 'preserve',\n"
+"which is no longer supported; use 'merges' instead"
+msgstr ""
+
+#, fuzzy
+msgid "no rebase in progress"
+msgstr "athbhunú atá ar siúl; ar "
+
+msgid "The --edit-todo action can only be used during interactive rebase."
+msgstr ""
+
+msgid "Cannot read HEAD"
+msgstr ""
+
+msgid ""
+"You must edit all merge conflicts and then\n"
+"mark them as resolved using git add"
+msgstr ""
+
+#, fuzzy
+msgid "could not discard worktree changes"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not move back to %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid ""
+"It seems that there is already a %s directory, and\n"
+"I wonder if you are in the middle of another rebase.  If that is the\n"
+"case, please try\n"
+"\t%s\n"
+"If that is not the case, please\n"
+"\t%s\n"
+"and run me again.  I am stopping in case you still have something\n"
+"valuable there.\n"
+msgstr ""
+
+msgid "switch `C' expects a numerical value"
+msgstr ""
+
+msgid ""
+"apply options are incompatible with rebase.rebaseMerges.  Consider adding --"
+"no-rebase-merges"
+msgstr ""
+
+msgid ""
+"apply options are incompatible with rebase.updateRefs.  Consider adding --no-"
+"update-refs"
+msgstr ""
+
+#, c-format
+msgid "Unknown rebase backend: %s"
+msgstr ""
+
+msgid "--reschedule-failed-exec requires --exec or --interactive"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid upstream '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy
+msgid "Could not create new root commit"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "no such branch/commit '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy, c-format
+msgid "No such ref: %s"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy
+msgid "Could not resolve HEAD to a commit"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "'%s': need exactly one merge base with branch"
+msgstr ""
+
+#, c-format
+msgid "'%s': need exactly one merge base"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Does not point to a valid commit '%s'"
+msgstr "Ní chuireann HEAD in iúl do bhrainse"
+
+#, fuzzy
+msgid "HEAD is up to date."
+msgstr "Tá HEAD anois ag"
+
+#, fuzzy, c-format
+msgid "Current branch %s is up to date.\n"
+msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
+
+msgid "HEAD is up to date, rebase forced."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Current branch %s is up to date, rebase forced.\n"
+msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
+
+msgid "The pre-rebase hook refused to rebase."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Changes to %s:\n"
+msgstr "Ag brú chuig %s\n"
+
+#, c-format
+msgid "Changes from %s to %s:\n"
+msgstr ""
+
+#, c-format
+msgid "First, rewinding head to replay your work on top of it...\n"
+msgstr ""
+
+#, fuzzy
+msgid "Could not detach HEAD"
+msgstr "Níl CEANN bailí agat."
+
+#, c-format
+msgid "Fast-forwarded %s to %s.\n"
+msgstr ""
+
+#, fuzzy
+msgid "git receive-pack <git-dir>"
+msgstr "clár pacáiste a fháil"
+
+msgid ""
+"By default, updating the current branch in a non-bare repository\n"
+"is denied, because it will make the index and work tree inconsistent\n"
+"with what you pushed, and will require 'git reset --hard' to match\n"
+"the work tree to HEAD.\n"
+"\n"
+"You can set the 'receive.denyCurrentBranch' configuration variable\n"
+"to 'ignore' or 'warn' in the remote repository to allow pushing into\n"
+"its current branch; however, this is not recommended unless you\n"
+"arranged to update its work tree to match what you pushed in some\n"
+"other way.\n"
+"\n"
+"To squelch this message and still keep the default behaviour, set\n"
+"'receive.denyCurrentBranch' configuration variable to 'refuse'."
+msgstr ""
+
+msgid ""
+"By default, deleting the current branch is denied, because the next\n"
+"'git clone' won't result in any file checked out, causing confusion.\n"
+"\n"
+"You can set 'receive.denyDeleteCurrent' configuration variable to\n"
+"'warn' or 'ignore' in the remote repository to allow deleting the\n"
+"current branch, with or without a warning message.\n"
+"\n"
+"To squelch this message, you can set it to 'refuse'."
+msgstr ""
+
+msgid "quiet"
+msgstr ""
+
+#, fuzzy
+msgid "you must specify a directory"
+msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
+
+#, fuzzy
+msgid "git reflog [show] [<log-options>] [<ref>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "git reflog list"
+msgstr ""
+
+msgid ""
+"git reflog expire [--expire=<time>] [--expire-unreachable=<time>]\n"
+"                  [--rewrite] [--updateref] [--stale-fix]\n"
+"                  [--dry-run | -n] [--verbose] [--all [--single-worktree] | "
+"<refs>...]"
+msgstr ""
+
+msgid ""
+"git reflog delete [--rewrite] [--updateref]\n"
+"                  [--dry-run | -n] [--verbose] <ref>@{<specifier>}..."
+msgstr ""
+
+msgid "git reflog exists <ref>"
+msgstr ""
+
+msgid "git reflog drop [--all [--single-worktree] | <refs>...]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid timestamp '%s' given to '--%s'"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, fuzzy, c-format
+msgid "%s does not accept arguments: '%s'"
+msgstr "git checkout: --detach ní ghlacann argóint cosáin '%s'"
+
+msgid "do not actually prune any entries"
+msgstr ""
+
+msgid ""
+"rewrite the old SHA1 with the new SHA1 of the entry that now precedes it"
+msgstr ""
+
+msgid "update the reference to the value of the top reflog entry"
+msgstr ""
+
+msgid "print extra information on screen"
+msgstr ""
+
+#, fuzzy
+msgid "timestamp"
+msgstr "am"
+
+msgid "prune entries older than the specified time"
+msgstr ""
+
+msgid ""
+"prune entries older than <time> that are not reachable from the current tip "
+"of the branch"
+msgstr ""
+
+msgid "prune any reflog entries that point to broken commits"
+msgstr ""
+
+msgid "process the reflogs of all references"
+msgstr ""
+
+msgid "limits processing to reflogs from the current worktree only"
+msgstr ""
+
+#, c-format
+msgid "Marking reachable objects..."
+msgstr ""
+
+#, c-format
+msgid "reflog could not be found: '%s'"
+msgstr ""
+
+msgid "no reflog specified to delete"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid ref format: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "drop the reflogs of all references"
+msgstr ""
+
+msgid "drop reflogs from the current worktree only"
+msgstr ""
+
+msgid "references specified along with --all"
+msgstr ""
+
+msgid "git refs migrate --ref-format=<format> [--no-reflog] [--dry-run]"
+msgstr ""
+
+msgid "git refs verify [--strict] [--verbose]"
+msgstr ""
+
+#, fuzzy
+msgid "specify the reference format to convert to"
+msgstr "sonraigh an fhormáid tagartha le húsáid"
+
+msgid "perform a non-destructive dry-run"
+msgstr ""
+
+msgid "drop reflogs entirely during the migration"
+msgstr ""
+
+msgid "missing --ref-format=<format>"
+msgstr ""
+
+#, c-format
+msgid "repository already uses '%s' format"
+msgstr ""
+
+#, fuzzy
+msgid "enable strict checking"
+msgstr "in ann crann oibre a sheiceáil"
+
+msgid "'git refs verify' takes no arguments"
+msgstr ""
+
+msgid ""
+"git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--"
+"mirror=<fetch|push>] <name> <url>"
+msgstr ""
+
+msgid "git remote rename [--[no-]progress] <old> <new>"
+msgstr ""
+
+msgid "git remote remove <name>"
+msgstr ""
+
+msgid "git remote set-head <name> (-a | --auto | -d | --delete | <branch>)"
+msgstr ""
+
+msgid "git remote [-v | --verbose] show [-n] <name>"
+msgstr ""
+
+msgid "git remote prune [-n | --dry-run] <name>"
+msgstr ""
+
+msgid ""
+"git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]"
+msgstr ""
+
+msgid "git remote set-branches [--add] <name> <branch>..."
+msgstr ""
+
+msgid "git remote get-url [--push] [--all] <name>"
+msgstr ""
+
+msgid "git remote set-url [--push] <name> <newurl> [<oldurl>]"
+msgstr ""
+
+msgid "git remote set-url --add <name> <newurl>"
+msgstr ""
+
+msgid "git remote set-url --delete <name> <url>"
+msgstr ""
+
+#, fuzzy
+msgid "git remote add [<options>] <name> <url>"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+msgid "git remote set-branches <name> <branch>..."
+msgstr ""
+
+msgid "git remote set-branches --add <name> <branch>..."
+msgstr ""
+
+#, fuzzy
+msgid "git remote show [<options>] <name>"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+#, fuzzy
+msgid "git remote prune [<options>] <name>"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+#, fuzzy
+msgid "git remote update [<options>] [<group> | <remote>]..."
+msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+
+#, c-format
+msgid "Updating %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not fetch %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid ""
+"--mirror is dangerous and deprecated; please\n"
+"\t use --mirror=fetch or --mirror=push instead"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown --mirror argument: %s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+msgid "fetch the remote branches"
+msgstr ""
+
+msgid ""
+"import all tags and associated objects when fetching\n"
+"or do not fetch any tag at all (--no-tags)"
+msgstr ""
+
+msgid "branch(es) to track"
+msgstr ""
+
+#, fuzzy
+msgid "master branch"
+msgstr "brainse"
+
+msgid "set up remote as a mirror to push to or fetch from"
+msgstr ""
+
+msgid "specifying a master branch makes no sense with --mirror"
+msgstr ""
+
+msgid "specifying branches to track makes sense only with fetch mirrors"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "remote %s already exists."
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, fuzzy, c-format
+msgid "Could not setup master '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "more than one %s"
+msgstr ""
+
+#, c-format
+msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not get fetch map for refspec %s"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+msgid "(matching)"
+msgstr ""
+
+#, fuzzy
+msgid "(delete)"
+msgstr "scriosta:"
+
+#, fuzzy, c-format
+msgid "could not set '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not unset '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid ""
+"The %s configuration remote.pushDefault in:\n"
+"\t%s:%d\n"
+"now names the non-existent remote '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "No such remote: '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy, c-format
+msgid "Could not rename config section '%s' to '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid ""
+"Not updating non-default fetch refspec\n"
+"\t%s\n"
+"\tPlease update the configuration manually if necessary."
+msgstr ""
+
+msgid "Renaming remote references"
+msgstr ""
+
+#, c-format
+msgid "deleting '%s' failed"
+msgstr ""
+
+#, c-format
+msgid "creating '%s' failed"
+msgstr ""
+
+msgid ""
+"Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
+"to delete it, use:"
+msgid_plural ""
+"Note: Some branches outside the refs/remotes/ hierarchy were not removed;\n"
+"to delete them, use:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy, c-format
+msgid "Could not remove config section '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid " new (next fetch will store in remotes/%s)"
+msgstr ""
+
+#, fuzzy
+msgid " tracked"
+msgstr "Comhaid neamhrianaithe"
+
+msgid " skipped"
+msgstr ""
+
+msgid " stale (use 'git remote prune' to remove)"
+msgstr ""
+
+msgid " ???"
+msgstr ""
+
+#, c-format
+msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "rebases interactively onto remote %s"
+msgstr "iarraidh idirbheart adamach ar an taobh iargúl"
+
+#, c-format
+msgid "rebases interactively (with merges) onto remote %s"
+msgstr ""
+
+#, c-format
+msgid "rebases onto remote %s"
+msgstr ""
+
+#, c-format
+msgid " merges with remote %s"
+msgstr ""
+
+#, c-format
+msgid "merges with remote %s"
+msgstr ""
+
+#, c-format
+msgid "%-*s    and with remote %s\n"
+msgstr ""
+
+msgid "create"
+msgstr ""
+
+#, fuzzy
+msgid "delete"
+msgstr "scriosta:"
+
+#, fuzzy
+msgid "up to date"
+msgstr "nach féidir %s a nuashonrú"
+
+msgid "fast-forwardable"
+msgstr ""
+
+msgid "local out of date"
+msgstr ""
+
+#, c-format
+msgid "    %-*s forces to %-*s (%s)"
+msgstr ""
+
+#, c-format
+msgid "    %-*s pushes to %-*s (%s)"
+msgstr ""
+
+#, c-format
+msgid "    %-*s forces to %s"
+msgstr ""
+
+#, c-format
+msgid "    %-*s pushes to %s"
+msgstr ""
+
+msgid "do not query remotes"
+msgstr ""
+
+#, c-format
+msgid "* remote %s"
+msgstr ""
+
+#, c-format
+msgid "  Fetch URL: %s"
+msgstr ""
+
+#. TRANSLATORS: the colon ':' should align
+#. with the one in " Fetch URL: %s"
+#. translation.
+#.
+#, c-format
+msgid "  Push  URL: %s"
+msgstr ""
+
+msgid "(no URL)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  HEAD branch: %s"
+msgstr "CEAD (gan aon bhrainse)"
+
+msgid "(not queried)"
+msgstr ""
+
+#, fuzzy
+msgid "(unknown)"
+msgstr "anaithnid:"
+
+#, c-format
+msgid ""
+"  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  Remote branch:%s"
+msgid_plural "  Remote branches:%s"
+msgstr[0] "Athshocraigh brainse '%s'\n"
+msgstr[1] "Athshocraigh brainse '%s'\n"
+msgstr[2] "Athshocraigh brainse '%s'\n"
+
+msgid " (status not queried)"
+msgstr ""
+
+msgid "  Local branch configured for 'git pull':"
+msgid_plural "  Local branches configured for 'git pull':"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "  Local refs will be mirrored by 'git push'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  Local ref configured for 'git push'%s:"
+msgid_plural "  Local refs configured for 'git push'%s:"
+msgstr[0] "níl aon chumrú suas srutha le haghaidh brainse '%s'"
+msgstr[1] "níl aon chumrú suas srutha le haghaidh brainse '%s'"
+msgstr[2] "níl aon chumrú suas srutha le haghaidh brainse '%s'"
+
+#, c-format
+msgid "'%s/HEAD' is unchanged and points to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "'%s/HEAD' has changed from '%s' and now points to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "'%s/HEAD' is now created and points to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "'%s/HEAD' was detached at '%s' and now points to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"'%s/HEAD' used to point to '%s' (which is not a remote branch), but now "
+"points to '%s'\n"
+msgstr ""
+
+msgid "set refs/remotes/<name>/HEAD according to remote"
+msgstr ""
+
+msgid "delete refs/remotes/<name>/HEAD"
+msgstr ""
+
+msgid "Cannot determine remote HEAD"
+msgstr ""
+
+msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not delete %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "Not a valid ref: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, fuzzy, c-format
+msgid "Could not set up %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid " %s will become dangling!"
+msgstr ""
+
+#, c-format
+msgid " %s has become dangling!"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Pruning %s"
+msgstr "Ag brú chuig %s\n"
+
+#, c-format
+msgid "URL: %s"
+msgstr ""
+
+#, c-format
+msgid " * [would prune] %s"
+msgstr ""
+
+#, c-format
+msgid " * [pruned] %s"
+msgstr ""
+
+msgid "prune remotes after fetching"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "No such remote '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, fuzzy
+msgid "add branch"
+msgstr "brainse"
+
+msgid "no remote specified"
+msgstr ""
+
+msgid "query push URLs rather than fetch URLs"
+msgstr ""
+
+msgid "return all URLs"
+msgstr ""
+
+msgid "manipulate push URLs"
+msgstr ""
+
+msgid "add URL"
+msgstr ""
+
+#, fuzzy
+msgid "delete URLs"
+msgstr "scrios réimsí"
+
+#, fuzzy
+msgid "--add --delete doesn't make sense"
+msgstr "--delete níl ciall leis gan aon réiteoirí"
+
+#, c-format
+msgid "Invalid old URL pattern: %s"
+msgstr ""
+
+#, c-format
+msgid "No such URL found: %s"
+msgstr ""
+
+msgid "Will not delete all non-push URLs"
+msgstr ""
+
+msgid "be verbose; must be placed before a subcommand"
+msgstr ""
+
+msgid ""
+"git repack [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b] [-m]\n"
+"[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]\n"
+"[--write-midx] [--name-hash-version=<n>]"
+msgstr ""
+
+msgid ""
+"Incremental repacks are incompatible with bitmap indexes.  Use\n"
+"--no-write-bitmap-index or disable the pack.writeBitmaps configuration."
+msgstr ""
+
+#, fuzzy
+msgid "could not start pack-objects to repack promisor objects"
+msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+
+#, fuzzy
+msgid "failed to feed promisor objects to pack-objects"
+msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+
+#, fuzzy
+msgid "repack: Expecting full hex object ID lines only from pack-objects."
+msgstr ""
+"index-pack: Ag súil le línte aitheantais réada heicsidheachúlach iomlán ó "
+"pack-objects amháin."
+
+#, fuzzy
+msgid "could not finish pack-objects to repack promisor objects"
+msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+
+#, fuzzy, c-format
+msgid "cannot open index for %s"
+msgstr "Ní féidir comhad idx pacáiste atá ann cheana a oscailt do '%s'"
+
+#, c-format
+msgid "pack %s too large to consider in geometric progression"
+msgstr ""
+
+#, c-format
+msgid "pack %s too large to roll up"
+msgstr ""
+
+#, c-format
+msgid "could not open tempfile %s for writing"
+msgstr ""
+
+msgid "could not close refs snapshot tempfile"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not remove stale bitmap: %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "pack prefix %s does not begin with objdir %s"
+msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
+
+msgid "pack everything in a single pack"
+msgstr ""
+
+msgid "same as -a, and turn unreachable objects loose"
+msgstr ""
+
+msgid "same as -a, pack unreachable cruft objects separately"
+msgstr ""
+
+msgid "approxidate"
+msgstr ""
+
+msgid "with --cruft, expire objects older than this"
+msgstr ""
+
+msgid "with --cruft, only repack cruft packs smaller than this"
+msgstr ""
+
+msgid "remove redundant packs, and run git-prune-packed"
+msgstr ""
+
+msgid "pass --no-reuse-delta to git-pack-objects"
+msgstr ""
+
+#, fuzzy
+msgid "pass --no-reuse-object to git-pack-objects"
+msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+
+msgid ""
+"specify the name hash version to use for grouping similar objects by path"
+msgstr ""
+
+msgid "do not run git-update-server-info"
+msgstr ""
+
+#, fuzzy
+msgid "pass --local to git-pack-objects"
+msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+
+#, fuzzy
+msgid "write bitmap index"
+msgstr "an t-innéacs a chur ar ais"
+
+msgid "pass --delta-islands to git-pack-objects"
+msgstr ""
+
+msgid "with -A, do not loosen objects older than this"
+msgstr ""
+
+msgid "with -a, repack unreachable objects"
+msgstr ""
+
+msgid "size of the window used for delta compression"
+msgstr ""
+
+msgid "bytes"
+msgstr ""
+
+msgid "same as the above, but limit memory size instead of entries count"
+msgstr ""
+
+msgid "limits the maximum delta depth"
+msgstr ""
+
+msgid "limits the maximum number of threads"
+msgstr ""
+
+msgid "maximum size of each packfile"
+msgstr ""
+
+msgid "repack objects in packs marked with .keep"
+msgstr ""
+
+msgid "do not repack this pack"
+msgstr ""
+
+msgid "find a geometric progression with factor <N>"
+msgstr ""
+
+msgid "write a multi-pack index of the resulting packs"
+msgstr ""
+
+msgid "pack prefix to store a pack containing filtered out objects"
+msgstr ""
+
+msgid "cannot delete packs in a precious-objects repo"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "option '%s' can only be used along with '%s'"
+msgstr "Ní féidir '%s' a úsáid le '%s'"
+
+msgid "Nothing new to pack."
+msgstr ""
+
+#, c-format
+msgid "renaming pack to '%s' failed"
+msgstr ""
+
+#, c-format
+msgid "pack-objects did not write a '%s' file for pack %s-%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not unlink: %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "git replace [-f] <object> <replacement>"
+msgstr ""
+
+msgid "git replace [-f] --edit <object>"
+msgstr ""
+
+msgid "git replace [-f] --graft <commit> [<parent>...]"
+msgstr ""
+
+msgid "git replace -d <object>..."
+msgstr ""
+
+msgid "git replace [--format=<format>] [-l [<pattern>]]"
+msgstr ""
+
+#, c-format
+msgid ""
+"invalid replace format '%s'\n"
+"valid formats are 'short', 'medium' and 'long'"
+msgstr ""
+
+#, c-format
+msgid "replace ref '%s' not found"
+msgstr ""
+
+#, c-format
+msgid "Deleted replace ref '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid ref name"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, fuzzy, c-format
+msgid "replace ref '%s' already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, c-format
+msgid ""
+"Objects must be of the same type.\n"
+"'%s' points to a replaced object of type '%s'\n"
+"while '%s' points to a replacement object of type '%s'."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to open %s for writing"
+msgstr "nach féidir %s a nuashonrú"
+
+msgid "cat-file reported failure"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to open %s for reading"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy
+msgid "unable to spawn mktree"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, fuzzy
+msgid "unable to read from mktree"
+msgstr "nach féidir crann a léamh (%s)"
+
+msgid "mktree reported failure"
+msgstr ""
+
+#, fuzzy
+msgid "mktree did not return an object name"
+msgstr "níor sheol iargúlta gach rud riachtanach"
+
+#, fuzzy, c-format
+msgid "unable to fstat %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy
+msgid "unable to write object to database"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "unable to get object type for %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+msgid "editing object file failed"
+msgstr ""
+
+#, c-format
+msgid "new object is the same as the old one: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse %s as a commit"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "bad mergetag in commit '%s'"
+msgstr "droch-stóras '%s'"
+
+#, c-format
+msgid "malformed mergetag in commit '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"original commit '%s' contains mergetag '%s' that is discarded; use --edit "
+"instead of --graft"
+msgstr ""
+
+#, c-format
+msgid "the original commit '%s' has a gpg signature"
+msgstr ""
+
+msgid "the signature will be removed in the replacement commit!"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not write replacement commit for: '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid "graft for '%s' unnecessary"
+msgstr ""
+
+#, c-format
+msgid "new commit is the same as the old one: '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"could not convert the following graft(s):\n"
+"%s"
+msgstr ""
+
+msgid "list replace refs"
+msgstr ""
+
+#, fuzzy
+msgid "delete replace refs"
+msgstr "scrios réimsí"
+
+#, fuzzy
+msgid "edit existing object"
+msgstr "Rudaí innéacsála"
+
+msgid "change a commit's parents"
+msgstr ""
+
+msgid "convert existing graft file"
+msgstr ""
+
+msgid "replace the ref if it exists"
+msgstr ""
+
+msgid "do not pretty-print contents for --edit"
+msgstr ""
+
+#, fuzzy
+msgid "use this format"
+msgstr "bain úsáid as pacáiste tanaí"
+
+#, fuzzy
+msgid "--format cannot be used when not listing"
+msgstr "ní féidir cosáin a úsáid le brainsí a athrú"
+
+msgid "-f only makes sense when writing a replacement"
+msgstr ""
+
+msgid "--raw only makes sense with --edit"
+msgstr ""
+
+msgid "-d needs at least one argument"
+msgstr ""
+
+msgid "bad number of arguments"
+msgstr ""
+
+msgid "-e needs exactly one argument"
+msgstr ""
+
+msgid "-g needs at least one argument"
+msgstr ""
+
+msgid "--convert-graft-file takes no argument"
+msgstr ""
+
+msgid "only one pattern can be given with -l"
+msgstr ""
+
+msgid "need some commits to replay"
+msgstr ""
+
+msgid "all positive revisions given must be references"
+msgstr ""
+
+msgid "argument to --advance must be a reference"
+msgstr ""
+
+msgid ""
+"cannot advance target with multiple sources because ordering would be ill-"
+"defined"
+msgstr ""
+
+msgid ""
+"cannot implicitly determine whether this is an --advance or --onto operation"
+msgstr ""
+
+msgid ""
+"cannot advance target with multiple source branches because ordering would "
+"be ill-defined"
+msgstr ""
+
+msgid "cannot implicitly determine correct base for --onto"
+msgstr ""
+
+msgid ""
+"(EXPERIMENTAL!) git replay ([--contained] --onto <newbase> | --advance "
+"<branch>) <revision-range>..."
+msgstr ""
+
+msgid "make replay advance given branch"
+msgstr ""
+
+msgid "replay onto given commit"
+msgstr ""
+
+msgid "advance all branches contained in revision-range"
+msgstr ""
+
+msgid "option --onto or --advance is mandatory"
+msgstr ""
+
+#, c-format
+msgid ""
+"some rev walking options will be overridden as '%s' bit in 'struct rev_info' "
+"will be forced"
+msgstr ""
+
+#, fuzzy
+msgid "error preparing revisions"
+msgstr "earráid inmheánach i dsiúlóid"
+
+msgid "replaying down to root commit is not supported yet!"
+msgstr ""
+
+msgid "replaying merge commits is not supported yet!"
+msgstr ""
+
+msgid ""
+"git rerere [clear | forget <pathspec>... | diff | status | remaining | gc]"
+msgstr ""
+
+msgid "register clean resolutions in index"
+msgstr ""
+
+msgid "'git rerere forget' without paths is deprecated"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to generate diff for '%s'"
+msgstr "theip ar athrá thar '%s'"
+
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 msgstr ""
@@ -1473,22 +11384,21 @@ msgid "reset HEAD but keep local changes"
 msgstr "athshocraigh HEAD ach coinnigh athruithe áiti"
 
 msgid "record only the fact that removed paths will be added later"
-msgstr "ní thaifeadadh ach an fíric go gcuirfear cosáin bainte leis níos déanaí"
+msgstr ""
+"ní thaifeadadh ach an fíric go gcuirfear cosáin bainte leis níos déanaí"
 
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Theip ar '%s' a réiteach mar athbhreithniú bailí."
 
 #, c-format
-msgid "Could not parse object '%s'."
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
-
-#, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Theip ar '%s' a réiteach mar chrann bailí."
 
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
-msgstr "--mixed le cosáin imithe i léig; bain úsáid as 'git reset -- <cosáin>' ina ionad."
+msgstr ""
+"--mixed le cosáin imithe i léig; bain úsáid as 'git reset -- <cosáin>' ina "
+"ionad."
 
 #, c-format
 msgid "Cannot do %s reset with paths."
@@ -1516,6 +11426,7791 @@ msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
 
 msgid "Could not write new index file."
 msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "unable to get disk usage of %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, c-format
+msgid "invalid value for '%s': '%s', the only allowed format is '%s'"
+msgstr ""
+
+msgid "-z option used with unsupported option"
+msgstr ""
+
+msgid "rev-list does not support display of notes"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "marked counting and '%s' cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+#, fuzzy
+msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
+msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+
+msgid "keep the `--` passed as an arg"
+msgstr ""
+
+msgid "stop parsing after the first non-option argument"
+msgstr ""
+
+msgid "output in stuck long form"
+msgstr ""
+
+#, fuzzy
+msgid "premature end of input"
+msgstr "earráid léigh ar ionchur"
+
+msgid "no usage string given before the `--' separator"
+msgstr ""
+
+msgid "missing opt-spec before option flags"
+msgstr ""
+
+msgid "Needed a single revision"
+msgstr ""
+
+msgid ""
+"git rev-parse --parseopt [<options>] -- [<args>...]\n"
+"   or: git rev-parse --sq-quote [<arg>...]\n"
+"   or: git rev-parse [<options>] [<arg>...]\n"
+"\n"
+"Run \"git rev-parse --parseopt -h\" for more information on the first usage."
+msgstr ""
+
+msgid "--resolve-git-dir requires an argument"
+msgstr ""
+
+#, c-format
+msgid "not a gitdir '%s'"
+msgstr ""
+
+msgid "--git-path requires an argument"
+msgstr ""
+
+#, fuzzy
+msgid "-n requires an argument"
+msgstr "--stdin teastaíonn stórlann git"
+
+msgid "--path-format requires an argument"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown argument to --path-format: %s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+msgid "--default requires an argument"
+msgstr ""
+
+msgid "--prefix requires an argument"
+msgstr ""
+
+msgid "no object format specified"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unsupported object format: %s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, c-format
+msgid "unknown mode for --abbrev-ref: %s"
+msgstr ""
+
+msgid "this operation must be run in a work tree"
+msgstr ""
+
+#, fuzzy
+msgid "Could not read the index"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "unknown mode for --show-object-format: %s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+msgid ""
+"git revert [--[no-]edit] [-n] [-m <parent-number>] [-s] [-S[<keyid>]] "
+"<commit>..."
+msgstr ""
+
+msgid "git revert (--continue | --skip | --abort | --quit)"
+msgstr ""
+
+msgid ""
+"git cherry-pick [--edit] [-n] [-m <parent-number>] [-s] [-x] [--ff]\n"
+"                [-S[<keyid>]] <commit>..."
+msgstr ""
+
+#, fuzzy
+msgid "git cherry-pick (--continue | --skip | --abort | --quit)"
+msgstr " (reáchtáil “git cherry-pick --continue ” chun leanúint ar aghaidh)"
+
+#, c-format
+msgid "option `%s' expects a number greater than zero"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s: %s cannot be used with %s"
+msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
+
+msgid "end revert or cherry-pick sequence"
+msgstr ""
+
+msgid "resume revert or cherry-pick sequence"
+msgstr ""
+
+msgid "cancel revert or cherry-pick sequence"
+msgstr ""
+
+msgid "skip current commit and continue"
+msgstr ""
+
+#, fuzzy
+msgid "don't automatically commit"
+msgstr "Tiomantas tosaigh"
+
+msgid "edit the commit message"
+msgstr ""
+
+msgid "parent-number"
+msgstr ""
+
+msgid "select mainline parent"
+msgstr ""
+
+msgid "merge strategy"
+msgstr ""
+
+#, fuzzy
+msgid "option for merge strategy"
+msgstr "rogha a tharchur"
+
+msgid "append commit name"
+msgstr ""
+
+msgid "preserve initially empty commits"
+msgstr ""
+
+msgid "allow commits with empty messages"
+msgstr ""
+
+msgid "deprecated: use --empty=keep instead"
+msgstr ""
+
+#, fuzzy
+msgid "use the 'reference' format to refer to commits"
+msgstr "sonraigh an fhormáid tagartha le húsáid"
+
+#, fuzzy
+msgid "revert failed"
+msgstr "theip ar socrú siúlóid ath"
+
+msgid "cherry-pick failed"
+msgstr ""
+
+msgid ""
+"git rm [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch]\n"
+"       [--quiet] [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"       [--] [<pathspec>...]"
+msgstr ""
+
+msgid ""
+"the following file has staged content different from both the\n"
+"file and the HEAD:"
+msgid_plural ""
+"the following files have staged content different from both the\n"
+"file and the HEAD:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid ""
+"\n"
+"(use -f to force removal)"
+msgstr ""
+
+msgid "the following file has changes staged in the index:"
+msgid_plural "the following files have changes staged in the index:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid ""
+"\n"
+"(use --cached to keep the file, or -f to force removal)"
+msgstr ""
+
+#, fuzzy
+msgid "the following file has local modifications:"
+msgid_plural "the following files have local modifications:"
+msgstr[0] "modhnuithe áitiúla a chaitheamh"
+msgstr[1] "modhnuithe áitiúla a chaitheamh"
+msgstr[2] "modhnuithe áitiúla a chaitheamh"
+
+msgid "do not list removed files"
+msgstr ""
+
+#, fuzzy
+msgid "only remove from the index"
+msgstr "an t-innéacs a chur ar ais"
+
+msgid "override the up-to-date check"
+msgstr ""
+
+msgid "allow recursive removal"
+msgstr ""
+
+msgid "exit with a zero status even if nothing matched"
+msgstr ""
+
+msgid "No pathspec was given. Which files should I remove?"
+msgstr ""
+
+msgid "please stage your changes to .gitmodules or stash them to proceed"
+msgstr ""
+
+#, c-format
+msgid "not removing '%s' recursively without -r"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "git rm: unable to remove %s"
+msgstr "nach féidir %s a léamh"
+
+msgid ""
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [--[no-]signed | --signed=(true|false|if-asked)]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
+msgstr ""
+
+#, fuzzy
+msgid "remote name"
+msgstr "athainmnithe:"
+
+#, fuzzy
+msgid "push all refs"
+msgstr "brúigh gach brainse"
+
+msgid "use stateless RPC protocol"
+msgstr ""
+
+msgid "read refs from stdin"
+msgstr ""
+
+msgid "print status from remote helper"
+msgstr ""
+
+#, fuzzy
+msgid "git shortlog [<options>] [<revision-range>] [[--] <path>...]"
+msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+
+msgid "git log --pretty=short | git shortlog [<options>]"
+msgstr ""
+
+msgid "using multiple --group options with stdin is not supported"
+msgstr ""
+
+#, c-format
+msgid "using %s with stdin is not supported"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown group type: %s"
+msgstr "cineál réad anaithnid %d"
+
+msgid "group by committer rather than author"
+msgstr ""
+
+msgid "sort output according to the number of commits per author"
+msgstr ""
+
+msgid "suppress commit descriptions, only provides commit count"
+msgstr ""
+
+msgid "show the email address of each author"
+msgstr ""
+
+msgid "<w>[,<i1>[,<i2>]]"
+msgstr ""
+
+#, fuzzy
+msgid "linewrap output"
+msgstr "aschur inléite meaisín"
+
+msgid "field"
+msgstr ""
+
+msgid "group by field"
+msgstr ""
+
+msgid "too many arguments given outside repository"
+msgstr ""
+
+msgid ""
+"git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics]\n"
+"                [(<rev> | <glob>)...]"
+msgstr ""
+
+msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
+msgstr ""
+
+#, c-format
+msgid "ignoring %s; cannot handle more than %d ref"
+msgid_plural "ignoring %s; cannot handle more than %d refs"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "no matching refs with %s"
+msgstr ""
+
+msgid "show remote-tracking and local branches"
+msgstr ""
+
+#, fuzzy
+msgid "show remote-tracking branches"
+msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
+
+msgid "color '*!+-' corresponding to the branch"
+msgstr ""
+
+msgid "show <n> more commits after the common ancestor"
+msgstr ""
+
+msgid "synonym to more=-1"
+msgstr ""
+
+#, fuzzy
+msgid "suppress naming strings"
+msgstr "cur chun cinn tuairiscithe"
+
+#, fuzzy
+msgid "include the current branch"
+msgstr "brainse nua gan breith"
+
+msgid "name commits with their object names"
+msgstr ""
+
+msgid "show possible merge bases"
+msgstr ""
+
+msgid "show refs unreachable from any other ref"
+msgstr ""
+
+msgid "show commits in topological order"
+msgstr ""
+
+msgid "show only commits not on the first branch"
+msgstr ""
+
+msgid "show merges reachable from only one tip"
+msgstr ""
+
+msgid "topologically sort, maintaining date order where possible"
+msgstr ""
+
+msgid "<n>[,<base>]"
+msgstr ""
+
+msgid "show <n> most recent ref-log entries starting at base"
+msgstr ""
+
+msgid "no branches given, and HEAD is not valid"
+msgstr ""
+
+#, fuzzy
+msgid "--reflog option needs one branch name"
+msgstr "--track tá ainm brainse ag teastáil"
+
+#, c-format
+msgid "only %d entry can be shown at one time."
+msgid_plural "only %d entries can be shown at one time."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy, c-format
+msgid "no such ref %s"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#, c-format
+msgid "cannot handle more than %d rev."
+msgid_plural "cannot handle more than %d revs."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid ref."
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid "cannot find commit %s (%s)"
+msgstr ""
+
+#, fuzzy
+msgid "hash-algorithm"
+msgstr "algartam hais anaithnid '%s'"
+
+#, fuzzy
+msgid "Unknown hash algorithm"
+msgstr "algartam hais anaithnid '%s'"
+
+msgid ""
+"git show-ref [--head] [-d | --dereference]\n"
+"             [-s | --hash[=<n>]] [--abbrev[=<n>]] [--branches] [--tags]\n"
+"             [--] [<pattern>...]"
+msgstr ""
+
+msgid ""
+"git show-ref --verify [-q | --quiet] [-d | --dereference]\n"
+"             [-s | --hash[=<n>]] [--abbrev[=<n>]]\n"
+"             [--] [<ref>...]"
+msgstr ""
+
+msgid "git show-ref --exclude-existing[=<pattern>]"
+msgstr ""
+
+msgid "git show-ref --exists <ref>"
+msgstr ""
+
+#, fuzzy
+msgid "reference does not exist"
+msgstr "ní crann é tagairt: %s"
+
+msgid "failed to look up reference"
+msgstr ""
+
+#, fuzzy
+msgid "only show tags (can be combined with --branches)"
+msgstr ""
+"clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
+
+msgid "only show branches (can be combined with --tags)"
+msgstr ""
+
+msgid "check for reference existence without resolving"
+msgstr ""
+
+msgid "stricter reference checking, requires exact ref path"
+msgstr ""
+
+msgid "show the HEAD reference, even if it would be filtered out"
+msgstr ""
+
+#, fuzzy
+msgid "dereference tags into object IDs"
+msgstr "ní crann é tagairt: %s"
+
+msgid "only show SHA1 hash using <n> digits"
+msgstr ""
+
+msgid "do not print results to stdout (useful with --verify)"
+msgstr ""
+
+#, fuzzy
+msgid "show refs from stdin that aren't in local repository"
+msgstr "a chlónú ó stór áitiúil"
+
+msgid ""
+"git sparse-checkout (init | list | set | add | reapply | disable | check-"
+"rules) [<options>]"
+msgstr ""
+
+msgid "this worktree is not sparse"
+msgstr ""
+
+msgid "this worktree is not sparse (sparse-checkout file may not exist)"
+msgstr ""
+
+#, c-format
+msgid ""
+"directory '%s' contains untracked files, but is not in the sparse-checkout "
+"cone"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to remove directory '%s'"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy
+msgid "failed to create directory for sparse-checkout file"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "unable to fdopen %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy
+msgid "failed to initialize worktree config"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+#, fuzzy
+msgid "failed to modify sparse-index config"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+#, fuzzy
+msgid "initialize the sparse-checkout in cone mode"
+msgstr ""
+"comhad seiceála neamhchoitianta a thosú chun comhaid amháin a áireamh ag "
+"fréamh"
+
+msgid "toggle the use of a sparse index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to create leading directories of %s"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "failed to open '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy, c-format
+msgid "could not normalize path %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "unable to unquote C-style string '%s'"
+msgstr ""
+
+#, fuzzy
+msgid "unable to load existing sparse-checkout patterns"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+msgid "existing sparse-checkout patterns do not use cone mode"
+msgstr ""
+
+msgid "please run from the toplevel directory in non-cone mode"
+msgstr ""
+
+msgid "specify directories rather than patterns (no leading slash)"
+msgstr ""
+
+msgid ""
+"specify directories rather than patterns.  If your directory starts with a "
+"'!', pass --skip-checks"
+msgstr ""
+
+msgid ""
+"specify directories rather than patterns.  If your directory really has any "
+"of '*?[]\\' in it, pass --skip-checks"
+msgstr ""
+
+#, c-format
+msgid ""
+"'%s' is not a directory; to treat it as a directory anyway, rerun with --"
+"skip-checks"
+msgstr ""
+
+#, c-format
+msgid ""
+"pass a leading slash before paths such as '%s' if you want a single file "
+"(see NON-CONE PROBLEMS in the git-sparse-checkout manual)."
+msgstr ""
+
+msgid "git sparse-checkout add [--skip-checks] (--stdin | <patterns>)"
+msgstr ""
+
+msgid ""
+"skip some sanity checks on the given paths that might give false positives"
+msgstr ""
+
+msgid "read patterns from standard in"
+msgstr ""
+
+msgid "no sparse-checkout to add to"
+msgstr ""
+
+msgid ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] [--skip-checks] "
+"(--stdin | <patterns>)"
+msgstr ""
+
+msgid "must be in a sparse-checkout to reapply sparsity patterns"
+msgstr ""
+
+#, fuzzy
+msgid "error while refreshing working directory"
+msgstr "earráid agus comhad pacáiste á dúnadh"
+
+msgid ""
+"git sparse-checkout check-rules [-z] [--skip-checks][--[no-]cone] [--rules-"
+"file <file>]"
+msgstr ""
+
+msgid "terminate input and output files by a NUL character"
+msgstr ""
+
+msgid "when used with --rules-file interpret patterns as cone mode patterns"
+msgstr ""
+
+msgid "use patterns in <file> instead of the current ones."
+msgstr ""
+
+#, fuzzy
+msgid "git stash list [<log-options>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid ""
+"git stash show [-u | --include-untracked | --only-untracked] [<diff-"
+"options>] [<stash>]"
+msgstr ""
+
+msgid "git stash drop [-q | --quiet] [<stash>]"
+msgstr ""
+
+msgid "git stash pop [--index] [-q | --quiet] [<stash>]"
+msgstr ""
+
+msgid "git stash apply [--index] [-q | --quiet] [<stash>]"
+msgstr ""
+
+msgid "git stash branch <branchname> [<stash>]"
+msgstr ""
+
+msgid "git stash store [(-m | --message) <message>] [-q | --quiet] <commit>"
+msgstr ""
+
+msgid ""
+"git stash [push [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q "
+"| --quiet]\n"
+"          [-u | --include-untracked] [-a | --all] [(-m | --message) "
+"<message>]\n"
+"          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"          [--] [<pathspec>...]]"
+msgstr ""
+
+msgid ""
+"git stash save [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q | "
+"--quiet]\n"
+"          [-u | --include-untracked] [-a | --all] [<message>]"
+msgstr ""
+
+msgid "git stash create [<message>]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a stash-like commit"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid "Too many revisions specified:%s"
+msgstr ""
+
+msgid "No stash entries found."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s is not a valid reference"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+msgid "git stash clear with arguments is unimplemented"
+msgstr ""
+
+#, c-format
+msgid ""
+"WARNING: Untracked file in way of tracked file!  Renaming\n"
+"            %s -> %s\n"
+"         to make room.\n"
+msgstr ""
+
+#, fuzzy
+msgid "cannot apply a stash in the middle of a merge"
+msgstr "Ní féidir athshocrú %s a dhéanamh i lár cumaisc."
+
+#, fuzzy, c-format
+msgid "could not generate diff %s^!."
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+msgid "conflicts in index. Try without --index."
+msgstr ""
+
+#, fuzzy
+msgid "could not save index tree"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, c-format
+msgid "Merging %s with %s"
+msgstr ""
+
+msgid "Index was not unstashed."
+msgstr ""
+
+#, fuzzy
+msgid "could not restore untracked files from stash"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy
+msgid "attempt to recreate the index"
+msgstr "an t-innéacs a chur ar ais"
+
+#, c-format
+msgid "Dropped %s (%s)"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not drop stash entry"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a stash reference"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+msgid "The stash entry is kept in case you need it again."
+msgstr ""
+
+msgid "No branch name specified"
+msgstr ""
+
+#, fuzzy
+msgid "failed to parse tree"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, fuzzy
+msgid "failed to unpack trees"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy
+msgid "include untracked files in the stash"
+msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+
+#, fuzzy
+msgid "only show untracked files in the stash"
+msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+
+#, fuzzy, c-format
+msgid "Cannot update %s with %s"
+msgstr "Ní féidir %s a athshocrú le cosáin."
+
+msgid "stash message"
+msgstr ""
+
+msgid "\"git stash store\" requires one <commit> argument"
+msgstr ""
+
+#, fuzzy
+msgid "No staged changes"
+msgstr "Gan aon athruithe"
+
+#, fuzzy
+msgid "No changes selected"
+msgstr "Gan aon athruithe"
+
+#, fuzzy
+msgid "You do not have the initial commit yet"
+msgstr "Níl CEANN bailí agat."
+
+#, fuzzy
+msgid "Cannot save the current index state"
+msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
+
+#, fuzzy
+msgid "Cannot save the untracked files"
+msgstr "ní féidir le pacáiste fstat"
+
+msgid "Cannot save the current worktree state"
+msgstr ""
+
+#, fuzzy
+msgid "Cannot save the current staged state"
+msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+
+#, fuzzy
+msgid "Cannot record working tree state"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+#, fuzzy
+msgid "Can't use --patch and --include-untracked or --all at the same time"
+msgstr ""
+"Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
+
+msgid "Can't use --staged and --include-untracked or --all at the same time"
+msgstr ""
+
+msgid "Did you forget to 'git add'?"
+msgstr ""
+
+msgid "No local changes to save"
+msgstr ""
+
+#, fuzzy
+msgid "Cannot initialize stash"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+msgid "Cannot save the current status"
+msgstr ""
+
+#, c-format
+msgid "Saved working directory and index state %s"
+msgstr ""
+
+msgid "Cannot remove worktree changes"
+msgstr ""
+
+msgid "keep index"
+msgstr ""
+
+msgid "stash staged changes only"
+msgstr ""
+
+msgid "stash in patch mode"
+msgstr ""
+
+msgid "quiet mode"
+msgstr ""
+
+#, fuzzy
+msgid "include untracked files in stash"
+msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+
+#, fuzzy
+msgid "include ignore files"
+msgstr "Comhaid neamhaird"
+
+msgid "skip and remove all lines starting with comment character"
+msgstr ""
+
+msgid "prepend comment character and space to each line"
+msgstr ""
+
+#, c-format
+msgid "Expecting a full ref name, got %s"
+msgstr ""
+
+#, c-format
+msgid "could not get a repository handle for submodule '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"could not look up configuration '%s'. Assuming this repository is its own "
+"authoritative upstream."
+msgstr ""
+
+#, c-format
+msgid "No url found for submodule path '%s' in .gitmodules"
+msgstr ""
+
+#, c-format
+msgid "Entering '%s'\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"run_command returned non-zero status for %s\n"
+"."
+msgstr ""
+
+#, c-format
+msgid ""
+"run_command returned non-zero status while recursing in the nested "
+"submodules of %s\n"
+"."
+msgstr ""
+
+msgid "suppress output of entering each submodule command"
+msgstr ""
+
+#, fuzzy
+msgid "recurse into nested submodules"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+msgid "git submodule foreach [--quiet] [--recursive] [--] <command>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Failed to register url for submodule path '%s'"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+#, c-format
+msgid "Submodule '%s' (%s) registered for path '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "warning: command update mode suggested for submodule '%s'\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Failed to register update mode for submodule path '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+msgid "suppress output for initializing a submodule"
+msgstr ""
+
+#, fuzzy
+msgid "git submodule init [<options>] [<path>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+#, c-format
+msgid "no submodule mapping found in .gitmodules for path '%s'"
+msgstr ""
+
+#, c-format
+msgid "could not resolve HEAD ref inside the submodule '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to recurse into submodule '%s'"
+msgstr "theip ar nasc '%s' a chruthú"
+
+msgid "suppress submodule status output"
+msgstr ""
+
+msgid ""
+"use commit stored in the index instead of the one stored in the submodule "
+"HEAD"
+msgstr ""
+
+msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
+msgstr ""
+
+#, c-format
+msgid "* %s %s(blob)->%s(submodule)"
+msgstr ""
+
+#, c-format
+msgid "* %s %s(submodule)->%s(blob)"
+msgstr ""
+
+#, c-format
+msgid "%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "couldn't hash object from '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "unexpected mode %o"
+msgstr ""
+
+#, fuzzy
+msgid "use the commit stored in the index instead of the submodule HEAD"
+msgstr "seiceáil <brainse> in ionad CEAD an iargúlta"
+
+msgid "compare the commit in the index with that in the submodule HEAD"
+msgstr ""
+
+msgid "skip submodules with 'ignore_config' value set to 'all'"
+msgstr ""
+
+msgid "limit the summary size"
+msgstr ""
+
+msgid "git submodule summary [<options>] [<commit>] [--] [<path>]"
+msgstr ""
+
+msgid "could not fetch a revision for HEAD"
+msgstr ""
+
+#, c-format
+msgid "Synchronizing submodule url for '%s'\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to register url for submodule path '%s'"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+#, fuzzy, c-format
+msgid "failed to update remote for submodule '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+msgid "suppress output of synchronizing submodule url"
+msgstr ""
+
+msgid "git submodule sync [--quiet] [--recursive] [<path>]"
+msgstr ""
+
+#, c-format
+msgid ""
+"Submodule work tree '%s' contains a .git directory. This will be replaced "
+"with a .git file by using absorbgitdirs."
+msgstr ""
+
+#, c-format
+msgid ""
+"Submodule work tree '%s' contains local modifications; use '-f' to discard "
+"them"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Cleared directory '%s'\n"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "Could not remove submodule work tree '%s'\n"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not create empty submodule directory %s"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
+msgstr ""
+
+msgid "remove submodule working trees even if they contain local changes"
+msgstr ""
+
+msgid "unregister all submodules"
+msgstr ""
+
+msgid ""
+"git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
+msgstr ""
+
+msgid "Use '--all' if you really want to deinitialize all submodules"
+msgstr ""
+
+msgid ""
+"An alternate computed from a superproject's alternate is invalid.\n"
+"To allow Git to clone without an alternate in such a case, set\n"
+"submodule.alternateErrorStrategy to 'info' or, equivalently, clone with\n"
+"'--reference-if-able' instead of '--reference'."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not get a repository handle for gitdir '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "submodule '%s' cannot add alternate: %s"
+msgstr "eolas: Ní féidir malartach a chur le haghaidh '%s': %s\n"
+
+#, c-format
+msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
+msgstr ""
+
+#, c-format
+msgid "Value '%s' for submodule.alternateLocation is not recognized"
+msgstr ""
+
+#, c-format
+msgid "refusing to create/use '%s' in another submodule's git dir"
+msgstr ""
+
+#, c-format
+msgid "directory not empty: '%s'"
+msgstr ""
+
+#, c-format
+msgid "clone of '%s' into submodule path '%s' failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not get submodule directory for '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+msgid "alternative anchor for relative paths"
+msgstr ""
+
+#, fuzzy
+msgid "where the new submodule will be cloned to"
+msgstr "beidh aon fho-mhodúil clónaithe éadrom"
+
+msgid "name of the new submodule"
+msgstr ""
+
+msgid "url where to clone the submodule from"
+msgstr ""
+
+msgid "depth for shallow clones"
+msgstr ""
+
+#, fuzzy
+msgid "force cloning progress"
+msgstr "tuairisciú dul chun cinn"
+
+msgid "disallow cloning into non-empty directory"
+msgstr ""
+
+msgid ""
+"git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
+"<repository>] [--name <name>] [--depth <depth>] [--single-branch] [--filter "
+"<filter-spec>] --url <url> --path <path>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Invalid update mode '%s' configured for submodule path '%s'"
+msgstr "níl aon chumrú suas srutha le haghaidh brainse '%s'"
+
+#, c-format
+msgid "Submodule path '%s' not initialized"
+msgstr ""
+
+msgid "Maybe you want to use 'update --init'?"
+msgstr ""
+
+#, c-format
+msgid "Skipping unmerged submodule %s"
+msgstr ""
+
+#, c-format
+msgid "Skipping submodule '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot clone submodule '%s' without a URL"
+msgstr "beidh aon fho-mhodúil clónaithe éadrom"
+
+#, c-format
+msgid "Failed to clone '%s'. Retry scheduled"
+msgstr ""
+
+#, c-format
+msgid "Failed to clone '%s' a second time, aborting"
+msgstr ""
+
+#, c-format
+msgid "Unable to checkout '%s' in submodule path '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Unable to rebase '%s' in submodule path '%s'"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, fuzzy, c-format
+msgid "Unable to merge '%s' in submodule path '%s'"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+#, c-format
+msgid "Execution of '%s %s' failed in submodule path '%s'"
+msgstr ""
+
+#, c-format
+msgid "Submodule path '%s': checked out '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "Submodule path '%s': rebased into '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "Submodule path '%s': merged in '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "Submodule path '%s': '%s %s'\n"
+msgstr ""
+
+#, c-format
+msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
+msgstr ""
+
+#, c-format
+msgid ""
+"Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
+"of that commit failed."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not initialize submodule at path '%s'"
+msgstr "fo-mhodúil a thionscnamh sa chlón"
+
+#, c-format
+msgid ""
+"Submodule (%s) branch configured to inherit branch from superproject, but "
+"the superproject is not on any branch"
+msgstr ""
+
+#, c-format
+msgid "Unable to find current revision in submodule path '%s'"
+msgstr ""
+
+#, c-format
+msgid "Unable to fetch in submodule path '%s'"
+msgstr ""
+
+#, c-format
+msgid "Unable to find %s revision in submodule path '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Failed to recurse into submodule path '%s'"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+#, fuzzy
+msgid "force checkout updates"
+msgstr "nuashonruithe fórsa"
+
+#, fuzzy
+msgid "initialize uninitialized submodules before update"
+msgstr "fo-mhodúil a thionscnamh sa chlón"
+
+#, fuzzy
+msgid "use SHA-1 of submodule's remote tracking branch"
+msgstr "úsáidfidh aon fho-mhodúil clónaithe a mbrainse cianrianaithe"
+
+msgid "traverse submodules recursively"
+msgstr ""
+
+msgid "don't fetch new objects from the remote site"
+msgstr ""
+
+msgid "use the 'checkout' update strategy (default)"
+msgstr ""
+
+msgid "use the 'merge' update strategy"
+msgstr ""
+
+msgid "use the 'rebase' update strategy"
+msgstr ""
+
+#, fuzzy
+msgid "create a shallow clone truncated to the specified number of revisions"
+msgstr "clón éadrom a chruthú ó am ar leith"
+
+msgid "parallel jobs"
+msgstr ""
+
+msgid "whether the initial clone should follow the shallow recommendation"
+msgstr ""
+
+msgid "don't print cloning progress"
+msgstr ""
+
+msgid "disallow cloning into non-empty directory, implies --init"
+msgstr ""
+
+msgid ""
+"git submodule [--quiet] update [--init [--filter=<filter-spec>]] [--remote] "
+"[-N|--no-fetch] [-f|--force] [--checkout|--merge|--rebase] [--[no-]recommend-"
+"shallow] [--reference <repository>] [--recursive] [--[no-]single-branch] "
+"[--] [<path>...]"
+msgstr ""
+
+#, fuzzy
+msgid "Failed to resolve HEAD as a valid ref."
+msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+
+#, fuzzy
+msgid "git submodule absorbgitdirs [<options>] [<path>...]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+msgid "suppress output for setting url of a submodule"
+msgstr ""
+
+msgid "git submodule set-url [--quiet] <path> <newurl>"
+msgstr ""
+
+msgid "set the default tracking branch to master"
+msgstr ""
+
+#, fuzzy
+msgid "set the default tracking branch"
+msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
+
+msgid "git submodule set-branch [-q|--quiet] (-d|--default) <path>"
+msgstr ""
+
+msgid "git submodule set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
+msgstr ""
+
+msgid "--branch or --default required"
+msgstr ""
+
+msgid "print only error messages"
+msgstr ""
+
+msgid "force creation"
+msgstr ""
+
+msgid "show whether the branch would be created"
+msgstr ""
+
+msgid ""
+"git submodule--helper create-branch [-f|--force] [--create-reflog] [-q|--"
+"quiet] [-t|--track] [-n|--dry-run] <name> <start-oid> <start-name>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "creating branch '%s'"
+msgstr "Athshocraigh brainse '%s'\n"
+
+#, c-format
+msgid "Adding existing repo at '%s' to the index\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' already exists and is not a valid git repo"
+msgstr "Tá %s ann agus ní eolaire é"
+
+#, c-format
+msgid "A git directory for '%s' is found locally with remote(s):\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"If you want to reuse this local git directory instead of cloning again from\n"
+"  %s\n"
+"use the '--force' option. If the local git directory is not the correct "
+"repo\n"
+"or you are unsure what this means choose another name with the '--name' "
+"option."
+msgstr ""
+
+#, c-format
+msgid "Reactivating local git directory for submodule '%s'\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to checkout submodule '%s'"
+msgstr "in ann crann oibre a sheiceáil"
+
+msgid "please make sure that the .gitmodules file is in the working tree"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Failed to add submodule '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+#, fuzzy, c-format
+msgid "Failed to register submodule '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+#, c-format
+msgid "'%s' already exists in the index"
+msgstr ""
+
+#, c-format
+msgid "'%s' already exists in the index and is not a submodule"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' does not have a commit checked out"
+msgstr "Teastaíonn '%s' na cosáin chun seiceáil"
+
+msgid "branch of repository to add as submodule"
+msgstr ""
+
+msgid "allow adding an otherwise ignored submodule path"
+msgstr ""
+
+msgid "borrow the objects from reference repositories"
+msgstr ""
+
+msgid ""
+"sets the submodule's name to the given string instead of defaulting to its "
+"path"
+msgstr ""
+
+#, fuzzy
+msgid "git submodule add [<options>] [--] <repository> [<path>]"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+msgid "Relative path can only be used from the toplevel of the working tree"
+msgstr ""
+
+#, c-format
+msgid "repo URL: '%s' must be absolute or begin with ./|../"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid submodule name"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+msgid "git submodule--helper <command>"
+msgstr ""
+
+msgid "git symbolic-ref [-m <reason>] <name> <ref>"
+msgstr ""
+
+msgid "git symbolic-ref [-q] [--short] [--no-recurse] <name>"
+msgstr ""
+
+msgid "git symbolic-ref --delete [-q] <name>"
+msgstr ""
+
+msgid "suppress error message for non-symbolic (detached) refs"
+msgstr ""
+
+#, fuzzy
+msgid "delete symbolic ref"
+msgstr "scrios réimsí"
+
+msgid "shorten ref output"
+msgstr ""
+
+#, fuzzy
+msgid "recursively dereference (default)"
+msgstr "úsáid modh forleagtha (réamhshocraithe)"
+
+msgid "reason"
+msgstr ""
+
+msgid "reason of the update"
+msgstr ""
+
+msgid ""
+"git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>] [-e]\n"
+"        [(--trailer <token>[(=|:)<value>])...]\n"
+"        <tagname> [<commit> | <object>]"
+msgstr ""
+
+msgid "git tag -d <tagname>..."
+msgstr ""
+
+msgid ""
+"git tag [-n[<num>]] -l [--contains <commit>] [--no-contains <commit>]\n"
+"        [--points-at <object>] [--column[=<options>] | --no-column]\n"
+"        [--create-reflog] [--sort=<key>] [--format=<format>]\n"
+"        [--merged <commit>] [--no-merged <commit>] [<pattern>...]"
+msgstr ""
+
+msgid "git tag -v [--format=<format>] <tagname>..."
+msgstr ""
+
+#, c-format
+msgid "tag '%s' not found."
+msgstr ""
+
+#, c-format
+msgid "Deleted tag '%s' (was %s)\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"\n"
+"Write a message for tag:\n"
+"  %s\n"
+"Lines starting with '%s' will be ignored.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"\n"
+"Write a message for tag:\n"
+"  %s\n"
+"Lines starting with '%s' will be kept; you may remove them yourself if you "
+"want to.\n"
+msgstr ""
+
+#, fuzzy
+msgid "unable to sign the tag"
+msgstr "nach féidir %s a nuashonrú"
+
+#, c-format
+msgid ""
+"You have created a nested tag. The object referred to by your new tag is\n"
+"already a tag. If you meant to tag the object that it points to, use:\n"
+"\n"
+"\tgit tag -f %s %s^{}"
+msgstr ""
+
+#, fuzzy
+msgid "bad object type."
+msgstr "cineál réad anaithnid %d"
+
+msgid "no tag message?"
+msgstr ""
+
+#, c-format
+msgid "The tag message has been left in %s\n"
+msgstr ""
+
+msgid "list tag names"
+msgstr ""
+
+msgid "print <n> lines of each tag message"
+msgstr ""
+
+#, fuzzy
+msgid "delete tags"
+msgstr "scrios réimsí"
+
+msgid "verify tags"
+msgstr ""
+
+msgid "Tag creation options"
+msgstr ""
+
+msgid "annotated tag, needs a message"
+msgstr ""
+
+msgid "tag message"
+msgstr ""
+
+msgid "force edit of tag message"
+msgstr ""
+
+msgid "annotated and GPG-signed tag"
+msgstr ""
+
+msgid "use another key to sign the tag"
+msgstr ""
+
+msgid "replace the tag if exists"
+msgstr ""
+
+#, fuzzy
+msgid "create a reflog"
+msgstr "stóras lom a chruthú"
+
+msgid "Tag listing options"
+msgstr ""
+
+msgid "show tag list in columns"
+msgstr ""
+
+msgid "print only tags that contain the commit"
+msgstr ""
+
+msgid "print only tags that don't contain the commit"
+msgstr ""
+
+msgid "print only tags that are merged"
+msgstr ""
+
+msgid "print only tags that are not merged"
+msgstr ""
+
+msgid "print only tags of the object"
+msgstr ""
+
+msgid "could not start 'git column'"
+msgstr ""
+
+#, c-format
+msgid "the '%s' option is only allowed in list mode"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid tag name."
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, fuzzy, c-format
+msgid "tag '%s' already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, fuzzy, c-format
+msgid "Invalid cleanup mode %s"
+msgstr "réad blob neamhbhailí %s"
+
+#, c-format
+msgid "Updated tag '%s' (was %s)\n"
+msgstr ""
+
+#, fuzzy
+msgid "pack exceeds maximum allowed size"
+msgstr "sáraíonn an pacáiste an méid uasta ceadaithe (%s)"
+
+#, fuzzy
+msgid "failed to write object in stream"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "inflate returned (%d)"
+msgstr "infleáil ar ais %d"
+
+#, fuzzy
+msgid "invalid blob object from stream"
+msgstr "réad blob neamhbhailí %s"
+
+#, fuzzy
+msgid "Unpacking objects"
+msgstr "Rud a sheiceáil"
+
+#, fuzzy, c-format
+msgid "failed to create directory %s"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "failed to delete file %s"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "failed to delete directory %s"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, c-format
+msgid "Testing mtime in '%s' "
+msgstr ""
+
+msgid "directory stat info does not change after adding a new file"
+msgstr ""
+
+msgid "directory stat info does not change after adding a new directory"
+msgstr ""
+
+msgid "directory stat info changes after updating a file"
+msgstr ""
+
+msgid "directory stat info changes after adding a file inside subdirectory"
+msgstr ""
+
+msgid "directory stat info does not change after deleting a file"
+msgstr ""
+
+msgid "directory stat info does not change after deleting a directory"
+msgstr ""
+
+msgid " OK"
+msgstr ""
+
+#, fuzzy
+msgid "git update-index [<options>] [--] [<file>...]"
+msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+
+msgid "continue refresh even when index needs update"
+msgstr ""
+
+#, fuzzy
+msgid "refresh: ignore submodules"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+#, fuzzy
+msgid "do not ignore new files"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+msgid "let files replace directories and vice-versa"
+msgstr ""
+
+msgid "notice files missing from worktree"
+msgstr ""
+
+msgid "refresh even if index contains unmerged entries"
+msgstr ""
+
+msgid "refresh stat information"
+msgstr ""
+
+msgid "like --refresh, but ignore assume-unchanged setting"
+msgstr ""
+
+msgid "<mode>,<object>,<path>"
+msgstr ""
+
+#, fuzzy
+msgid "add the specified entry to the index"
+msgstr "Nuashonraíodh %d cosán ón innéacs"
+
+msgid "mark files as \"not changing\""
+msgstr ""
+
+msgid "clear assumed-unchanged bit"
+msgstr ""
+
+msgid "mark files as \"index-only\""
+msgstr ""
+
+msgid "clear skip-worktree bit"
+msgstr ""
+
+msgid "do not touch index-only entries"
+msgstr ""
+
+msgid "add to index only; do not add content to object database"
+msgstr ""
+
+msgid "remove named paths even if present in worktree"
+msgstr ""
+
+msgid "with --stdin: input lines are terminated by null bytes"
+msgstr ""
+
+msgid "read list of paths to be updated from standard input"
+msgstr ""
+
+msgid "add entries from standard input to the index"
+msgstr ""
+
+msgid "repopulate stages #2 and #3 for the listed paths"
+msgstr ""
+
+msgid "only update entries that differ from HEAD"
+msgstr ""
+
+msgid "ignore files missing from worktree"
+msgstr ""
+
+msgid "report actions to standard output"
+msgstr ""
+
+msgid "(for porcelains) forget saved unresolved conflicts"
+msgstr ""
+
+msgid "write index in this format"
+msgstr ""
+
+msgid "report on-disk index format version"
+msgstr ""
+
+msgid "enable or disable split index"
+msgstr ""
+
+msgid "enable/disable untracked cache"
+msgstr ""
+
+msgid "test if the filesystem supports untracked cache"
+msgstr ""
+
+msgid "enable untracked cache without testing the filesystem"
+msgstr ""
+
+msgid "write out the index even if is not flagged as changed"
+msgstr ""
+
+msgid "enable or disable file system monitor"
+msgstr ""
+
+msgid "mark files as fsmonitor valid"
+msgstr ""
+
+msgid "clear fsmonitor valid bit"
+msgstr ""
+
+#, c-format
+msgid "%d\n"
+msgstr ""
+
+#, c-format
+msgid "index-version: was %d, set to %d"
+msgstr ""
+
+msgid ""
+"core.splitIndex is set to false; remove or change it, if you really want to "
+"enable split index"
+msgstr ""
+
+msgid ""
+"core.splitIndex is set to true; remove or change it, if you really want to "
+"disable split index"
+msgstr ""
+
+msgid ""
+"core.untrackedCache is set to true; remove or change it, if you really want "
+"to disable the untracked cache"
+msgstr ""
+
+#, fuzzy
+msgid "Untracked cache disabled"
+msgstr "Comhaid neamhrianaithe"
+
+msgid ""
+"core.untrackedCache is set to false; remove or change it, if you really want "
+"to enable the untracked cache"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Untracked cache enabled for '%s'"
+msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
+
+msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
+msgstr ""
+
+msgid "fsmonitor enabled"
+msgstr ""
+
+msgid ""
+"core.fsmonitor is set; remove it if you really want to disable fsmonitor"
+msgstr ""
+
+msgid "fsmonitor disabled"
+msgstr ""
+
+#, fuzzy
+msgid "git update-ref [<options>] -d <refname> [<old-oid>]"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+#, fuzzy
+msgid "git update-ref [<options>]    <refname> <new-oid> [<old-oid>]"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+msgid "git update-ref [<options>] --stdin [-z] [--batch-updates]"
+msgstr ""
+
+#, fuzzy
+msgid "delete the reference"
+msgstr "scrios réimsí"
+
+msgid "update <refname> not the one it points to"
+msgstr ""
+
+msgid "stdin has NUL-terminated arguments"
+msgstr ""
+
+msgid "read updates from stdin"
+msgstr ""
+
+#, fuzzy
+msgid "batch reference updates"
+msgstr "nuashonruithe fórsa"
+
+#, fuzzy
+msgid "update the info files from scratch"
+msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
+
+msgid ""
+"git-upload-pack [--[no-]strict] [--timeout=<n>] [--stateless-rpc]\n"
+"                [--advertise-refs] <directory>"
+msgstr ""
+
+msgid "quit after a single request/response exchange"
+msgstr ""
+
+msgid "serve up the info/refs for git-http-backend"
+msgstr ""
+
+msgid "do not try <directory>/.git/ if <directory> is no Git directory"
+msgstr ""
+
+msgid "interrupt transfer after <n> seconds of inactivity"
+msgstr ""
+
+msgid "git verify-commit [-v | --verbose] [--raw] <commit>..."
+msgstr ""
+
+msgid "print commit contents"
+msgstr ""
+
+msgid "print raw gpg status output"
+msgstr ""
+
+msgid "git verify-pack [-v | --verbose] [-s | --stat-only] [--] <pack>.idx..."
+msgstr ""
+
+msgid "verbose"
+msgstr ""
+
+msgid "show statistics only"
+msgstr ""
+
+msgid "git verify-tag [-v | --verbose] [--format=<format>] [--raw] <tag>..."
+msgstr ""
+
+msgid "print tag contents"
+msgstr ""
+
+msgid ""
+"git worktree add [-f] [--detach] [--checkout] [--lock [--reason <string>]]\n"
+"                 [--orphan] [(-b | -B) <new-branch>] <path> [<commit-ish>]"
+msgstr ""
+
+msgid "git worktree list [-v | --porcelain [-z]]"
+msgstr ""
+
+msgid "git worktree lock [--reason <string>] <worktree>"
+msgstr ""
+
+msgid "git worktree move <worktree> <new-path>"
+msgstr ""
+
+msgid "git worktree prune [-n] [-v] [--expire <expire>]"
+msgstr ""
+
+msgid "git worktree remove [-f] <worktree>"
+msgstr ""
+
+msgid "git worktree repair [<path>...]"
+msgstr ""
+
+msgid "git worktree unlock <worktree>"
+msgstr ""
+
+msgid "No possible source branch, inferring '--orphan'"
+msgstr ""
+
+#, c-format
+msgid ""
+"If you meant to create a worktree containing a new unborn branch\n"
+"(branch with no commits) for this repository, you can do so\n"
+"using the --orphan flag:\n"
+"\n"
+"    git worktree add --orphan -b %s %s\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"If you meant to create a worktree containing a new unborn branch\n"
+"(branch with no commits) for this repository, you can do so\n"
+"using the --orphan flag:\n"
+"\n"
+"    git worktree add --orphan %s\n"
+msgstr ""
+
+#, c-format
+msgid "Removing %s/%s: %s"
+msgstr ""
+
+#, fuzzy
+msgid "report pruned working trees"
+msgstr "athshocraigh HEAD, innéacs agus crann oibre"
+
+msgid "expire working trees older than <time>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, fuzzy, c-format
+msgid "unusable worktree destination '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid ""
+"'%s' is a missing but locked worktree;\n"
+"use '%s -f -f' to override, or 'unlock' and 'prune' or 'remove' to clear"
+msgstr ""
+
+#, c-format
+msgid ""
+"'%s' is a missing but already registered worktree;\n"
+"use '%s -f' to override, or 'prune' or 'remove' to clear"
+msgstr ""
+
+#, c-format
+msgid "failed to copy '%s' to '%s'; sparse-checkout may not work correctly"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to copy worktree config from '%s' to '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, fuzzy, c-format
+msgid "failed to unset '%s' in '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy, c-format
+msgid "could not create directory of '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+msgid "initializing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not find created worktree '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "Preparing worktree (new branch '%s')"
+msgstr ""
+
+#, c-format
+msgid "Preparing worktree (resetting branch '%s'; was at %s)"
+msgstr ""
+
+#, c-format
+msgid "Preparing worktree (checking out '%s')"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unreachable: invalid reference: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "Preparing worktree (detached HEAD %s)"
+msgstr ""
+
+#, c-format
+msgid ""
+"HEAD points to an invalid (or orphaned) reference.\n"
+"HEAD path: '%s'\n"
+"HEAD contents: '%s'"
+msgstr ""
+
+msgid ""
+"No local or remote refs exist despite at least one remote\n"
+"present, stopping; use 'add -f' to override or fetch a remote first"
+msgstr ""
+
+msgid "checkout <branch> even if already checked out in other worktree"
+msgstr ""
+
+#, fuzzy
+msgid "create a new branch"
+msgstr "cruthú reflog do bhrainse nua"
+
+#, fuzzy
+msgid "create or reset a branch"
+msgstr "cruthú reflog do bhrainse nua"
+
+#, fuzzy
+msgid "create unborn branch"
+msgstr "brainse nua gan breith"
+
+#, fuzzy
+msgid "populate the new working tree"
+msgstr "in ann crann oibre a sheiceáil"
+
+#, fuzzy
+msgid "keep the new working tree locked"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+msgid "reason for locking"
+msgstr ""
+
+msgid "set up tracking mode (see git-branch(1))"
+msgstr ""
+
+#, fuzzy
+msgid "try to match the new branch name with a remote-tracking branch"
+msgstr "brainse suas srutha '%s' nach stóráiltear mar bhrainse cianrianaithe"
+
+#, fuzzy
+msgid "use relative paths for worktrees"
+msgstr "git dir ar leithligh ó chrann oibre"
+
+#, fuzzy, c-format
+msgid "options '%s', '%s', and '%s' cannot be used together"
+msgstr "ní féidir na roghanna '-%c', '-%c', agus '%s' a úsáid le chéile"
+
+#, fuzzy, c-format
+msgid "option '%s' and commit-ish cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+msgid "added with --lock"
+msgstr ""
+
+msgid "--[no-]track can only be used if a new branch is created"
+msgstr ""
+
+msgid "show extended annotations and reasons, if available"
+msgstr ""
+
+msgid "add 'prunable' annotation to worktrees older than <time>"
+msgstr ""
+
+msgid "terminate records with a NUL character"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a working tree"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+msgid "The main working tree cannot be locked or unlocked"
+msgstr ""
+
+#, c-format
+msgid "'%s' is already locked, reason: %s"
+msgstr ""
+
+#, c-format
+msgid "'%s' is already locked"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not locked"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+msgid "working trees containing submodules cannot be moved or removed"
+msgstr ""
+
+msgid "force move even if worktree is dirty or locked"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is a main working tree"
+msgstr "git dir ar leithligh ó chrann oibre"
+
+#, c-format
+msgid "could not figure out destination name from '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"cannot move a locked working tree, lock reason: %s\n"
+"use 'move -f -f' to override or unlock first"
+msgstr ""
+
+msgid ""
+"cannot move a locked working tree;\n"
+"use 'move -f -f' to override or unlock first"
+msgstr ""
+
+#, c-format
+msgid "validation failed, cannot move working tree: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to move '%s' to '%s'"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+#, fuzzy, c-format
+msgid "failed to run 'git status' on '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid "'%s' contains modified or untracked files, use --force to delete it"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to run 'git status' on '%s', code %d"
+msgstr "theip ar '%s' a stáil"
+
+msgid "force removal even if worktree is dirty or locked"
+msgstr ""
+
+#, c-format
+msgid ""
+"cannot remove a locked working tree, lock reason: %s\n"
+"use 'remove -f -f' to override or unlock first"
+msgstr ""
+
+msgid ""
+"cannot remove a locked working tree;\n"
+"use 'remove -f -f' to override or unlock first"
+msgstr ""
+
+#, c-format
+msgid "validation failed, cannot remove working tree: %s"
+msgstr ""
+
+#, c-format
+msgid "repair: %s: %s"
+msgstr ""
+
+#, c-format
+msgid "error: %s: %s"
+msgstr ""
+
+msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
+msgstr ""
+
+msgid "<prefix>/"
+msgstr ""
+
+msgid "write tree object for a subdirectory <prefix>"
+msgstr ""
+
+msgid "only useful for debugging"
+msgstr ""
+
+msgid "core.fsyncMethod = batch is unsupported on this platform"
+msgstr ""
+
+#, c-format
+msgid "could not parse bundle list key %s with value '%s'"
+msgstr ""
+
+#, c-format
+msgid "bundle list at '%s' has no mode"
+msgstr ""
+
+#, fuzzy
+msgid "failed to create temporary file"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+msgid "insufficient capabilities"
+msgstr ""
+
+#, c-format
+msgid "file downloaded from '%s' is not a bundle"
+msgstr ""
+
+#, fuzzy
+msgid "failed to store maximum creation token"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+#, c-format
+msgid "unrecognized bundle mode from URI '%s'"
+msgstr ""
+
+#, c-format
+msgid "exceeded bundle URI recursion limit (%d)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to download bundle from URI '%s'"
+msgstr "theip ar rudaí a fháil ó URI '%s'"
+
+#, c-format
+msgid "file at URI '%s' is not a bundle or bundle list"
+msgstr ""
+
+#, c-format
+msgid "bundle-uri: unexpected argument: '%s'"
+msgstr ""
+
+msgid "bundle-uri: expected flush after arguments"
+msgstr ""
+
+msgid "bundle-uri: got an empty line"
+msgstr ""
+
+msgid "bundle-uri: line is not of the form 'key=value'"
+msgstr ""
+
+msgid "bundle-uri: line has empty key or value"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unrecognized bundle hash algorithm: %s"
+msgstr "algartam hais anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "unknown capability '%s'"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+#, c-format
+msgid "'%s' does not look like a v2 or v3 bundle file"
+msgstr ""
+
+#, c-format
+msgid "unrecognized header: %s%s (%d)"
+msgstr ""
+
+msgid "Repository lacks these prerequisite commits:"
+msgstr ""
+
+msgid ""
+"some prerequisite commits exist in the object store, but are not connected "
+"to the repository's history"
+msgstr ""
+
+#, c-format
+msgid "The bundle contains this ref:"
+msgid_plural "The bundle contains these %<PRIuMAX> refs:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "The bundle records a complete history."
+msgstr ""
+
+#, c-format
+msgid "The bundle requires this ref:"
+msgid_plural "The bundle requires these %<PRIuMAX> refs:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy, c-format
+msgid "The bundle uses this hash algorithm: %s"
+msgstr "algartam hais anaithnid '%s'"
+
+#, c-format
+msgid "The bundle uses this filter: %s"
+msgstr ""
+
+#, fuzzy
+msgid "unable to dup bundle descriptor"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy
+msgid "Could not spawn pack-objects"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+msgid "pack-objects died"
+msgstr ""
+
+#, c-format
+msgid "ref '%s' is excluded by the rev-list options"
+msgstr ""
+
+#, c-format
+msgid "unsupported bundle version %d"
+msgstr ""
+
+#, c-format
+msgid "cannot write bundle version %d with algorithm %s"
+msgstr ""
+
+msgid "Refusing to create empty bundle."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot create '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+msgid "index-pack died"
+msgstr ""
+
+#, c-format
+msgid "directory '%s' is present in index, but not sparse"
+msgstr ""
+
+msgid "corrupted cache-tree has entries not present in index"
+msgstr ""
+
+#, c-format
+msgid "%s with flags 0x%x should not be in cache-tree"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bad subtree '%.*s'"
+msgstr "droch-stóras '%s'"
+
+#, c-format
+msgid "cache-tree for path %.*s does not match. Expected %s got %s"
+msgstr ""
+
+msgid "terminating chunk id appears earlier than expected"
+msgstr ""
+
+#, c-format
+msgid "chunk id %<PRIx32> not %d-byte aligned"
+msgstr ""
+
+#, c-format
+msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
+msgstr ""
+
+#, c-format
+msgid "duplicate chunk ID %<PRIx32> found"
+msgstr ""
+
+#, c-format
+msgid "final chunk has non-zero id %<PRIx32>"
+msgstr ""
+
+#, fuzzy
+msgid "invalid hash version"
+msgstr "sonraíocht cosáin nebhail"
+
+#, fuzzy, c-format
+msgid "invalid color value: %.*s"
+msgstr "luach neamhbhailí do '%s'"
+
+msgid "Add file contents to the index"
+msgstr ""
+
+msgid "Apply a series of patches from a mailbox"
+msgstr ""
+
+msgid "Annotate file lines with commit information"
+msgstr ""
+
+msgid "Apply a patch to files and/or to the index"
+msgstr ""
+
+msgid "Import a GNU Arch repository into Git"
+msgstr ""
+
+msgid "Create an archive of files from a named tree"
+msgstr ""
+
+msgid "Download missing objects in a partial clone"
+msgstr ""
+
+msgid "Use binary search to find the commit that introduced a bug"
+msgstr ""
+
+msgid "Show what revision and author last modified each line of a file"
+msgstr ""
+
+#, fuzzy
+msgid "List, create, or delete branches"
+msgstr "Ní féidir %s a réiteach chuig an mbrainse"
+
+msgid "Collect information for user to file a bug report"
+msgstr ""
+
+msgid "Move objects and refs by archive"
+msgstr ""
+
+msgid "Provide contents or details of repository objects"
+msgstr ""
+
+msgid "Display gitattributes information"
+msgstr ""
+
+msgid "Debug gitignore / exclude files"
+msgstr ""
+
+msgid "Show canonical names and email addresses of contacts"
+msgstr ""
+
+msgid "Ensures that a reference name is well formed"
+msgstr ""
+
+#, fuzzy
+msgid "Switch branches or restore working tree files"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+msgid "Copy files from the index to the working tree"
+msgstr ""
+
+msgid "Find commits yet to be applied to upstream"
+msgstr ""
+
+msgid "Apply the changes introduced by some existing commits"
+msgstr ""
+
+msgid "Graphical alternative to git-commit"
+msgstr ""
+
+#, fuzzy
+msgid "Remove untracked files from the working tree"
+msgstr "git dir ar leithligh ó chrann oibre"
+
+msgid "Clone a repository into a new directory"
+msgstr ""
+
+msgid "Display data in columns"
+msgstr ""
+
+#, fuzzy
+msgid "Record changes to the repository"
+msgstr "stóras lom a chruthú"
+
+msgid "Write and verify Git commit-graph files"
+msgstr ""
+
+msgid "Create a new commit object"
+msgstr ""
+
+msgid "Get and set repository or global options"
+msgstr ""
+
+msgid "Count unpacked number of objects and their disk consumption"
+msgstr ""
+
+msgid "Retrieve and store user credentials"
+msgstr ""
+
+msgid "Helper to temporarily store passwords in memory"
+msgstr ""
+
+msgid "Helper to store credentials on disk"
+msgstr ""
+
+msgid "Export a single commit to a CVS checkout"
+msgstr ""
+
+msgid "Salvage your data out of another SCM people love to hate"
+msgstr ""
+
+msgid "A CVS server emulator for Git"
+msgstr ""
+
+msgid "A really simple server for Git repositories"
+msgstr ""
+
+msgid "Give an object a human readable name based on an available ref"
+msgstr ""
+
+msgid "Generate a zip archive of diagnostic information"
+msgstr ""
+
+#, fuzzy
+msgid "Show changes between commits, commit and working tree, etc"
+msgstr "aon rud le tiomantas, crann oibre glan\n"
+
+msgid "Compares files in the working tree and the index"
+msgstr ""
+
+#, fuzzy
+msgid "Compare a tree to the working tree or index"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+msgid "Compare the content and mode of provided blob pairs"
+msgstr ""
+
+msgid "Compares the content and mode of blobs found via two tree objects"
+msgstr ""
+
+msgid "Show changes using common diff tools"
+msgstr ""
+
+msgid "Git data exporter"
+msgstr ""
+
+msgid "Backend for fast Git data importers"
+msgstr ""
+
+msgid "Download objects and refs from another repository"
+msgstr ""
+
+msgid "Receive missing objects from another repository"
+msgstr ""
+
+#, fuzzy
+msgid "Rewrite branches"
+msgstr "Athshocraigh brainse '%s'\n"
+
+msgid "Produce a merge commit message"
+msgstr ""
+
+msgid "Output information on each ref"
+msgstr ""
+
+msgid "Run a Git command on a list of repositories"
+msgstr ""
+
+msgid "Prepare patches for e-mail submission"
+msgstr ""
+
+msgid "Verifies the connectivity and validity of the objects in the database"
+msgstr ""
+
+msgid "Cleanup unnecessary files and optimize the local repository"
+msgstr ""
+
+msgid "Extract commit ID from an archive created using git-archive"
+msgstr ""
+
+msgid "Print lines matching a pattern"
+msgstr ""
+
+msgid "A portable graphical interface to Git"
+msgstr ""
+
+msgid "Compute object ID and optionally create an object from a file"
+msgstr ""
+
+msgid "Display help information about Git"
+msgstr ""
+
+msgid "Run git hooks"
+msgstr ""
+
+msgid "Server side implementation of Git over HTTP"
+msgstr ""
+
+msgid "Download from a remote Git repository via HTTP"
+msgstr ""
+
+msgid "Push objects over HTTP/DAV to another repository"
+msgstr ""
+
+msgid "Send a collection of patches from stdin to an IMAP folder"
+msgstr ""
+
+msgid "Build pack index file for an existing packed archive"
+msgstr ""
+
+msgid "Create an empty Git repository or reinitialize an existing one"
+msgstr ""
+
+msgid "Instantly browse your working repository in gitweb"
+msgstr ""
+
+msgid "Add or parse structured information in commit messages"
+msgstr ""
+
+#, fuzzy
+msgid "Show commit logs"
+msgstr "tiomantais nua, "
+
+msgid "Show information about files in the index and the working tree"
+msgstr ""
+
+#, fuzzy
+msgid "List references in a remote repository"
+msgstr "stór tagartha"
+
+msgid "List the contents of a tree object"
+msgstr ""
+
+msgid "Extracts patch and authorship from a single e-mail message"
+msgstr ""
+
+msgid "Simple UNIX mbox splitter program"
+msgstr ""
+
+msgid "Run tasks to optimize Git repository data"
+msgstr ""
+
+msgid "Join two or more development histories together"
+msgstr ""
+
+msgid "Find as good common ancestors as possible for a merge"
+msgstr ""
+
+msgid "Run a three-way file merge"
+msgstr ""
+
+msgid "Run a merge for files needing merging"
+msgstr ""
+
+msgid "The standard helper program to use with git-merge-index"
+msgstr ""
+
+msgid "Perform merge without touching index or working tree"
+msgstr ""
+
+msgid "Run merge conflict resolution tools to resolve merge conflicts"
+msgstr ""
+
+msgid "Creates a tag object with extra validation"
+msgstr ""
+
+msgid "Build a tree-object from ls-tree formatted text"
+msgstr ""
+
+msgid "Write and verify multi-pack-indexes"
+msgstr ""
+
+msgid "Move or rename a file, a directory, or a symlink"
+msgstr ""
+
+msgid "Find symbolic names for given revs"
+msgstr ""
+
+#, fuzzy
+msgid "Add or inspect object notes"
+msgstr "nár bhfuair sé réad ag súil leis %s"
+
+msgid "Import from and submit to Perforce repositories"
+msgstr ""
+
+msgid "Create a packed archive of objects"
+msgstr ""
+
+#, fuzzy
+msgid "Find redundant pack files"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+msgid "Pack heads and tags for efficient repository access"
+msgstr ""
+
+msgid "Compute unique ID for a patch"
+msgstr ""
+
+msgid "Prune all unreachable objects from the object database"
+msgstr ""
+
+msgid "Remove extra objects that are already in pack files"
+msgstr ""
+
+msgid "Fetch from and integrate with another repository or a local branch"
+msgstr ""
+
+msgid "Update remote refs along with associated objects"
+msgstr ""
+
+msgid "Applies a quilt patchset onto the current branch"
+msgstr ""
+
+msgid "Compare two commit ranges (e.g. two versions of a branch)"
+msgstr ""
+
+msgid "Reads tree information into the index"
+msgstr ""
+
+msgid "Reapply commits on top of another base tip"
+msgstr ""
+
+msgid "Receive what is pushed into the repository"
+msgstr ""
+
+msgid "Manage reflog information"
+msgstr ""
+
+msgid "Low-level access to refs"
+msgstr ""
+
+#, fuzzy
+msgid "Manage set of tracked repositories"
+msgstr "socrú mar stór roinnte"
+
+msgid "Pack unpacked objects in a repository"
+msgstr ""
+
+msgid "Create, list, delete refs to replace objects"
+msgstr ""
+
+msgid "EXPERIMENTAL: Replay commits on a new base, works with bare repos too"
+msgstr ""
+
+msgid "Generates a summary of pending changes"
+msgstr ""
+
+msgid "Reuse recorded resolution of conflicted merges"
+msgstr ""
+
+msgid "Reset current HEAD to the specified state"
+msgstr ""
+
+#, fuzzy
+msgid "Restore working tree files"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+msgid "Lists commit objects in reverse chronological order"
+msgstr ""
+
+msgid "Pick out and massage parameters"
+msgstr ""
+
+msgid "Revert some existing commits"
+msgstr ""
+
+msgid "Remove files from the working tree and from the index"
+msgstr ""
+
+msgid "Send a collection of patches as emails"
+msgstr ""
+
+msgid "Push objects over Git protocol to another repository"
+msgstr ""
+
+msgid "Git's i18n setup code for shell scripts"
+msgstr ""
+
+msgid "Common Git shell script setup code"
+msgstr ""
+
+msgid "Restricted login shell for Git-only SSH access"
+msgstr ""
+
+msgid "Summarize 'git log' output"
+msgstr ""
+
+msgid "Show various types of objects"
+msgstr ""
+
+#, fuzzy
+msgid "Show branches and their commits"
+msgstr "níl aon athruithe curtha le tiomantas\n"
+
+msgid "Show packed archive index"
+msgstr ""
+
+#, fuzzy
+msgid "List references in a local repository"
+msgstr "stór tagartha"
+
+#, fuzzy
+msgid "Reduce your working tree to a subset of tracked files"
+msgstr " (bain úsáid as an rogha -u chun comhaid neamhrianaithe a thaispeáint)"
+
+msgid "Add file contents to the staging area"
+msgstr ""
+
+msgid "Stash the changes in a dirty working directory away"
+msgstr ""
+
+#, fuzzy
+msgid "Show the working tree status"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+msgid "Remove unnecessary whitespace"
+msgstr ""
+
+msgid "Initialize, update or inspect submodules"
+msgstr ""
+
+msgid "Bidirectional operation between a Subversion repository and Git"
+msgstr ""
+
+#, fuzzy
+msgid "Switch branches"
+msgstr "Aistrithe go brainse '%s'\n"
+
+msgid "Read, modify and delete symbolic refs"
+msgstr ""
+
+msgid "Create, list, delete or verify a tag object signed with GPG"
+msgstr ""
+
+msgid "Creates a temporary file with a blob's contents"
+msgstr ""
+
+msgid "Unpack objects from a packed archive"
+msgstr ""
+
+msgid "Register file contents in the working tree to the index"
+msgstr ""
+
+msgid "Update the object name stored in a ref safely"
+msgstr ""
+
+msgid "Update auxiliary info file to help dumb servers"
+msgstr ""
+
+msgid "Send archive back to git-archive"
+msgstr ""
+
+msgid "Send objects packed back to git-fetch-pack"
+msgstr ""
+
+msgid "Show a Git logical variable"
+msgstr ""
+
+msgid "Check the GPG signature of commits"
+msgstr ""
+
+msgid "Validate packed Git archive files"
+msgstr ""
+
+msgid "Check the GPG signature of tags"
+msgstr ""
+
+msgid "Display version information about Git"
+msgstr ""
+
+msgid "Show logs with differences each commit introduces"
+msgstr ""
+
+#, fuzzy
+msgid "Manage multiple working trees"
+msgstr "in ann crann oibre a sheiceáil"
+
+msgid "Create a tree object from the current index"
+msgstr ""
+
+msgid "Defining attributes per path"
+msgstr ""
+
+msgid "Git command-line interface and conventions"
+msgstr ""
+
+msgid "A Git core tutorial for developers"
+msgstr ""
+
+msgid "Providing usernames and passwords to Git"
+msgstr ""
+
+msgid "Git for CVS users"
+msgstr ""
+
+msgid "Tweaking diff output"
+msgstr ""
+
+msgid "A useful minimum set of commands for Everyday Git"
+msgstr ""
+
+msgid "Frequently asked questions about using Git"
+msgstr ""
+
+#, fuzzy
+msgid "The bundle file format"
+msgstr "comhad innéacs truaillithe"
+
+msgid "Chunk-based file formats"
+msgstr ""
+
+msgid "Git commit-graph format"
+msgstr ""
+
+msgid "Git index format"
+msgstr ""
+
+msgid "Git pack format"
+msgstr ""
+
+msgid "Git cryptographic signature formats"
+msgstr ""
+
+msgid "A Git Glossary"
+msgstr ""
+
+msgid "Hooks used by Git"
+msgstr ""
+
+msgid "Specifies intentionally untracked files to ignore"
+msgstr ""
+
+msgid "The Git repository browser"
+msgstr ""
+
+msgid "Map author/committer names and/or E-Mail addresses"
+msgstr ""
+
+msgid "Defining submodule properties"
+msgstr ""
+
+msgid "Git namespaces"
+msgstr ""
+
+msgid "Protocol v0 and v1 capabilities"
+msgstr ""
+
+msgid "Things common to various protocols"
+msgstr ""
+
+msgid "Git HTTP-based protocols"
+msgstr ""
+
+msgid "How packs are transferred over-the-wire"
+msgstr ""
+
+msgid "Git Wire Protocol, Version 2"
+msgstr ""
+
+msgid "Helper programs to interact with remote repositories"
+msgstr ""
+
+msgid "Git Repository Layout"
+msgstr ""
+
+msgid "Specifying revisions and ranges for Git"
+msgstr ""
+
+msgid "Mounting one repository inside another"
+msgstr ""
+
+msgid "A tutorial introduction to Git"
+msgstr ""
+
+msgid "A tutorial introduction to Git: part two"
+msgstr ""
+
+msgid "Git web interface (web frontend to Git repositories)"
+msgstr ""
+
+msgid "An overview of recommended workflows with Git"
+msgstr ""
+
+msgid "A tool for managing large Git repositories"
+msgstr ""
+
+msgid "commit-graph file is too small"
+msgstr ""
+
+msgid "commit-graph oid fanout chunk is wrong size"
+msgstr ""
+
+msgid "commit-graph fanout values out of order"
+msgstr ""
+
+msgid "commit-graph OID lookup chunk is the wrong size"
+msgstr ""
+
+msgid "commit-graph commit data chunk is wrong size"
+msgstr ""
+
+msgid "commit-graph generations chunk is wrong size"
+msgstr ""
+
+msgid "commit-graph changed-path index chunk is too small"
+msgstr ""
+
+#, c-format
+msgid ""
+"ignoring too-small changed-path chunk (%<PRIuMAX> < %<PRIuMAX>) in commit-"
+"graph file"
+msgstr ""
+
+#, c-format
+msgid "commit-graph signature %X does not match signature %X"
+msgstr ""
+
+#, c-format
+msgid "commit-graph version %X does not match version %X"
+msgstr ""
+
+#, c-format
+msgid "commit-graph hash version %X does not match version %X"
+msgstr ""
+
+#, c-format
+msgid "commit-graph file is too small to hold %u chunks"
+msgstr ""
+
+msgid "commit-graph required OID fanout chunk missing or corrupted"
+msgstr ""
+
+msgid "commit-graph required OID lookup chunk missing or corrupted"
+msgstr ""
+
+msgid "commit-graph required commit data chunk missing or corrupted"
+msgstr ""
+
+#, c-format
+msgid ""
+"disabling Bloom filters for commit-graph layer '%s' due to incompatible "
+"settings"
+msgstr ""
+
+msgid "commit-graph has no base graphs chunk"
+msgstr ""
+
+msgid "commit-graph base graphs chunk is too small"
+msgstr ""
+
+msgid "commit-graph chain does not match"
+msgstr ""
+
+#, c-format
+msgid "commit count in base graph too high: %<PRIuMAX>"
+msgstr ""
+
+msgid "commit-graph chain file too small"
+msgstr ""
+
+#, c-format
+msgid "invalid commit-graph chain: line '%s' not a hash"
+msgstr ""
+
+#, fuzzy
+msgid "unable to find all commit-graph files"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+msgid "invalid commit position. commit-graph is likely corrupt"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not find commit %s"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+msgid "commit-graph requires overflow generation data but has none"
+msgstr ""
+
+msgid "commit-graph overflow generation data is too small"
+msgstr ""
+
+msgid "commit-graph extra-edges pointer out of bounds"
+msgstr ""
+
+msgid "Loading known commits in commit graph"
+msgstr ""
+
+msgid "Expanding reachable commits in commit graph"
+msgstr ""
+
+msgid "Clearing commit marks in commit graph"
+msgstr ""
+
+msgid "Computing commit graph topological levels"
+msgstr ""
+
+msgid "Computing commit graph generation numbers"
+msgstr ""
+
+msgid "Computing commit changed paths Bloom filters"
+msgstr ""
+
+msgid "Collecting referenced commits"
+msgstr ""
+
+#, c-format
+msgid "Finding commits for commit graph in %<PRIuMAX> pack"
+msgid_plural "Finding commits for commit graph in %<PRIuMAX> packs"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy, c-format
+msgid "error adding pack %s"
+msgstr "fsck earráid i rudaí pacáiste"
+
+#, c-format
+msgid "error opening index for %s"
+msgstr ""
+
+msgid "Finding commits for commit graph among packed objects"
+msgstr ""
+
+msgid "Finding extra edges in commit graph"
+msgstr ""
+
+msgid "failed to write correct number of base graph ids"
+msgstr ""
+
+#, fuzzy
+msgid "unable to create temporary graph layer"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, fuzzy, c-format
+msgid "unable to adjust shared permissions for '%s'"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+#, c-format
+msgid "Writing out commit graph in %d pass"
+msgid_plural "Writing out commit graph in %d passes"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, fuzzy
+msgid "unable to open commit-graph chain file"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+msgid "failed to rename base commit-graph file"
+msgstr ""
+
+#, fuzzy
+msgid "failed to rename temporary commit-graph file"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, c-format
+msgid "cannot merge graphs with %<PRIuMAX>, %<PRIuMAX> commits"
+msgstr ""
+
+#, c-format
+msgid "cannot merge graph %s, too many commits: %<PRIuMAX>"
+msgstr ""
+
+msgid "Scanning merged commits"
+msgstr ""
+
+msgid "Merging commit-graph"
+msgstr ""
+
+msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
+msgstr ""
+
+#, c-format
+msgid ""
+"attempting to write a commit-graph, but 'commitGraph.changedPathsVersion' "
+"(%d) is not supported"
+msgstr ""
+
+msgid "too many commits to write graph"
+msgstr ""
+
+msgid "the commit-graph file has incorrect checksum and is likely corrupt"
+msgstr ""
+
+#, c-format
+msgid "commit-graph has incorrect OID order: %s then %s"
+msgstr ""
+
+#, c-format
+msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to parse commit %s from commit-graph"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "failed to parse commit %s from object database for commit-graph"
+msgstr ""
+
+#, c-format
+msgid "root tree OID for commit %s in commit-graph is %s != %s"
+msgstr ""
+
+#, c-format
+msgid "commit-graph parent list for commit %s is too long"
+msgstr ""
+
+#, c-format
+msgid "commit-graph parent for %s is %s != %s"
+msgstr ""
+
+#, c-format
+msgid "commit-graph parent list for commit %s terminates early"
+msgstr ""
+
+#, c-format
+msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
+msgstr ""
+
+#, c-format
+msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
+msgstr ""
+
+#, c-format
+msgid ""
+"commit-graph has both zero and non-zero generations (e.g., commits '%s' and "
+"'%s')"
+msgstr ""
+
+msgid "Verifying commits in commit graph"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse commit %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "%s %s is not a commit!"
+msgstr ""
+
+msgid ""
+"Support for <GIT_DIR>/info/grafts is deprecated\n"
+"and will be removed in a future Git version.\n"
+"\n"
+"Please use \"git replace --convert-graft-file\"\n"
+"to convert the grafts into replace refs.\n"
+"\n"
+"Turn this message off by running\n"
+"\"git config set advice.graftFileDeprecated false\""
+msgstr ""
+
+#, c-format
+msgid "commit %s exists in commit-graph but not in the object database"
+msgstr ""
+
+#, c-format
+msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
+msgstr ""
+
+#, c-format
+msgid "Commit %s has a bad GPG signature allegedly by %s."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Commit %s does not have a GPG signature."
+msgstr "níl ár leagan ag cosán '%s'"
+
+#, c-format
+msgid "Commit %s has a good GPG signature by %s\n"
+msgstr ""
+
+msgid ""
+"Warning: commit message did not conform to UTF-8.\n"
+"You may want to amend it after fixing the message, or set the config\n"
+"variable i18n.commitEncoding to the encoding your project uses.\n"
+msgstr ""
+
+msgid "no compiler information available\n"
+msgstr ""
+
+msgid "no libc information available\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not determine free disk size for '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not get info for '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "[GLE %ld] health thread could not open '%ls'"
+msgstr ""
+
+#, c-format
+msgid "[GLE %ld] health thread getting BHFI for '%ls'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not convert to wide characters: '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "BHFI changed '%ls'"
+msgstr ""
+
+#, c-format
+msgid "unhandled case in 'has_worktree_moved': %d"
+msgstr ""
+
+#, c-format
+msgid "health thread wait failed [GLE %ld]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Invalid path: %s"
+msgstr "%s neamhbhailí"
+
+#, fuzzy
+msgid "Unable to create FSEventStream."
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy
+msgid "Failed to start the FSEventStream"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+#, c-format
+msgid "[GLE %ld] could not convert path to UTF-8: '%.*ls'"
+msgstr ""
+
+#, c-format
+msgid "[GLE %ld] could not watch '%s'"
+msgstr ""
+
+#, c-format
+msgid "[GLE %ld] could not get longname of '%s'"
+msgstr ""
+
+#, c-format
+msgid "ReadDirectoryChangedW failed on '%s' [GLE %ld]"
+msgstr ""
+
+#, c-format
+msgid "GetOverlappedResult failed on '%s' [GLE %ld]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read directory changes [GLE %ld]"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid "opendir('%s') failed"
+msgstr ""
+
+#, c-format
+msgid "lstat('%s') failed"
+msgstr ""
+
+#, c-format
+msgid "strbuf_readlink('%s') failed"
+msgstr ""
+
+#, c-format
+msgid "closedir('%s') failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "[GLE %ld] unable to open for read '%ls'"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "[GLE %ld] unable to get protocol information for '%ls'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to copy SID (%ld)"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, fuzzy, c-format
+msgid "failed to get owner for '%s' (%ld)"
+msgstr "theip ar athrá thar '%s'"
+
+msgid "memory exhausted"
+msgstr ""
+
+msgid "Success"
+msgstr ""
+
+msgid "No match"
+msgstr ""
+
+msgid "Invalid regular expression"
+msgstr ""
+
+msgid "Invalid collation character"
+msgstr ""
+
+msgid "Invalid character class name"
+msgstr ""
+
+msgid "Trailing backslash"
+msgstr ""
+
+#, fuzzy
+msgid "Invalid back reference"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "Unmatched [ or [^"
+msgstr ""
+
+msgid "Unmatched ( or \\("
+msgstr ""
+
+msgid "Unmatched \\{"
+msgstr ""
+
+msgid "Invalid content of \\{\\}"
+msgstr ""
+
+msgid "Invalid range end"
+msgstr ""
+
+msgid "Memory exhausted"
+msgstr ""
+
+msgid "Invalid preceding regular expression"
+msgstr ""
+
+msgid "Premature end of regular expression"
+msgstr ""
+
+msgid "Regular expression too big"
+msgstr ""
+
+msgid "Unmatched ) or \\)"
+msgstr ""
+
+msgid "No previous regular expression"
+msgstr ""
+
+msgid "could not send IPC command"
+msgstr ""
+
+#, fuzzy
+msgid "could not read IPC response"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not start accept_thread '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not start worker[0] for '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "ConnectNamedPipe failed for '%s' (%lu)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not create fd from pipe for '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not start thread[0] for '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "wait for hEvent failed for '%s'"
+msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
+
+msgid "cannot resume in the background, please use 'fg' to resume"
+msgstr ""
+
+msgid "cannot restore terminal settings"
+msgstr ""
+
+#, c-format
+msgid ""
+"exceeded maximum include depth (%d) while including\n"
+"\t%s\n"
+"from\n"
+"\t%s\n"
+"This might be due to circular includes."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not expand include path '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+msgid "relative config includes must come from files"
+msgstr ""
+
+msgid "relative config include conditionals must come from files"
+msgstr ""
+
+msgid ""
+"remote URLs cannot be configured in file directly or indirectly included by "
+"includeIf.hasconfig:remote.*.url"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid config format: %s"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "missing environment variable name for configuration '%.*s'"
+msgstr ""
+
+#, c-format
+msgid "missing environment variable '%s' for configuration '%.*s'"
+msgstr ""
+
+#, c-format
+msgid "key does not contain a section: %s"
+msgstr ""
+
+#, c-format
+msgid "key does not contain variable name: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid key: %s"
+msgstr "%s neamhbhailí"
+
+#, fuzzy, c-format
+msgid "invalid key (newline): %s"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "empty config key"
+msgstr ""
+
+#, c-format
+msgid "bogus config parameter: %s"
+msgstr ""
+
+#, c-format
+msgid "bogus format in %s"
+msgstr ""
+
+#, c-format
+msgid "bogus count in %s"
+msgstr ""
+
+#, c-format
+msgid "too many entries in %s"
+msgstr ""
+
+#, c-format
+msgid "missing config key %s"
+msgstr ""
+
+#, c-format
+msgid "missing config value %s"
+msgstr ""
+
+#, c-format
+msgid "bad config line %d in blob %s"
+msgstr ""
+
+#, c-format
+msgid "bad config line %d in file %s"
+msgstr ""
+
+#, c-format
+msgid "bad config line %d in standard input"
+msgstr ""
+
+#, c-format
+msgid "bad config line %d in submodule-blob %s"
+msgstr ""
+
+#, c-format
+msgid "bad config line %d in command line %s"
+msgstr ""
+
+#, c-format
+msgid "bad config line %d in %s"
+msgstr ""
+
+msgid "out of range"
+msgstr ""
+
+#, fuzzy
+msgid "invalid unit"
+msgstr "%s neamhbhailí"
+
+#, c-format
+msgid "bad numeric config value '%s' for '%s': %s"
+msgstr ""
+
+#, c-format
+msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
+msgstr ""
+
+#, c-format
+msgid "bad numeric config value '%s' for '%s' in file %s: %s"
+msgstr ""
+
+#, c-format
+msgid "bad numeric config value '%s' for '%s' in standard input: %s"
+msgstr ""
+
+#, c-format
+msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
+msgstr ""
+
+#, c-format
+msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
+msgstr ""
+
+#, c-format
+msgid "bad numeric config value '%s' for '%s' in %s: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid value for variable %s"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "ignoring unknown core.fsync component '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bad boolean config value '%s' for '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "failed to expand user dir in: '%s'"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "'%s' for '%s' is not a valid timestamp"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid "abbrev length out of range: %d"
+msgstr ""
+
+#, c-format
+msgid "bad zlib compression level %d"
+msgstr ""
+
+#, c-format
+msgid "%s cannot contain newline"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s must have at least one character"
+msgstr "ní chóir go mbeadh carachtair líne nua ag roghanna brú"
+
+#, c-format
+msgid "ignoring unknown core.fsyncMethod value '%s'"
+msgstr ""
+
+msgid "core.fsyncObjectFiles is deprecated; use core.fsync instead"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid mode for object creation: %s"
+msgstr "réad blob neamhbhailí %s"
+
+#, fuzzy, c-format
+msgid "malformed value for %s"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "malformed value for %s: %s"
+msgstr "luach neamhbhailí do '%s'"
+
+msgid "must be one of nothing, matching, simple, upstream or current"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to load config blob object '%s'"
+msgstr "réad blob neamhbhailí %s"
+
+#, fuzzy, c-format
+msgid "reference '%s' does not point to a blob"
+msgstr "Ní chuireann HEAD in iúl do bhrainse"
+
+#, fuzzy, c-format
+msgid "unable to resolve config blob '%s'"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy
+msgid "unable to parse command-line config"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+msgid "unknown error occurred while reading the configuration files"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Invalid %s: '%s'"
+msgstr "%s neamhbhailí"
+
+#, c-format
+msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to parse '%s' from command-line config"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "bad config variable '%s' in file '%s' at line %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid section name '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "%s has multiple values"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to write new configuration file %s"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "no multi-line comment allowed: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not lock config file %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "opening %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid config file %s"
+msgstr "réad blob neamhbhailí %s"
+
+#, c-format
+msgid "fstat on %s failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to mmap '%s'%s"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "chmod on %s failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not write config file %s"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "could not set '%s' to '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "invalid section name: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "refusing to work with overly long line in '%s' on line %<PRIuMAX>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "missing value for '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+msgid "the remote end hung up upon initial contact"
+msgstr ""
+
+msgid ""
+"Could not read from remote repository.\n"
+"\n"
+"Please make sure you have the correct access rights\n"
+"and the repository exists."
+msgstr ""
+
+#, c-format
+msgid "server doesn't support '%s'"
+msgstr ""
+
+#, c-format
+msgid "server doesn't support feature '%s'"
+msgstr ""
+
+msgid "expected flush after capabilities"
+msgstr ""
+
+#, c-format
+msgid "ignoring capabilities after first line '%s'"
+msgstr ""
+
+msgid "protocol error: unexpected capabilities^{}"
+msgstr ""
+
+#, c-format
+msgid "protocol error: expected shallow sha-1, got '%s'"
+msgstr ""
+
+msgid "repository on the other end cannot be shallow"
+msgstr ""
+
+#, fuzzy
+msgid "invalid packet"
+msgstr "%s neamhbhailí"
+
+#, c-format
+msgid "protocol error: unexpected '%s'"
+msgstr ""
+
+#, c-format
+msgid "unknown object format '%s' specified by server"
+msgstr ""
+
+#, c-format
+msgid "error on bundle-uri response line %d: %s"
+msgstr ""
+
+msgid "expected flush after bundle-uri listing"
+msgstr ""
+
+msgid "expected response end packet after ref listing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid ls-refs response: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "expected flush after ref listing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "protocol '%s' is not supported"
+msgstr "níl an stóras '%s' ann"
+
+msgid "unable to set SO_KEEPALIVE on socket"
+msgstr ""
+
+#, c-format
+msgid "Looking up %s ... "
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to look up %s (port %s) (%s)"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#. TRANSLATORS: this is the end of "Looking up %s ... "
+#, c-format
+msgid ""
+"done.\n"
+"Connecting to %s (port %s) ... "
+msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"unable to connect to %s:\n"
+"%s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
+#, fuzzy
+msgid "done."
+msgstr "déanta.\n"
+
+#, fuzzy, c-format
+msgid "unable to look up %s (%s)"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy, c-format
+msgid "unknown port %s"
+msgstr "algartam hais anaithnid '%s'"
+
+#, c-format
+msgid "strange hostname '%s' blocked"
+msgstr ""
+
+#, c-format
+msgid "strange port '%s' blocked"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot start proxy %s"
+msgstr "ní féidir le pacáiste fstat"
+
+msgid "no path specified; see 'git help pull' for valid url syntax"
+msgstr ""
+
+msgid "newline is forbidden in git:// hosts and repo paths"
+msgstr ""
+
+msgid "ssh variant 'simple' does not support -4"
+msgstr ""
+
+msgid "ssh variant 'simple' does not support -6"
+msgstr ""
+
+msgid "ssh variant 'simple' does not support setting port"
+msgstr ""
+
+#, c-format
+msgid "strange pathname '%s' blocked"
+msgstr ""
+
+#, fuzzy
+msgid "unable to fork"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy
+msgid "Could not run 'git rev-list'"
+msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
+
+#, fuzzy
+msgid "failed write to rev-list"
+msgstr "theip ar nasc '%s' a chruthú"
+
+msgid "failed to close rev-list's stdin"
+msgstr ""
+
+#, c-format
+msgid "illegal crlf_action %d"
+msgstr ""
+
+#, c-format
+msgid "CRLF would be replaced by LF in %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"in the working copy of '%s', CRLF will be replaced by LF the next time Git "
+"touches it"
+msgstr ""
+
+#, c-format
+msgid "LF would be replaced by CRLF in %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"in the working copy of '%s', LF will be replaced by CRLF the next time Git "
+"touches it"
+msgstr ""
+
+#, c-format
+msgid "BOM is prohibited in '%s' if encoded as %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The file '%s' contains a byte order mark (BOM). Please use UTF-%.*s as "
+"working-tree-encoding."
+msgstr ""
+
+#, c-format
+msgid "BOM is required in '%s' if encoded as %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The file '%s' is missing a byte order mark (BOM). Please use UTF-%sBE or UTF-"
+"%sLE (depending on the byte order) as working-tree-encoding."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to encode '%s' from %s to %s"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+#, c-format
+msgid "encoding '%s' from %s to %s and back is not the same"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot fork to run external filter '%s'"
+msgstr "Ní féidir comhad pacáiste atá ann cheana '%s' a oscailt"
+
+#, fuzzy, c-format
+msgid "cannot feed the input to external filter '%s'"
+msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
+
+#, c-format
+msgid "external filter '%s' failed %d"
+msgstr ""
+
+#, c-format
+msgid "read from external filter '%s' failed"
+msgstr ""
+
+#, c-format
+msgid "external filter '%s' failed"
+msgstr ""
+
+msgid "unexpected filter type"
+msgstr ""
+
+msgid "path name too long for external filter"
+msgstr ""
+
+#, c-format
+msgid ""
+"external filter '%s' is not available anymore although not all paths have "
+"been filtered"
+msgstr ""
+
+msgid "true/false are no valid working-tree-encodings"
+msgstr ""
+
+#, c-format
+msgid "%s: clean filter '%s' failed"
+msgstr ""
+
+#, c-format
+msgid "%s: smudge filter %s failed"
+msgstr ""
+
+#, c-format
+msgid "skipping credential lookup for key: credential.%s"
+msgstr ""
+
+msgid "refusing to work with credential missing host field"
+msgstr ""
+
+msgid "refusing to work with credential missing protocol field"
+msgstr ""
+
+#, c-format
+msgid "url contains a newline in its %s component: %s"
+msgstr ""
+
+#, c-format
+msgid "url has no scheme: %s"
+msgstr ""
+
+#, c-format
+msgid "credential url cannot be parsed: %s"
+msgstr ""
+
+#, c-format
+msgid "invalid timeout '%s', expecting a non-negative integer"
+msgstr ""
+
+#, c-format
+msgid "invalid init-timeout '%s', expecting a non-negative integer"
+msgstr ""
+
+#, c-format
+msgid "invalid max-connections '%s', expecting an integer"
+msgstr ""
+
+msgid "in the future"
+msgstr ""
+
+#, c-format
+msgid "%<PRIuMAX> second ago"
+msgid_plural "%<PRIuMAX> seconds ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%<PRIuMAX> minute ago"
+msgid_plural "%<PRIuMAX> minutes ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%<PRIuMAX> hour ago"
+msgid_plural "%<PRIuMAX> hours ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%<PRIuMAX> day ago"
+msgid_plural "%<PRIuMAX> days ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%<PRIuMAX> week ago"
+msgid_plural "%<PRIuMAX> weeks ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%<PRIuMAX> month ago"
+msgid_plural "%<PRIuMAX> months ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%<PRIuMAX> year"
+msgid_plural "%<PRIuMAX> years"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#. TRANSLATORS: "%s" is "<n> years"
+#, c-format
+msgid "%s, %<PRIuMAX> month ago"
+msgid_plural "%s, %<PRIuMAX> months ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "%<PRIuMAX> year ago"
+msgid_plural "%<PRIuMAX> years ago"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "Propagating island marks"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bad tree object %s"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "failed to load island regex for '%s': %s"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, c-format
+msgid "island regex from config has too many capture groups (max=%d)"
+msgstr ""
+
+#, c-format
+msgid "Marked %d islands, done.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid --%s value '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "could not archive missing directory '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "could not open directory '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid "skipping '%s', which is neither file nor directory"
+msgstr ""
+
+#, fuzzy
+msgid "could not duplicate stdout"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not add directory '%s' to archiver"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, fuzzy
+msgid "failed to write archive"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+msgid "--merge-base does not work with ranges"
+msgstr ""
+
+#, fuzzy
+msgid "unable to get HEAD"
+msgstr "in ann HEAD a nuashonrú"
+
+msgid "no merge base found"
+msgstr ""
+
+msgid "multiple merge bases found"
+msgstr ""
+
+msgid "cannot compare stdin to a directory"
+msgstr ""
+
+msgid "cannot compare a named pipe to a directory"
+msgstr ""
+
+#, fuzzy
+msgid "git diff --no-index [<options>] <path> <path>"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+
+msgid ""
+"Not a git repository. Use --no-index to compare two paths outside a working "
+"tree"
+msgstr ""
+
+#, c-format
+msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "  Unknown dirstat parameter '%s'\n"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+msgid ""
+"color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
+"'dimmed-zebra', 'plain'"
+msgstr ""
+
+#, c-format
+msgid ""
+"unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
+"'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-change'"
+msgstr ""
+
+msgid ""
+"color-moved-ws: allow-indentation-change cannot be combined with other "
+"whitespace modes"
+msgstr ""
+
+#, c-format
+msgid "Unknown value for 'diff.submodule' config variable: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown value for config '%s': %s"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+#, c-format
+msgid ""
+"Found errors in 'diff.dirstat' config variable:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid "external diff died, stopping at %s"
+msgstr ""
+
+msgid "--follow requires exactly one pathspec"
+msgstr ""
+
+#, c-format
+msgid "pathspec magic not supported by --follow: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "options '%s', '%s', '%s', and '%s' cannot be used together"
+msgstr "ní féidir na roghanna '-%c', '-%c', agus '%s' a úsáid le chéile"
+
+#, fuzzy, c-format
+msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+#, fuzzy, c-format
+msgid ""
+"options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+#, fuzzy, c-format
+msgid "invalid --stat value: %s"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "%s expects a numerical value"
+msgstr ""
+
+#, c-format
+msgid ""
+"Failed to parse --dirstat/-X option parameter:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid "unknown change class '%c' in --diff-filter=%s"
+msgstr ""
+
+#, c-format
+msgid "unknown value after ws-error-highlight=%.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to resolve '%s'"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "%s expects <n>/<m> form"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s expects a character, got '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, c-format
+msgid "bad --color-moved argument: %s"
+msgstr ""
+
+#, c-format
+msgid "invalid mode '%s' in --color-moved-ws"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid argument to %s"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "invalid regex given to -I: '%s'"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "-G requires a non-empty argument"
+msgstr ""
+
+msgid "-S requires a non-empty argument"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to parse --submodule option parameter: '%s'"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+#, c-format
+msgid "bad --word-diff argument: %s"
+msgstr ""
+
+msgid "Diff output format options"
+msgstr ""
+
+#, fuzzy
+msgid "generate patch"
+msgstr "Cosáin neamh-chumasaithe:"
+
+msgid "<n>"
+msgstr ""
+
+msgid "generate diffs with <n> lines context"
+msgstr ""
+
+msgid "generate the diff in raw format"
+msgstr ""
+
+msgid "synonym for '-p --raw'"
+msgstr ""
+
+msgid "synonym for '-p --stat'"
+msgstr ""
+
+#, fuzzy
+msgid "machine friendly --stat"
+msgstr "aschur inléite meaisín"
+
+msgid "output only the last line of --stat"
+msgstr ""
+
+msgid "<param1>,<param2>..."
+msgstr ""
+
+msgid ""
+"output the distribution of relative amount of changes for each sub-directory"
+msgstr ""
+
+msgid "synonym for --dirstat=cumulative"
+msgstr ""
+
+msgid "synonym for --dirstat=files,<param1>,<param2>..."
+msgstr ""
+
+msgid "warn if changes introduce conflict markers or whitespace errors"
+msgstr ""
+
+msgid "condensed summary such as creations, renames and mode changes"
+msgstr ""
+
+msgid "show only names of changed files"
+msgstr ""
+
+msgid "show only names and status of changed files"
+msgstr ""
+
+msgid "<width>[,<name-width>[,<count>]]"
+msgstr ""
+
+msgid "generate diffstat"
+msgstr ""
+
+msgid "<width>"
+msgstr ""
+
+msgid "generate diffstat with a given width"
+msgstr ""
+
+msgid "generate diffstat with a given name width"
+msgstr ""
+
+msgid "generate diffstat with a given graph width"
+msgstr ""
+
+msgid "<count>"
+msgstr ""
+
+msgid "generate diffstat with limited lines"
+msgstr ""
+
+msgid "generate compact summary in diffstat"
+msgstr ""
+
+msgid "output a binary diff that can be applied"
+msgstr ""
+
+msgid "show full pre- and post-image object names on the \"index\" lines"
+msgstr ""
+
+msgid "show colored diff"
+msgstr ""
+
+msgid "<kind>"
+msgstr ""
+
+msgid ""
+"highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
+"diff"
+msgstr ""
+
+msgid ""
+"do not munge pathnames and use NULs as output field terminators in --raw or "
+"--numstat"
+msgstr ""
+
+msgid "<prefix>"
+msgstr ""
+
+msgid "show the given source prefix instead of \"a/\""
+msgstr ""
+
+msgid "show the given destination prefix instead of \"b/\""
+msgstr ""
+
+msgid "prepend an additional prefix to every line of output"
+msgstr ""
+
+msgid "do not show any source or destination prefix"
+msgstr ""
+
+msgid "use default prefixes a/ and b/"
+msgstr ""
+
+msgid "show context between diff hunks up to the specified number of lines"
+msgstr ""
+
+msgid "<char>"
+msgstr ""
+
+msgid "specify the character to indicate a new line instead of '+'"
+msgstr ""
+
+msgid "specify the character to indicate an old line instead of '-'"
+msgstr ""
+
+msgid "specify the character to indicate a context instead of ' '"
+msgstr ""
+
+msgid "Diff rename options"
+msgstr ""
+
+msgid "<n>[/<m>]"
+msgstr ""
+
+msgid "break complete rewrite changes into pairs of delete and create"
+msgstr ""
+
+msgid "detect renames"
+msgstr ""
+
+msgid "omit the preimage for deletes"
+msgstr ""
+
+msgid "detect copies"
+msgstr ""
+
+msgid "use unmodified files as source to find copies"
+msgstr ""
+
+msgid "disable rename detection"
+msgstr ""
+
+msgid "use empty blobs as rename source"
+msgstr ""
+
+msgid "continue listing the history of a file beyond renames"
+msgstr ""
+
+msgid ""
+"prevent rename/copy detection if the number of rename/copy targets exceeds "
+"given limit"
+msgstr ""
+
+msgid "Diff algorithm options"
+msgstr ""
+
+msgid "produce the smallest possible diff"
+msgstr ""
+
+msgid "ignore whitespace when comparing lines"
+msgstr ""
+
+msgid "ignore changes in amount of whitespace"
+msgstr ""
+
+msgid "ignore changes in whitespace at EOL"
+msgstr ""
+
+msgid "ignore carrier-return at the end of line"
+msgstr ""
+
+msgid "ignore changes whose lines are all blank"
+msgstr ""
+
+msgid "<regex>"
+msgstr ""
+
+msgid "ignore changes whose all lines match <regex>"
+msgstr ""
+
+msgid "heuristic to shift diff hunk boundaries for easy reading"
+msgstr ""
+
+msgid "generate diff using the \"patience diff\" algorithm"
+msgstr ""
+
+msgid "generate diff using the \"histogram diff\" algorithm"
+msgstr ""
+
+msgid "<text>"
+msgstr ""
+
+msgid "generate diff using the \"anchored diff\" algorithm"
+msgstr ""
+
+msgid "<mode>"
+msgstr ""
+
+msgid "show word diff, using <mode> to delimit changed words"
+msgstr ""
+
+msgid "use <regex> to decide what a word is"
+msgstr ""
+
+msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
+msgstr ""
+
+msgid "moved lines of code are colored differently"
+msgstr ""
+
+msgid "how white spaces are ignored in --color-moved"
+msgstr ""
+
+msgid "Other diff options"
+msgstr ""
+
+msgid "when run from subdir, exclude changes outside and show relative paths"
+msgstr ""
+
+msgid "treat all files as text"
+msgstr ""
+
+msgid "swap two inputs, reverse the diff"
+msgstr ""
+
+msgid "exit with 1 if there were differences, 0 otherwise"
+msgstr ""
+
+msgid "disable all output of the program"
+msgstr ""
+
+msgid "allow an external diff helper to be executed"
+msgstr ""
+
+msgid "run external text conversion filters when comparing binary files"
+msgstr ""
+
+msgid "<when>"
+msgstr ""
+
+msgid "ignore changes to submodules in the diff generation"
+msgstr ""
+
+#, fuzzy
+msgid "<format>"
+msgstr "formáid"
+
+msgid "specify how differences in submodules are shown"
+msgstr ""
+
+#, fuzzy
+msgid "hide 'git add -N' entries from the index"
+msgstr "Nuashonraíodh %d cosán ón innéacs"
+
+msgid "treat 'git add -N' entries as real in the index"
+msgstr ""
+
+msgid "<string>"
+msgstr ""
+
+msgid ""
+"look for differences that change the number of occurrences of the specified "
+"string"
+msgstr ""
+
+msgid ""
+"look for differences that change the number of occurrences of the specified "
+"regex"
+msgstr ""
+
+msgid "show all changes in the changeset with -S or -G"
+msgstr ""
+
+msgid "treat <string> in -S as extended POSIX regular expression"
+msgstr ""
+
+msgid "control the order in which files appear in the output"
+msgstr ""
+
+#, fuzzy
+msgid "<path>"
+msgstr "cosán"
+
+msgid "show the change in the specified path first"
+msgstr ""
+
+msgid "skip the output to the specified path"
+msgstr ""
+
+msgid "<object-id>"
+msgstr ""
+
+msgid ""
+"look for differences that change the number of occurrences of the specified "
+"object"
+msgstr ""
+
+msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
+msgstr ""
+
+msgid "select files by diff type"
+msgstr ""
+
+msgid "<file>"
+msgstr ""
+
+msgid "output to a specific file"
+msgstr ""
+
+msgid "exhaustive rename detection was skipped due to too many files."
+msgstr ""
+
+msgid "only found copies from modified paths due to too many files."
+msgstr ""
+
+#, c-format
+msgid ""
+"you may want to set your %s variable to at least %d and retry the command."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to read orderfile '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+msgid "Performing inexact rename detection"
+msgstr ""
+
+#, c-format
+msgid "No such path '%s' in the diff"
+msgstr ""
+
+#, c-format
+msgid "pathspec '%s' did not match any file(s) known to git"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unrecognized pattern: '%s'"
+msgstr "aistriú luacha transfer.credentialsInUrl: '%s'"
+
+#, fuzzy, c-format
+msgid "unrecognized negative pattern: '%s'"
+msgstr "aistriú luacha transfer.credentialsInUrl: '%s'"
+
+#, c-format
+msgid "your sparse-checkout file may have issues: pattern '%s' is repeated"
+msgstr ""
+
+msgid "disabling cone pattern matching"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot use %s as an exclude file"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+msgid "failed to get kernel name and information"
+msgstr ""
+
+msgid "untracked cache is disabled on this system or location"
+msgstr ""
+
+msgid ""
+"No directory name could be guessed.\n"
+"Please specify a directory on the command line"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "index file corrupt in repo %s"
+msgstr "comhad innéacs truaillithe"
+
+#, fuzzy, c-format
+msgid "could not create directories for %s"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "could not migrate git directory from '%s' to '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid "hint: Waiting for your editor to close the file...%c"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not write to '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not edit '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "Filtering content"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not stat file '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "bad git namespace path \"%s\""
+msgstr ""
+
+#, fuzzy, c-format
+msgid "too many args to run %s"
+msgstr "An iomarca argóintí."
+
+#, c-format
+msgid ""
+"You are attempting to fetch %s, which is in the commit graph file but not in "
+"the object database.\n"
+"This is probably due to repo corruption.\n"
+"If you are attempting to repair this repo corruption by refetching the "
+"missing object, use 'git fetch --refetch' with the missing object."
+msgstr ""
+
+msgid "git fetch-pack: expected shallow list"
+msgstr ""
+
+msgid "git fetch-pack: expected a flush packet after shallow list"
+msgstr ""
+
+msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "git fetch-pack: expected ACK/NAK, got '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, fuzzy
+msgid "unable to write to remote"
+msgstr "nach féidir crann a léamh (%s)"
+
+msgid "Server supports filter"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid shallow line: %s"
+msgstr "réad blob neamhbhailí %s"
+
+#, fuzzy, c-format
+msgid "invalid unshallow line: %s"
+msgstr "réad blob neamhbhailí %s"
+
+#, c-format
+msgid "object not found: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "error in object: %s"
+msgstr "fsck earráid i rudaí pacáiste"
+
+#, c-format
+msgid "no shallow found: %s"
+msgstr ""
+
+#, c-format
+msgid "expected shallow/unshallow, got %s"
+msgstr ""
+
+#, c-format
+msgid "got %s %d %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid commit %s"
+msgstr "%s neamhbhailí"
+
+msgid "giving up"
+msgstr ""
+
+#, fuzzy
+msgid "done"
+msgstr "déanta.\n"
+
+#, c-format
+msgid "got %s (%d) %s"
+msgstr ""
+
+#, c-format
+msgid "Marking %s as complete"
+msgstr ""
+
+#, c-format
+msgid "already have %s (%s)"
+msgstr ""
+
+msgid "fetch-pack: unable to fork off sideband demultiplexer"
+msgstr ""
+
+msgid "protocol error: bad pack header"
+msgstr ""
+
+#, c-format
+msgid "fetch-pack: unable to fork off %s"
+msgstr ""
+
+msgid "fetch-pack: invalid index-pack output"
+msgstr ""
+
+#, c-format
+msgid "%s failed"
+msgstr ""
+
+msgid "error in sideband demultiplexer"
+msgstr ""
+
+#, c-format
+msgid "Server version is %.*s"
+msgstr ""
+
+#, c-format
+msgid "Server supports %s"
+msgstr ""
+
+msgid "Server does not support shallow clients"
+msgstr ""
+
+msgid "Server does not support --shallow-since"
+msgstr ""
+
+msgid "Server does not support --shallow-exclude"
+msgstr ""
+
+msgid "Server does not support --deepen"
+msgstr ""
+
+msgid "Server does not support this repository's object format"
+msgstr ""
+
+#, fuzzy
+msgid "no common commits"
+msgstr "aon rud le tiomantas\n"
+
+msgid "git fetch-pack: fetch failed."
+msgstr ""
+
+#, c-format
+msgid "mismatched algorithms: client %s; server %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "the server does not support algorithm '%s'"
+msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
+
+msgid "Server does not support shallow requests"
+msgstr ""
+
+#, fuzzy
+msgid "unable to write request to remote"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+#, fuzzy, c-format
+msgid "expected '%s', received '%s'"
+msgstr "tá %s ag teastáil don rogha '%s'"
+
+#, fuzzy, c-format
+msgid "expected '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, c-format
+msgid "unexpected acknowledgment line: '%s'"
+msgstr ""
+
+#, c-format
+msgid "error processing acks: %d"
+msgstr ""
+
+#. TRANSLATORS: The parameter will be 'ready', a protocol
+#. keyword.
+#.
+#, c-format
+msgid "expected packfile to be sent after '%s'"
+msgstr ""
+
+#. TRANSLATORS: The parameter will be 'ready', a protocol
+#. keyword.
+#.
+#, c-format
+msgid "expected no other sections to be sent after no '%s'"
+msgstr ""
+
+#, c-format
+msgid "error processing shallow info: %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "expected wanted-ref, got '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, c-format
+msgid "unexpected wanted-ref: '%s'"
+msgstr ""
+
+#, c-format
+msgid "error processing wanted refs: %d"
+msgstr ""
+
+msgid "git fetch-pack: expected response end packet"
+msgstr ""
+
+msgid "no matching remote head"
+msgstr ""
+
+msgid "unexpected 'ready' from remote"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "no such remote ref %s"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+#, c-format
+msgid "Server does not allow request for unadvertised object %s"
+msgstr ""
+
+#, c-format
+msgid "fsmonitor_ipc__send_query: invalid path '%s'"
+msgstr ""
+
+#, c-format
+msgid "fsmonitor_ipc__send_query: unspecified error on '%s'"
+msgstr ""
+
+msgid "fsmonitor--daemon is not running"
+msgstr ""
+
+#, c-format
+msgid "could not send '%s' command to fsmonitor--daemon"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bare repository '%s' is incompatible with fsmonitor"
+msgstr "níl an stóras '%s' ann"
+
+#, c-format
+msgid "repository '%s' is incompatible with fsmonitor due to errors"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "remote repository '%s' is incompatible with fsmonitor"
+msgstr "níl an stóras '%s' ann"
+
+#, c-format
+msgid "virtual repository '%s' is incompatible with fsmonitor"
+msgstr ""
+
+#, c-format
+msgid ""
+"socket directory '%s' is incompatible with fsmonitor due to lack of Unix "
+"sockets support"
+msgstr ""
+
+msgid ""
+"git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]\n"
+"           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n"
+"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--no-"
+"lazy-fetch]\n"
+"           [--no-optional-locks] [--no-advice] [--bare] [--git-dir=<path>]\n"
+"           [--work-tree=<path>] [--namespace=<name>] [--config-"
+"env=<name>=<envvar>]\n"
+"           <command> [<args>]"
+msgstr ""
+
+msgid ""
+"'git help -a' and 'git help -g' list available subcommands and some\n"
+"concept guides. See 'git help <command>' or 'git help <concept>'\n"
+"to read about a specific subcommand or concept.\n"
+"See 'git help git' for an overview of the system."
+msgstr ""
+
+#, c-format
+msgid "unsupported command listing type '%s'"
+msgstr ""
+
+#, c-format
+msgid "no directory given for '%s' option\n"
+msgstr ""
+
+#, c-format
+msgid "no namespace given for --namespace\n"
+msgstr ""
+
+#, c-format
+msgid "-c expects a configuration string\n"
+msgstr ""
+
+#, c-format
+msgid "no config key given for --config-env\n"
+msgstr ""
+
+#, c-format
+msgid "no attribute source given for --attr-source\n"
+msgstr ""
+
+#, c-format
+msgid "unknown option: %s\n"
+msgstr ""
+
+#, c-format
+msgid "while expanding alias '%s': '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"alias '%s' changes environment variables.\n"
+"You can use '!git' in the alias to do this"
+msgstr ""
+
+#, c-format
+msgid "empty alias for %s"
+msgstr ""
+
+#, c-format
+msgid "recursive alias: %s"
+msgstr ""
+
+msgid "write failure on standard output"
+msgstr ""
+
+msgid "unknown write failure on standard output"
+msgstr ""
+
+msgid "close failed on standard output"
+msgstr ""
+
+#, c-format
+msgid "alias loop detected: expansion of '%s' does not terminate:%s"
+msgstr ""
+
+#, c-format
+msgid "cannot handle %s as a builtin"
+msgstr ""
+
+#, c-format
+msgid ""
+"usage: %s\n"
+"\n"
+msgstr ""
+
+#, c-format
+msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to run command '%s': %s\n"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy
+msgid "could not create temporary file"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "failed writing detached signature to '%s'"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+msgid ""
+"gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
+"signature verification"
+msgstr ""
+
+msgid ""
+"ssh-keygen -Y find-principals/verify is needed for ssh signature "
+"verification (available in openssh version 8.2p1+)"
+msgstr ""
+
+#, c-format
+msgid "ssh signing revocation file configured but not found: %s"
+msgstr ""
+
+#, c-format
+msgid "bad/incompatible signature '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to get the ssh fingerprint for key '%s'"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+msgid ""
+"either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
+msgstr ""
+
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
+msgstr ""
+
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"gpg failed to sign the data:\n"
+"%s"
+msgstr "theip ar '%s' a stáil"
+
+msgid "user.signingKey needs to be set for ssh signing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed writing ssh signing key to '%s'"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+#, fuzzy, c-format
+msgid "failed writing ssh signing key buffer to '%s'"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+msgid ""
+"ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
+"8.2p1+)"
+msgstr ""
+
+#, c-format
+msgid "failed reading ssh signing data buffer from '%s'"
+msgstr ""
+
+#, c-format
+msgid "ignored invalid color '%.*s' in log.graphColors"
+msgstr ""
+
+msgid ""
+"given pattern contains NULL byte (via -f <file>). This is only supported "
+"with -P under PCRE v2"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s': unable to read %s"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "'%s': short read"
+msgstr ""
+
+msgid "start a working area (see also: git help tutorial)"
+msgstr ""
+
+msgid "work on the current change (see also: git help everyday)"
+msgstr ""
+
+msgid "examine the history and state (see also: git help revisions)"
+msgstr ""
+
+msgid "grow, mark and tweak your common history"
+msgstr ""
+
+msgid "collaborate (see also: git help workflows)"
+msgstr ""
+
+msgid "Main Porcelain Commands"
+msgstr ""
+
+msgid "Ancillary Commands / Manipulators"
+msgstr ""
+
+msgid "Ancillary Commands / Interrogators"
+msgstr ""
+
+msgid "Interacting with Others"
+msgstr ""
+
+msgid "Low-level Commands / Manipulators"
+msgstr ""
+
+msgid "Low-level Commands / Interrogators"
+msgstr ""
+
+msgid "Low-level Commands / Syncing Repositories"
+msgstr ""
+
+msgid "Low-level Commands / Internal Helpers"
+msgstr ""
+
+msgid "User-facing repository, command and file interfaces"
+msgstr ""
+
+msgid "Developer-facing file formats, protocols and other interfaces"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "available git commands in '%s'"
+msgstr "theip ar nasc '%s' a chruthú"
+
+msgid "git commands available from elsewhere on your $PATH"
+msgstr ""
+
+msgid "These are common Git commands used in various situations:"
+msgstr ""
+
+msgid "The Git concept guides are:"
+msgstr ""
+
+msgid "User-facing repository, command and file interfaces:"
+msgstr ""
+
+msgid "File formats, protocols and other developer interfaces:"
+msgstr ""
+
+msgid "External commands"
+msgstr ""
+
+msgid "Command aliases"
+msgstr ""
+
+msgid "See 'git help <command>' to read about a specific subcommand"
+msgstr ""
+
+#, c-format
+msgid ""
+"'%s' appears to be a git command, but we were not\n"
+"able to execute it. Maybe git-%s is broken?"
+msgstr ""
+
+#, c-format
+msgid "git: '%s' is not a git command. See 'git --help'."
+msgstr ""
+
+msgid "Uh oh. Your system reports no Git commands at all."
+msgstr ""
+
+#, c-format
+msgid "WARNING: You called a Git command named '%s', which does not exist."
+msgstr ""
+
+#, c-format
+msgid "Continuing under the assumption that you meant '%s'."
+msgstr ""
+
+#, c-format
+msgid "Run '%s' instead [y/N]? "
+msgstr ""
+
+#, c-format
+msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
+msgstr ""
+
+msgid ""
+"\n"
+"The most similar command is"
+msgid_plural ""
+"\n"
+"The most similar commands are"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "git version [--build-options]"
+msgstr ""
+
+#, c-format
+msgid "%s: %s - %s"
+msgstr ""
+
+msgid ""
+"\n"
+"Did you mean this?"
+msgid_plural ""
+"\n"
+"Did you mean one of these?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid ""
+"The '%s' hook was ignored because it's not set as executable.\n"
+"You can disable this warning with `git config set advice.ignoredHook false`."
+msgstr ""
+
+#, fuzzy
+msgid "not a git repository"
+msgstr "stóras lom a chruthú"
+
+#, c-format
+msgid "argument to --packfile must be a valid hash (got '%s')"
+msgstr ""
+
+#, c-format
+msgid "negative value for http.postBuffer; defaulting to %d"
+msgstr ""
+
+msgid "Delegation control is not supported with cURL < 7.22.0"
+msgstr ""
+
+msgid "Unknown value for http.proactiveauth"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to parse %s"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
+msgstr ""
+
+#, c-format
+msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
+msgstr ""
+
+#, c-format
+msgid "Could not set SSL backend to '%s': already set"
+msgstr ""
+
+msgid "refusing to read cookies from http.cookiefile '-'"
+msgstr ""
+
+msgid "ignoring http.savecookies for empty http.cookiefile"
+msgstr ""
+
+#, c-format
+msgid ""
+"unable to update url base from redirection:\n"
+"  asked for: %s\n"
+"   redirect: %s"
+msgstr ""
+
+msgid "Author identity unknown\n"
+msgstr ""
+
+msgid "Committer identity unknown\n"
+msgstr ""
+
+msgid ""
+"\n"
+"*** Please tell me who you are.\n"
+"\n"
+"Run\n"
+"\n"
+"  git config --global user.email \"you@example.com\"\n"
+"  git config --global user.name \"Your Name\"\n"
+"\n"
+"to set your account's default identity.\n"
+"Omit --global to set the identity only in this repository.\n"
+"\n"
+msgstr ""
+
+msgid "no email was given and auto-detection is disabled"
+msgstr ""
+
+#, c-format
+msgid "unable to auto-detect email address (got '%s')"
+msgstr ""
+
+msgid "no name was given and auto-detection is disabled"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to auto-detect name (got '%s')"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, c-format
+msgid "empty ident name (for <%s>) not allowed"
+msgstr ""
+
+#, c-format
+msgid "name consists only of disallowed characters: %s"
+msgstr ""
+
+msgid "expected 'tree:<depth>'"
+msgstr ""
+
+msgid "sparse:path filters support has been dropped"
+msgstr ""
+
+#, c-format
+msgid "'%s' for 'object:type=<type>' is not a valid object type"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid filter-spec '%s'"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "must escape char in sub-filter-spec: '%c'"
+msgstr ""
+
+msgid "expected something after combine:"
+msgstr ""
+
+msgid "multiple filter-specs cannot be combined"
+msgstr ""
+
+msgid "unable to upgrade repository format to support partial clone"
+msgstr ""
+
+msgid "args"
+msgstr ""
+
+msgid "object filtering"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to access sparse blob in '%s'"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unable to parse sparse filter data in %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "entry '%s' in tree %s has tree mode, but is not a tree"
+msgstr ""
+
+#, c-format
+msgid "entry '%s' in tree %s has blob mode, but is not a blob"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to load root tree for commit %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid ""
+"Unable to create '%s.lock': %s.\n"
+"\n"
+"Another git process seems to be running in this repository, e.g.\n"
+"an editor opened by 'git commit'. Please make sure all processes\n"
+"are terminated then try again. If it still fails, a git process\n"
+"may have crashed in this repository earlier:\n"
+"remove the file manually to continue."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Unable to create '%s.lock': %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy
+msgid "unable to create temporary object directory"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, fuzzy, c-format
+msgid "could not write loose object index %s"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "failed to write loose object index %s"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, c-format
+msgid "unexpected line: '%s'"
+msgstr ""
+
+msgid "expected flush after ls-refs arguments"
+msgstr ""
+
+msgid "quoted CRLF detected"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to format message: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, c-format
+msgid "invalid marker-size '%s', expecting an integer"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not parse object '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "Failed to merge submodule %s (not checked out)"
+msgstr ""
+
+#, c-format
+msgid "Failed to merge submodule %s (no merge base)"
+msgstr ""
+
+#, c-format
+msgid "Failed to merge submodule %s (commits not present)"
+msgstr ""
+
+#, c-format
+msgid "error: failed to merge submodule %s (repository corrupt)"
+msgstr ""
+
+#, c-format
+msgid "Failed to merge submodule %s (commits don't follow merge-base)"
+msgstr ""
+
+#, c-format
+msgid "Note: Fast-forwarding submodule %s to %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Failed to merge submodule %s"
+msgstr "theip ar athrá thar '%s'"
+
+#, c-format
+msgid ""
+"Failed to merge submodule %s, but a possible merge resolution exists: %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Failed to merge submodule %s, but multiple possible merges exist:\n"
+"%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "error: failed to execute internal merge for %s"
+msgstr "theip ar athrá thar '%s'"
+
+#, c-format
+msgid "error: unable to add %s to database"
+msgstr ""
+
+#, c-format
+msgid "Auto-merging %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
+"implicit directory rename(s) putting the following path(s) there: %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
+"implicit directory renames tried to put these paths there: %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (directory rename split): Unclear where to rename %s to; it was "
+"renamed to multiple other directories, with no destination getting a "
+"majority of the files."
+msgstr ""
+
+#, c-format
+msgid ""
+"WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
+"renamed."
+msgstr ""
+
+#, c-format
+msgid ""
+"Path updated: %s added in %s inside a directory that was renamed in %s; "
+"moving it to %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
+"%s; moving it to %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (file location): %s added in %s inside a directory that was renamed "
+"in %s, suggesting it should perhaps be moved to %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
+"was renamed in %s, suggesting it should perhaps be moved to %s."
+msgstr ""
+
+#, c-format
+msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (rename involved in collision): rename of %s -> %s has content "
+"conflicts AND collides with another path; this may result in nested conflict "
+"markers."
+msgstr ""
+
+#, c-format
+msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "error: cannot read object %s"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+#, fuzzy, c-format
+msgid "error: object %s is not a blob"
+msgstr "tá réad áitiúil %s truaillithe"
+
+#, c-format
+msgid ""
+"CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
+"%s instead."
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (distinct types): %s had different types on each side; renamed both "
+"of them so each can be recorded somewhere."
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (distinct types): %s had different types on each side; renamed one "
+"of them so each can be recorded somewhere."
+msgstr ""
+
+msgid "content"
+msgstr ""
+
+msgid "add/add"
+msgstr ""
+
+msgid "submodule"
+msgstr ""
+
+#, c-format
+msgid "CONFLICT (%s): Merge conflict in %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
+"of %s left in tree."
+msgstr ""
+
+#. TRANSLATORS: This is a line of advice to resolve a merge
+#. conflict in a submodule. The first argument is the submodule
+#. name, and the second argument is the abbreviated id of the
+#. commit that needs to be merged.  For example:
+#.  - go to submodule (mysubmodule), and either merge commit abc1234"
+#.
+#, c-format
+msgid ""
+" - go to submodule (%s), and either merge commit %s\n"
+"   or update to an existing commit which has merged those changes\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Recursive merging with submodules currently only supports trivial cases.\n"
+"Please manually handle the merging of each conflicted submodule.\n"
+"This can be accomplished with the following steps:\n"
+"%s - come back to superproject and run:\n"
+"\n"
+"      git add %s\n"
+"\n"
+"   to record the above merge or update\n"
+" - resolve any other conflicts in the superproject\n"
+" - commit the resulting index in the superproject\n"
+msgstr ""
+
+#. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
+#. base, and 2-3) the trees for the two trees we're merging.
+#.
+#, c-format
+msgid "collecting merge info failed for trees %s, %s, %s"
+msgstr ""
+
+#, fuzzy
+msgid "failed to read the cache"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "failed to add packfile '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, fuzzy, c-format
+msgid "failed to open pack-index '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy, c-format
+msgid "failed to locate object %d in packfile"
+msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+
+#, fuzzy
+msgid "cannot store reverse index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "could not parse line: %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "malformed line: %s"
+msgstr ""
+
+#, fuzzy
+msgid "could not load pack"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not open index for %s"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, fuzzy, c-format
+msgid "unable to link '%s' to '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy, c-format
+msgid "failed to clear multi-pack-index at %s"
+msgstr "theip ar nasc '%s' a chruthú"
+
+msgid "ignoring existing multi-pack-index; checksum mismatch"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not load reverse index for MIDX %s"
+msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
+
+msgid "Adding packfiles to multi-pack-index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown preferred pack: '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, c-format
+msgid "cannot select preferred pack %s with no objects"
+msgstr ""
+
+#, c-format
+msgid "did not see pack-file %s to drop"
+msgstr ""
+
+#, c-format
+msgid "preferred pack '%s' is expired"
+msgstr ""
+
+msgid "no pack files to index."
+msgstr ""
+
+msgid "refusing to write multi-pack .bitmap without any objects"
+msgstr ""
+
+#, fuzzy
+msgid "unable to create temporary MIDX layer"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+msgid "could not write multi-pack bitmap"
+msgstr ""
+
+#, fuzzy
+msgid "unable to open multi-pack-index chain file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy
+msgid "unable to rename new multi-pack-index layer"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy
+msgid "could not write multi-pack-index"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+msgid "cannot expire packs from an incremental multi-pack-index"
+msgstr ""
+
+#, fuzzy
+msgid "Counting referenced objects"
+msgstr "níl ach tagairt amháin ag súil leis"
+
+msgid "Finding and deleting unreferenced packfiles"
+msgstr ""
+
+#, fuzzy
+msgid "cannot repack an incremental multi-pack-index"
+msgstr "ní féidir athphacáil chun glanadh"
+
+#, fuzzy
+msgid "could not start pack-objects"
+msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+
+#, fuzzy
+msgid "could not finish pack-objects"
+msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+
+msgid "multi-pack-index OID fanout is of the wrong size"
+msgstr ""
+
+#, c-format
+msgid ""
+"oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
+msgstr ""
+
+msgid "multi-pack-index OID lookup chunk is the wrong size"
+msgstr ""
+
+msgid "multi-pack-index object offset chunk is the wrong size"
+msgstr ""
+
+#, c-format
+msgid "multi-pack-index file %s is too small"
+msgstr ""
+
+#, c-format
+msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
+msgstr ""
+
+#, c-format
+msgid "multi-pack-index version %d not recognized"
+msgstr ""
+
+#, c-format
+msgid "multi-pack-index hash version %u does not match version %u"
+msgstr ""
+
+msgid "multi-pack-index required pack-name chunk missing or corrupted"
+msgstr ""
+
+msgid "multi-pack-index required OID fanout chunk missing or corrupted"
+msgstr ""
+
+msgid "multi-pack-index required OID lookup chunk missing or corrupted"
+msgstr ""
+
+msgid "multi-pack-index required object offsets chunk missing or corrupted"
+msgstr ""
+
+msgid "multi-pack-index pack-name chunk is too short"
+msgstr ""
+
+#, c-format
+msgid "multi-pack-index pack names out of order: '%s' before '%s'"
+msgstr ""
+
+msgid "multi-pack-index chain file too small"
+msgstr ""
+
+#, c-format
+msgid "pack count in base MIDX too high: %<PRIuMAX>"
+msgstr ""
+
+#, c-format
+msgid "object count in base MIDX too high: %<PRIuMAX>"
+msgstr ""
+
+#, c-format
+msgid "invalid multi-pack-index chain: line '%s' not a hash"
+msgstr ""
+
+#, fuzzy
+msgid "unable to find all multi-pack index files"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+msgid "invalid MIDX object position, MIDX is likely corrupt"
+msgstr ""
+
+#, c-format
+msgid "bad pack-int-id: %u (%u total packs)"
+msgstr ""
+
+msgid "MIDX does not contain the BTMP chunk"
+msgstr ""
+
+#, c-format
+msgid "could not load bitmapped pack %<PRIu32>"
+msgstr ""
+
+msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
+msgstr ""
+
+#, fuzzy
+msgid "multi-pack-index large offset out of bounds"
+msgstr "tá fhritháireamh bonn delta as ceangailte"
+
+msgid "multi-pack-index file exists, but failed to parse"
+msgstr ""
+
+msgid "incorrect checksum"
+msgstr ""
+
+#, fuzzy
+msgid "Looking for referenced packfiles"
+msgstr "níl ach tagairt amháin ag súil leis"
+
+msgid "the midx contains no oid"
+msgstr ""
+
+msgid "Verifying OID order in multi-pack-index"
+msgstr ""
+
+#, c-format
+msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
+msgstr ""
+
+msgid "Sorting objects by packfile"
+msgstr ""
+
+#, fuzzy
+msgid "Verifying object offsets"
+msgstr "Rudaí a fháil"
+
+#, c-format
+msgid "failed to load pack entry for oid[%d] = %s"
+msgstr ""
+
+#, c-format
+msgid "failed to load pack-index for packfile %s"
+msgstr ""
+
+#, c-format
+msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to create lazy_dir thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "unable to create lazy_name thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "unable to join lazy_name thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, c-format
+msgid ""
+"You have not concluded your previous notes merge (%s exists).\n"
+"Please, use 'git notes merge --commit' or 'git notes merge --abort' to "
+"commit/abort the previous merge before you start a new notes merge."
+msgstr ""
+
+#, c-format
+msgid "You have not concluded your notes merge (%s exists)."
+msgstr ""
+
+msgid "Cannot commit uninitialized/unreferenced notes tree"
+msgstr ""
+
+#, c-format
+msgid "Bad notes.rewriteMode value: '%s'"
+msgstr ""
+
+#, c-format
+msgid "Refusing to rewrite notes in %s (outside of refs/notes/)"
+msgstr ""
+
+#. TRANSLATORS: The first %s is the name of
+#. the environment variable, the second %s is
+#. its value.
+#.
+#, fuzzy, c-format
+msgid "Bad %s value: '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy
+msgid "failed to decode tree entry"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "failed to map tree entry for %s"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, c-format
+msgid "bad %s in commit"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to map %s %s in commit object"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "Failed to convert object from %s to %s"
+msgstr "theip ar rudaí a fháil ó URI '%s'"
+
+#, fuzzy, c-format
+msgid "object file %s is empty"
+msgstr "tá réad áitiúil %s truaillithe"
+
+#, fuzzy, c-format
+msgid "corrupt loose object '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "garbage at end of loose object '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to open loose object %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unable to parse %s header"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy
+msgid "invalid object type"
+msgstr "réad blob neamhbhailí %s"
+
+#, fuzzy, c-format
+msgid "unable to unpack %s header"
+msgstr "nach féidir %s a nuashonrú"
+
+#, c-format
+msgid "header for %s too long, exceeds %d bytes"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "loose object %s (stored in %s) is corrupt"
+msgstr "tá réad áitiúil %s truaillithe"
+
+#, fuzzy, c-format
+msgid "unable to open %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, c-format
+msgid "files '%s' and '%s' differ in contents"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to write file %s"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "unable to write repeatedly vanishing file %s"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+#, fuzzy, c-format
+msgid "unable to set permission to '%s'"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy
+msgid "error when closing loose object file"
+msgstr "earráid agus comhad pacáiste á dúnadh"
+
+#, c-format
+msgid "insufficient permission for adding an object to repository database %s"
+msgstr ""
+
+#, fuzzy
+msgid "unable to create temporary file"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, fuzzy
+msgid "unable to write loose object file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "unable to deflate new object %s (%d)"
+msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+
+#, c-format
+msgid "deflateEnd on object %s failed (%d)"
+msgstr ""
+
+#, c-format
+msgid "confused by unstable object source data for %s"
+msgstr ""
+
+#, c-format
+msgid "write stream object %ld != %<PRIuMAX>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to stream deflate new object (%d)"
+msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+
+#, c-format
+msgid "deflateEnd on stream object failed (%d)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to create directory %s"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "cannot read object for %s"
+msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+
+#, fuzzy, c-format
+msgid "cannot map object %s to %s"
+msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+
+#, c-format
+msgid "object fails fsck: %s"
+msgstr ""
+
+msgid "refusing to create malformed object"
+msgstr ""
+
+#, c-format
+msgid "read error while indexing %s"
+msgstr ""
+
+#, c-format
+msgid "short read while indexing %s"
+msgstr ""
+
+#, c-format
+msgid "%s: failed to insert into database"
+msgstr ""
+
+#, c-format
+msgid "%s: unsupported file type"
+msgstr ""
+
+#, c-format
+msgid "hash mismatch for %s (expected %s)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to mmap %s"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "unable to unpack header of %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy, c-format
+msgid "unable to parse header of %s"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "unable to unpack contents of %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#. TRANSLATORS: This is a line of ambiguous object
+#. output shown when we cannot look up or parse the
+#. object in question. E.g. "deadbeef [bad object]".
+#.
+#, c-format
+msgid "%s [bad object]"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous commit
+#. object output. E.g.:
+#. *
+#.    "deadbeef commit 2021-01-01 - Some Commit Message"
+#.
+#, fuzzy, c-format
+msgid "%s commit %s - %s"
+msgstr "Rianann %s %s agus %s araon"
+
+#. TRANSLATORS: This is a line of ambiguous
+#. tag object output. E.g.:
+#. *
+#.    "deadbeef tag 2022-01-01 - Some Tag Message"
+#. *
+#. The second argument is the YYYY-MM-DD found
+#. in the tag.
+#. *
+#. The third argument is the "tag" string
+#. from object.c.
+#.
+#, fuzzy, c-format
+msgid "%s tag %s - %s"
+msgstr "Rianann %s %s agus %s araon"
+
+#. TRANSLATORS: This is a line of ambiguous
+#. tag object output where we couldn't parse
+#. the tag itself. E.g.:
+#. *
+#.    "deadbeef [bad tag, could not parse it]"
+#.
+#, c-format
+msgid "%s [bad tag, could not parse it]"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous <type>
+#. object output. E.g. "deadbeef tree".
+#.
+#, c-format
+msgid "%s tree"
+msgstr ""
+
+#. TRANSLATORS: This is a line of ambiguous <type>
+#. object output. E.g. "deadbeef blob".
+#.
+#, c-format
+msgid "%s blob"
+msgstr ""
+
+#, c-format
+msgid "short object ID %s is ambiguous"
+msgstr ""
+
+#. TRANSLATORS: The argument is the list of ambiguous
+#. objects composed in show_ambiguous_object(). See
+#. its "TRANSLATORS" comments for details.
+#.
+#, c-format
+msgid ""
+"The candidates are:\n"
+"%s"
+msgstr ""
+
+msgid ""
+"Git normally never creates a ref that ends with 40 hex characters\n"
+"because it will be ignored when you just specify 40-hex. These refs\n"
+"may be created by mistake. For example,\n"
+"\n"
+"  git switch -c $br $(git rev-parse ...)\n"
+"\n"
+"where \"$br\" is somehow empty and a 40-hex ref is created. Please\n"
+"examine these refs and maybe delete them. Turn this message off by\n"
+"running \"git config set advice.objectNameWarning false\""
+msgstr ""
+
+#, c-format
+msgid "log for '%.*s' only goes back to %s"
+msgstr ""
+
+#, c-format
+msgid "log for '%.*s' only has %d entries"
+msgstr ""
+
+#, c-format
+msgid "path '%s' exists on disk, but not in '%.*s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"path '%s' exists, but not '%s'\n"
+"hint: Did you mean '%.*s:%s' aka '%.*s:./%s'?"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "path '%s' does not exist in '%.*s'"
+msgstr "níl an stóras '%s' ann"
+
+#, c-format
+msgid ""
+"path '%s' is in the index, but not at stage %d\n"
+"hint: Did you mean ':%d:%s'?"
+msgstr ""
+
+#, c-format
+msgid ""
+"path '%s' is in the index, but not '%s'\n"
+"hint: Did you mean ':%d:%s' aka ':%d:./%s'?"
+msgstr ""
+
+#, c-format
+msgid "path '%s' exists on disk, but not in the index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "path '%s' does not exist (neither on disk nor in the index)"
+msgstr "níl a leagan ag cosán '%s'"
+
+msgid "relative path syntax can't be used outside working tree"
+msgstr ""
+
+#, c-format
+msgid "<object>:<path> required, only <object> '%s' given"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid object name '%.*s'."
+msgstr "réad blob neamhbhailí %s"
+
+#, c-format
+msgid "object directory %s does not exist; check .git/objects/info/alternates"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to normalize alternate object path: %s"
+msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+
+#, c-format
+msgid "%s: ignoring alternate object stores, nesting too deep"
+msgstr ""
+
+#, fuzzy
+msgid "unable to fdopen alternates lockfile"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+#, fuzzy
+msgid "unable to read alternates file"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, fuzzy
+msgid "unable to move new alternates file into place"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#, fuzzy, c-format
+msgid "path '%s' does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#, c-format
+msgid "reference repository '%s' as a linked checkout is not supported yet."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "reference repository '%s' is not a local repository."
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy, c-format
+msgid "reference repository '%s' is shallow"
+msgstr "stór tagartha"
+
+#, fuzzy, c-format
+msgid "reference repository '%s' is grafted"
+msgstr "stór tagartha"
+
+#, fuzzy, c-format
+msgid "could not find object directory matching %s"
+msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+
+#, c-format
+msgid "invalid line while parsing alternate refs: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "replacement %s not found for %s"
+msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+
+#, fuzzy, c-format
+msgid "packed object %s (stored in %s) is corrupt"
+msgstr "tá réad áitiúil %s truaillithe"
+
+#, c-format
+msgid "missing mapping of %s to %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s is not a valid '%s' object"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, fuzzy, c-format
+msgid "invalid object type \"%s\""
+msgstr "réad blob neamhbhailí %s"
+
+#, fuzzy, c-format
+msgid "object %s is a %s, not a %s"
+msgstr "mímheaitseáil cineál réad ag %s"
+
+#, c-format
+msgid "object %s has unknown type id %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to parse object: %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "hash mismatch %s"
+msgstr ""
+
+#, c-format
+msgid "duplicate entry when writing bitmap index: %s"
+msgstr ""
+
+#, c-format
+msgid "attempted to store non-selected commit: '%s'"
+msgstr ""
+
+msgid "too many pseudo-merges"
+msgstr ""
+
+msgid "trying to write commit not in index"
+msgstr ""
+
+msgid "failed to load bitmap index (corrupted?)"
+msgstr ""
+
+msgid "corrupted bitmap index (too small)"
+msgstr ""
+
+msgid "corrupted bitmap index file (wrong header)"
+msgstr ""
+
+#, c-format
+msgid "unsupported version '%d' for bitmap index file"
+msgstr ""
+
+msgid "corrupted bitmap index file (too short to fit hash cache)"
+msgstr ""
+
+msgid "corrupted bitmap index file (too short to fit lookup table)"
+msgstr ""
+
+msgid ""
+"corrupted bitmap index file (too short to fit pseudo-merge table header)"
+msgstr ""
+
+msgid "corrupted bitmap index file (too short to fit pseudo-merge table)"
+msgstr ""
+
+msgid "corrupted bitmap index file, pseudo-merge table too short"
+msgstr ""
+
+#, c-format
+msgid "duplicate entry in bitmap index: '%s'"
+msgstr ""
+
+#, c-format
+msgid "corrupt ewah bitmap: truncated header for entry %d"
+msgstr ""
+
+#, c-format
+msgid "corrupt ewah bitmap: commit index %u out of range"
+msgstr ""
+
+msgid "corrupted bitmap pack index"
+msgstr ""
+
+msgid "invalid XOR offset in bitmap pack index"
+msgstr ""
+
+#, fuzzy
+msgid "cannot fstat bitmap file"
+msgstr "ní féidir le pacáiste fstat"
+
+msgid "checksum doesn't match in MIDX and bitmap"
+msgstr ""
+
+msgid "multi-pack bitmap is missing required reverse index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not open pack %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "corrupt bitmap lookup table: triplet position out of index"
+msgstr ""
+
+msgid "corrupt bitmap lookup table: xor chain exceeds entry count"
+msgstr ""
+
+#, c-format
+msgid "corrupt bitmap lookup table: commit index %u out of range"
+msgstr ""
+
+#, c-format
+msgid "corrupt ewah bitmap: truncated header for bitmap of commit \"%s\""
+msgstr ""
+
+#, c-format
+msgid "unable to load pack: '%s', disabling pack-reuse"
+msgstr ""
+
+msgid "unable to compute preferred pack, disabling pack-reuse"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "object '%s' not found in type bitmaps"
+msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+
+#, fuzzy, c-format
+msgid "object '%s' does not have a unique type"
+msgstr "níl ár leagan ag cosán '%s'"
+
+#, fuzzy, c-format
+msgid "object '%s': real type '%s', expected: '%s'"
+msgstr "réad %s: súil leis an gcineál %s, aimsíodh %s"
+
+#, c-format
+msgid "object not in bitmap: '%s'"
+msgstr ""
+
+#, fuzzy
+msgid "failed to load bitmap indexes"
+msgstr "theip ar delta a chur i bhfeidhm"
+
+#, fuzzy
+msgid "you must specify exactly one commit to test"
+msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
+
+#, c-format
+msgid "commit '%s' doesn't have an indexed bitmap"
+msgstr ""
+
+msgid "mismatch in bitmap results"
+msgstr ""
+
+#, c-format
+msgid "pseudo-merge index out of range (%<PRIu32> >= %<PRIuMAX>)"
+msgstr ""
+
+#, c-format
+msgid "could not find '%s' in pack '%s' at offset %<PRIuMAX>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to get disk usage of '%s'"
+msgstr "nach féidir %s a nuashonrú"
+
+#, c-format
+msgid "bitmap file '%s' has invalid checksum"
+msgstr ""
+
+#, c-format
+msgid "mtimes file %s is too small"
+msgstr ""
+
+#, c-format
+msgid "mtimes file %s has unknown signature"
+msgstr ""
+
+#, c-format
+msgid "mtimes file %s has unsupported version %<PRIu32>"
+msgstr ""
+
+#, c-format
+msgid "mtimes file %s has unsupported hash id %<PRIu32>"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "mtimes file %s is corrupt"
+msgstr "comhad innéacs truaillithe"
+
+#, c-format
+msgid "reverse-index file %s is too small"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "reverse-index file %s is corrupt"
+msgstr "comhad innéacs truaillithe"
+
+#, c-format
+msgid "reverse-index file %s has unknown signature"
+msgstr ""
+
+#, c-format
+msgid "reverse-index file %s has unsupported version %<PRIu32>"
+msgstr ""
+
+#, c-format
+msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
+msgstr ""
+
+#, fuzzy
+msgid "invalid checksum"
+msgstr "%s neamhbhailí"
+
+#, c-format
+msgid "invalid rev-index position at %<PRIu64>: %<PRIu32> != %<PRIu32>"
+msgstr ""
+
+msgid "multi-pack-index reverse-index chunk is the wrong size"
+msgstr ""
+
+msgid "could not determine preferred pack"
+msgstr ""
+
+msgid "cannot both write and verify reverse index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not stat: %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "failed to make %s readable"
+msgstr "theip ar '%s' a stáil"
+
+#, fuzzy, c-format
+msgid "could not write '%s' promisor file"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+msgid "offset before end of packfile (broken .idx?)"
+msgstr ""
+
+#, c-format
+msgid "packfile %s cannot be mapped%s"
+msgstr ""
+
+#, c-format
+msgid "offset before start of pack index for %s (corrupt index?)"
+msgstr ""
+
+#, c-format
+msgid "offset beyond end of pack index for %s (truncated index?)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "malformed expiration date '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid "option `%s' expects \"always\", \"auto\", or \"never\""
+msgstr ""
+
+#, fuzzy, c-format
+msgid "malformed object name '%s'"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#, c-format
+msgid "option `%s' expects \"%s\" or \"%s\""
+msgstr ""
+
+#, c-format
+msgid "%s requires a value"
+msgstr ""
+
+#, c-format
+msgid "%s takes no value"
+msgstr ""
+
+#, c-format
+msgid "%s isn't available"
+msgstr ""
+
+#, c-format
+msgid "value %s for %s not in range [%<PRIdMAX>,%<PRIdMAX>]"
+msgstr ""
+
+#, c-format
+msgid "%s expects an integer value with an optional k/m/g suffix"
+msgstr ""
+
+#, c-format
+msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
+msgstr ""
+
+#, c-format
+msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
+msgstr ""
+
+#, c-format
+msgid "did you mean `--%s` (with two dashes)?"
+msgstr ""
+
+#, c-format
+msgid "alias of --%s"
+msgstr ""
+
+msgid "need a subcommand"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown option `%s'"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "unknown switch `%c'"
+msgstr "algartam hais anaithnid '%s'"
+
+#, c-format
+msgid "unknown non-ascii option in string: `%s'"
+msgstr ""
+
+#. TRANSLATORS: The "<%s>" part of this string
+#. stands for an optional value given to a command
+#. line option in the long form, and "<>" is there
+#. as a convention to signal that it is a
+#. placeholder (i.e. the user should substitute it
+#. with the real value).  If your language uses a
+#. different convention, you can change "<%s>" part
+#. to match yours, e.g. it might use "|%s|" instead,
+#. or if the alphabet is different enough it may use
+#. "%s" without any placeholder signal.  Most
+#. translations leave this message as is.
+#.
+#, c-format
+msgid "[=<%s>]"
+msgstr ""
+
+#. TRANSLATORS: The "<%s>" part of this string
+#. stands for an optional value given to a command
+#. line option in the short form, and "<>" is there
+#. as a convention to signal that it is a
+#. placeholder (i.e. the user should substitute it
+#. with the real value).  If your language uses a
+#. different convention, you can change "<%s>" part
+#. to match yours, e.g. it might use "|%s|" instead,
+#. or if the alphabet is different enough it may use
+#. "%s" without any placeholder signal.  Most
+#. translations leave this message as is.
+#.
+#, c-format
+msgid "[<%s>]"
+msgstr ""
+
+#. TRANSLATORS: The "<%s>" part of this string stands for a
+#. value given to a command line option, and "<>" is there
+#. as a convention to signal that it is a placeholder
+#. (i.e. the user should substitute it with the real value).
+#. If your language uses a different convention, you can
+#. change "<%s>" part to match yours, e.g. it might use
+#. "|%s|" instead, or if the alphabet is different enough it
+#. may use "%s" without any placeholder signal.  Most
+#. translations leave this message as is.
+#.
+#, c-format
+msgid " <%s>"
+msgstr ""
+
+msgid "..."
+msgstr ""
+
+#, c-format
+msgid "usage: %s"
+msgstr ""
+
+#. TRANSLATORS: the colon here should align with the
+#. one in "usage: %s" translation.
+#.
+#, c-format
+msgid "   or: %s"
+msgstr ""
+
+#. TRANSLATORS: You should only need to translate this format
+#. string if your language is a RTL language (e.g. Arabic,
+#. Hebrew etc.), not if it's a LTR language (e.g. German,
+#. Russian, Chinese etc.).
+#. *
+#. When a translated usage string has an embedded "\n" it's
+#. because options have wrapped to the next line. The line
+#. after the "\n" will then be padded to align with the
+#. command name, such as N_("git cmd [opt]\n<8
+#. spaces>[opt2]"), where the 8 spaces are the same length as
+#. "git cmd ".
+#. *
+#. This format string prints out that already-translated
+#. line. The "%*s" is whitespace padding to account for the
+#. padding at the start of the line that we add in this
+#. function. The "%s" is a line in the (hopefully already
+#. translated) N_() usage string, which contained embedded
+#. newlines before we split it up.
+#.
+#, c-format
+msgid "%*s%s"
+msgstr ""
+
+#, c-format
+msgid "    %s"
+msgstr ""
+
+msgid "-NUM"
+msgstr ""
+
+#, c-format
+msgid "opposite of --no-%s"
+msgstr ""
+
+msgid "expiry-date"
+msgstr ""
+
+msgid "no-op (backward compatibility)"
+msgstr ""
+
+msgid "be more verbose"
+msgstr ""
+
+msgid "be more quiet"
+msgstr ""
+
+msgid "use <n> digits to display object names"
+msgstr ""
+
+#, fuzzy
+msgid "prefixed path to initial superproject"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+msgid "how to strip spaces and #comments from message"
+msgstr ""
+
+msgid "read pathspec from file"
+msgstr ""
+
+msgid ""
+"with --pathspec-from-file, pathspec elements are separated with NUL character"
+msgstr ""
+
+#, c-format
+msgid "bad boolean environment value '%s' for '%s'"
+msgstr ""
+
+#, c-format
+msgid "failed to walk children of tree %s: not found"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to find object %s"
+msgstr "Theip ar chrann %s a aimsiú."
+
+#, fuzzy, c-format
+msgid "failed to find tag %s"
+msgstr "Theip ar chrann %s a aimsiú."
+
+#, fuzzy
+msgid "failed to setup revision walk"
+msgstr "earráid inmheánach i dsiúlóid"
+
+#, c-format
+msgid "Could not make %s writable by group"
+msgstr ""
+
+msgid "Escape character '\\' not allowed as last character in attr value"
+msgstr ""
+
+msgid "Only one 'attr:' specification is allowed."
+msgstr ""
+
+msgid "attr spec must not be empty"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid attribute name %s"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
+msgstr ""
+
+msgid ""
+"global 'literal' pathspec setting is incompatible with all other global "
+"pathspec settings"
+msgstr ""
+
+msgid "invalid parameter for pathspec magic 'prefix'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Invalid pathspec magic '%.*s' in '%s'"
+msgstr "sonraíocht cosáin nebhail"
+
+#, c-format
+msgid "Missing ')' at the end of pathspec magic in '%s'"
+msgstr ""
+
+#, c-format
+msgid "Unimplemented pathspec magic '%c' in '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: 'literal' and 'glob' are incompatible"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is outside the directory tree"
+msgstr "Tá %s ann agus ní eolaire é"
+
+#, c-format
+msgid "%s: '%s' is outside repository at '%s'"
+msgstr ""
+
+#, c-format
+msgid "'%s' (mnemonic: '%c')"
+msgstr ""
+
+#, c-format
+msgid "%s: pathspec magic not supported by this command: %s"
+msgstr ""
+
+#, c-format
+msgid "pathspec '%s' is beyond a symbolic link"
+msgstr ""
+
+#, c-format
+msgid "line is badly quoted: %s"
+msgstr ""
+
+#, fuzzy
+msgid "unable to write flush packet"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy
+msgid "unable to write delim packet"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy
+msgid "unable to write response end packet"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+msgid "flush packet write failed"
+msgstr ""
+
+msgid "protocol error: impossibly long line"
+msgstr ""
+
+msgid "packet write with format failed"
+msgstr ""
+
+msgid "packet write failed - data exceeds max packet size"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "packet write failed: %s"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy
+msgid "read error"
+msgstr "earráid léigh ar ionchur"
+
+msgid "the remote end hung up unexpectedly"
+msgstr ""
+
+#, c-format
+msgid "protocol error: bad line length character: %.4s"
+msgstr ""
+
+#, c-format
+msgid "protocol error: bad line length %d"
+msgstr ""
+
+#, c-format
+msgid "remote error: %s"
+msgstr ""
+
+#, fuzzy
+msgid "Refreshing index"
+msgstr "an t-innéacs a chur ar ais"
+
+#, fuzzy, c-format
+msgid "unable to create threaded lstat: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy
+msgid "unable to parse --pretty format"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+msgid "lazy fetching disabled; some objects may not be available"
+msgstr ""
+
+msgid "promisor-remote: unable to fork off fetch subprocess"
+msgstr ""
+
+msgid "promisor-remote: could not write to fetch subprocess"
+msgstr ""
+
+msgid "promisor-remote: could not close stdin to fetch subprocess"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "promisor remote name cannot begin with '/': %s"
+msgstr "ní féidir le '/' tosú le gearrthánach iargúlta config: %s"
+
+#, c-format
+msgid "could not fetch %s from promisor remote"
+msgstr ""
+
+#, c-format
+msgid "no or empty URL advertised for remote '%s'"
+msgstr ""
+
+#, c-format
+msgid "known remote named '%s' but with URL '%s' instead of '%s'"
+msgstr ""
+
+#, c-format
+msgid "unknown '%s' value for '%s' config option"
+msgstr ""
+
+#, c-format
+msgid "unknown element '%s' from remote info"
+msgstr ""
+
+#, c-format
+msgid "accepted promisor remote '%s' not found"
+msgstr ""
+
+msgid "object-info: expected flush after arguments"
+msgstr ""
+
+#, fuzzy
+msgid "Removing duplicate objects"
+msgstr "Rudaí a fháil"
+
+#, fuzzy, c-format
+msgid "failed to load pseudo-merge regex for %s: '%s'"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+#, c-format
+msgid "%s must be non-negative, using default"
+msgstr ""
+
+#, c-format
+msgid "%s must be between 0 and 1, using default"
+msgstr ""
+
+#, c-format
+msgid "%s must be positive, using default"
+msgstr ""
+
+#, c-format
+msgid "pseudo-merge group '%s' missing required pattern"
+msgstr ""
+
+#, c-format
+msgid "pseudo-merge group '%s' has unstable threshold before stable one"
+msgstr ""
+
+#, c-format
+msgid ""
+"pseudo-merge regex from config has too many capture groups (max=%<PRIuMAX>)"
+msgstr ""
+
+#, c-format
+msgid "extended pseudo-merge read out-of-bounds (%<PRIuMAX> >= %<PRIuMAX>)"
+msgstr ""
+
+#, c-format
+msgid "extended pseudo-merge entry is too short (%<PRIuMAX> >= %<PRIuMAX>)"
+msgstr ""
+
+#, c-format
+msgid "could not find pseudo-merge for commit %s at offset %<PRIuMAX>"
+msgstr ""
+
+#, c-format
+msgid "extended pseudo-merge lookup out-of-bounds (%<PRIu32> >= %<PRIu32>)"
+msgstr ""
+
+#, c-format
+msgid "out-of-bounds read: (%<PRIuMAX> >= %<PRIuMAX>)"
+msgstr ""
+
+#, c-format
+msgid "could not read extended pseudo-merge table for commit %s"
+msgstr ""
+
+msgid "could not start `log`"
+msgstr ""
+
+msgid "could not read `log` output"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse commit '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid ""
+"could not parse first line of `log` output: did not start with 'commit ': "
+"'%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse git header '%.*s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy
+msgid "failed to generate diff"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "could not parse log for '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "invalid extra cruft tip: '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy
+msgid "unable to enumerate additional recent objects"
+msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+
+#, c-format
+msgid "will not add file alias '%s' ('%s' already exists in index)"
+msgstr ""
+
+#, fuzzy
+msgid "cannot create an empty blob in the object database"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+#, c-format
+msgid "%s: can only add regular files, symbolic links or git-directories"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to index file '%s'"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "unable to add '%s' to index"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "'%s' appears as both a file and as a directory"
+msgstr "Tá %s ann agus ní eolaire é"
+
+#, fuzzy
+msgid "Refresh index"
+msgstr "an t-innéacs a chur ar ais"
+
+#, c-format
+msgid ""
+"index.version set, but the value is invalid.\n"
+"Using version %i"
+msgstr ""
+
+#, c-format
+msgid ""
+"GIT_INDEX_VERSION set, but the value is invalid.\n"
+"Using version %i"
+msgstr ""
+
+#, c-format
+msgid "bad signature 0x%08x"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "bad index version %d"
+msgstr "droch-pack.indexVersion=%<PRIu32>"
+
+msgid "bad index file sha1 signature"
+msgstr ""
+
+#, c-format
+msgid "index uses %.4s extension, which we do not understand"
+msgstr ""
+
+#, c-format
+msgid "ignoring %.4s extension"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown index entry format 0x%08x"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, c-format
+msgid "malformed name field in the index, near path '%s'"
+msgstr ""
+
+msgid "unordered stage entries in index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "multiple stage entries for merged file '%s'"
+msgstr "seiceáil a leagan le haghaidh comhaid neamh-chumasaithe"
+
+#, fuzzy, c-format
+msgid "unordered stage entries for '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "unable to create load_cache_entries thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "unable to join load_cache_entries thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, c-format
+msgid "%s: index file open failed"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot stat the open index"
+msgstr ""
+
+#, c-format
+msgid "%s: index file smaller than expected"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s: unable to map index file%s"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy, c-format
+msgid "unable to create load_index_extensions thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "unable to join load_index_extensions thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "could not freshen shared index '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "broken index, expect %s in %s, got %s"
+msgstr ""
+
+msgid "cannot write split index for a sparse index"
+msgstr ""
+
+#, fuzzy
+msgid "failed to convert to a sparse-index"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+#, fuzzy, c-format
+msgid "unable to open git dir: %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unable to unlink: %s"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, fuzzy, c-format
+msgid "cannot fix permission bits on '%s'"
+msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+
+#, c-format
+msgid "%s: cannot drop to stage #0"
+msgstr ""
+
+#, c-format
+msgid "unexpected diff status %c"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "remove '%s'\n"
+msgstr "Ar '%s' cheana féin\n"
+
+msgid ""
+"You can fix this with 'git rebase --edit-todo' and then run 'git rebase --"
+"continue'.\n"
+"Or you can abort the rebase with 'git rebase --abort'.\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"unrecognized setting %s for option rebase.missingCommitsCheck. Ignoring."
+msgstr ""
+
+msgid ""
+"\n"
+"Commands:\n"
+"p, pick <commit> = use commit\n"
+"r, reword <commit> = use commit, but edit the commit message\n"
+"e, edit <commit> = use commit, but stop for amending\n"
+"s, squash <commit> = use commit, but meld into previous commit\n"
+"f, fixup [-C | -c] <commit> = like \"squash\" but keep only the previous\n"
+"                   commit's log message, unless -C is used, in which case\n"
+"                   keep only this commit's message; -c is same as -C but\n"
+"                   opens the editor\n"
+"x, exec <command> = run command (the rest of the line) using shell\n"
+"b, break = stop here (continue rebase later with 'git rebase --continue')\n"
+"d, drop <commit> = remove commit\n"
+"l, label <label> = label current HEAD with a name\n"
+"t, reset <label> = reset HEAD to a label\n"
+"m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
+"        create a merge commit using the original merge commit's\n"
+"        message (or the oneline, if no original merge commit was\n"
+"        specified); use -c <commit> to reword the commit message\n"
+"u, update-ref <ref> = track a placeholder for the <ref> to be updated\n"
+"                      to this position in the new commits. The <ref> is\n"
+"                      updated at the end of the rebase\n"
+"\n"
+"These lines can be re-ordered; they are executed from top to bottom.\n"
+msgstr ""
+
+#, c-format
+msgid "Rebase %s onto %s (%d command)"
+msgid_plural "Rebase %s onto %s (%d commands)"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid ""
+"\n"
+"Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
+msgstr ""
+
+msgid ""
+"\n"
+"If you remove a line here THAT COMMIT WILL BE LOST.\n"
+msgstr ""
+
+msgid ""
+"\n"
+"You are editing the todo file of an ongoing interactive rebase.\n"
+"To continue rebase after editing, run:\n"
+"    git rebase --continue\n"
+"\n"
+msgstr ""
+
+msgid ""
+"\n"
+"However, if you remove everything, the rebase will be aborted.\n"
+"\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not write '%s'."
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid ""
+"Warning: some commits may have been dropped accidentally.\n"
+"Dropped commits (newer to older):\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"To avoid this message, use \"drop\" to explicitly remove a commit.\n"
+"\n"
+"Use 'git config rebase.missingCommitsCheck' to change the level of "
+"warnings.\n"
+"The possible behaviours are: ignore, warn, error.\n"
+"\n"
+msgstr ""
+
+#, c-format
+msgid "%s: 'preserve' superseded by 'merges'"
+msgstr ""
+
+msgid "gone"
+msgstr "imithe"
+
+#, fuzzy, c-format
+msgid "ahead %d"
+msgstr "chun tosaigh "
+
+#, fuzzy, c-format
+msgid "behind %d"
+msgstr "taobh thiar "
+
+#, c-format
+msgid "ahead %d, behind %d"
+msgstr ""
+
+#, c-format
+msgid "%%(%.*s) does not take arguments"
+msgstr ""
+
+#, c-format
+msgid "unrecognized %%(%.*s) argument: %s"
+msgstr ""
+
+#, c-format
+msgid "expected format: %%(color:<color>)"
+msgstr ""
+
+#, c-format
+msgid "unrecognized color: %%(color:%s)"
+msgstr ""
+
+#, c-format
+msgid "Integer value expected refname:lstrip=%s"
+msgstr ""
+
+#, c-format
+msgid "Integer value expected refname:rstrip=%s"
+msgstr ""
+
+#, c-format
+msgid "expected %%(trailers:key=<value>)"
+msgstr ""
+
+#, c-format
+msgid "unknown %%(trailers) argument: %s"
+msgstr ""
+
+#, c-format
+msgid "positive value expected contents:lines=%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "argument expected for %s"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, c-format
+msgid "positive value expected %s=%s"
+msgstr ""
+
+#, c-format
+msgid "cannot fully parse %s=%s"
+msgstr ""
+
+#, c-format
+msgid "value expected %s="
+msgstr ""
+
+#, c-format
+msgid "positive value expected '%s' in %%(%s)"
+msgstr ""
+
+#, c-format
+msgid "expected format: %%(align:<width>,<position>)"
+msgstr ""
+
+#, c-format
+msgid "unrecognized position:%s"
+msgstr ""
+
+#, c-format
+msgid "unrecognized width:%s"
+msgstr ""
+
+#, c-format
+msgid "unrecognized %%(%s) argument: %s"
+msgstr ""
+
+#, c-format
+msgid "positive width expected with the %%(align) atom"
+msgstr ""
+
+#, c-format
+msgid "expected format: %%(ahead-behind:<committish>)"
+msgstr ""
+
+#, c-format
+msgid "expected format: %%(is-base:<committish>)"
+msgstr ""
+
+#, c-format
+msgid "malformed field name: %.*s"
+msgstr ""
+
+#, c-format
+msgid "unknown field name: %.*s"
+msgstr ""
+
+#, c-format
+msgid ""
+"not a git repository, but the field '%.*s' requires access to object data"
+msgstr ""
+
+#, c-format
+msgid "format: %%(%s) atom used without a %%(%s) atom"
+msgstr ""
+
+#, c-format
+msgid "format: %%(then) atom used more than once"
+msgstr ""
+
+#, c-format
+msgid "format: %%(then) atom used after %%(else)"
+msgstr ""
+
+#, c-format
+msgid "format: %%(else) atom used more than once"
+msgstr ""
+
+#, c-format
+msgid "format: %%(end) atom used without corresponding atom"
+msgstr ""
+
+#, c-format
+msgid "malformed format string %s"
+msgstr ""
+
+#, c-format
+msgid "this command reject atom %%(%.*s)"
+msgstr ""
+
+#, c-format
+msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
+msgstr ""
+
+#, fuzzy
+msgid "failed to run 'describe'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, c-format
+msgid "(no branch, rebasing %s)"
+msgstr ""
+
+#, c-format
+msgid "(no branch, rebasing detached HEAD %s)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "(no branch, bisect started on %s)"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, fuzzy, c-format
+msgid "(HEAD detached at %s)"
+msgstr "HEAD scoite ag "
+
+#, fuzzy, c-format
+msgid "(HEAD detached from %s)"
+msgstr "CEANN scartha ó "
+
+#, fuzzy
+msgid "(no branch)"
+msgstr "CEAD (gan aon bhrainse)"
+
+#, fuzzy, c-format
+msgid "missing object %s for %s"
+msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+
+#, c-format
+msgid "parse_object_buffer failed on %s for %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "malformed object at '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid "ignoring ref with broken name %s"
+msgstr ""
+
+#, c-format
+msgid "ignoring broken ref %s"
+msgstr ""
+
+#, c-format
+msgid "format: %%(end) atom missing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "malformed object name %s"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#, c-format
+msgid "option `%s' must point to a commit"
+msgstr ""
+
+msgid "key"
+msgstr ""
+
+msgid "field name to sort on"
+msgstr ""
+
+msgid "exclude refs which match pattern"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not a reflog: %s"
+msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+
+#, fuzzy, c-format
+msgid "no reflog for '%s'"
+msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+
+#, fuzzy, c-format
+msgid "%s does not point to a valid object!"
+msgstr "Ní chuireann HEAD in iúl do bhrainse"
+
+#, c-format
+msgid ""
+"Using '%s' as the name for the initial branch. This default branch name\n"
+"is subject to change. To configure the initial branch name to use in all\n"
+"of your new repositories, which will suppress this warning, call:\n"
+"\n"
+"\tgit config --global init.defaultBranch <name>\n"
+"\n"
+"Names commonly chosen instead of 'master' are 'main', 'trunk' and\n"
+"'development'. The just-created branch can be renamed via this command:\n"
+"\n"
+"\tgit branch -m <name>\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not retrieve `%s`"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "invalid branch name: %s = %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "ignoring dangling symref %s"
+msgstr ""
+
+#, c-format
+msgid "log for ref %s has gap after %s"
+msgstr ""
+
+#, c-format
+msgid "log for ref %s unexpectedly ended on %s"
+msgstr ""
+
+#, c-format
+msgid "log for %s is empty"
+msgstr ""
+
+#, c-format
+msgid "refusing to update reflog for pseudoref '%s'"
+msgstr ""
+
+#, c-format
+msgid "refusing to update pseudoref '%s'"
+msgstr ""
+
+#, c-format
+msgid "refusing to update reflog with bad name '%s'"
+msgstr ""
+
+#, c-format
+msgid "refusing to update ref with bad name '%s'"
+msgstr ""
+
+msgid "refusing to force and skip creation of reflog"
+msgstr ""
+
+#, c-format
+msgid "update_ref failed for ref '%s': %s"
+msgstr ""
+
+#, c-format
+msgid "multiple updates for ref '%s' not allowed"
+msgstr ""
+
+msgid "ref updates forbidden inside quarantine environment"
+msgstr ""
+
+msgid "ref updates aborted by hook"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' exists; cannot create '%s'"
+msgstr "Ní féidir '%s' a úsáid le '%s'"
+
+#, fuzzy, c-format
+msgid "cannot process '%s' and '%s' at the same time"
+msgstr ""
+"Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
+
+#, fuzzy, c-format
+msgid "could not delete reference %s: %s"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not delete references: %s"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+#, c-format
+msgid "Finished dry-run migration of refs, the result can be found at '%s'\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not remove temporary migration directory '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid "migrated refs can be found at '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"cannot lock ref '%s': expected symref with target '%s': but is a regular ref"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot read ref file '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy, c-format
+msgid "cannot open directory %s"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+msgid "Checking references consistency"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to open '%s'"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy, c-format
+msgid "unable to read '%s'"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "refname is dangerous: %s"
+msgstr ""
+
+#, c-format
+msgid "trying to write ref '%s' with nonexistent object %s"
+msgstr ""
+
+#, c-format
+msgid "trying to write non-commit object %s to branch '%s'"
+msgstr ""
+
+#, c-format
+msgid ""
+"multiple updates for 'HEAD' (including one via its referent '%s') are not "
+"allowed"
+msgstr ""
+
+#, c-format
+msgid "cannot lock ref '%s': unable to resolve reference '%s'"
+msgstr ""
+
+#, c-format
+msgid "cannot lock ref '%s': error reading reference"
+msgstr ""
+
+#, c-format
+msgid ""
+"multiple updates for '%s' (including one via symref '%s') are not allowed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot lock ref '%s': reference already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, c-format
+msgid "cannot lock ref '%s': reference is missing but expected %s"
+msgstr ""
+
+#, c-format
+msgid "cannot lock ref '%s': is at %s but expected %s"
+msgstr ""
+
+#, c-format
+msgid "reftable: transaction prepare: %s"
+msgstr ""
+
+#, c-format
+msgid "reftable: transaction failure: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to compact stack: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, c-format
+msgid "refname %s not found"
+msgstr ""
+
+#, c-format
+msgid "refname %s is a symbolic ref, copying it is not supported"
+msgstr ""
+
+#, c-format
+msgid "pattern '%s' has no '*'"
+msgstr ""
+
+#, c-format
+msgid "replacement '%s' has no '*'"
+msgstr ""
+
+#, c-format
+msgid "invalid quoting in push-option value: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown value for object-format: %s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, fuzzy, c-format
+msgid "%sinfo/refs not valid: is this a git repository?"
+msgstr "Ní cheadaítear athshocrú %s i stóras lom"
+
+msgid "invalid server response; expected service, got flush packet"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid server response; got '%s'"
+msgstr "tagairt neamhbhailí: %s"
+
+#, fuzzy, c-format
+msgid "repository '%s' not found"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy, c-format
+msgid "Authentication failed for '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to access '%s': %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, c-format
+msgid "redirecting to %s"
+msgstr ""
+
+msgid "shouldn't have EOF when not gentle on EOF"
+msgstr ""
+
+msgid "remote server sent unexpected response end packet"
+msgstr ""
+
+msgid "unable to rewind rpc post data - try increasing http.postBuffer"
+msgstr ""
+
+#, c-format
+msgid "remote-curl: bad line length character: %.4s"
+msgstr ""
+
+msgid "remote-curl: unexpected response end packet"
+msgstr ""
+
+#, c-format
+msgid "RPC failed; %s"
+msgstr ""
+
+msgid "cannot handle pushes this big"
+msgstr ""
+
+#, c-format
+msgid "cannot deflate request; zlib deflate error %d"
+msgstr ""
+
+#, c-format
+msgid "cannot deflate request; zlib end error %d"
+msgstr ""
+
+#, c-format
+msgid "%d bytes of length header were received"
+msgstr ""
+
+#, c-format
+msgid "%d bytes of body are still expected"
+msgstr ""
+
+msgid "dumb http transport does not support shallow capabilities"
+msgstr ""
+
+msgid "fetch failed."
+msgstr ""
+
+msgid "cannot fetch by sha1 over smart http"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "protocol error: expected sha/ref, got '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#, c-format
+msgid "http transport does not support %s"
+msgstr ""
+
+msgid "protocol error: expected '<url> <path>', missing space"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to download file at URL '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+msgid "git-http-push failed"
+msgstr ""
+
+msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
+msgstr ""
+
+msgid "remote-curl: error reading command stream from git"
+msgstr ""
+
+msgid "remote-curl: fetch attempted without a local repo"
+msgstr ""
+
+#, c-format
+msgid "remote-curl: unknown command '%s' from git"
+msgstr ""
 
 #, c-format
 msgid ""
@@ -1710,9 +19405,6 @@ msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ag neamhaird den tagairt ghreannmhar '%s' go háitiúil"
 
-msgid "revision walk setup failed"
-msgstr "theip ar socrú siúlóid ath"
-
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Tá do bhrainse bunaithe ar '%s', ach tá an suas sruth imithe.\n"
@@ -1789,6 +19481,2303 @@ msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
 #, c-format
 msgid "cannot strip one component off url '%s'"
 msgstr "ní féidir comhpháirt amháin a bhaint as url '%s'"
+
+#, fuzzy, c-format
+msgid "bad replace ref name: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "duplicate replace ref: %s"
+msgstr ""
+
+#, c-format
+msgid "replace depth too high for object %s"
+msgstr ""
+
+msgid "corrupt MERGE_RR"
+msgstr ""
+
+#, fuzzy
+msgid "unable to write rerere record"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid "there were errors while writing '%s' (%s)"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse conflict hunks in '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, fuzzy, c-format
+msgid "failed utime() on '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, c-format
+msgid "writing '%s' failed"
+msgstr ""
+
+#, c-format
+msgid "Staged '%s' using previous resolution."
+msgstr ""
+
+#, c-format
+msgid "Recorded resolution for '%s'."
+msgstr ""
+
+#, c-format
+msgid "Resolved '%s' using previous resolution."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot unlink stray '%s'"
+msgstr "ní féidir le comhad malartacha sealadacha a dhínascadh"
+
+#, c-format
+msgid "Recorded preimage for '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to update conflicted state in '%s'"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "no remembered resolution for '%s'"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+#, fuzzy, c-format
+msgid "Updated preimage for '%s'"
+msgstr "Nuashonraíodh %d cosán ó %s"
+
+#, c-format
+msgid "Forgot resolution for '%s'\n"
+msgstr ""
+
+#, fuzzy
+msgid "unable to open rr-cache directory"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+msgid "update the index with reused conflict resolution if possible"
+msgstr ""
+
+#, fuzzy
+msgid "could not determine HEAD revision"
+msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
+
+#, fuzzy, c-format
+msgid "failed to find tree of %s"
+msgstr "Theip ar chrann %s a aimsiú."
+
+#, c-format
+msgid "unsupported section for hidden refs: %s"
+msgstr ""
+
+msgid "--exclude-hidden= passed more than once"
+msgstr ""
+
+#, c-format
+msgid "resolve-undo records `%s` which is missing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s exists but is a symbolic ref"
+msgstr "Tá %s ann agus ní eolaire é"
+
+msgid ""
+"--merge requires one of the pseudorefs MERGE_HEAD, CHERRY_PICK_HEAD, "
+"REVERT_HEAD or REBASE_HEAD"
+msgstr ""
+
+#, c-format
+msgid "could not get commit for --ancestry-path argument %s"
+msgstr ""
+
+msgid "--unpacked=<packfile> no longer supported"
+msgstr ""
+
+#, c-format
+msgid "invalid option '%s' in --stdin mode"
+msgstr ""
+
+#, fuzzy
+msgid "your current branch appears to be broken"
+msgstr "Tá tú ar bhrainse nach rugadh fós"
+
+#, c-format
+msgid "your current branch '%s' does not have any commits yet"
+msgstr ""
+
+msgid "object filtering requires --objects"
+msgstr ""
+
+msgid "-L does not yet support diff formats besides -p and -s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot create async thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#, fuzzy, c-format
+msgid "'%s' does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy, c-format
+msgid "could not switch to '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "need a working directory"
+msgstr ""
+
+msgid "Scalar enlistments require a worktree"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not configure %s=%s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "could not configure log.excludeDecoration"
+msgstr ""
+
+msgid "could not add enlistment"
+msgstr ""
+
+msgid "could not set recommended config"
+msgstr ""
+
+msgid "could not turn on maintenance"
+msgstr ""
+
+msgid "could not start the FSMonitor daemon"
+msgstr ""
+
+msgid "could not turn off maintenance"
+msgstr ""
+
+#, fuzzy
+msgid "could not remove enlistment"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "remote HEAD is not a branch: '%.*s'"
+msgstr ""
+
+msgid "failed to get default branch name from remote; using local default"
+msgstr ""
+
+msgid "failed to get default branch name"
+msgstr ""
+
+#, fuzzy
+msgid "failed to unregister repository"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+msgid "failed to stop the FSMonitor daemon"
+msgstr ""
+
+#, fuzzy
+msgid "failed to delete enlistment directory"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+msgid "branch to checkout after clone"
+msgstr ""
+
+msgid "when cloning, create full working directory"
+msgstr ""
+
+msgid "only download metadata for the branch that will be checked out"
+msgstr ""
+
+msgid "create repository within 'src' directory"
+msgstr ""
+
+msgid "specify if tags should be fetched during clone"
+msgstr ""
+
+msgid ""
+"scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]\n"
+"\t[--[no-]src] [--[no-]tags] <url> [<enlistment>]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot deduce worktree name from '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, c-format
+msgid "directory '%s' exists already"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to get default branch for '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+#, fuzzy, c-format
+msgid "could not configure remote in '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not disable tags in '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not configure '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "partial clone failed; attempting full clone"
+msgstr ""
+
+msgid "could not configure for full clone"
+msgstr ""
+
+msgid "scalar diagnose [<enlistment>]"
+msgstr ""
+
+msgid "`scalar list` does not take arguments"
+msgstr ""
+
+msgid "scalar register [<enlistment>]"
+msgstr ""
+
+msgid "reconfigure all registered enlistments"
+msgstr ""
+
+msgid "scalar reconfigure [--all | <enlistment>]"
+msgstr ""
+
+msgid "--all or <enlistment>, but not both"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not remove stale scalar.repo '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, c-format
+msgid "removed stale scalar.repo '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "repository at '%s' has different owner"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy, c-format
+msgid "repository at '%s' has a format issue"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy, c-format
+msgid "repository not found in '%s'"
+msgstr "droch-stóras '%s'"
+
+#, c-format
+msgid ""
+"to unregister this repository from Scalar, run\n"
+"\tgit config --global --unset --fixed-value scalar.repo \"%s\""
+msgstr ""
+
+msgid ""
+"scalar run <task> [<enlistment>]\n"
+"Tasks:\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "no such task: '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+msgid "scalar unregister [<enlistment>]"
+msgstr ""
+
+msgid "scalar delete <enlistment>"
+msgstr ""
+
+msgid "refusing to delete current working directory"
+msgstr ""
+
+msgid "include Git version"
+msgstr ""
+
+msgid "include Git's build options"
+msgstr ""
+
+msgid "scalar verbose [-v | --verbose] [--build-options]"
+msgstr ""
+
+#, fuzzy
+msgid "-C requires a <directory>"
+msgstr "--stdin teastaíonn stórlann git"
+
+#, fuzzy, c-format
+msgid "could not change to '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+msgid "-c requires a <key>=<value> argument"
+msgstr ""
+
+msgid ""
+"scalar [-C <directory>] [-c <key>=<value>] <command> [<options>]\n"
+"\n"
+"Commands:\n"
+msgstr ""
+
+msgid "unexpected flush packet while reading remote unpack status"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to parse remote unpack status: %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, c-format
+msgid "remote unpack failed: %s"
+msgstr ""
+
+msgid "failed to sign the push certificate"
+msgstr ""
+
+msgid "send-pack: unable to fork off fetch subprocess"
+msgstr ""
+
+msgid "push negotiation failed; proceeding anyway with push"
+msgstr ""
+
+msgid "the receiving end does not support this repository's hash algorithm"
+msgstr ""
+
+msgid "the receiving end does not support --signed push"
+msgstr ""
+
+msgid ""
+"not sending a push certificate since the receiving end does not support --"
+"signed push"
+msgstr ""
+
+msgid "the receiving end does not support --atomic push"
+msgstr ""
+
+msgid "the receiving end does not support push options"
+msgstr ""
+
+#, c-format
+msgid "invalid commit message cleanup mode '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not delete '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "revert"
+msgstr ""
+
+msgid "cherry-pick"
+msgstr ""
+
+msgid "rebase"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown action: %d"
+msgstr "cineál réad anaithnid %d"
+
+msgid ""
+"Resolve all conflicts manually, mark them as resolved with\n"
+"\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
+"You can instead skip this commit: run \"git rebase --skip\".\n"
+"To abort and get back to the state before \"git rebase\", run \"git rebase --"
+"abort\"."
+msgstr ""
+
+msgid ""
+"after resolving the conflicts, mark the corrected paths\n"
+"with 'git add <paths>' or 'git rm <paths>'"
+msgstr ""
+
+msgid ""
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git cherry-pick --continue\".\n"
+"You can instead skip this commit with \"git cherry-pick --skip\".\n"
+"To abort and get back to the state before \"git cherry-pick\",\n"
+"run \"git cherry-pick --abort\"."
+msgstr ""
+
+msgid ""
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git revert --continue\".\n"
+"You can instead skip this commit with \"git revert --skip\".\n"
+"To abort and get back to the state before \"git revert\",\n"
+"run \"git revert --abort\"."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not lock '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not write eol to '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "failed to finalize '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, c-format
+msgid "your local changes would be overwritten by %s."
+msgstr ""
+
+msgid "commit your changes or stash them to proceed."
+msgstr ""
+
+#. TRANSLATORS: %s will be "revert", "cherry-pick" or
+#. "rebase".
+#.
+#, fuzzy, c-format
+msgid "%s: Unable to write new index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, fuzzy
+msgid "unable to update cache tree"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy
+msgid "could not resolve HEAD commit"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "no key present in '%.*s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to dequote value of '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+msgid "'GIT_AUTHOR_NAME' already given"
+msgstr ""
+
+msgid "'GIT_AUTHOR_EMAIL' already given"
+msgstr ""
+
+msgid "'GIT_AUTHOR_DATE' already given"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown variable '%s'"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+msgid "missing 'GIT_AUTHOR_NAME'"
+msgstr ""
+
+msgid "missing 'GIT_AUTHOR_EMAIL'"
+msgstr ""
+
+msgid "missing 'GIT_AUTHOR_DATE'"
+msgstr ""
+
+#, c-format
+msgid ""
+"you have staged changes in your working tree\n"
+"If these changes are meant to be squashed into the previous commit, run:\n"
+"\n"
+"  git commit --amend %s\n"
+"\n"
+"If they are meant to go into a new commit, run:\n"
+"\n"
+"  git commit %s\n"
+"\n"
+"In both cases, once you're done, continue with:\n"
+"\n"
+"  git rebase --continue\n"
+msgstr ""
+
+msgid "'prepare-commit-msg' hook failed"
+msgstr ""
+
+msgid ""
+"Your name and email address were configured automatically based\n"
+"on your username and hostname. Please check that they are accurate.\n"
+"You can suppress this message by setting them explicitly. Run the\n"
+"following command and follow the instructions in your editor to edit\n"
+"your configuration file:\n"
+"\n"
+"    git config --global --edit\n"
+"\n"
+"After doing this, you may fix the identity used for this commit with:\n"
+"\n"
+"    git commit --amend --reset-author\n"
+msgstr ""
+
+msgid ""
+"Your name and email address were configured automatically based\n"
+"on your username and hostname. Please check that they are accurate.\n"
+"You can suppress this message by setting them explicitly:\n"
+"\n"
+"    git config --global user.name \"Your Name\"\n"
+"    git config --global user.email you@example.com\n"
+"\n"
+"After doing this, you may fix the identity used for this commit with:\n"
+"\n"
+"    git commit --amend --reset-author\n"
+msgstr ""
+
+msgid "couldn't look up newly created commit"
+msgstr ""
+
+msgid "could not parse newly created commit"
+msgstr ""
+
+msgid "unable to resolve HEAD after creating commit"
+msgstr ""
+
+#, fuzzy
+msgid "detached HEAD"
+msgstr "HEAD scoite ag "
+
+msgid " (root-commit)"
+msgstr ""
+
+#, fuzzy
+msgid "could not parse HEAD"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "HEAD %s is not a commit!"
+msgstr "Tá HEAD anois ag"
+
+#, fuzzy
+msgid "unable to parse commit author"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unable to read commit message from '%s'"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "invalid author identity '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+msgid "corrupt author: missing date information"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not update %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy, c-format
+msgid "could not parse parent commit %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unknown command: %d"
+msgstr "Níl aon orduithe déanta."
+
+msgid "This is the 1st commit message:"
+msgstr ""
+
+#, c-format
+msgid "This is the commit message #%d:"
+msgstr ""
+
+msgid "The 1st commit message will be skipped:"
+msgstr ""
+
+#, c-format
+msgid "The commit message #%d will be skipped:"
+msgstr ""
+
+#, c-format
+msgid "This is a combination of %d commits."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot write '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+msgid "need a HEAD to fixup"
+msgstr ""
+
+#, fuzzy
+msgid "could not read HEAD"
+msgstr "ní fhéadfaí %s a réiteach"
+
+msgid "could not read HEAD's commit message"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read commit message of %s"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+msgid "your index file is unmerged."
+msgstr ""
+
+#, fuzzy
+msgid "cannot fixup root commit"
+msgstr "aon rud le tiomantas\n"
+
+#, c-format
+msgid "commit %s is a merge but no -m option was given."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "commit %s does not have parent %d"
+msgstr "níl ár leagan ag cosán '%s'"
+
+#, c-format
+msgid "cannot get commit message for %s"
+msgstr ""
+
+#. TRANSLATORS: The first %s will be a "todo" command like
+#. "revert" or "pick", the second %s a SHA1.
+#, fuzzy, c-format
+msgid "%s: cannot parse parent commit %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "could not revert %s... %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not apply %s... %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "dropping %s %s -- patch contents already upstream\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "git %s: failed to read the index"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#, c-format
+msgid "git %s: failed to refresh the index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid label"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, fuzzy, c-format
+msgid "'%s' is not a valid refname"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#, c-format
+msgid "update-ref requires a fully qualified refname e.g. refs/heads/%s"
+msgstr ""
+
+#, c-format
+msgid "'%s' does not accept merge commits"
+msgstr ""
+
+#. TRANSLATORS: 'pick' and 'merge -C' should not be
+#. translated.
+#.
+msgid ""
+"'pick' does not take a merge commit. If you wanted to\n"
+"replay the merge, use 'merge -C' on the commit."
+msgstr ""
+
+#. TRANSLATORS: 'reword' and 'merge -c' should not be
+#. translated.
+#.
+msgid ""
+"'reword' does not take a merge commit. If you wanted to\n"
+"replay the merge and reword the commit message, use\n"
+"'merge -c' on the commit"
+msgstr ""
+
+#. TRANSLATORS: 'edit', 'merge -C' and 'break' should
+#. not be translated.
+#.
+msgid ""
+"'edit' does not take a merge commit. If you wanted to\n"
+"replay the merge, use 'merge -C' on the commit, and then\n"
+"'break' to give the control back to you so that you can\n"
+"do 'git commit --amend && git rebase --continue'."
+msgstr ""
+
+msgid "cannot squash merge commit into another commit"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "invalid command '%.*s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "missing arguments for %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not parse '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "invalid line %d: %.*s"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "cannot '%s' without a previous commit"
+msgstr ""
+
+#, fuzzy
+msgid "cancelling a cherry picking in progress"
+msgstr "Cherry-pick atá ar siúl faoi láthair."
+
+msgid "cancelling a revert in progress"
+msgstr ""
+
+msgid "please fix this using 'git rebase --edit-todo'."
+msgstr ""
+
+#, c-format
+msgid "unusable instruction sheet: '%s'"
+msgstr ""
+
+#, fuzzy
+msgid "no commits parsed."
+msgstr "Níl aon gealltanais fós"
+
+msgid "cannot cherry-pick during a revert."
+msgstr ""
+
+msgid "cannot revert during a cherry-pick."
+msgstr ""
+
+msgid "unusable squash-onto"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "malformed options sheet: '%s'"
+msgstr "theip ar '%s' a stáil"
+
+msgid "empty commit set passed"
+msgstr ""
+
+#, fuzzy
+msgid "revert is already in progress"
+msgstr "Ar ais atá ar siúl faoi láthair."
+
+#, fuzzy, c-format
+msgid "try \"git revert (--continue | %s--abort | --quit)\""
+msgstr " (reáchtáil “git revert --continue” chun leanúint ar aghaidh)"
+
+#, fuzzy
+msgid "cherry-pick is already in progress"
+msgstr "Cherry-pick atá ar siúl faoi láthair."
+
+#, fuzzy, c-format
+msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
+msgstr " (reáchtáil “git cherry-pick --continue ” chun leanúint ar aghaidh)"
+
+#, fuzzy, c-format
+msgid "could not create sequencer directory '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, fuzzy
+msgid "no cherry-pick or revert in progress"
+msgstr "Cherry-pick atá ar siúl faoi láthair."
+
+#, fuzzy
+msgid "cannot resolve HEAD"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "cannot abort from a branch yet to be born"
+msgstr "Tá tú ar bhrainse nach rugadh fós"
+
+#, fuzzy, c-format
+msgid "cannot read '%s': %s"
+msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+
+msgid "unexpected end of file"
+msgstr ""
+
+#, c-format
+msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
+msgstr ""
+
+msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
+msgstr ""
+
+#, fuzzy
+msgid "no revert in progress"
+msgstr "Ar ais atá ar siúl faoi láthair."
+
+#, fuzzy
+msgid "no cherry-pick in progress"
+msgstr "Cherry-pick atá ar siúl faoi láthair."
+
+#, fuzzy
+msgid "failed to skip the commit"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+msgid "there is nothing to skip"
+msgstr ""
+
+#, c-format
+msgid ""
+"have you committed already?\n"
+"try \"git %s --continue\""
+msgstr ""
+
+#, fuzzy
+msgid "cannot read HEAD"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+#, fuzzy
+msgid "could not write commit message file"
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#, c-format
+msgid ""
+"You can amend the commit now, with\n"
+"\n"
+"  git commit --amend %s\n"
+"\n"
+"Once you are satisfied with your changes, run\n"
+"\n"
+"  git rebase --continue\n"
+msgstr ""
+
+#, c-format
+msgid "Could not apply %s... %.*s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not merge %.*s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "Executing: %s\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid ""
+"execution failed: %s\n"
+"%sYou can fix the problem, and then run\n"
+"\n"
+"  git rebase --continue\n"
+"\n"
+msgstr ""
+" (déan coinbhleachtaí a shocrú agus ansin rith “git rebase --continue”)"
+
+#, fuzzy
+msgid "and made changes to the index and/or the working tree.\n"
+msgstr "athshocraigh HEAD, innéacs agus crann oibre"
+
+#, c-format
+msgid ""
+"execution succeeded: %s\n"
+"but left changes to the index and/or the working tree.\n"
+"Commit or stash your changes, and then run\n"
+"\n"
+"  git rebase --continue\n"
+"\n"
+msgstr ""
+
+#, c-format
+msgid "illegal label name: '%.*s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not resolve '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "writing fake root commit"
+msgstr "aon rud le tiomantas\n"
+
+msgid "writing squash-onto"
+msgstr ""
+
+msgid "cannot merge without a current revision"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to parse '%.*s'"
+msgstr "nach féidir %s a nuashonrú"
+
+#, c-format
+msgid "nothing to merge: '%.*s'"
+msgstr ""
+
+msgid "octopus merge cannot be executed on top of a [new root]"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not get commit message of '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#, fuzzy, c-format
+msgid "could not even attempt to merge '%.*s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy
+msgid "merge: Unable to write new index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#, c-format
+msgid ""
+"another 'rebase' process appears to be running; '%s.lock' already exists"
+msgstr ""
+
+#, c-format
+msgid ""
+"Updated the following refs with %s:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Failed to update the following refs with %s:\n"
+"%s"
+msgstr ""
+
+msgid "Cannot autostash"
+msgstr ""
+
+#, c-format
+msgid "Unexpected stash response: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not create directory for '%s'"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#, c-format
+msgid "Created autostash: %s\n"
+msgstr ""
+
+#, fuzzy
+msgid "could not reset --hard"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "Applied autostash.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot store %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid ""
+"%s\n"
+"Your changes are safe in the stash.\n"
+"You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
+msgstr ""
+
+msgid "Applying autostash resulted in conflicts."
+msgstr ""
+
+msgid "Autostash exists; creating a new stash entry."
+msgstr ""
+
+msgid "autostash reference is a symref"
+msgstr ""
+
+#, fuzzy
+msgid "could not detach HEAD"
+msgstr "Níl CEANN bailí agat."
+
+#, c-format
+msgid "Stopped at HEAD\n"
+msgstr ""
+
+#, c-format
+msgid "Stopped at %s\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Could not execute the todo command\n"
+"\n"
+"    %.*s\n"
+"It has been rescheduled; To edit the command before continuing, please\n"
+"edit the todo list first:\n"
+"\n"
+"    git rebase --edit-todo\n"
+"    git rebase --continue\n"
+msgstr ""
+
+#, c-format
+msgid "Stopped at %s...  %.*s\n"
+msgstr ""
+
+#, c-format
+msgid "Rebasing (%d/%d)%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown command %d"
+msgstr "Níl aon orduithe déanta."
+
+#, fuzzy
+msgid "could not read orig-head"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "could not read 'onto'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "could not update HEAD to %s"
+msgstr "in ann HEAD a nuashonrú"
+
+#, c-format
+msgid "Successfully rebased and updated %s.\n"
+msgstr ""
+
+#, fuzzy
+msgid "cannot rebase: You have unstaged changes."
+msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+
+#, fuzzy
+msgid "cannot amend non-existing commit"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+#, fuzzy, c-format
+msgid "invalid file: '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, fuzzy, c-format
+msgid "invalid contents: '%s'"
+msgstr "tagairt neamhbhailí: %s"
+
+msgid ""
+"\n"
+"You have uncommitted changes in your working tree. Please, commit them\n"
+"first and then run 'git rebase --continue' again."
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not write file: '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy
+msgid "could not remove CHERRY_PICK_HEAD"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy
+msgid "could not commit staged changes."
+msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+
+#, c-format
+msgid "%s: can't cherry-pick a %s"
+msgstr ""
+
+#, c-format
+msgid "%s: bad revision"
+msgstr ""
+
+msgid "can't revert as initial commit"
+msgstr ""
+
+#, c-format
+msgid "skipped previously applied commit %s"
+msgstr ""
+
+msgid "use --reapply-cherry-picks to include skipped commits"
+msgstr ""
+
+msgid "make_script: unhandled options"
+msgstr ""
+
+msgid "make_script: error preparing revisions"
+msgstr ""
+
+#, fuzzy
+msgid "nothing to do"
+msgstr "aon rud le tiomantas\n"
+
+msgid "could not skip unnecessary pick commands"
+msgstr ""
+
+msgid "the script was already rearranged."
+msgstr ""
+
+#, c-format
+msgid "update-refs file at '%s' is invalid"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' is outside repository at '%s'"
+msgstr "droch-stóras '%s'"
+
+#, c-format
+msgid ""
+"%s: no such path in the working tree.\n"
+"Use 'git <command> -- <path>...' to specify paths that do not exist locally."
+msgstr ""
+
+#, c-format
+msgid ""
+"ambiguous argument '%s': unknown revision or path not in the working tree.\n"
+"Use '--' to separate paths from revisions, like this:\n"
+"'git <command> [<revision>...] -- [<file>...]'"
+msgstr ""
+
+#, c-format
+msgid "option '%s' must come before non-option arguments"
+msgstr ""
+
+#, c-format
+msgid ""
+"ambiguous argument '%s': both revision and filename\n"
+"Use '--' to separate paths from revisions, like this:\n"
+"'git <command> [<revision>...] -- [<file>...]'"
+msgstr ""
+
+msgid "unable to set up work tree using invalid config"
+msgstr ""
+
+#, c-format
+msgid "'%s' already specified as '%s'"
+msgstr ""
+
+#, c-format
+msgid "Expected git repo version <= %d, found %d"
+msgstr ""
+
+msgid "unknown repository extension found:"
+msgid_plural "unknown repository extensions found:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+msgid "repo version is 0, but v1-only extension found:"
+msgid_plural "repo version is 0, but v1-only extensions found:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "error opening '%s'"
+msgstr ""
+
+#, c-format
+msgid "too large to be a .git file: '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "error reading %s"
+msgstr "nach féidir %s a léamh"
+
+#, fuzzy, c-format
+msgid "invalid gitfile format: %s"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "no path in gitfile: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not a git repository: %s"
+msgstr "droch-stóras '%s'"
+
+#, c-format
+msgid "'$%s' too big"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "not a git repository: '%s'"
+msgstr "droch-stóras '%s'"
+
+#, fuzzy, c-format
+msgid "cannot chdir to '%s'"
+msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
+
+#, fuzzy
+msgid "cannot come back to cwd"
+msgstr "Ní féidir teacht ar ais chuig cwd"
+
+#, fuzzy, c-format
+msgid "failed to stat '%*s%s%s'"
+msgstr "theip ar '%s' a stáil"
+
+#, c-format
+msgid "safe.directory '%s' not absolute"
+msgstr ""
+
+#, c-format
+msgid ""
+"detected dubious ownership in repository at '%s'\n"
+"%sTo add an exception for this directory, call:\n"
+"\n"
+"\tgit config --global --add safe.directory %s"
+msgstr ""
+
+#, fuzzy
+msgid "Unable to read current working directory"
+msgstr "in ann crann oibre a sheiceáil"
+
+#, fuzzy, c-format
+msgid "cannot change to '%s'"
+msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
+
+#, c-format
+msgid "not a git repository (or any of the parent directories): %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"not a git repository (or any parent up to mount point %s)\n"
+"Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)."
+msgstr ""
+
+#, c-format
+msgid "cannot use bare repository '%s' (safe.bareRepository is '%s')"
+msgstr ""
+
+#, c-format
+msgid ""
+"problem with core.sharedRepository filemode value (0%.3o).\n"
+"The owner of files must always have read and write permissions."
+msgstr ""
+
+msgid "fork failed"
+msgstr ""
+
+msgid "setsid failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "cannot stat template '%s'"
+msgstr "ní féidir le pacáiste fstat"
+
+#, fuzzy, c-format
+msgid "cannot opendir '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy, c-format
+msgid "cannot readlink '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy, c-format
+msgid "cannot symlink '%s' '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, fuzzy, c-format
+msgid "cannot copy '%s' to '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, c-format
+msgid "ignoring template %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "templates not found in %s"
+msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+
+#, fuzzy, c-format
+msgid "not copying templates from '%s': %s"
+msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+
+#, fuzzy, c-format
+msgid "invalid initial branch name: '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#, c-format
+msgid "re-init: ignored --initial-branch=%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to handle file type %d"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, fuzzy, c-format
+msgid "unable to move %s to %s"
+msgstr "nach féidir %s a léamh"
+
+msgid "attempt to reinitialize repository with different hash"
+msgstr ""
+
+msgid ""
+"attempt to reinitialize repository with different reference storage format"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s already exists"
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#, c-format
+msgid "Reinitialized existing shared Git repository in %s%s\n"
+msgstr ""
+
+#, c-format
+msgid "Reinitialized existing Git repository in %s%s\n"
+msgstr ""
+
+#, c-format
+msgid "Initialized empty shared Git repository in %s%s\n"
+msgstr ""
+
+#, c-format
+msgid "Initialized empty Git repository in %s%s\n"
+msgstr ""
+
+#, c-format
+msgid "index entry is a directory, but not sparse (%08x)"
+msgstr ""
+
+msgid "cannot use split index with a sparse index"
+msgstr ""
+
+#. TRANSLATORS: The first %s is a command like "ls-tree".
+#, fuzzy, c-format
+msgid "bad %s format: element '%s' does not start with '('"
+msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
+
+#. TRANSLATORS: The first %s is a command like "ls-tree".
+#, fuzzy, c-format
+msgid "bad %s format: element '%s' does not end in ')'"
+msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
+
+#. TRANSLATORS: %s is a command like "ls-tree".
+#, c-format
+msgid "bad %s format: %%%.*s"
+msgstr ""
+
+#. TRANSLATORS: IEC 80000-13:2008 gibibyte
+#, c-format
+msgid "%u.%2.2u GiB"
+msgstr ""
+
+#. TRANSLATORS: IEC 80000-13:2008 gibibyte/second
+#, c-format
+msgid "%u.%2.2u GiB/s"
+msgstr ""
+
+#. TRANSLATORS: IEC 80000-13:2008 mebibyte
+#, c-format
+msgid "%u.%2.2u MiB"
+msgstr ""
+
+#. TRANSLATORS: IEC 80000-13:2008 mebibyte/second
+#, c-format
+msgid "%u.%2.2u MiB/s"
+msgstr ""
+
+#. TRANSLATORS: IEC 80000-13:2008 kibibyte
+#, c-format
+msgid "%u.%2.2u KiB"
+msgstr ""
+
+#. TRANSLATORS: IEC 80000-13:2008 kibibyte/second
+#, c-format
+msgid "%u.%2.2u KiB/s"
+msgstr ""
+
+#. TRANSLATORS: IEC 80000-13:2008 byte
+#, c-format
+msgid "%u byte"
+msgid_plural "%u bytes"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#. TRANSLATORS: IEC 80000-13:2008 byte/second
+#, c-format
+msgid "%u byte/s"
+msgid_plural "%u bytes/s"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#, c-format
+msgid "ignoring suspicious submodule name: %s"
+msgstr ""
+
+msgid "negative values not allowed for submodule.fetchJobs"
+msgstr ""
+
+#, c-format
+msgid "ignoring '%s' which may be interpreted as a command-line option: %s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not update .gitmodules entry %s"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
+msgstr ""
+
+#, c-format
+msgid "Could not find section in .gitmodules where path=%s"
+msgstr ""
+
+#, c-format
+msgid "Could not remove .gitmodules entry for %s"
+msgstr ""
+
+msgid "staging updated .gitmodules failed"
+msgstr ""
+
+#, c-format
+msgid "in unpopulated submodule '%s'"
+msgstr ""
+
+#, c-format
+msgid "Pathspec '%s' is in submodule '%.*s'"
+msgstr ""
+
+#, c-format
+msgid "bad --ignore-submodules argument: %s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Submodule in commit %s at path: '%s' collides with a submodule named the "
+"same. Skipping it."
+msgstr ""
+
+#, c-format
+msgid "submodule entry '%s' (%s) is a %s, not a commit"
+msgstr ""
+
+#, c-format
+msgid ""
+"Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
+"submodule %s"
+msgstr ""
+
+#, c-format
+msgid "process for submodule '%s' failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Pushing submodule '%s'\n"
+msgstr "Ag brú chuig %s\n"
+
+#, fuzzy, c-format
+msgid "Unable to push submodule '%s'\n"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+#, c-format
+msgid "Fetching submodule %s%s\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not access submodule '%s'\n"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "Could not access submodule '%s' at commit %s\n"
+msgstr ""
+
+#, c-format
+msgid "Fetching submodule %s%s at commit %s\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"Errors during submodule fetch:\n"
+"%s"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' not recognized as a git repository"
+msgstr "--stdin teastaíonn stórlann git"
+
+#, c-format
+msgid "Could not run 'git status --porcelain=2' in submodule %s"
+msgstr ""
+
+#, c-format
+msgid "'git status --porcelain=2' failed in submodule %s"
+msgstr ""
+
+#, c-format
+msgid "could not start 'git status' in submodule '%s'"
+msgstr ""
+
+#, c-format
+msgid "could not run 'git status' in submodule '%s'"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Could not unset core.worktree setting in submodule '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#, fuzzy, c-format
+msgid "could not recurse into submodule '%s'"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+#, fuzzy
+msgid "could not reset submodule index"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "submodule '%s' has dirty index"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "Submodule '%s' could not be updated."
+msgstr "Fo-mhodúil athraithe ach gan nuashonrú:"
+
+#, c-format
+msgid "submodule git dir '%s' is inside git dir '%.*s'"
+msgstr ""
+
+#, c-format
+msgid "expected '%.*s' in submodule path '%s' not to be a symbolic link"
+msgstr ""
+
+#, c-format
+msgid "expected submodule path '%s' not to be a symbolic link"
+msgstr ""
+
+#, c-format
+msgid ""
+"relocate_gitdir for submodule '%s' with more than one worktree not supported"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not lookup name for submodule '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, c-format
+msgid "refusing to move '%s' into an existing git dir"
+msgstr ""
+
+#, c-format
+msgid ""
+"Migrating git directory of '%s%s' from\n"
+"'%s' to\n"
+"'%s'\n"
+msgstr ""
+
+#, fuzzy
+msgid "could not start ls-files in .."
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "ls-tree returned unexpected return code %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "failed to lstat '%s'"
+msgstr "theip ar '%s' a stáil"
+
+msgid "no remote configured to get bundle URIs from"
+msgstr ""
+
+msgid "could not get the bundle-uri list"
+msgstr ""
+
+msgid "test-tool cache-tree <options> (control|prime|update)"
+msgstr ""
+
+msgid "clear the cache tree before each iteration"
+msgstr ""
+
+msgid "number of entries in the cache tree to invalidate (default 0)"
+msgstr ""
+
+msgid "the number of objects to write"
+msgstr ""
+
+msgid "test-tool path-walk <options> -- <revision-options>"
+msgstr ""
+
+#, fuzzy
+msgid "toggle inclusion of blob objects"
+msgstr "réad blob neamhbhailí %s"
+
+msgid "toggle inclusion of commit objects"
+msgstr ""
+
+msgid "toggle inclusion of tag objects"
+msgstr ""
+
+msgid "toggle inclusion of tree objects"
+msgstr ""
+
+msgid "toggle pruning of uninteresting paths"
+msgstr ""
+
+msgid "read a pattern list over stdin"
+msgstr ""
+
+#, c-format
+msgid "commit %s is not marked reachable"
+msgstr ""
+
+msgid "too many commits marked reachable"
+msgstr ""
+
+msgid "could not determine MIDX preferred pack"
+msgstr ""
+
+msgid "test-tool serve-v2 [<options>]"
+msgstr ""
+
+msgid "exit immediately after advertising capabilities"
+msgstr ""
+
+msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
+msgstr ""
+
+msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
+msgstr ""
+
+msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
+msgstr ""
+
+msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
+msgstr ""
+
+msgid "test-helper simple-ipc send         [<name>] [<token>]"
+msgstr ""
+
+msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
+msgstr ""
+
+msgid ""
+"test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
+"[<batchsize>]"
+msgstr ""
+
+msgid "name or pathname of unix domain socket"
+msgstr ""
+
+msgid "named-pipe name"
+msgstr ""
+
+msgid "number of threads in server thread pool"
+msgstr ""
+
+msgid "seconds to wait for daemon to start or stop"
+msgstr ""
+
+msgid "number of bytes"
+msgstr ""
+
+#, fuzzy
+msgid "number of requests per thread"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+msgid "byte"
+msgstr ""
+
+msgid "ballast character"
+msgstr ""
+
+msgid "token"
+msgstr ""
+
+msgid "command token to send to the server"
+msgstr ""
+
+msgid "unit-test [<options>]"
+msgstr ""
+
+msgid "immediately exit upon the first failed test"
+msgstr ""
+
+msgid "suite[::test]"
+msgstr ""
+
+msgid "run only test suite or individual test <suite[::test]>"
+msgstr ""
+
+msgid "suite"
+msgstr ""
+
+msgid "exclude test suite <suite>"
+msgstr ""
+
+#, c-format
+msgid "running trailer command '%s' failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unknown value '%s' for key '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, c-format
+msgid "empty trailer token in trailer '%.*s'"
+msgstr ""
+
+msgid "full write to remote helper failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to find remote helper for '%s'"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+msgid "can't dup helper output fd"
+msgstr ""
+
+#, c-format
+msgid ""
+"unknown mandatory capability %s; this remote helper probably needs newer "
+"version of Git"
+msgstr ""
+
+msgid "this remote helper should implement refspec capability"
+msgstr ""
+
+#, c-format
+msgid "%s unexpectedly said: '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s also locked %s"
+msgstr ""
+
+msgid "couldn't run fast-import"
+msgstr ""
+
+#, fuzzy
+msgid "error while running fast-import"
+msgstr "earráid agus comhad pacáiste á dúnadh"
+
+#, fuzzy, c-format
+msgid "could not read ref %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "unknown response to connect: %s"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+msgid "setting remote service path not supported by protocol"
+msgstr ""
+
+#, fuzzy
+msgid "invalid remote service path"
+msgstr "tagairt neamhbhailí: %s"
+
+#, c-format
+msgid "can't connect to subservice %s"
+msgstr ""
+
+msgid "--negotiate-only requires protocol v2"
+msgstr ""
+
+msgid "'option' without a matching 'ok/error' directive"
+msgstr ""
+
+#, c-format
+msgid "expected ok/error, helper said '%s'"
+msgstr ""
+
+#, c-format
+msgid "helper reported unexpected status of %s"
+msgstr ""
+
+#, c-format
+msgid "helper %s does not support dry-run"
+msgstr ""
+
+#, c-format
+msgid "helper %s does not support --signed"
+msgstr ""
+
+#, c-format
+msgid "helper %s does not support --signed=if-asked"
+msgstr ""
+
+#, c-format
+msgid "helper %s does not support --atomic"
+msgstr ""
+
+#, c-format
+msgid "helper %s does not support --%s"
+msgstr ""
+
+#, c-format
+msgid "helper %s does not support 'push-option'"
+msgstr ""
+
+msgid "remote-helper doesn't support push; refspec needed"
+msgstr ""
+
+#, c-format
+msgid "helper %s does not support '--force'"
+msgstr ""
+
+msgid "couldn't run fast-export"
+msgstr ""
+
+#, fuzzy
+msgid "error while running fast-export"
+msgstr "earráid agus comhad pacáiste á dúnadh"
+
+#, c-format
+msgid ""
+"No refs in common and none specified; doing nothing.\n"
+"Perhaps you should specify a branch.\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unsupported object format '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#, c-format
+msgid "malformed response in ref list: %s"
+msgstr ""
+
+#, c-format
+msgid "read(%s) failed"
+msgstr ""
+
+#, c-format
+msgid "write(%s) failed"
+msgstr ""
+
+#, c-format
+msgid "%s thread failed"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "%s thread failed to join: %s"
+msgstr "theip ar '%s' a dhínascadh"
+
+#, c-format
+msgid "can't start thread for copying data: %s"
+msgstr ""
+
+#, c-format
+msgid "%s process failed to wait"
+msgstr ""
+
+#, c-format
+msgid "%s process failed"
+msgstr ""
+
+msgid "can't start thread for copying data"
+msgstr ""
+
+#, c-format
+msgid "Would set upstream of '%s' to '%s' of '%s'\n"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not read bundle '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, c-format
+msgid "transport: invalid depth option '%s'"
+msgstr ""
+
+msgid "see protocol.version in 'git help config' for more details"
+msgstr ""
+
+msgid "server options require protocol version 2 or later"
+msgstr ""
+
+msgid "server does not support wait-for-done"
+msgstr ""
+
+msgid "could not parse transport.color.* config"
+msgstr ""
+
+msgid "support for protocol v2 not implemented yet"
+msgstr ""
+
+#, c-format
+msgid "transport '%s' not allowed"
+msgstr ""
+
+msgid "git-over-rsync is no longer supported"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following submodule paths contain changes that can\n"
+"not be found on any remote:\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"\n"
+"Please try\n"
+"\n"
+"\tgit push --recurse-submodules=on-demand\n"
+"\n"
+"or cd to the path and use\n"
+"\n"
+"\tgit push\n"
+"\n"
+"to push them to a remote.\n"
+"\n"
+msgstr ""
+
+msgid "Aborting."
+msgstr ""
+
+#, fuzzy
+msgid "failed to push all needed submodules"
+msgstr "theip orthu beartáin fógraithe a fháil"
+
+msgid "bundle-uri operation not supported by protocol"
+msgstr ""
+
+#, fuzzy
+msgid "could not retrieve server-advertised bundle-uri list"
+msgstr "theip orthu beartáin fógraithe a fháil"
+
+msgid "operation not supported by protocol"
+msgstr ""
+
+msgid "too-short tree object"
+msgstr ""
+
+msgid "malformed mode in tree entry"
+msgstr ""
+
+msgid "empty filename in tree entry"
+msgstr ""
+
+msgid "too-short tree file"
+msgstr ""
+
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by checkout:\n"
+"%%sPlease commit your changes or stash them before you switch branches."
+msgstr ""
+
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by checkout:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by merge:\n"
+"%%sPlease commit your changes or stash them before you merge."
+msgstr ""
+
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by merge:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by %s:\n"
+"%%sPlease commit your changes or stash them before you %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by %s:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Updating the following directories would lose untracked files in them:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"Refusing to remove the current working directory:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be removed by checkout:\n"
+"%%sPlease move or remove them before you switch branches."
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be removed by checkout:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be removed by merge:\n"
+"%%sPlease move or remove them before you merge."
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be removed by merge:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be removed by %s:\n"
+"%%sPlease move or remove them before you %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be removed by %s:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be overwritten by "
+"checkout:\n"
+"%%sPlease move or remove them before you switch branches."
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be overwritten by "
+"checkout:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be overwritten by merge:\n"
+"%%sPlease move or remove them before you merge."
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be overwritten by merge:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be overwritten by %s:\n"
+"%%sPlease move or remove them before you %s."
+msgstr ""
+
+#, c-format
+msgid ""
+"The following untracked working tree files would be overwritten by %s:\n"
+"%%s"
+msgstr ""
+
+#, c-format
+msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
+msgstr ""
+
+#, c-format
+msgid ""
+"Cannot update submodule:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following paths are not up to date and were left despite sparse "
+"patterns:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following paths are unmerged and were left despite sparse patterns:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid ""
+"The following paths were already present and thus not updated despite sparse "
+"patterns:\n"
+"%s"
+msgstr ""
+
+#, c-format
+msgid "Aborting\n"
+msgstr ""
+
+#, c-format
+msgid ""
+"After fixing the above paths, you may want to run `git sparse-checkout "
+"reapply`.\n"
+msgstr ""
+
+msgid "Updating files"
+msgstr ""
+
+msgid ""
+"the following paths have collided (e.g. case-sensitive paths\n"
+"on a case-insensitive filesystem) and only one from the same\n"
+"colliding group is in the working tree:\n"
+msgstr ""
+
+msgid "Updating index flags"
+msgstr ""
+
+#, c-format
+msgid "worktree and untracked commit have duplicate entries: %s"
+msgstr ""
+
+msgid "expected flush after fetch arguments"
+msgstr ""
+
+msgid "invalid URL scheme name or missing '://' suffix"
+msgstr ""
+
+#, c-format
+msgid "invalid %XX escape sequence"
+msgstr ""
+
+msgid "missing host and scheme is not 'file:'"
+msgstr ""
+
+msgid "a 'file:' URL may not have a port number"
+msgstr ""
+
+msgid "invalid characters in host name"
+msgstr ""
+
+msgid "invalid port number"
+msgstr ""
+
+#, fuzzy
+msgid "invalid '..' path segment"
+msgstr "sonraíocht cosáin nebhail"
+
+#, fuzzy, c-format
+msgid "error: unable to format message: %s\n"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+msgid "usage: "
+msgstr ""
+
+msgid "fatal: "
+msgstr ""
+
+msgid "error: "
+msgstr ""
+
+msgid "warning: "
+msgstr ""
+
+#, c-format
+msgid "uname() failed with error '%s' (%d)\n"
+msgstr ""
+
+#, fuzzy
+msgid "Fetching objects"
+msgstr "Rud a sheiceáil"
+
+#, c-format
+msgid "'%s' at main working tree is not the repository directory"
+msgstr ""
+
+#, c-format
+msgid "'%s' file does not contain absolute path to the working tree location"
+msgstr ""
+
+#, c-format
+msgid "'%s' is not a .git file, error code %d"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "'%s' does not point back to '%s'"
+msgstr "Ní chuireann HEAD in iúl do bhrainse"
+
+#, fuzzy
+msgid "not a directory"
+msgstr "eolaire teimpléad"
+
+msgid ".git is not a file"
+msgstr ""
+
+msgid ".git file broken"
+msgstr ""
+
+#, fuzzy
+msgid ".git file incorrect"
+msgstr "comhad innéacs truaillithe"
+
+msgid ".git file absolute/relative path mismatch"
+msgstr ""
+
+msgid "not a valid path"
+msgstr ""
+
+msgid "unable to locate repository; .git is not a file"
+msgstr ""
+
+msgid "unable to locate repository; .git file does not reference a repository"
+msgstr ""
+
+msgid "unable to locate repository; .git file broken"
+msgstr ""
+
+msgid "gitdir unreadable"
+msgstr ""
+
+msgid "gitdir absolute/relative path mismatch"
+msgstr ""
+
+msgid "gitdir incorrect"
+msgstr ""
+
+msgid "not a valid directory"
+msgstr ""
+
+#, fuzzy
+msgid "gitdir file does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#, fuzzy, c-format
+msgid "unable to read gitdir file (%s)"
+msgstr "nach féidir crann a léamh (%s)"
+
+#, c-format
+msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
+msgstr ""
+
+msgid "invalid gitdir file"
+msgstr ""
+
+msgid "gitdir file points to non-existent location"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to set %s in '%s'"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#, fuzzy, c-format
+msgid "unable to unset %s in '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+msgid "failed to set extensions.worktreeConfig setting"
+msgstr ""
+
+msgid "unable to upgrade repository format to support relative worktrees"
+msgstr ""
+
+msgid "unable to set extensions.relativeWorktrees setting"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "could not setenv '%s'"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#, fuzzy, c-format
+msgid "unable to create '%s'"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "could not open '%s' for reading and writing"
+msgstr ""
+
+#, fuzzy, c-format
+msgid "unable to access '%s'"
+msgstr "nach féidir %s a nuashonrú"
+
+#, fuzzy
+msgid "unable to get current working directory"
+msgstr "in ann crann oibre a sheiceáil"
+
+#, fuzzy
+msgid "unable to get random bytes"
+msgstr "nach féidir %s a léamh"
+
+#, c-format
+msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
+msgstr ""
+
+#, c-format
+msgid "mmap failed%s"
+msgstr ""
 
 msgid "Unmerged paths:"
 msgstr "Cosáin neamh-chumasaithe:"
@@ -2232,9 +22221,6 @@ msgstr "Níl aon gealltanas ar aghaidh go fóill "
 msgid "HEAD (no branch)"
 msgstr "CEAD (gan aon bhrainse)"
 
-msgid "gone"
-msgstr "imithe"
-
 msgid "different"
 msgstr "difriúil"
 
@@ -2255,3 +22241,364 @@ msgstr "ina theannta sin, tá athruithe neamhthiomanta i d'innéacs."
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "ní féidir %s: Tá athruithe neamhthiomanta ag d'innéacs."
+
+#, fuzzy, c-format
+msgid "unknown style '%s' given for '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+msgid ""
+"Error: Your local changes to the following files would be overwritten by "
+"merge"
+msgstr ""
+
+msgid "Automated merge did not work."
+msgstr ""
+
+msgid "Should not be doing an octopus."
+msgstr ""
+
+#, sh-format
+msgid "Unable to find common commit with $pretty_name"
+msgstr ""
+
+#, sh-format
+msgid "Already up to date with $pretty_name"
+msgstr ""
+
+#, sh-format
+msgid "Fast-forwarding to: $pretty_name"
+msgstr ""
+
+#, sh-format
+msgid "Trying simple merge with $pretty_name"
+msgstr ""
+
+msgid "Simple merge did not work, trying automatic merge."
+msgstr ""
+
+#, sh-format
+msgid "usage: $dashless $USAGE"
+msgstr ""
+
+#, sh-format
+msgid "Cannot chdir to $cdup, the toplevel of the working tree"
+msgstr ""
+
+#, sh-format
+msgid "fatal: $program_name cannot be used without a working tree."
+msgstr ""
+
+#, fuzzy
+msgid "Cannot rewrite branches: You have unstaged changes."
+msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+
+#, fuzzy, sh-format
+msgid "Cannot $action: You have unstaged changes."
+msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+
+#, fuzzy, sh-format
+msgid "Cannot $action: Your index contains uncommitted changes."
+msgstr "ní féidir %s: Tá athruithe neamhthiomanta ag d'innéacs."
+
+#, fuzzy
+msgid "Additionally, your index contains uncommitted changes."
+msgstr "ina theannta sin, tá athruithe neamhthiomanta i d'innéacs."
+
+msgid "You need to run this command from the toplevel of the working tree."
+msgstr ""
+
+msgid "Unable to determine absolute path of git directory"
+msgstr ""
+
+msgid "local zone differs from GMT by a non-minute interval\n"
+msgstr ""
+
+msgid "local time offset greater than or equal to 24 hours\n"
+msgstr ""
+
+#, perl-format
+msgid "fatal: command '%s' died with exit code %d"
+msgstr ""
+
+msgid "the editor exited uncleanly, aborting everything"
+msgstr ""
+
+#, perl-format
+msgid ""
+"'%s' contains an intermediate version of the email you were composing.\n"
+msgstr ""
+
+#, perl-format
+msgid "'%s.final' contains the composed email.\n"
+msgstr ""
+
+msgid "--dump-aliases incompatible with other options\n"
+msgstr ""
+
+msgid "--dump-aliases and --translate-aliases are mutually exclusive\n"
+msgstr ""
+
+msgid ""
+"fatal: found configuration options for 'sendmail'\n"
+"git-send-email is configured with the sendemail.* options - note the 'e'.\n"
+"Set sendemail.forbidSendmailVariables to false to disable this check.\n"
+msgstr ""
+
+msgid "Cannot run git format-patch from outside a repository\n"
+msgstr ""
+
+msgid ""
+"`batch-size` and `relogin` must be specified together (via command-line or "
+"configuration option)\n"
+msgstr ""
+
+#, perl-format
+msgid "Unknown --suppress-cc field: '%s'\n"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "Unknown --confirm setting: '%s'\n"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+#, perl-format
+msgid "warning: sendmail alias with quotes is not supported: %s\n"
+msgstr ""
+
+#, perl-format
+msgid "warning: `:include:` not supported: %s\n"
+msgstr ""
+
+#, perl-format
+msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
+msgstr ""
+
+#, perl-format
+msgid "warning: sendmail line is not recognized: %s\n"
+msgstr ""
+
+#, perl-format
+msgid ""
+"File '%s' exists but it could also be the range of commits\n"
+"to produce patches for.  Please disambiguate by...\n"
+"\n"
+"    * Saying \"./%s\" if you mean a file; or\n"
+"    * Giving --format-patch option if you mean a range.\n"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "Failed to opendir %s: %s"
+msgstr "Theip ar chrann %s a aimsiú."
+
+msgid ""
+"\n"
+"No patch files specified!\n"
+"\n"
+msgstr ""
+
+#, perl-format
+msgid "No subject line in %s?"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "Failed to open for writing %s: %s"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+msgid ""
+"Lines beginning in \"GIT:\" will be removed.\n"
+"Consider including an overall diffstat or table of contents\n"
+"for the patch you are writing.\n"
+"\n"
+"Clear the body content if you don't wish to send a summary.\n"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "Failed to open %s.final: %s"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, fuzzy, perl-format
+msgid "Failed to open %s: %s"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+msgid "Summary email is empty, skipping it\n"
+msgstr ""
+
+#. TRANSLATORS: please keep [y/N] as is.
+#, perl-format
+msgid "Are you sure you want to use <%s> [y/N]? "
+msgstr ""
+
+msgid ""
+"The following files are 8bit, but do not declare a Content-Transfer-"
+"Encoding.\n"
+msgstr ""
+
+msgid "Which 8bit encoding should I declare [UTF-8]? "
+msgstr ""
+
+#, perl-format
+msgid ""
+"Refusing to send because the patch\n"
+"\t%s\n"
+"has the template subject '*** SUBJECT HERE ***'. Pass --force if you really "
+"want to send.\n"
+msgstr ""
+
+msgid "To whom should the emails be sent (if anyone)?"
+msgstr ""
+
+#, perl-format
+msgid "fatal: alias '%s' expands to itself\n"
+msgstr ""
+
+msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
+msgstr ""
+
+#, perl-format
+msgid "error: unable to extract a valid address from: %s\n"
+msgstr ""
+
+#. TRANSLATORS: Make sure to include [q] [d] [e] in your
+#. translation. The program will only accept English input
+#. at this point.
+msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "CA path \"%s\" does not exist"
+msgstr "níl an stóras '%s' ann"
+
+msgid ""
+"    The Cc list above has been expanded by additional\n"
+"    addresses found in the patch commit message. By default\n"
+"    send-email prompts before sending whenever this occurs.\n"
+"    This behavior is controlled by the sendemail.confirm\n"
+"    configuration setting.\n"
+"\n"
+"    For additional information, run 'git send-email --help'.\n"
+"    To retain the current behavior, but squelch this message,\n"
+"    run 'git config --global sendemail.confirm auto'.\n"
+"\n"
+msgstr ""
+
+#. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
+#. translation. The program will only accept English input
+#. at this point.
+msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
+msgstr ""
+
+msgid "Send this email reply required"
+msgstr ""
+
+msgid "The required SMTP server is not properly defined."
+msgstr ""
+
+#, perl-format
+msgid "Server does not support STARTTLS! %s"
+msgstr ""
+
+#, perl-format
+msgid "STARTTLS failed! %s"
+msgstr ""
+
+msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
+msgstr ""
+
+#, perl-format
+msgid "Outlook reassigned Message-ID to: %s\n"
+msgstr ""
+
+msgid "Warning: Could not retrieve Message-ID from server response.\n"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "Failed to send %s\n"
+msgstr "theip ar '%s' a stáil"
+
+#, perl-format
+msgid "Dry-Sent %s"
+msgstr ""
+
+#, perl-format
+msgid "Sent %s"
+msgstr ""
+
+msgid "Dry-OK. Log says:"
+msgstr ""
+
+msgid "OK. Log says:"
+msgstr ""
+
+msgid "Result: "
+msgstr ""
+
+msgid "Result: OK"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "can't open file %s"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#, perl-format
+msgid "(mbox) Adding cc: %s from line '%s'\n"
+msgstr ""
+
+#, perl-format
+msgid "(mbox) Adding to: %s from line '%s'\n"
+msgstr ""
+
+#, perl-format
+msgid "(non-mbox) Adding cc: %s from line '%s'\n"
+msgstr ""
+
+#, perl-format
+msgid "(body) Adding cc: %s from line '%s'\n"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "(%s) Could not execute '%s'"
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#, perl-format
+msgid "(%s) Malformed output from '%s'"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "(%s) failed to close pipe to '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#, perl-format
+msgid "(%s) Adding %s: %s from: '%s'\n"
+msgstr ""
+
+msgid "cannot send message as 7bit"
+msgstr ""
+
+#, fuzzy
+msgid "invalid transfer encoding"
+msgstr "tagairt neamhbhailí: %s"
+
+#, perl-format
+msgid ""
+"fatal: %s: rejected by %s hook\n"
+"%s\n"
+"warning: no patches were sent\n"
+msgstr ""
+
+#, fuzzy, perl-format
+msgid "unable to open %s: %s\n"
+msgstr "nach féidir %s a nuashonrú"
+
+#, perl-format
+msgid ""
+"fatal: %s:%d is longer than 998 characters\n"
+"warning: no patches were sent\n"
+msgstr ""
+
+#, perl-format
+msgid "Skipping %s with backup suffix '%s'.\n"
+msgstr ""
+
+#. TRANSLATORS: please keep "[y|N]" as is.
+#, perl-format
+msgid "Do you really want to send %s? [y|N]: "
+msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -1,0 +1,2676 @@
+# Irish translations for Git package.
+# Copyright (C) 2025 THE Git'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Git package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Git\n"
+"Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
+"POT-Creation-Date: 2025-05-14 08:56+0100\n"
+"PO-Revision-Date: 2025-05-14 13:12+0100\n"
+"Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
+"Language-Team: none\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#: builtin/checkout.c:47
+msgid "git checkout [<options>] <branch>"
+msgstr "git checkout [<roghanna>] <brainse>"
+
+#: builtin/checkout.c:48
+msgid "git checkout [<options>] [<branch>] -- <file>..."
+msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+
+#: builtin/checkout.c:53
+msgid "git switch [<options>] [<branch>]"
+msgstr "git switch [<roghanna>] [<brainse>]"
+
+#: builtin/checkout.c:58
+msgid "git restore [<options>] [--source=<branch>] <file>..."
+msgstr "git restore [<roghanna>] [--source=<brainse>] <comhad>..."
+
+#: builtin/checkout.c:215 builtin/checkout.c:254
+#, c-format
+msgid "path '%s' does not have our version"
+msgstr "níl ár leagan ag cosán '%s'"
+
+#: builtin/checkout.c:217 builtin/checkout.c:256
+#, c-format
+msgid "path '%s' does not have their version"
+msgstr "níl a leagan ag cosán '%s'"
+
+#: builtin/checkout.c:233
+#, c-format
+msgid "path '%s' does not have all necessary versions"
+msgstr "níl gach leagan riachtanach ag cosán '%s'"
+
+#: builtin/checkout.c:288
+#, c-format
+msgid "path '%s' does not have necessary versions"
+msgstr "níl leaganacha riachtanacha ag cosán '%s'"
+
+#: builtin/checkout.c:308
+#, c-format
+msgid "path '%s': cannot merge"
+msgstr "cosán '%s': ní féidir a chumasc"
+
+#: builtin/checkout.c:324
+#, c-format
+msgid "Unable to add merge result for '%s'"
+msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+
+#: builtin/checkout.c:328 builtin/reset.c:186
+#, c-format
+msgid "make_cache_entry failed for path '%s'"
+msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
+
+#: builtin/checkout.c:442
+#, c-format
+msgid "Recreated %d merge conflict"
+msgid_plural "Recreated %d merge conflicts"
+msgstr[0] "Athchruthaíodh %d coimhlint chumasc"
+msgstr[1] "Athchruthaíodh %d coinbhleachtaí chumaisc"
+msgstr[2] "Athchruthaíodh %d coinbhleachtaí chumaisc"
+
+#: builtin/checkout.c:447
+#, c-format
+msgid "Updated %d path from %s"
+msgid_plural "Updated %d paths from %s"
+msgstr[0] "Nuashonraíodh %d cosán ó %s"
+msgstr[1] "Nuashonraíodh %d cosán ó %s"
+msgstr[2] "Nuashonraíodh %d cosán ó %s"
+
+#: builtin/checkout.c:454
+#, c-format
+msgid "Updated %d path from the index"
+msgid_plural "Updated %d paths from the index"
+msgstr[0] "Nuashonraíodh %d cosán ón innéacs"
+msgstr[1] "Nuashonraíodh %d cosán ón innéacs"
+msgstr[2] "Nuashonraíodh %d cosán ón innéacs"
+
+#: builtin/checkout.c:477 builtin/checkout.c:480 builtin/checkout.c:483 builtin/checkout.c:487
+#, c-format
+msgid "'%s' cannot be used with updating paths"
+msgstr "Ní féidir '%s' a úsáid le cosáin a nuashonrú"
+
+#: builtin/checkout.c:490 builtin/checkout.c:493 builtin/checkout.c:1805 builtin/checkout.c:1915
+#: builtin/checkout.c:1918 builtin/clone.c:1033 builtin/clone.c:1038 builtin/index-pack.c:2026
+#: builtin/reset.c:388 builtin/reset.c:425
+#, c-format
+msgid "options '%s' and '%s' cannot be used together"
+msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+
+#: builtin/checkout.c:497
+#, c-format
+msgid "Cannot update paths and switch to branch '%s' at the same time."
+msgstr "Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
+
+#: builtin/checkout.c:501
+#, c-format
+msgid "neither '%s' or '%s' is specified"
+msgstr "níl '%s' ná '%s' sonraithe"
+
+#: builtin/checkout.c:505
+#, c-format
+msgid "'%s' must be used when '%s' is not specified"
+msgstr "Ní mór '%s' a úsáid nuair nach sonraítear '%s'"
+
+#: builtin/checkout.c:523 builtin/checkout.c:527
+#, c-format
+msgid "'%s' or '%s' cannot be used with %s"
+msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
+
+#: builtin/checkout.c:537
+#, c-format
+msgid "'%s', '%s', or '%s' cannot be used when checking out of a tree"
+msgstr "Ní féidir '%s', '%s', nó '%s' a úsáid agus tú ag seiceáil amach as crann"
+
+#: builtin/checkout.c:573 builtin/checkout.c:789 builtin/reset.c:464
+msgid "index file corrupt"
+msgstr "comhad innéacs truaillithe"
+
+#: builtin/checkout.c:610 builtin/checkout.c:617
+#, c-format
+msgid "path '%s' is unmerged"
+msgstr "tá cosán '%s' neamh-chomhcheangailte"
+
+#: builtin/checkout.c:642 builtin/checkout.c:931 builtin/clone.c:693
+msgid "unable to write new index file"
+msgstr "in ann comhad innéacs nua a scríobh"
+
+#: builtin/checkout.c:802 builtin/checkout.c:1274 builtin/checkout.c:1280 builtin/reset.c:123
+#, c-format
+msgid "unable to read tree (%s)"
+msgstr "nach féidir crann a léamh (%s)"
+
+#: builtin/checkout.c:818
+msgid "you need to resolve your current index first"
+msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
+
+#: builtin/checkout.c:835 builtin/clone.c:683
+#, c-format
+msgid "unable to parse commit %s"
+msgstr "nach féidir le tiomantas %s a pharsáil"
+
+#: builtin/checkout.c:873
+#, c-format
+msgid ""
+"cannot continue with staged changes in the following files:\n"
+"%s"
+msgstr ""
+"ní féidir leanúint ar aghaidh le hathruithe céime sna comhaid seo a leanas:\n"
+"%s"
+
+#: builtin/checkout.c:971
+#, c-format
+msgid "Can not do reflog for '%s': %s\n"
+msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+
+#: builtin/checkout.c:1018
+msgid "HEAD is now at"
+msgstr "Tá HEAD anois ag"
+
+#: builtin/checkout.c:1022 builtin/clone.c:578 builtin/clone.c:608
+msgid "unable to update HEAD"
+msgstr "in ann HEAD a nuashonrú"
+
+#: builtin/checkout.c:1026
+#, c-format
+msgid "Reset branch '%s'\n"
+msgstr "Athshocraigh brainse '%s'\n"
+
+#: builtin/checkout.c:1029
+#, c-format
+msgid "Already on '%s'\n"
+msgstr "Ar '%s' cheana féin\n"
+
+#: builtin/checkout.c:1033
+#, c-format
+msgid "Switched to and reset branch '%s'\n"
+msgstr "Aistrigh agus athshocraigh brainse '%s'\n"
+
+#: builtin/checkout.c:1035 builtin/checkout.c:1488
+#, c-format
+msgid "Switched to a new branch '%s'\n"
+msgstr "Aistrithe go brainse nua '%s'\n"
+
+#: builtin/checkout.c:1037
+#, c-format
+msgid "Switched to branch '%s'\n"
+msgstr "Aistrithe go brainse '%s'\n"
+
+#: builtin/checkout.c:1090
+#, c-format
+msgid " ... and %d more.\n"
+msgstr " ... agus %d níos mó.\n"
+
+#: builtin/checkout.c:1096
+#, c-format
+msgid ""
+"Warning: you are leaving %d commit behind, not connected to\n"
+"any of your branches:\n"
+"\n"
+"%s\n"
+msgid_plural ""
+"Warning: you are leaving %d commits behind, not connected to\n"
+"any of your branches:\n"
+"\n"
+"%s\n"
+msgstr[0] ""
+"Rabhadh: tá %d tiomantas á fhágáil agat, gan cheangal le haon cheann de do bhrainsí:\n"
+"\n"
+"%s\n"
+msgstr[1] ""
+"Rabhadh: tá %d tiomantas á bhfágáil agat i do dhiaidh, gan aon cheangal le haon cheann de do "
+"bhrainsí:\n"
+"\n"
+"%s\n"
+msgstr[2] ""
+"Rabhadh: tá %d tiomantas á bhfágáil agat i do dhiaidh, gan aon cheangal le haon cheann de do "
+"bhrainsí:\n"
+"\n"
+"%s\n"
+
+#: builtin/checkout.c:1115
+#, c-format
+msgid ""
+"If you want to keep it by creating a new branch, this may be a good time\n"
+"to do so with:\n"
+"\n"
+" git branch <new-branch-name> %s\n"
+"\n"
+msgid_plural ""
+"If you want to keep them by creating a new branch, this may be a good time\n"
+"to do so with:\n"
+"\n"
+" git branch <new-branch-name> %s\n"
+"\n"
+msgstr[0] ""
+"Más mian leat é a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-am é seo chun é sin a "
+"dhéanamh le:\n"
+"\n"
+"git branch <ainm-brainse-nua> %s\n"
+msgstr[1] ""
+"Más mian leat iad a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-am é seo chun é sin a "
+"dhéanamh le:\n"
+"\n"
+"git branch <ainm-brainse-nua> %s\n"
+msgstr[2] ""
+"Más mian leat iad a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-am é seo chun é sin a "
+"dhéanamh le:\n"
+"\n"
+"git branch <ainm-brainse-nua> %s\n"
+
+#: builtin/checkout.c:1151
+msgid "internal error in revision walk"
+msgstr "earráid inmheánach i dsiúlóid"
+
+#: builtin/checkout.c:1155
+msgid "Previous HEAD position was"
+msgstr "Bhí post CEAD roimhe seo"
+
+#: builtin/checkout.c:1200 builtin/checkout.c:1482
+msgid "You are on a branch yet to be born"
+msgstr "Tá tú ar bhrainse nach rugadh fós"
+
+#: builtin/checkout.c:1293
+#, c-format
+msgid ""
+"'%s' could be both a local file and a tracking branch.\n"
+"Please use -- (and optionally --no-guess) to disambiguate"
+msgstr ""
+"D'fhéadfadh '%s' a bheith ina chomhad áitiúil agus ina bhrainse rianaithe araon.\n"
+"Úsáid le do thoil -- (agus go roghnach --no-thuairim) chun a dhíbhriú"
+
+#: builtin/checkout.c:1300
+msgid ""
+"If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
+"you can do so by fully qualifying the name with the --track option:\n"
+"\n"
+"    git checkout --track origin/<name>\n"
+"\n"
+"If you'd like to always have checkouts of an ambiguous <name> prefer\n"
+"one remote, e.g. the 'origin' remote, consider setting\n"
+"checkout.defaultRemote=origin in your config."
+msgstr ""
+"Má bhí sé i gceist agat brainse cianrianaithe a sheiceáil ar, m.sh. 'tionscnamh',\n"
+"is féidir leat é sin a dhéanamh tríd an ainm a cháiliú go hiomlán leis an rogha --track:\n"
+"\n"
+" seiceáil git --track bunaidh/<name>\n"
+"\n"
+"<name>Más mian leat seiceálacha débhríoch a bheith agat i gcónaí is fearr leat\n"
+"iargúlta amháin, m.sh. an iargúlta 'bunús', smaoinigh ar shocrú\n"
+"checkout.defaultRemote=Bunús i do chumraíocht."
+
+#: builtin/checkout.c:1310
+#, c-format
+msgid "'%s' matched multiple (%d) remote tracking branches"
+msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
+
+#: builtin/checkout.c:1377
+msgid "only one reference expected"
+msgstr "níl ach tagairt amháin ag súil leis"
+
+#: builtin/checkout.c:1394
+#, c-format
+msgid "only one reference expected, %d given."
+msgstr "níl ach tagairt amháin ag súil leis, %d tugtha."
+
+#: builtin/checkout.c:1440
+#, c-format
+msgid "invalid reference: %s"
+msgstr "tagairt neamhbhailí: %s"
+
+#: builtin/checkout.c:1453 builtin/checkout.c:1886
+#, c-format
+msgid "reference is not a tree: %s"
+msgstr "ní crann é tagairt: %s"
+
+#: builtin/checkout.c:1504
+#, c-format
+msgid "a branch is expected, got tag '%s'"
+msgstr "táthar ag súil le brainse, faightear tag '%s'"
+
+#: builtin/checkout.c:1506
+#, c-format
+msgid "a branch is expected, got remote branch '%s'"
+msgstr "táthar ag súil le brainse, fuair brainse iargúlta '%s'"
+
+#: builtin/checkout.c:1508 builtin/checkout.c:1517
+#, c-format
+msgid "a branch is expected, got '%s'"
+msgstr "táthar ag súil le brainse, fuair '%s'"
+
+#: builtin/checkout.c:1511
+#, c-format
+msgid "a branch is expected, got commit '%s'"
+msgstr "táthar ag súil le brainse, fuair sé tiomantas '%s'"
+
+#: builtin/checkout.c:1520
+msgid "If you want to detach HEAD at the commit, try again with the --detach option."
+msgstr "Más mian leat HEAD a dhícheangal ag an tiomantas, déan iarracht arís leis an rogha --detach."
+
+#: builtin/checkout.c:1533
+msgid ""
+"cannot switch branch while merging\n"
+"Consider \"git merge --quit\" or \"git worktree add\"."
+msgstr ""
+"ní féidir brainse a athrú agus cumasc á dhéanamh\n"
+"Smaoinigh ar \"git merge --quit\" nó \"git worktree add\"."
+
+#: builtin/checkout.c:1537
+msgid ""
+"cannot switch branch in the middle of an am session\n"
+"Consider \"git am --quit\" or \"git worktree add\"."
+msgstr ""
+"ní féidir brainse a athrú i lár seisiún am\n"
+"Smaoinigh ar \"git am --quit\" nó \"git worktree add\"."
+
+#: builtin/checkout.c:1541
+msgid ""
+"cannot switch branch while rebasing\n"
+"Consider \"git rebase --quit\" or \"git worktree add\"."
+msgstr ""
+"ní féidir brainse a athrú agus athbhunú á dhéanamh\n"
+"Smaoinigh ar \"git rebase --quit\" nó \"git worktree add\"."
+
+#: builtin/checkout.c:1545
+msgid ""
+"cannot switch branch while cherry-picking\n"
+"Consider \"git cherry-pick --quit\" or \"git worktree add\"."
+msgstr ""
+"ní féidir brainse a athrú agus tú ag roghnú brainse nua\n"
+"Smaoinigh ar \"git cherry-pick --quit\" nó \"git worktree add\"."
+
+#: builtin/checkout.c:1549
+msgid ""
+"cannot switch branch while reverting\n"
+"Consider \"git revert --quit\" or \"git worktree add\"."
+msgstr ""
+"ní féidir brainse a athrú agus aisiompú á dhéanamh\n"
+"Smaoinigh ar \"git revert --quit\" nó \"git worktree add\"."
+
+#: builtin/checkout.c:1553
+msgid "you are switching branch while bisecting"
+msgstr "tá tú ag athrú brainse agus tú ag déileáil"
+
+#: builtin/checkout.c:1587
+msgid "paths cannot be used with switching branches"
+msgstr "ní féidir cosáin a úsáid le brainsí a athrú"
+
+#: builtin/checkout.c:1590 builtin/checkout.c:1594 builtin/checkout.c:1602
+#, c-format
+msgid "'%s' cannot be used with switching branches"
+msgstr "Ní féidir '%s' a úsáid le brainsí a athrú"
+
+#: builtin/checkout.c:1600
+#, c-format
+msgid "'%s' needs the paths to check out"
+msgstr "Teastaíonn '%s' na cosáin chun seiceáil"
+
+#: builtin/checkout.c:1607 builtin/checkout.c:1610 builtin/checkout.c:1613 builtin/checkout.c:1618
+#: builtin/checkout.c:1623
+#, c-format
+msgid "'%s' cannot be used with '%s'"
+msgstr "Ní féidir '%s' a úsáid le '%s'"
+
+#: builtin/checkout.c:1620
+#, c-format
+msgid "'%s' cannot take <start-point>"
+msgstr "Ní féidir '%s' a ghlacadh <start-point>"
+
+#: builtin/checkout.c:1628
+#, c-format
+msgid "Cannot switch branch to a non-commit '%s'"
+msgstr "Ní féidir brainse a aistriú go '%s' neamh-thiomanta"
+
+#: builtin/checkout.c:1633
+msgid "missing branch or commit argument"
+msgstr "brainse ar iarraidh nó argóint a dhéanamh"
+
+#: builtin/checkout.c:1678
+#, c-format
+msgid "unknown conflict style '%s'"
+msgstr "stíl choimhlinte anaithnid '%s'"
+
+#: builtin/checkout.c:1690
+msgid "suppress progress reporting"
+msgstr "cur chun cinn tuairiscithe"
+
+#: builtin/checkout.c:1694 builtin/clone.c:917 builtin/push.c:586
+msgid "force progress reporting"
+msgstr "tuairisciú dul chun cinn"
+
+#: builtin/checkout.c:1695
+msgid "perform a 3-way merge with the new branch"
+msgstr "cumasc 3 bhealach a dhéanamh leis an mbrainse nua"
+
+#: builtin/checkout.c:1696
+msgid "style"
+msgstr "stíl"
+
+#: builtin/checkout.c:1697
+msgid "conflict style (merge, diff3, or zdiff3)"
+msgstr "stíl choimhlinte (cumaisc, diff3, nó zdiff3)"
+
+#: builtin/checkout.c:1710
+msgid "detach HEAD at named commit"
+msgstr "dícheangail HEAD ag an tiomnú ainmnithe"
+
+#: builtin/checkout.c:1712
+msgid "set branch tracking configuration"
+msgstr "cumraíocht rianaithe brainse a shoc"
+
+#: builtin/checkout.c:1715
+msgid "force checkout (throw away local modifications)"
+msgstr "seiceáil fórsa (caith modhnuithe áitiúla)"
+
+#: builtin/checkout.c:1717
+msgid "new-branch"
+msgstr "brainse-nua"
+
+#: builtin/checkout.c:1717
+msgid "new unborn branch"
+msgstr "brainse nua gan breith"
+
+#: builtin/checkout.c:1719
+msgid "update ignored files (default)"
+msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
+
+#: builtin/checkout.c:1722
+msgid "do not check if another worktree is using this branch"
+msgstr "ná seiceáil an bhfuil crann oibre eile á úsáid ag baint úsáide as an mbrainse seo"
+
+#: builtin/checkout.c:1735
+msgid "checkout our version for unmerged files"
+msgstr "seiceáil ár leagan le haghaidh comhaid neamh-chumasaithe"
+
+#: builtin/checkout.c:1738
+msgid "checkout their version for unmerged files"
+msgstr "seiceáil a leagan le haghaidh comhaid neamh-chumasaithe"
+
+#: builtin/checkout.c:1740 builtin/reset.c:372
+msgid "select hunks interactively"
+msgstr "roghnaigh hunks idirghníomhach"
+
+#: builtin/checkout.c:1742
+msgid "do not limit pathspecs to sparse entries only"
+msgstr "ná teorainn le speisiúintí cosáin le hiontrálacha neamhchoitianta"
+
+#: builtin/checkout.c:1801
+#, c-format
+msgid "options '-%c', '-%c', and '%s' cannot be used together"
+msgstr "ní féidir na roghanna '-%c', '-%c', agus '%s' a úsáid le chéile"
+
+#: builtin/checkout.c:1842
+msgid "--track needs a branch name"
+msgstr "Teastaíonn ainm brainse ó --track"
+
+#: builtin/checkout.c:1847
+#, c-format
+msgid "missing branch name; try -%c"
+msgstr "ainm brainse ar iarraidh; iarracht -%c"
+
+#: builtin/checkout.c:1879
+#, c-format
+msgid "could not resolve %s"
+msgstr "ní fhéadfaí %s a réiteach"
+
+#: builtin/checkout.c:1895
+msgid "invalid path specification"
+msgstr "sonraíocht cosáin nebhail"
+
+#: builtin/checkout.c:1902
+#, c-format
+msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
+msgstr "Ní tiomantas é '%s' agus ní féidir brainse '%s' a chruthú uaidh"
+
+#: builtin/checkout.c:1906
+#, c-format
+msgid "git checkout: --detach does not take a path argument '%s'"
+msgstr "git checkout: Ní ghlacann --detach argóint cosáin '%s'"
+
+#: builtin/checkout.c:1912 builtin/reset.c:391
+#, c-format
+msgid "'%s' and pathspec arguments cannot be used together"
+msgstr "Ní féidir argóintí '%s' agus pathspec a úsáid le chéile"
+
+#: builtin/checkout.c:1924 builtin/clone.c:1269 builtin/clone.c:1272 builtin/index-pack.c:2020
+#: builtin/reset.c:397 builtin/reset.c:458
+#, c-format
+msgid "the option '%s' requires '%s'"
+msgstr "tá %s ag teastáil don rogha '%s'"
+
+#: builtin/checkout.c:1931
+msgid ""
+"git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
+"checking out of the index."
+msgstr ""
+"git checkout: - ours/--a gcuid féin, --force agus --merge neamhoiriúnach nuair\n"
+"seiceáil amach as an innéacs."
+
+#: builtin/checkout.c:1936
+msgid "you must specify path(s) to restore"
+msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
+
+#: builtin/checkout.c:1971 builtin/checkout.c:1973 builtin/checkout.c:2021 builtin/checkout.c:2023
+#: builtin/clone.c:956
+msgid "branch"
+msgstr "brainse"
+
+#: builtin/checkout.c:1972
+msgid "create and checkout a new branch"
+msgstr "brainse nua a chruthú agus a sheiceáil"
+
+#: builtin/checkout.c:1974
+msgid "create/reset and checkout a branch"
+msgstr "cruthaigh/athshocraigh agus seiceáil amach brainse"
+
+#: builtin/checkout.c:1975
+msgid "create reflog for new branch"
+msgstr "cruthú reflog do bhrainse nua"
+
+#: builtin/checkout.c:1977
+msgid "second guess 'git checkout <no-such-branch>' (default)"
+msgstr "an dara tuairim 'git check <no-such-branch>'(réamhshocraithe)"
+
+#: builtin/checkout.c:1978
+msgid "use overlay mode (default)"
+msgstr "úsáid modh forleagtha (réamhshocraithe)"
+
+#: builtin/checkout.c:2022
+msgid "create and switch to a new branch"
+msgstr "cruthú agus aistrigh go brainse nua"
+
+#: builtin/checkout.c:2024
+msgid "create/reset and switch to a branch"
+msgstr "cruthú/athshocraigh agus aistrigh go brainse"
+
+#: builtin/checkout.c:2026
+msgid "second guess 'git switch <no-such-branch>'"
+msgstr "buille faoi thuairim eile 'git switch <gan-bhrainse-den-sórt-sin>'"
+
+#: builtin/checkout.c:2028
+msgid "throw away local modifications"
+msgstr "modhnuithe áitiúla a chaitheamh"
+
+#: builtin/checkout.c:2061
+msgid "which tree-ish to checkout from"
+msgstr "cén crainn le seiceáil uaidh"
+
+#: builtin/checkout.c:2063
+msgid "restore the index"
+msgstr "an t-innéacs a chur ar ais"
+
+#: builtin/checkout.c:2065
+msgid "restore the working tree (default)"
+msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+
+#: builtin/checkout.c:2067
+msgid "ignore unmerged entries"
+msgstr "neamhaird a dhéanamh ar iontrálacha"
+
+#: builtin/checkout.c:2068
+msgid "use overlay mode"
+msgstr "úsáid modh forleagtha"
+
+#: builtin/clone.c:169
+#, c-format
+msgid "info: Could not add alternate for '%s': %s\n"
+msgstr "eolas: Ní féidir malartach a chur le haghaidh '%s': %s\n"
+
+#: builtin/clone.c:238
+#, c-format
+msgid "failed to create directory '%s'"
+msgstr "theip ar eolaire '%s' a chruthú"
+
+#: builtin/clone.c:240
+#, c-format
+msgid "failed to stat '%s'"
+msgstr "theip ar '%s' a stáil"
+
+#: builtin/clone.c:242
+#, c-format
+msgid "%s exists and is not a directory"
+msgstr "Tá %s ann agus ní eolaire é"
+
+#: builtin/clone.c:276
+#, c-format
+msgid "'%s' is a symlink, refusing to clone with --local"
+msgstr "Is nasc comhsheasmhach é '%s', ag diúltú clónú le --local"
+
+#: builtin/clone.c:280
+#, c-format
+msgid "failed to start iterator over '%s'"
+msgstr "theip ar an iterator a thosú thar '%s'"
+
+#: builtin/clone.c:295
+#, c-format
+msgid "symlink '%s' exists, refusing to clone with --local"
+msgstr "tá nasc symlink '%s' ann, ag diúltú clónú le --local"
+
+#: builtin/clone.c:310
+#, c-format
+msgid "failed to unlink '%s'"
+msgstr "theip ar '%s' a dhínascadh"
+
+#: builtin/clone.c:322
+#, c-format
+msgid "hardlink cannot be checked at '%s'"
+msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
+
+#: builtin/clone.c:329
+#, c-format
+msgid "hardlink different from source at '%s'"
+msgstr "crua-nasc difriúil ó fhoinse ag '%s'"
+
+#: builtin/clone.c:334
+#, c-format
+msgid "failed to create link '%s'"
+msgstr "theip ar nasc '%s' a chruthú"
+
+#: builtin/clone.c:338
+#, c-format
+msgid "failed to copy file to '%s'"
+msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+
+#: builtin/clone.c:343
+#, c-format
+msgid "failed to iterate over '%s'"
+msgstr "theip ar athrá thar '%s'"
+
+#: builtin/clone.c:370
+#, c-format
+msgid "done.\n"
+msgstr "déanta.\n"
+
+#: builtin/clone.c:384
+msgid ""
+"Clone succeeded, but checkout failed.\n"
+"You can inspect what was checked out with 'git status'\n"
+"and retry with 'git restore --source=HEAD :/'\n"
+msgstr ""
+"D'éirigh le clón, ach theip ar an tseiceáil.\n"
+"Is féidir leat iniúchadh a dhéanamh ar an méid a sheiceáladh le 'git status'\n"
+"agus déan iarracht arís le 'git restore --source=head: /'\n"
+
+#: builtin/clone.c:550
+msgid "remote did not send all necessary objects"
+msgstr "níor sheol iargúlta gach rud riachtanach"
+
+#: builtin/clone.c:566
+#, c-format
+msgid "unable to update %s"
+msgstr "nach féidir %s a nuashonrú"
+
+#: builtin/clone.c:628
+msgid "failed to initialize sparse-checkout"
+msgstr "theip ar sheiceáil éagsúil a thosú"
+
+#: builtin/clone.c:652
+msgid "remote HEAD refers to nonexistent ref, unable to checkout"
+msgstr "tagraíonn iargúlta HEAD do thagartha nach bhfuil ann, nach féidir a sheiceáil"
+
+#: builtin/clone.c:662
+msgid "HEAD not found below refs/heads!"
+msgstr "Ní fhaightear CEAD thíos na tagairtí/cinn!"
+
+#: builtin/clone.c:688
+msgid "unable to checkout working tree"
+msgstr "in ann crann oibre a sheiceáil"
+
+#: builtin/clone.c:782
+msgid "unable to write parameters to config file"
+msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+
+#: builtin/clone.c:849
+msgid "cannot repack to clean up"
+msgstr "ní féidir athphacáil chun glanadh"
+
+#: builtin/clone.c:851
+msgid "cannot unlink temporary alternates file"
+msgstr "ní féidir le comhad malartacha sealadacha a dhínascadh"
+
+#: builtin/clone.c:919
+msgid "don't clone shallow repository"
+msgstr "ná clóin stór éadomhain"
+
+#: builtin/clone.c:921
+msgid "don't create a checkout"
+msgstr "ná cruthaigh seiceáil"
+
+#: builtin/clone.c:922 builtin/clone.c:924
+msgid "create a bare repository"
+msgstr "stóras lom a chruthú"
+
+#: builtin/clone.c:926
+msgid "create a mirror repository (implies --bare)"
+msgstr "stóras scátháin a chruthú (tugann le tuiscint --lom)"
+
+#: builtin/clone.c:928
+msgid "to clone from a local repository"
+msgstr "a chlónú ó stór áitiúil"
+
+#: builtin/clone.c:930
+msgid "don't use local hardlinks, always copy"
+msgstr "ná húsáid crua-naisc áitiúla, cóipeáil i gcónaí"
+
+#: builtin/clone.c:932
+msgid "setup as shared repository"
+msgstr "socrú mar stór roinnte"
+
+#: builtin/clone.c:937
+msgid "pathspec"
+msgstr "sonraíocht chosáin"
+
+#: builtin/clone.c:938
+msgid "initialize submodules in the clone"
+msgstr "fo-mhodúil a thionscnamh sa chlón"
+
+#: builtin/clone.c:945
+msgid "number of submodules cloned in parallel"
+msgstr "líon na bhfo-mhodúil atá clónaithe go comhthreomhar"
+
+#: builtin/clone.c:946
+msgid "template-directory"
+msgstr "eolaire teimpléad"
+
+#: builtin/clone.c:947
+msgid "directory from which templates will be used"
+msgstr "eolaire as a n-úsáidfear teimpléid"
+
+#: builtin/clone.c:948 builtin/clone.c:951
+msgid "repo"
+msgstr "stór"
+
+#: builtin/clone.c:949 builtin/clone.c:951
+msgid "reference repository"
+msgstr "stór tagartha"
+
+#: builtin/clone.c:953
+msgid "use --reference only while cloning"
+msgstr "bain úsáid as --reference amháin agus tú ag clónú"
+
+#: builtin/clone.c:954
+msgid "name"
+msgstr "ainm"
+
+#: builtin/clone.c:955
+msgid "use <name> instead of 'origin' to track upstream"
+msgstr "úsáid in <name>ionad 'tionscnamh' chun suas an sruth a rianú"
+
+#: builtin/clone.c:957
+msgid "checkout <branch> instead of the remote's HEAD"
+msgstr "seiceáil <brainse>in ionad CEAD an iargúlta"
+
+#: builtin/clone.c:958
+msgid "rev"
+msgstr "rev"
+
+#: builtin/clone.c:959
+msgid "clone single revision <rev> and check out"
+msgstr "clóin athbhreithni <rev>ú aonair agus seiceáil"
+
+#: builtin/clone.c:960
+msgid "path"
+msgstr "cosán"
+
+#: builtin/clone.c:961
+msgid "path to git-upload-pack on the remote"
+msgstr "cosán chuig pacáiste uaslódála git-ar an iargúlta"
+
+#: builtin/clone.c:962
+msgid "depth"
+msgstr "doimhneacht"
+
+#: builtin/clone.c:963
+msgid "create a shallow clone of that depth"
+msgstr "clón éadomhain den doimhneacht sin a chruthú"
+
+#: builtin/clone.c:964
+msgid "time"
+msgstr "am"
+
+#: builtin/clone.c:965
+msgid "create a shallow clone since a specific time"
+msgstr "clón éadrom a chruthú ó am ar leith"
+
+#: builtin/clone.c:966
+msgid "ref"
+msgstr "tagairt"
+
+#: builtin/clone.c:967
+msgid "deepen history of shallow clone, excluding ref"
+msgstr "stair an chlóin éadomhain a dhoimhniú, gan tagairt"
+
+#: builtin/clone.c:969
+msgid "clone only one branch, HEAD or --branch"
+msgstr "clóin ach brainse amháin, HEAD nó --branch"
+
+#: builtin/clone.c:971
+msgid "clone tags, and make later fetches not to follow them"
+msgstr "clibeanna clóin, agus tógáil níos déanaí a dhéanamh gan iad a leanúint"
+
+#: builtin/clone.c:973
+msgid "any cloned submodules will be shallow"
+msgstr "beidh aon fho-mhodúil clónaithe éadrom"
+
+#: builtin/clone.c:974
+msgid "gitdir"
+msgstr "gitdir"
+
+#: builtin/clone.c:975
+msgid "separate git dir from working tree"
+msgstr "git dir ar leithligh ó chrann oibre"
+
+#: builtin/clone.c:976
+msgid "format"
+msgstr "formáid"
+
+#: builtin/clone.c:977
+msgid "specify the reference format to use"
+msgstr "sonraigh an fhormáid tagartha le húsáid"
+
+#: builtin/clone.c:978
+msgid "key=value"
+msgstr "eochair=luach"
+
+#: builtin/clone.c:979
+msgid "set config inside the new repository"
+msgstr "socraigh cumraíocht taobh istigh den stór nua"
+
+#: builtin/clone.c:981 builtin/push.c:595
+msgid "server-specific"
+msgstr "freastalaí-shonrach"
+
+#: builtin/clone.c:981 builtin/push.c:595
+msgid "option to transmit"
+msgstr "rogha a tharchur"
+
+#: builtin/clone.c:985
+msgid "apply partial clone filters to submodules"
+msgstr "cuir scagairí clóin páirteacha i bhfeidhm"
+
+#: builtin/clone.c:987
+msgid "any cloned submodules will use their remote-tracking branch"
+msgstr "úsáidfidh aon fho-mhodúil clónaithe a mbrainse cianrianaithe"
+
+#: builtin/clone.c:989
+msgid "initialize sparse-checkout file to include only files at root"
+msgstr "comhad seiceála neamhchoitianta a thosú chun comhaid amháin a áireamh ag fréamh"
+
+#: builtin/clone.c:991
+msgid "uri"
+msgstr "uri"
+
+#: builtin/clone.c:991
+msgid "a URI for downloading bundles before fetching from origin remote"
+msgstr "a URI chun cuachtaí a íoslódáil sula n-iarrtar iad ó chianchéim tionscnaimh"
+
+#: builtin/clone.c:996
+msgid "git clone [<options>] [--] <repo> [<dir>]"
+msgstr "git clone [<roghanna>] [--] <stór>[<eolaire>]"
+
+#: builtin/clone.c:1008
+msgid "Too many arguments."
+msgstr "An iomarca argóintí."
+
+#: builtin/clone.c:1012
+msgid "You must specify a repository to clone."
+msgstr "Ní mór duit stór a shonrú le clónú."
+
+#: builtin/clone.c:1023
+#, c-format
+msgid "unknown ref storage format '%s'"
+msgstr "formáid stórála tagartha anaithnid '%s'"
+
+#: builtin/clone.c:1052
+#, c-format
+msgid "repository '%s' does not exist"
+msgstr "níl an stóras '%s' ann"
+
+#: builtin/clone.c:1056
+#, c-format
+msgid "depth %s is not a positive number"
+msgstr "ní uimhir dhearfach é doimhneacht %s"
+
+#: builtin/clone.c:1066
+#, c-format
+msgid "destination path '%s' already exists and is not an empty directory."
+msgstr "tá cosán ceann scríbe '%s' ann cheana féin agus ní eolaire folamh é."
+
+#: builtin/clone.c:1072
+#, c-format
+msgid "repository path '%s' already exists and is not an empty directory."
+msgstr "tá cosán stórais '%s' ann cheana féin agus ní eolaire folamh é."
+
+#: builtin/clone.c:1086
+#, c-format
+msgid "working tree '%s' already exists."
+msgstr "tá crann oibre '%s' ann cheana féin."
+
+#: builtin/clone.c:1101 builtin/clone.c:1122
+#, c-format
+msgid "could not create leading directories of '%s'"
+msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+
+#: builtin/clone.c:1106
+#, c-format
+msgid "could not create work tree dir '%s'"
+msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+
+#: builtin/clone.c:1126
+#, c-format
+msgid "Cloning into bare repository '%s'...\n"
+msgstr "Clónáil isteach i stóras lom '%s'...\n"
+
+#: builtin/clone.c:1128
+#, c-format
+msgid "Cloning into '%s'...\n"
+msgstr "Clónáil isteach '%s'...\n"
+
+#: builtin/clone.c:1157
+msgid "clone --recursive is not compatible with both --reference and --reference-if-able"
+msgstr "níl clón --recursive comhoiriúnach le --reference agus --reference-if-able araon"
+
+#: builtin/clone.c:1288
+#, c-format
+msgid "'%s' is not a valid remote name"
+msgstr "Ní ainm iargúlta bailí é '%s'"
+
+#: builtin/clone.c:1323
+msgid "--depth is ignored in local clones; use file:// instead."
+msgstr "Déantar neamhaird ar --deep i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+
+#: builtin/clone.c:1325
+msgid "--shallow-since is ignored in local clones; use file:// instead."
+msgstr "Déantar neamhaird ar --shallow-since i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+
+#: builtin/clone.c:1327
+msgid "--shallow-exclude is ignored in local clones; use file:// instead."
+msgstr ""
+"Déantar neamhaird ar --shallow-exclusive i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+
+#: builtin/clone.c:1329
+msgid "--filter is ignored in local clones; use file:// instead."
+msgstr "Déantar neamhaird ar --filter i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+
+#: builtin/clone.c:1332
+msgid "source repository is shallow, reject to clone."
+msgstr "tá stóras foinse éadrom, diúltaigh clóin."
+
+#: builtin/clone.c:1334
+msgid "source repository is shallow, ignoring --local"
+msgstr "tá stóras foinse éadrom, ag neamhaird a dhéanamh ar --local"
+
+#: builtin/clone.c:1339
+msgid "--local is ignored"
+msgstr "Déantar neamhaird a dhéanamh ar --local"
+
+#: builtin/clone.c:1355
+msgid "cannot clone from filtered bundle"
+msgstr "ní féidir clónú ó bhearta scagtha"
+
+#: builtin/clone.c:1463 builtin/clone.c:1494
+msgid "failed to initialize the repo, skipping bundle URI"
+msgstr "theip ar an repo a thionscnamh, ag scipeáil URI beartán"
+
+#: builtin/clone.c:1465
+#, c-format
+msgid "failed to fetch objects from bundle URI '%s'"
+msgstr "theip ar rudaí a fháil ó URI '%s'"
+
+#: builtin/clone.c:1497
+msgid "failed to fetch advertised bundles"
+msgstr "theip orthu beartáin fógraithe a fháil"
+
+#: builtin/clone.c:1530 builtin/clone.c:1597
+msgid "remote transport reported error"
+msgstr "earráid tuairiscithe ar iompar"
+
+#: builtin/clone.c:1541
+#, c-format
+msgid "Remote branch %s not found in upstream %s"
+msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+
+#: builtin/clone.c:1546
+#, c-format
+msgid "Remote revision %s not found in upstream %s"
+msgstr "Ní aimsíodh athbhreithniú iargúlta %s i suas sruth %s"
+
+#: builtin/clone.c:1557
+msgid "You appear to have cloned an empty repository."
+msgstr "Is cosúil gur chlónaigh tú stór folamh."
+
+#: builtin/index-pack.c:245
+#, c-format
+msgid "object type mismatch at %s"
+msgstr "mímheaitseáil cineál réad ag %s"
+
+#: builtin/index-pack.c:265
+#, c-format
+msgid "did not receive expected object %s"
+msgstr "nár bhfuair sé réad ag súil leis %s"
+
+#: builtin/index-pack.c:268
+#, c-format
+msgid "object %s: expected type %s, found %s"
+msgstr "réad %s: súil leis an gcineál %s, aimsíodh %s"
+
+#: builtin/index-pack.c:286
+msgid "Checking objects"
+msgstr "Rud a sheiceáil"
+
+#: builtin/index-pack.c:319
+#, c-format
+msgid "cannot fill %d byte"
+msgid_plural "cannot fill %d bytes"
+msgstr[0] "ní féidir %d beart a líonadh"
+msgstr[1] "ní féidir %d beart a líonadh"
+msgstr[2] "ní féidir %d beart a líonadh"
+
+#: builtin/index-pack.c:329
+msgid "early EOF"
+msgstr "luath EOF"
+
+#: builtin/index-pack.c:330
+msgid "read error on input"
+msgstr "earráid léigh ar ionchur"
+
+#: builtin/index-pack.c:342
+msgid "used more bytes than were available"
+msgstr "úsáideadh níos mó bytes ná mar a bhí ar fáil"
+
+#: builtin/index-pack.c:349
+msgid "pack too large for current definition of off_t"
+msgstr "pacáiste ró-mhór le haghaidh sainmhíniú reatha ar off_t"
+
+#: builtin/index-pack.c:354
+#, c-format
+msgid "pack exceeds maximum allowed size (%s)"
+msgstr "sáraíonn an pacáiste an méid uasta ceadaithe (%s)"
+
+#: builtin/index-pack.c:387
+msgid "pack signature mismatch"
+msgstr "mímheaitseáil sínithe pacáiste"
+
+#: builtin/index-pack.c:390
+#, c-format
+msgid "pack version %<PRIu32> unsupported"
+msgstr "leagan pacáiste %<PRIu32> gan tacaíocht"
+
+#: builtin/index-pack.c:407
+#, c-format
+msgid "pack has bad object at offset %<PRIuMAX>: %s"
+msgstr "tá réad lochtach sa phacáiste ag an bhfritháireamh %<PRIuMAX>: %s"
+
+#: builtin/index-pack.c:513
+#, c-format
+msgid "inflate returned %d"
+msgstr "infleáil ar ais %d"
+
+#: builtin/index-pack.c:563
+msgid "offset value overflow for delta base object"
+msgstr "ró-shreabhadh luacha a fhritháireamh do réad"
+
+#: builtin/index-pack.c:571
+msgid "delta base offset is out of bound"
+msgstr "tá fhritháireamh bonn delta as ceangailte"
+
+#: builtin/index-pack.c:579
+#, c-format
+msgid "unknown object type %d"
+msgstr "cineál réad anaithnid %d"
+
+#: builtin/index-pack.c:610
+msgid "cannot pread pack file"
+msgstr "ní féidir comhad pacáiste a roghnú"
+
+#: builtin/index-pack.c:612
+#, c-format
+msgid "premature end of pack file, %<PRIuMAX> byte missing"
+msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
+msgstr[0] "deireadh roimh am comhaid phacáiste, %<PRIuMAX> beart ar iarraidh"
+msgstr[1] "deireadh roimh am comhaid phacáiste, %<PRIuMAX> beart ar iarraidh"
+msgstr[2] "deireadh roimh am comhaid phacáiste, %<PRIuMAX> beart ar iarraidh"
+
+#: builtin/index-pack.c:638
+msgid "serious inflate inconsistency"
+msgstr "neamhchomhsheasmhacht tromchúiseach"
+
+#: builtin/index-pack.c:783 builtin/index-pack.c:789 builtin/index-pack.c:814
+#: builtin/index-pack.c:915 builtin/index-pack.c:925
+#, c-format
+msgid "SHA1 COLLISION FOUND WITH %s !"
+msgstr "FUARTHAS IMBHALL SHA1 LE %s!"
+
+#: builtin/index-pack.c:786
+#, c-format
+msgid "unable to read %s"
+msgstr "nach féidir %s a léamh"
+
+#: builtin/index-pack.c:913
+#, c-format
+msgid "cannot read existing object info %s"
+msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+
+#: builtin/index-pack.c:922
+#, c-format
+msgid "cannot read existing object %s"
+msgstr "ní féidir réad %s atá ann cheana a léamh"
+
+#: builtin/index-pack.c:936
+#, c-format
+msgid "invalid blob object %s"
+msgstr "réad blob neamhbhailí %s"
+
+#: builtin/index-pack.c:939 builtin/index-pack.c:958
+msgid "fsck error in packed object"
+msgstr "earráid fsck i réad pacáilte"
+
+#: builtin/index-pack.c:955
+#, c-format
+msgid "invalid %s"
+msgstr "%s neamhbhailí"
+
+#: builtin/index-pack.c:960
+#, c-format
+msgid "Not all child objects of %s are reachable"
+msgstr "Níl gach réad leanbh de %s inrochtana"
+
+#: builtin/index-pack.c:1023 builtin/index-pack.c:1070
+msgid "failed to apply delta"
+msgstr "theip ar delta a chur i bhfeidhm"
+
+#: builtin/index-pack.c:1264
+msgid "Receiving objects"
+msgstr "Rudaí a fháil"
+
+#: builtin/index-pack.c:1264
+msgid "Indexing objects"
+msgstr "Rudaí innéacsála"
+
+#: builtin/index-pack.c:1300
+msgid "pack is corrupted (SHA1 mismatch)"
+msgstr "tá an pacáiste truaillithe (neamhoiriúnú SHA1)"
+
+#: builtin/index-pack.c:1305
+msgid "cannot fstat packfile"
+msgstr "ní féidir le pacáiste fstat"
+
+#: builtin/index-pack.c:1308
+msgid "pack has junk at the end"
+msgstr "tá bruscar ag an bpacáiste ag an deireadh"
+
+#: builtin/index-pack.c:1320
+msgid "confusion beyond insanity in parse_pack_objects()"
+msgstr "mearbhall níos faide ná imní i parse_pack_objects()"
+
+#: builtin/index-pack.c:1344
+msgid "Resolving deltas"
+msgstr "Deltas a réiteach"
+
+#: builtin/index-pack.c:1355
+#, c-format
+msgid "unable to create thread: %s"
+msgstr "nach féidir snáithe a chruthú: %s"
+
+#: builtin/index-pack.c:1388
+msgid "confusion beyond insanity"
+msgstr "mearbhall níos faide ná mar gheall"
+
+#: builtin/index-pack.c:1394
+#, c-format
+msgid "completed with %d local object"
+msgid_plural "completed with %d local objects"
+msgstr[0] "críochnaithe le %d réad áitiúil"
+msgstr[1] "críochnaithe le %d réad áitiúil"
+msgstr[2] "críochnaithe le %d réad áitiúil"
+
+#: builtin/index-pack.c:1406
+#, c-format
+msgid "Unexpected tail checksum for %s (disk corruption?)"
+msgstr "Seicsum eireaball gan choinne do %s (éilliú diosca?)"
+
+#: builtin/index-pack.c:1410
+#, c-format
+msgid "pack has %d unresolved delta"
+msgid_plural "pack has %d unresolved deltas"
+msgstr[0] "tá %d delta gan réiteach sa phacáiste"
+msgstr[1] "tá %d deiltí gan réiteach sa phacáiste"
+msgstr[2] "tá %d deiltí gan réiteach sa phacáiste"
+
+#: builtin/index-pack.c:1434
+#, c-format
+msgid "unable to deflate appended object (%d)"
+msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+
+#: builtin/index-pack.c:1530
+#, c-format
+msgid "local object %s is corrupt"
+msgstr "tá réad áitiúil %s truaillithe"
+
+#: builtin/index-pack.c:1552
+#, c-format
+msgid "packfile name '%s' does not end with '.%s'"
+msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
+
+#: builtin/index-pack.c:1576
+#, c-format
+msgid "cannot write %s file '%s'"
+msgstr "ní féidir comhad %s '%s' a scríobh"
+
+#: builtin/index-pack.c:1584
+#, c-format
+msgid "cannot close written %s file '%s'"
+msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
+
+#: builtin/index-pack.c:1601
+#, c-format
+msgid "unable to rename temporary '*.%s' file to '%s'"
+msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+
+#: builtin/index-pack.c:1624
+msgid "error while closing pack file"
+msgstr "earráid agus comhad pacáiste á dúnadh"
+
+#: builtin/index-pack.c:1676
+#, c-format
+msgid "bad pack.indexVersion=%<PRIu32>"
+msgstr "droch-pack.indexVersion=%<PRIu32>"
+
+#: builtin/index-pack.c:1682
+#, c-format
+msgid "invalid number of threads specified (%d)"
+msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
+
+#: builtin/index-pack.c:1685 builtin/index-pack.c:1965
+#, c-format
+msgid "no threads support, ignoring %s"
+msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
+
+#: builtin/index-pack.c:1751
+#, c-format
+msgid "Cannot open existing pack file '%s'"
+msgstr "Ní féidir comhad pacáiste atá ann cheana '%s' a oscailt"
+
+#: builtin/index-pack.c:1753
+#, c-format
+msgid "Cannot open existing pack idx file for '%s'"
+msgstr "Ní féidir comhad idx pacáiste atá ann cheana a oscailt do '%s'"
+
+#: builtin/index-pack.c:1801
+#, c-format
+msgid "non delta: %d object"
+msgid_plural "non delta: %d objects"
+msgstr[0] "neamh-delta: %d réad"
+msgstr[1] "neamh-delta: %d réad"
+msgstr[2] "neamh-delta: %d réad"
+
+#: builtin/index-pack.c:1808
+#, c-format
+msgid "chain length = %d: %lu object"
+msgid_plural "chain length = %d: %lu objects"
+msgstr[0] "fad slabhra = %d: %lu réad"
+msgstr[1] "fad slabhra = %d: %lu réada"
+msgstr[2] "fad slabhra = %d: %lu réada"
+
+#: builtin/index-pack.c:1850
+msgid "could not start pack-objects to repack local links"
+msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+
+#: builtin/index-pack.c:1855
+msgid "failed to feed local object to pack-objects"
+msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+
+#: builtin/index-pack.c:1868
+msgid "index-pack: Expecting full hex object ID lines only from pack-objects."
+msgstr ""
+"index-pack: Ag súil le línte aitheantais réada heicsidheachúlach iomlán ó pack-objects amháin."
+
+#: builtin/index-pack.c:1879
+msgid "could not finish pack-objects to repack local links"
+msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+
+#: builtin/index-pack.c:1921
+msgid "Cannot come back to cwd"
+msgstr "Ní féidir teacht ar ais chuig cwd"
+
+#: builtin/index-pack.c:1972
+#, c-format
+msgid "bad --pack_header: %s"
+msgstr "droch --pack_header: %s"
+
+#: builtin/index-pack.c:1991 builtin/index-pack.c:1995
+#, c-format
+msgid "bad %s"
+msgstr "droch %s"
+
+#: builtin/index-pack.c:2001
+#, c-format
+msgid "unknown hash algorithm '%s'"
+msgstr "algartam hais anaithnid '%s'"
+
+#: builtin/index-pack.c:2022
+msgid "--promisor cannot be used with a pack name"
+msgstr "Ní féidir --promisor a úsáid le hainm pacáiste"
+
+#: builtin/index-pack.c:2024
+msgid "--stdin requires a git repository"
+msgstr "Teastaíonn stór git ag teastáil ó --stdin"
+
+#: builtin/index-pack.c:2050
+msgid "--verify with no packfile name given"
+msgstr "- fíorú gan aon ainm pacáiste a thugtar"
+
+#: builtin/index-pack.c:2117
+msgid "fsck error in pack objects"
+msgstr "earráid fsck i rudaí pacáiste"
+
+#: builtin/push.c:26
+msgid "git push [<options>] [<repository> [<refspec>...]]"
+msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+
+#: builtin/push.c:112
+msgid "tag shorthand without <tag>"
+msgstr "gearrthand clib gan <tag>"
+
+#: builtin/push.c:120
+msgid "--delete only accepts plain target ref names"
+msgstr "Ní ghlacann --delete ach le spriocainmneacha tagartha simplí"
+
+#: builtin/push.c:162
+msgid ""
+"\n"
+"To choose either option permanently, see push.default in 'git help config'.\n"
+msgstr ""
+"\n"
+"Chun ceachtar rogha a roghnú go buan, féach push.default i 'git help config'.\n"
+
+#: builtin/push.c:166
+msgid ""
+"\n"
+"To avoid automatically configuring an upstream branch when its name\n"
+"won't match the local branch, see option 'simple' of branch.autoSetupMerge\n"
+"in 'git help config'.\n"
+msgstr ""
+"\n"
+"Chun brainse suas srutha a chumrú go huathoibríoch a sheachaint nuair a\n"
+"ní mheaitseoidh sé leis an mbrainse áitiúil, féach an rogha 'simplí' de branch.autoSetupMerge\n"
+"i 'git help config'.\n"
+
+#: builtin/push.c:172
+#, c-format
+msgid ""
+"The upstream branch of your current branch does not match\n"
+"the name of your current branch.  To push to the upstream branch\n"
+"on the remote, use\n"
+"\n"
+"    git push %s HEAD:%s\n"
+"\n"
+"To push to the branch of the same name on the remote, use\n"
+"\n"
+"    git push %s HEAD\n"
+"%s%s"
+msgstr ""
+"Ní mheaitseálann an brainse suas srutha de do bhrainse reatha\n"
+"ainm do bhrainse reatha. Chun brú go dtí an bhrainse suas srutha\n"
+"ar an iargúlta, bain úsáid as\n"
+"\n"
+"    git push %s HEAD:%s\n"
+"\n"
+"Chun brú chuig an mbrainse den ainm céanna ar an iargúlta, bain úsáid as\n"
+"\n"
+"    git push %s HEAD\n"
+"%s%s"
+
+#: builtin/push.c:188
+#, c-format
+msgid ""
+"You are not currently on a branch.\n"
+"To push the history leading to the current (detached HEAD)\n"
+"state now, use\n"
+"\n"
+"    git push %s HEAD:<name-of-remote-branch>\n"
+msgstr ""
+"Níl tú ar bhrainse faoi láthair.\n"
+"Chun an stair a bhrú mar thoradh ar an gceann reatha (CEAD scoite)\n"
+"stát anois, bain úsáid as\n"
+"\n"
+" git push %s HEAD:<ainm-na-brainse-cianda>\n"
+
+#: builtin/push.c:204
+msgid ""
+"\n"
+"To have this happen automatically for branches without a tracking\n"
+"upstream, see 'push.autoSetupRemote' in 'git help config'.\n"
+msgstr ""
+"\n"
+"Chun é seo a tharlóidh go huathoibríoch do bhrainsí gan rianú\n"
+"suas sruth, féach 'Push.AutoSetUpRemote' i 'git help config'.\n"
+
+#: builtin/push.c:210
+#, c-format
+msgid ""
+"The current branch %s has no upstream branch.\n"
+"To push the current branch and set the remote as upstream, use\n"
+"\n"
+"    git push --set-upstream %s %s\n"
+"%s"
+msgstr ""
+"Níl brainse suas srutha ag an mbrainse reatha %s.\n"
+"Chun an brainse reatha a bhrú agus an iargúlta a shocrú mar thuas an sruth, bain úsáid as\n"
+"\n"
+"    git push --set-upstream %s %s\n"
+"%s"
+
+#: builtin/push.c:221
+#, c-format
+msgid "The current branch %s has multiple upstream branches, refusing to push."
+msgstr "Tá brainsí iolracha suas srutha ag an mbrainse reatha %s, ag diúltú brú."
+
+#: builtin/push.c:239
+msgid "You didn't specify any refspecs to push, and push.default is \"nothing\"."
+msgstr "Níor shonraigh tú aon refspec le brú, agus is é push.default “rud ar bith”."
+
+#: builtin/push.c:265
+#, c-format
+msgid ""
+"You are pushing to remote '%s', which is not the upstream of\n"
+"your current branch '%s', without telling me what to push\n"
+"to update which remote branch."
+msgstr ""
+"Tá tú ag brú chuig '%s' iargúlta, nach bhfuil suas sruth\n"
+"do bhrainse reatha '%s', gan insint liom cad ba cheart a bhrú\n"
+"chun an brainse iargúlta a nuashonrú."
+
+#: builtin/push.c:288
+msgid ""
+"Updates were rejected because the tip of your current branch is behind\n"
+"its remote counterpart. If you want to integrate the remote changes,\n"
+"use 'git pull' before pushing again.\n"
+"See the 'Note about fast-forwards' in 'git push --help' for details."
+msgstr ""
+"Diúltaíodh nuashonruithe toisc go bhfuil barr do bhrainse reatha taobh thiar de\n"
+"a mhacasamhail iargúlta. Más mian leat na hathruithe iargúlta a chomhtháthú,\n"
+"bain úsáid as 'git pull' sula mbrú arís.\n"
+"Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
+
+#: builtin/push.c:294
+msgid ""
+"Updates were rejected because a pushed branch tip is behind its remote\n"
+"counterpart. If you want to integrate the remote changes, use 'git pull'\n"
+"before pushing again.\n"
+"See the 'Note about fast-forwards' in 'git push --help' for details."
+msgstr ""
+"Diúltaíodh nuashonruithe toisc go bhfuil barr brainse brúite taobh thiar dá\n"
+"comhghleacaí. Más mian leat na hathruithe iargúlta a chomhtháthú, bain úsáid as 'git pull'\n"
+"sula ndéantar é a bhrú arís.\n"
+"Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
+
+#: builtin/push.c:300
+msgid ""
+"Updates were rejected because the remote contains work that you do not\n"
+"have locally. This is usually caused by another repository pushing to\n"
+"the same ref. If you want to integrate the remote changes, use\n"
+"'git pull' before pushing again.\n"
+"See the 'Note about fast-forwards' in 'git push --help' for details."
+msgstr ""
+"Diúltaíodh nuashonruithe toisc go bhfuil obair nach ndéanann tú san iargúlta\n"
+"a bheith agat go háitiúil. De ghnáth bíonn stór eile ag brú chuig seo\n"
+"an tagairt chéanna. Más mian leat na hathruithe iargúlta a chomhtháthú, bain úsáid as\n"
+"'git tarraing' sula ndéantar é a bhrú arís.\n"
+"Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
+
+#: builtin/push.c:307
+msgid "Updates were rejected because the tag already exists in the remote."
+msgstr "Diúltaíodh nuashonruithe toisc go bhfuil an clib ann cheana féin sa iargúlta."
+
+#: builtin/push.c:310
+msgid ""
+"You cannot update a remote ref that points at a non-commit object,\n"
+"or update a remote ref to make it point at a non-commit object,\n"
+"without using the '--force' option.\n"
+msgstr ""
+"Ní féidir leat tagairt iargúlta a nuashonrú a chuireann in iúl ar réad neamh-thiomanta,\n"
+"nó tagairt iargúlta a nuashonrú chun é a chur in iúl ar réad neamh-thiomanta,\n"
+"gan an rogha '--force' a úsáid.\n"
+
+#: builtin/push.c:315
+msgid ""
+"Updates were rejected because the tip of the remote-tracking branch has\n"
+"been updated since the last checkout. If you want to integrate the\n"
+"remote changes, use 'git pull' before pushing again.\n"
+"See the 'Note about fast-forwards' in 'git push --help' for details."
+msgstr ""
+"Diúltaíodh nuashonruithe toisc go bhfuil barr na brainse cianrianaithe\n"
+"nuashonraíodh ón tseiceáil deireanach. Más mian leat an\n"
+"athruithe iargúlta, bain úsáid as 'git pull' sula mbrú arís.\n"
+"Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
+
+#: builtin/push.c:385
+#, c-format
+msgid "Pushing to %s\n"
+msgstr "Ag brú chuig %s\n"
+
+#: builtin/push.c:392
+#, c-format
+msgid "failed to push some refs to '%s'"
+msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+
+#: builtin/push.c:458
+msgid "recursing into submodule with push.recurseSubmodules=only; using on-demand instead"
+msgstr ""
+"athfhillteach isteach i bhfo-mhodúl le push.RecursesubModules=amháin; ag baint úsáide as ar-"
+"éileamh ina ionad"
+
+#: builtin/push.c:515
+#, c-format
+msgid "invalid value for '%s'"
+msgstr "luach neamhbhailí do '%s'"
+
+#: builtin/push.c:563
+msgid "repository"
+msgstr "stóras"
+
+#: builtin/push.c:564
+msgid "push all branches"
+msgstr "brúigh gach brainse"
+
+#: builtin/push.c:566
+msgid "mirror all refs"
+msgstr "scáthán gach ceann"
+
+#: builtin/push.c:568
+msgid "delete refs"
+msgstr "scrios réimsí"
+
+#: builtin/push.c:569
+msgid "push tags (can't be used with --all or --branches or --mirror)"
+msgstr "clibeanna brú (ní féidir iad a úsáid le --all nó --crainsí nó --scáthán)"
+
+#: builtin/push.c:570
+msgid "dry run"
+msgstr "rith tirim"
+
+#: builtin/push.c:571
+msgid "machine-readable output"
+msgstr "aschur inléite meaisín"
+
+#: builtin/push.c:572
+msgid "force updates"
+msgstr "nuashonruithe fórsa"
+
+#: builtin/push.c:573
+msgid "<refname>:<expect>"
+msgstr "<refname>:<expect>"
+
+#: builtin/push.c:574
+msgid "require old value of ref to be at this value"
+msgstr "a cheangal go mbeadh seanluach an tagartha ag an luach seo"
+
+#: builtin/push.c:577
+msgid "require remote updates to be integrated locally"
+msgstr "éilíonn go ndéanfaí nuashonruithe iargúlta"
+
+#: builtin/push.c:580
+msgid "control recursive pushing of submodules"
+msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+
+#: builtin/push.c:581
+msgid "use thin pack"
+msgstr "bain úsáid as pacáiste tanaí"
+
+#: builtin/push.c:582 builtin/push.c:583
+msgid "receive pack program"
+msgstr "clár pacáiste a fháil"
+
+#: builtin/push.c:584
+msgid "set upstream for git pull/status"
+msgstr "socraigh suas sruth le haghaidh tarraing/stádas git"
+
+#: builtin/push.c:587
+msgid "prune locally removed refs"
+msgstr "gearradh a bhaintear go háitiúil"
+
+#: builtin/push.c:589
+msgid "bypass pre-push hook"
+msgstr "seachbhóthar crúca réamh"
+
+#: builtin/push.c:590
+msgid "push missing but relevant tags"
+msgstr "clibeanna atá ar iarraidh ach ábhartha a"
+
+#: builtin/push.c:592
+msgid "GPG sign the push"
+msgstr "Síníonn GPG an brú"
+
+#: builtin/push.c:594
+msgid "request atomic transaction on remote side"
+msgstr "iarraidh idirbheart adamach ar an taobh iargúl"
+
+#: builtin/push.c:613
+msgid "--delete doesn't make sense without any refs"
+msgstr "--ní bhíonn ciall ag scriosadh gan aon ghearradh"
+
+#: builtin/push.c:631
+#, c-format
+msgid "bad repository '%s'"
+msgstr "droch-stóras '%s'"
+
+#: builtin/push.c:632
+msgid ""
+"No configured push destination.\n"
+"Either specify the URL from the command-line or configure a remote repository using\n"
+"\n"
+"    git remote add <name> <url>\n"
+"\n"
+"and then push using the remote name\n"
+"\n"
+"    git push <name>\n"
+msgstr ""
+"Gan aon cheann scríbe brúite cumraithe.\n"
+"Sonraigh an URL ón líne ordaithe nó cumraigh stór iargúlta ag baint úsáide as\n"
+"\n"
+"    git remote add <name> <url>\n"
+"\n"
+"agus ansin brúigh ag úsáid an ainm iargúlta\n"
+"\n"
+"    git push <ainm>\n"
+
+#: builtin/push.c:650
+msgid "--all can't be combined with refspecs"
+msgstr "--ní féidir gach rud a chomhcheangal le refspecs"
+
+#: builtin/push.c:654
+msgid "--mirror can't be combined with refspecs"
+msgstr "--ní féidir scáthán a chomhcheangal le refspecs"
+
+#: builtin/push.c:662
+msgid "push options must not have new line characters"
+msgstr "ní chóir go mbeadh carachtair líne nua ag roghanna brú"
+
+#: builtin/reset.c:45
+msgid "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
+msgstr "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
+
+#: builtin/reset.c:46
+msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+
+#: builtin/reset.c:47
+msgid "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
+msgstr "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
+
+#: builtin/reset.c:48
+msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+
+#: builtin/reset.c:54
+msgid "mixed"
+msgstr "measctha"
+
+#: builtin/reset.c:54
+msgid "soft"
+msgstr "bog"
+
+#: builtin/reset.c:54
+msgid "hard"
+msgstr "crua"
+
+#: builtin/reset.c:54
+msgid "merge"
+msgstr "cumaisc"
+
+#: builtin/reset.c:54
+msgid "keep"
+msgstr "coinnigh"
+
+#: builtin/reset.c:104
+msgid "You do not have a valid HEAD."
+msgstr "Níl CEANN bailí agat."
+
+#: builtin/reset.c:106
+msgid "Failed to find tree of HEAD."
+msgstr "Theip ar chrann HEAD a aimsiú."
+
+#: builtin/reset.c:112
+#, c-format
+msgid "Failed to find tree of %s."
+msgstr "Theip ar chrann %s a aimsiú."
+
+#: builtin/reset.c:141
+#, c-format
+msgid "HEAD is now at %s"
+msgstr "Tá HEAD anois ag %s"
+
+#: builtin/reset.c:242
+#, c-format
+msgid "Cannot do a %s reset in the middle of a merge."
+msgstr "Ní féidir athshocrú %s a dhéanamh i lár cumaisc."
+
+#: builtin/reset.c:350
+msgid "be quiet, only report errors"
+msgstr "bí ciúin, ní thuairiscigh ach earráidí"
+
+#: builtin/reset.c:352
+msgid "skip refreshing the index after reset"
+msgstr "scipeáil an t-innéacs a athnuachan tar éis"
+
+#: builtin/reset.c:354
+msgid "reset HEAD and index"
+msgstr "athshocraigh HEAD agus innéacs"
+
+#: builtin/reset.c:357
+msgid "reset only HEAD"
+msgstr "athshocraigh CEAD amháin"
+
+#: builtin/reset.c:360 builtin/reset.c:363
+msgid "reset HEAD, index and working tree"
+msgstr "athshocraigh HEAD, innéacs agus crann oibre"
+
+#: builtin/reset.c:366
+msgid "reset HEAD but keep local changes"
+msgstr "athshocraigh HEAD ach coinnigh athruithe áiti"
+
+#: builtin/reset.c:374
+msgid "record only the fact that removed paths will be added later"
+msgstr "ní thaifeadadh ach an fíric go gcuirfear cosáin bainte leis níos déanaí"
+
+#: builtin/reset.c:408
+#, c-format
+msgid "Failed to resolve '%s' as a valid revision."
+msgstr "Theip ar '%s' a réiteach mar athbhreithniú bailí."
+
+#: builtin/reset.c:411 builtin/reset.c:419
+#, c-format
+msgid "Could not parse object '%s'."
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+
+#: builtin/reset.c:416
+#, c-format
+msgid "Failed to resolve '%s' as a valid tree."
+msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+
+#: builtin/reset.c:437
+msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
+msgstr "<paths>Tá - measctha le cosáin míshuanta; bain úsáid as 'git reset -- 'ina ionad sin."
+
+#: builtin/reset.c:439
+#, c-format
+msgid "Cannot do %s reset with paths."
+msgstr "Ní féidir %s a athshocrú le cosáin."
+
+#: builtin/reset.c:454
+#, c-format
+msgid "%s reset is not allowed in a bare repository"
+msgstr "Ní cheadaítear athshocrú %s i stóras lom"
+
+#: builtin/reset.c:488
+msgid "Unstaged changes after reset:"
+msgstr "Athruithe gan stáitse tar éis athshocrú:"
+
+#: builtin/reset.c:491
+#, c-format
+msgid ""
+"It took %.2f seconds to refresh the index after reset.  You can use\n"
+"'--no-refresh' to avoid this."
+msgstr ""
+"Thóg sé %.2f soicind an t-innéacs a athnuachan tar éis athshocrú. Is féidir leat úsáid a bhaint "
+"as\n"
+"'--no-athnuachan' chun é seo a sheachaint."
+
+#: builtin/reset.c:509
+#, c-format
+msgid "Could not reset index file to revision '%s'."
+msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
+
+#: builtin/reset.c:514
+msgid "Could not write new index file."
+msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+
+#: remote.c:308
+#, c-format
+msgid ""
+"reading remote from \"%s/%s\", which is nominated for removal.\n"
+"\n"
+"If you still use the \"remotes/\" directory it is recommended to\n"
+"migrate to config-based remotes:\n"
+"\n"
+"\tgit remote rename %s %s\n"
+"\n"
+"If you cannot, please let us know why you still need to use it by\n"
+"sending an e-mail to <git@vger.kernel.org>."
+msgstr ""
+"léamh iargúlta ó \"%s/%s\", atá ainmnithe lena bhaint.\n"
+"\n"
+"Má úsáideann tú an eolaire “iargúlta/” fós moltar\n"
+"aistriú chuig iargúlta bunaithe ar chumraíocht:\n"
+"\n"
+" git iargúlta a athainmniú %s %s\n"
+"\n"
+"Mura féidir leat, cuir in iúl dúinn le do thoil cén fáth a gcaithfidh tú\n"
+"é a úsáid fós trí ríomhphost a sheoladh chuig <git@vger.kernel.org>."
+
+#: remote.c:469
+#, c-format
+msgid "config remote shorthand cannot begin with '/': %s"
+msgstr "ní féidir le '/' tosú le gearrthánach iargúlta config: %s"
+
+#: remote.c:515
+msgid "more than one receivepack given, using the first"
+msgstr "níos mó ná pacáiste glacadóra amháin a thugtar, ag baint úsáide as an gcéad"
+
+#: remote.c:523
+msgid "more than one uploadpack given, using the first"
+msgstr "níos mó ná pacáiste uaslódála amháin tugtha, ag baint úsáide as an gcéad"
+
+#: remote.c:558
+#, c-format
+msgid "unrecognized followRemoteHEAD value '%s' ignored"
+msgstr "neamhaird a dhéanamh ar luach FollowRemoteHead '%s' gan aithint"
+
+#: remote.c:732
+#, c-format
+msgid "unrecognized value transfer.credentialsInUrl: '%s'"
+msgstr "aistriú luacha neamhaitheantaí.CredentialsInURL: '%s'"
+
+#: remote.c:748 remote.c:750
+#, c-format
+msgid "URL '%s' uses plaintext credentials"
+msgstr "Úsáideann URL '%s' dhintiúir téacs simplí"
+
+#: remote.c:853
+#, c-format
+msgid "Cannot fetch both %s and %s to %s"
+msgstr "Ní féidir %s agus %s a fháil chuig %s"
+
+#: remote.c:857
+#, c-format
+msgid "%s usually tracks %s, not %s"
+msgstr "Is gnách go rianann %s %s, ní %s"
+
+#: remote.c:861
+#, c-format
+msgid "%s tracks both %s and %s"
+msgstr "Rianann %s %s agus %s araon"
+
+#: remote.c:1147
+#, c-format
+msgid "src refspec %s does not match any"
+msgstr "src refspec %s ní mheaitseálann aon"
+
+#: remote.c:1152
+#, c-format
+msgid "src refspec %s matches more than one"
+msgstr "meaitseálann src refspec %s níos mó ná ceann amháin"
+
+#. TRANSLATORS: "matches '%s'%" is the <dst> part of "git push
+#. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
+#. the <src>.
+#.
+#: remote.c:1167
+#, c-format
+msgid ""
+"The destination you provided is not a full refname (i.e.,\n"
+"starting with \"refs/\"). We tried to guess what you meant by:\n"
+"\n"
+"- Looking for a ref that matches '%s' on the remote side.\n"
+"- Checking if the <src> being pushed ('%s')\n"
+"  is a ref in \"refs/{heads,tags}/\". If so we add a corresponding\n"
+"  refs/{heads,tags}/ prefix on the remote side.\n"
+"\n"
+"Neither worked, so we gave up. You must fully qualify the ref."
+msgstr ""
+"Ní ainm athainmnithe iomlán é an ceann scríbe a sholáthair tú (i.e., \n"
+"ag tosú le \"refs/\"). Rinneamar iarracht buille faoi thuairim a thabhairt faoi cad a bhí i gceist "
+"agat le:\n"
+"\n"
+"- Ag lorg tagartha a mheaitseálann '%s' ar an taobh iargúlta.\n"
+"- Ag seiceáil an bhfuil an <src> atá á bhrú ('%s') ina thagairt \n"
+"  i \"refs/{heads,tags}/\". Más ea, cuirimid réimír comhfhreagrach r\n"
+"  efs/{heads,tags}/ leis ar an taobh iargúlta.\n"
+"\n"
+"Níor oibrigh ceachtar acu, mar sin thugamar suas. Caithfidh tú an tagairt a cháiliú go hiomlán."
+
+#: remote.c:1187
+#, c-format
+msgid ""
+"The <src> part of the refspec is a commit object.\n"
+"Did you mean to create a new branch by pushing to\n"
+"'%s:refs/heads/%s'?"
+msgstr ""
+"Is <src>réad tiomanta í an chuid den refspec.\n"
+"An raibh i gceist agat brainse nua a chruthú trí bhrú chuig\n"
+"'%s:refs/heads/%s'?"
+
+#: remote.c:1192
+#, c-format
+msgid ""
+"The <src> part of the refspec is a tag object.\n"
+"Did you mean to create a new tag by pushing to\n"
+"'%s:refs/tags/%s'?"
+msgstr ""
+"Is <src>réad clibeanna é an chuid den refspec.\n"
+"An raibh i gceist agat clib nua a chruthú trí bhrú chuig\n"
+"'%s:refs/tags/%s'?"
+
+#: remote.c:1197
+#, c-format
+msgid ""
+"The <src> part of the refspec is a tree object.\n"
+"Did you mean to tag a new tree by pushing to\n"
+"'%s:refs/tags/%s'?"
+msgstr ""
+"Is <src>réad crann í an chuid den refspec.\n"
+"An raibh sé i gceist agat crann nua a chlibeáil trí bhrú chuig\n"
+"'%s:refs/tags/%s'?"
+
+#: remote.c:1202
+#, c-format
+msgid ""
+"The <src> part of the refspec is a blob object.\n"
+"Did you mean to tag a new blob by pushing to\n"
+"'%s:refs/tags/%s'?"
+msgstr ""
+"Is <src>réad blob é an chuid den refspec.\n"
+"An raibh sé i gceist agat blob nua a chlibeáil trí bhrú chuig\n"
+"'%s:refs/tags/%s'?"
+
+#: remote.c:1242
+#, c-format
+msgid "%s cannot be resolved to branch"
+msgstr "Ní féidir %s a réiteach chuig an mbrainse"
+
+#: remote.c:1253
+#, c-format
+msgid "unable to delete '%s': remote ref does not exist"
+msgstr "ní féidir '%s' a scriosadh: níl tagairt iargúlta ann"
+
+#: remote.c:1265
+#, c-format
+msgid "dst refspec %s matches more than one"
+msgstr "meaitseálann dst refspec %s níos mó ná ceann amháin"
+
+#: remote.c:1276
+#, c-format
+msgid "dst ref %s receives from more than one src"
+msgstr "faigheann dst ref %s ó níos mó ná src amháin"
+
+#: remote.c:1806 remote.c:1913
+msgid "HEAD does not point to a branch"
+msgstr "Ní chuireann HEAD in iúl do bhrainse"
+
+#: remote.c:1815
+#, c-format
+msgid "no such branch: '%s'"
+msgstr "aon bhrainse den sórt sin: '%s'"
+
+#: remote.c:1818
+#, c-format
+msgid "no upstream configured for branch '%s'"
+msgstr "níl aon chumrú suas srutha le haghaidh brainse '%s'"
+
+#: remote.c:1824
+#, c-format
+msgid "upstream branch '%s' not stored as a remote-tracking branch"
+msgstr "brainse suas srutha '%s' nach stóráiltear mar bhrainse cianrianaithe"
+
+#: remote.c:1839
+#, c-format
+msgid "push destination '%s' on remote '%s' has no local tracking branch"
+msgstr "níl aon bhrainse rianaithe áitiúil ag ceann scríbe brúite '%s' ar iargúlta '%s'"
+
+#: remote.c:1854
+#, c-format
+msgid "branch '%s' has no remote for pushing"
+msgstr "níl aon iargúlta ag brainse '%s' chun brú"
+
+#: remote.c:1864
+#, c-format
+msgid "push refspecs for '%s' do not include '%s'"
+msgstr "ní chuimsíonn '%s' brú refspections do '%s'"
+
+#: remote.c:1877
+msgid "push has no destination (push.default is 'nothing')"
+msgstr "níl aon cheann scríbe ag brú (is é 'rud ar bith' push.default)"
+
+#: remote.c:1899
+msgid "cannot resolve 'simple' push to a single destination"
+msgstr "ní féidir brú 'simplí' a réiteach chuig ceann scríbe amháin"
+
+#: remote.c:2034
+#, c-format
+msgid "couldn't find remote ref %s"
+msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+
+#: remote.c:2047
+#, c-format
+msgid "* Ignoring funny ref '%s' locally"
+msgstr "* Ag neamhaird den tagairt ghreannmhar '%s' go háitiúil"
+
+#: remote.c:2135
+msgid "revision walk setup failed"
+msgstr "theip ar socrú siúlóid ath"
+
+#: remote.c:2216
+#, c-format
+msgid "Your branch is based on '%s', but the upstream is gone.\n"
+msgstr "Tá do bhrainse bunaithe ar '%s', ach tá an suas sruth imithe.\n"
+
+#: remote.c:2220
+msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
+msgstr " (bain úsáid as \"git branch --unset-upstream\" chun é a dheisiú)\n"
+
+#: remote.c:2223
+#, c-format
+msgid "Your branch is up to date with '%s'.\n"
+msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
+
+#: remote.c:2227
+#, c-format
+msgid "Your branch and '%s' refer to different commits.\n"
+msgstr "Tagraíonn do bhrainse agus '%s' do thiomnuithe difriúla.\n"
+
+#: remote.c:2230
+#, c-format
+msgid "  (use \"%s\" for details)\n"
+msgstr " (bain úsáid as \"%s\" le haghaidh sonraí)\n"
+
+#: remote.c:2234
+#, c-format
+msgid "Your branch is ahead of '%s' by %d commit.\n"
+msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
+msgstr[0] "Tá do bhrainse chun tosaigh ar '%s' le tiomantas %d.\n"
+msgstr[1] "Tá do bhrainse chun tosaigh ar '%s' le tiomantais %d.\n"
+msgstr[2] "Tá do bhrainse chun tosaigh ar '%s' le tiomantais %d.\n"
+
+#: remote.c:2240
+msgid "  (use \"git push\" to publish your local commits)\n"
+msgstr " (bain úsáid as “git push” chun do thiomanta áitiúla a fhoilsiú)\n"
+
+#: remote.c:2243
+#, c-format
+msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
+msgid_plural "Your branch is behind '%s' by %d commits, and can be fast-forwarded.\n"
+msgstr[0] ""
+"Tá do bhrainse taobh thiar de '%s' faoi %d tiomantas, agus is féidir é a luasghéarú ar aghaidh.\n"
+msgstr[1] ""
+"Tá do bhrainse taobh thiar de '%s' faoi %d tiomnuithe, agus is féidir é a luasghéarú ar aghaidh.\n"
+msgstr[2] ""
+"Tá do bhrainse taobh thiar de '%s' faoi %d tiomnuithe, agus is féidir é a luasghéarú ar aghaidh.\n"
+
+#: remote.c:2251
+msgid "  (use \"git pull\" to update your local branch)\n"
+msgstr " (bain úsáid as “git pull” chun do bhrainse áitiúil a nuashonrú)\n"
+
+#: remote.c:2254
+#, c-format
+msgid ""
+"Your branch and '%s' have diverged,\n"
+"and have %d and %d different commit each, respectively.\n"
+msgid_plural ""
+"Your branch and '%s' have diverged,\n"
+"and have %d and %d different commits each, respectively.\n"
+msgstr[0] ""
+"Tá do bhrainse agus '%s' scartha óna chéile,\n"
+"agus tá %d agus %d tiomnú difriúil acu faoi seach.\n"
+msgstr[1] ""
+"Tá do bhrainse agus '%s' scartha óna chéile,\n"
+"agus tá %d agus %d tiomnuithe difriúla acu faoi seach.\n"
+msgstr[2] ""
+"Tá do bhrainse agus '%s' scartha óna chéile,\n"
+"agus tá %d agus %d tiomnuithe difriúla acu faoi seach.\n"
+
+#: remote.c:2265
+msgid "  (use \"git pull\" if you want to integrate the remote branch with yours)\n"
+msgstr " (bain úsáid as “git pull” más mian leat an brainse iargúlta a chomhtháthú le leatsa)\n"
+
+#: remote.c:2464
+#, c-format
+msgid "cannot parse expected object name '%s'"
+msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+
+#: remote.c:2757
+#, c-format
+msgid "cannot strip one component off url '%s'"
+msgstr "ní féidir comhpháirt amháin a bhaint as url '%s'"
+
+#: wt-status.c:178
+msgid "Unmerged paths:"
+msgstr "Cosáin neamh-chumasaithe:"
+
+#: wt-status.c:207 wt-status.c:239
+msgid "  (use \"git restore --staged <file>...\" to unstage)"
+msgstr " (bain úsáid as “git restore --stage <comhad>...” chun an stáitse a dhíchur)"
+
+#: wt-status.c:210 wt-status.c:242
+#, c-format
+msgid "  (use \"git restore --source=%s --staged <file>...\" to unstage)"
+msgstr " (bain úsáid as \"git restore --source=%s --staged <comhad>...\" chun an stáitse a dhí-ardú)"
+
+#: wt-status.c:213 wt-status.c:245
+msgid "  (use \"git rm --cached <file>...\" to unstage)"
+msgstr " (bain úsáid as “git rm --cached <comhad>...” chun an stáitse a dhíchur)"
+
+#: wt-status.c:217
+msgid "  (use \"git add <file>...\" to mark resolution)"
+msgstr " (bain úsáid as “git add <comhad>...” chun réiteach a mharcáil)"
+
+#: wt-status.c:219 wt-status.c:223
+msgid "  (use \"git add/rm <file>...\" as appropriate to mark resolution)"
+msgstr " (bain úsáid \"git add/rm <comhad>...\" de réir mar is cuí chun réiteach a mharcáil)"
+
+#: wt-status.c:221
+msgid "  (use \"git rm <file>...\" to mark resolution)"
+msgstr " (bain úsáid as “git rm <comhad>...” chun réiteach a mharcáil)"
+
+#: wt-status.c:231 wt-status.c:1174
+msgid "Changes to be committed:"
+msgstr "Athruithe atá le déanamh:"
+
+#: wt-status.c:254 wt-status.c:1183
+msgid "Changes not staged for commit:"
+msgstr "Athruithe nach ndearnadh a chur ar stáitse le haghaidh tiomantais:"
+
+#: wt-status.c:258
+msgid "  (use \"git add <file>...\" to update what will be committed)"
+msgstr "  (bain úsáid as “git add <comhad>...” chun an méid a bheidh tiomanta a nuashonrú)"
+
+#: wt-status.c:260
+msgid "  (use \"git add/rm <file>...\" to update what will be committed)"
+msgstr "  (bain úsáid as “git add/rm <comhad>...” chun an méid a bheidh tiomanta a nuashonrú)"
+
+#: wt-status.c:261
+msgid "  (use \"git restore <file>...\" to discard changes in working directory)"
+msgstr " (bain úsáid as “git restore <comhad>...” chun athruithe ar eolaire oibre a dhiúscairt)"
+
+#: wt-status.c:263
+msgid "  (commit or discard the untracked or modified content in submodules)"
+msgstr " (an t-ábhar neamhrianaithe nó modhnaithe i bhfo-mhodúil a thiomsú nó a dhiúscairt)"
+
+#: wt-status.c:274
+#, c-format
+msgid "  (use \"git %s <file>...\" to include in what will be committed)"
+msgstr " (bain úsáid as “git %s <comhad>...” chun an méid a bheidh tiomanta san áireamh)"
+
+#: wt-status.c:286
+msgid "both deleted:"
+msgstr "scriosta an dá cheann:"
+
+#: wt-status.c:288
+msgid "added by us:"
+msgstr "curtha leis againn:"
+
+#: wt-status.c:290
+msgid "deleted by them:"
+msgstr "scriosta ag siad:"
+
+#: wt-status.c:292
+msgid "added by them:"
+msgstr "a chuir siad leis:"
+
+#: wt-status.c:294
+msgid "deleted by us:"
+msgstr "scriosta againn:"
+
+#: wt-status.c:296
+msgid "both added:"
+msgstr "chuir an bheirt leis:"
+
+#: wt-status.c:298
+msgid "both modified:"
+msgstr "an dá cheann modhnaithe:"
+
+#: wt-status.c:308
+msgid "new file:"
+msgstr "comhad nua:"
+
+#: wt-status.c:310
+msgid "copied:"
+msgstr "cóipeáilte:"
+
+#: wt-status.c:312
+msgid "deleted:"
+msgstr "scriosta:"
+
+#: wt-status.c:314
+msgid "modified:"
+msgstr "modhnaithe:"
+
+#: wt-status.c:316
+msgid "renamed:"
+msgstr "athainmnithe:"
+
+#: wt-status.c:318
+msgid "typechange:"
+msgstr "cineál cineál:"
+
+#: wt-status.c:320
+msgid "unknown:"
+msgstr "anaithnid:"
+
+#: wt-status.c:322
+msgid "unmerged:"
+msgstr "gan chumasc:"
+
+#: wt-status.c:402
+msgid "new commits, "
+msgstr "tiomantais nua, "
+
+#: wt-status.c:404
+msgid "modified content, "
+msgstr "ábhar modhnaithe, "
+
+#: wt-status.c:406
+msgid "untracked content, "
+msgstr "ábhar neamhrianaithe, "
+
+#: wt-status.c:1000
+#, c-format
+msgid "Your stash currently has %d entry"
+msgid_plural "Your stash currently has %d entries"
+msgstr[0] "Tá %d iontráil i do stash faoi láthair"
+msgstr[1] "Tá %d iontrálacha ar do stash faoi láthair"
+msgstr[2] "Tá %d iontrálacha ar do stash faoi láthair"
+
+#: wt-status.c:1031
+msgid "Submodules changed but not updated:"
+msgstr "Fo-mhodúil athraithe ach gan nuashonrú:"
+
+#: wt-status.c:1033
+msgid "Submodule changes to be committed:"
+msgstr "Athruithe fo-mhodúil atá le tiomantas:"
+
+#: wt-status.c:1118
+msgid ""
+"Do not modify or remove the line above.\n"
+"Everything below it will be ignored."
+msgstr ""
+"Ná déan an líne thuas a mhodhnú ná a bhaint.\n"
+"Déanfar neamhaird ar gach rud thíos é."
+
+#: wt-status.c:1214
+#, c-format
+msgid ""
+"\n"
+"It took %.2f seconds to compute the branch ahead/behind values.\n"
+"You can use '--no-ahead-behind' to avoid this.\n"
+msgstr ""
+"\n"
+"Thóg sé %.2f soicind chun luachanna na brainse chun tosaigh/taobh thiar a ríomh.\n"
+"Is féidir leat '--no-ahead-behind' a úsáid chun seo a sheachaint.\n"
+
+#: wt-status.c:1246
+msgid "You have unmerged paths."
+msgstr "Tá cosáin neamh-chumasaithe agat."
+
+#: wt-status.c:1249
+msgid "  (fix conflicts and run \"git commit\")"
+msgstr " (coinbhleachtaí a shocrú agus reáchtáil “git commit”)"
+
+#: wt-status.c:1251
+msgid "  (use \"git merge --abort\" to abort the merge)"
+msgstr " (bain úsáid as “git merge --abort” chun an cumaisc a chur ar deireadh)"
+
+#: wt-status.c:1255
+msgid "All conflicts fixed but you are still merging."
+msgstr "Socraíodh gach coinbhleacht ach tá tú fós ag cumasc."
+
+#: wt-status.c:1258
+msgid "  (use \"git commit\" to conclude merge)"
+msgstr "  (bain úsáid as “git commit” chun cumasc a thabhairt i gcrích)"
+
+#: wt-status.c:1269
+msgid "You are in the middle of an am session."
+msgstr "Tá tú i lár seisiún am."
+
+#: wt-status.c:1272
+msgid "The current patch is empty."
+msgstr "Tá an paiste reatha folamh."
+
+#: wt-status.c:1277
+msgid "  (fix conflicts and then run \"git am --continue\")"
+msgstr "  (déan coinbhleachtaí a shocrú agus ansin rith “git am --continue”)"
+
+#: wt-status.c:1279
+msgid "  (use \"git am --skip\" to skip this patch)"
+msgstr " (bain úsáid as “git am --skip” chun an paiste seo a scipeáil)"
+
+#: wt-status.c:1282
+msgid "  (use \"git am --allow-empty\" to record this patch as an empty commit)"
+msgstr ""
+" (bain úsáid as “git am --allow-empty” chun an paiste seo a thaifeadadh mar thiomantas folamh)"
+
+#: wt-status.c:1284
+msgid "  (use \"git am --abort\" to restore the original branch)"
+msgstr " (bain úsáid as “git am --abort” chun an bhrainse bunaidh a chur ar ais)"
+
+#: wt-status.c:1430
+msgid "git-rebase-todo is missing."
+msgstr "tá git-rebase-todo ar iarraidh."
+
+#: wt-status.c:1432
+msgid "No commands done."
+msgstr "Níl aon orduithe déanta."
+
+#: wt-status.c:1435
+#, c-format
+msgid "Last command done (%<PRIuMAX> command done):"
+msgid_plural "Last commands done (%<PRIuMAX> commands done):"
+msgstr[0] "An chéad ordú eile le déanamh (%<PRIuMAX>ordú atá fágtha):"
+msgstr[1] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
+msgstr[2] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
+
+#: wt-status.c:1447
+#, c-format
+msgid "  (see more in file %s)"
+msgstr " (féach tuilleadh i gcomhad %s)"
+
+#: wt-status.c:1454
+msgid "No commands remaining."
+msgstr "Níl aon orduithe fágtha."
+
+#: wt-status.c:1457
+#, c-format
+msgid "Next command to do (%<PRIuMAX> remaining command):"
+msgid_plural "Next commands to do (%<PRIuMAX> remaining commands):"
+msgstr[0] "An chéad ordú eile le déanamh (%<PRIuMAX> an t-ordú atá fágtha):"
+msgstr[1] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
+msgstr[2] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
+
+#: wt-status.c:1465
+msgid "  (use \"git rebase --edit-todo\" to view and edit)"
+msgstr " (bain úsáid as “git rebase --edit-todo” chun féachaint agus eagar a chur in eagar)"
+
+#: wt-status.c:1477
+#, c-format
+msgid "You are currently rebasing branch '%s' on '%s'."
+msgstr "Tá tú ag athbhunú brainse '%s' faoi láthair ar '%s'."
+
+#: wt-status.c:1482
+msgid "You are currently rebasing."
+msgstr "Tá tú ag athbhunú faoi láthair."
+
+#: wt-status.c:1495
+msgid "  (fix conflicts and then run \"git rebase --continue\")"
+msgstr " (déan coinbhleachtaí a shocrú agus ansin rith “git rebase --continue”)"
+
+#: wt-status.c:1497
+msgid "  (use \"git rebase --skip\" to skip this patch)"
+msgstr " (bain úsáid as “git rebase --skip” chun an paiste seo a scipeáil)"
+
+#: wt-status.c:1499
+msgid "  (use \"git rebase --abort\" to check out the original branch)"
+msgstr " (bain úsáid as “git rebase --abort” chun an bhrainse bunaidh a sheiceáil)"
+
+#: wt-status.c:1506
+msgid "  (all conflicts fixed: run \"git rebase --continue\")"
+msgstr " (gach coinbhleacht socraithe: reáchtáil “git rebase --continue”)"
+
+#: wt-status.c:1510
+#, c-format
+msgid "You are currently splitting a commit while rebasing branch '%s' on '%s'."
+msgstr "Tá tiomantas á roinnt agat faoi láthair agus tú ag athbhunú brainse '%s' ar '%s'."
+
+#: wt-status.c:1515
+msgid "You are currently splitting a commit during a rebase."
+msgstr "Tá tú ag roinnt tiomantas faoi láthair le linn athbhunaithe."
+
+#: wt-status.c:1518
+msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
+msgstr " (Nuair a bheidh d'eolaire oibre glan, reáchtáil “git rebase --continue”)"
+
+#: wt-status.c:1522
+#, c-format
+msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
+msgstr "Tá tú ag eagarthóireacht faoi láthair agus tú ag athbhunú brainse '%s' ar '%s'."
+
+#: wt-status.c:1527
+msgid "You are currently editing a commit during a rebase."
+msgstr "Tá tú ag eagarthóireacht tiomanta faoi láthair le linn athbhunaithe."
+
+#: wt-status.c:1530
+msgid "  (use \"git commit --amend\" to amend the current commit)"
+msgstr " (bain úsáid as “git commit --amend” chun an tiomantas reatha a leasú)"
+
+#: wt-status.c:1532
+msgid "  (use \"git rebase --continue\" once you are satisfied with your changes)"
+msgstr " (bain úsáid as “git rebase --continue” nuair a bheidh tú sásta le d'athruithe)"
+
+#: wt-status.c:1543
+msgid "Cherry-pick currently in progress."
+msgstr "Cherry-pick atá ar siúl faoi láthair."
+
+#: wt-status.c:1546
+#, c-format
+msgid "You are currently cherry-picking commit %s."
+msgstr "Tá tiomantas %s ag piocadh silíní faoi láthair."
+
+#: wt-status.c:1553
+msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
+msgstr " (coinbhleachtaí a shocrú agus reáchtáil “git cherry-pick --continue”)"
+
+#: wt-status.c:1556
+msgid "  (run \"git cherry-pick --continue\" to continue)"
+msgstr " (reáchtáil “git cherry-pick - lean” chun leanúint ar aghaidh)"
+
+#: wt-status.c:1559
+msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
+msgstr " (gach coinbhleacht socraithe: reáchtáil “git cherry-pick --continue”)"
+
+#: wt-status.c:1561
+msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
+msgstr " (bain úsáid as “git cherry-pick --skip” chun an paiste seo a scipeáil)"
+
+#: wt-status.c:1563
+msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
+msgstr " (bain úsáid as “git cherry-pick --abort” chun an oibríocht pioc silíní a chealú)"
+
+#: wt-status.c:1573
+msgid "Revert currently in progress."
+msgstr "Ar ais atá ar siúl faoi láthair."
+
+#: wt-status.c:1576
+#, c-format
+msgid "You are currently reverting commit %s."
+msgstr "Tá tiomantas %s á chur ar ais faoi láthair."
+
+#: wt-status.c:1582
+msgid "  (fix conflicts and run \"git revert --continue\")"
+msgstr " (déan coinbhleachtaí a shocrú agus rith “git revert --continue”)"
+
+#: wt-status.c:1585
+msgid "  (run \"git revert --continue\" to continue)"
+msgstr " (reáchtáil “git revert --continue” chun leanúint ar aghaidh)"
+
+#: wt-status.c:1588
+msgid "  (all conflicts fixed: run \"git revert --continue\")"
+msgstr " (gach coinbhleacht socraithe: reáchtáil “git revert --continue”)"
+
+#: wt-status.c:1590
+msgid "  (use \"git revert --skip\" to skip this patch)"
+msgstr " (bain úsáid as “git revert --skip” chun an paiste seo a scipeáil)"
+
+#: wt-status.c:1592
+msgid "  (use \"git revert --abort\" to cancel the revert operation)"
+msgstr " (bain úsáid as “git revert --abort” chun an oibríocht aisghabhála a chealú)"
+
+#: wt-status.c:1602
+#, c-format
+msgid "You are currently bisecting, started from branch '%s'."
+msgstr "Tá tú ag déileáil faoi láthair, tosaigh tú ó bhrainse '%s'."
+
+#: wt-status.c:1606
+msgid "You are currently bisecting."
+msgstr "Tá tú ag déileáil faoi láthair."
+
+#: wt-status.c:1609
+msgid "  (use \"git bisect reset\" to get back to the original branch)"
+msgstr " (bain úsáid as “git bisect reset” chun filleadh ar an mbrainse bunaidh)"
+
+#: wt-status.c:1620
+msgid "You are in a sparse checkout."
+msgstr "Tá tú i seiceáil neamhchoitianta."
+
+#: wt-status.c:1623
+#, c-format
+msgid "You are in a sparse checkout with %d%% of tracked files present."
+msgstr "Tá tú i seiceáil neamhchoitianta le %d%% de na comhaid rianaithe i láthair."
+
+#: wt-status.c:1871
+msgid "On branch "
+msgstr "Ar bhrainse "
+
+#: wt-status.c:1878
+msgid "interactive rebase in progress; onto "
+msgstr "athbhunú idirghníomhach atá ar siúl; ar "
+
+#: wt-status.c:1880
+msgid "rebase in progress; onto "
+msgstr "athbhunú atá ar siúl; ar "
+
+#: wt-status.c:1885
+msgid "HEAD detached at "
+msgstr "HEAD scoite ag "
+
+#: wt-status.c:1887
+msgid "HEAD detached from "
+msgstr "CEANN scartha ó "
+
+#: wt-status.c:1890
+msgid "Not currently on any branch."
+msgstr "Níl sé ar aon bhrainse faoi láthair."
+
+#: wt-status.c:1907
+msgid "Initial commit"
+msgstr "Tiomantas tosaigh"
+
+#: wt-status.c:1908
+msgid "No commits yet"
+msgstr "Níl aon gealltanais fós"
+
+#: wt-status.c:1922
+msgid "Untracked files"
+msgstr "Comhaid neamhrianaithe"
+
+#: wt-status.c:1924
+msgid "Ignored files"
+msgstr "Comhaid neamhaird"
+
+#: wt-status.c:1929
+#, c-format
+msgid ""
+"It took %.2f seconds to enumerate untracked files,\n"
+"but the results were cached, and subsequent runs may be faster."
+msgstr ""
+"Thóg sé %.2f soicind comhaid gan rianú a áireamh,\n"
+"ach cuireadh na torthaí a chosc, agus d'fhéadfadh rith ina dhiaidh sin a bheith níos gasta."
+
+#: wt-status.c:1934
+#, c-format
+msgid "It took %.2f seconds to enumerate untracked files."
+msgstr "Thóg sé %.2f soicind comhaid gan rianú a áireamh."
+
+#: wt-status.c:1938
+msgid "See 'git help status' for information on how to improve this."
+msgstr "Féach 'git help status' le haghaidh faisnéise maidir le conas é seo a fheabhsú."
+
+#: wt-status.c:1942
+#, c-format
+msgid "Untracked files not listed%s"
+msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+
+#: wt-status.c:1944
+msgid " (use -u option to show untracked files)"
+msgstr " (bain úsáid as an rogha -u chun comhaid neamhrianaithe a thaispeáint)"
+
+#: wt-status.c:1950
+msgid "No changes"
+msgstr "Gan aon athruithe"
+
+#: wt-status.c:1955
+#, c-format
+msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
+msgstr "níl aon athruithe curtha le tiomantas (bain úsáid as “git add” agus/nó “git commit -a”)\n"
+
+#: wt-status.c:1959
+#, c-format
+msgid "no changes added to commit\n"
+msgstr "níl aon athruithe curtha le tiomantas\n"
+
+#: wt-status.c:1963
+#, c-format
+msgid "nothing added to commit but untracked files present (use \"git add\" to track)\n"
+msgstr ""
+"ní chuirtear aon rud le tiomantas ach comhaid neamhrianaithe i láthair (bain úsáid as “git add” "
+"chun rianú)\n"
+
+#: wt-status.c:1967
+#, c-format
+msgid "nothing added to commit but untracked files present\n"
+msgstr "ní chuir aon rud le tiomantas ach comhaid neamhrianaithe i láthair\n"
+
+#: wt-status.c:1971
+#, c-format
+msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
+msgstr "aon rud le tiomantas (comhaid a chruthú/cóipeáil agus bain úsáid as “git add” chun rianú)\n"
+
+#: wt-status.c:1975 wt-status.c:1981
+#, c-format
+msgid "nothing to commit\n"
+msgstr "aon rud le tiomantas\n"
+
+#: wt-status.c:1978
+#, c-format
+msgid "nothing to commit (use -u to show untracked files)\n"
+msgstr "aon rud le tiomantas (bain úsáid as -u chun comhaid neamhrianaithe a thaispeáint)\n"
+
+#: wt-status.c:1983
+#, c-format
+msgid "nothing to commit, working tree clean\n"
+msgstr "aon rud le tiomantas, crann oibre glan\n"
+
+#: wt-status.c:2088
+msgid "No commits yet on "
+msgstr "Níl aon gealltanas ar aghaidh go fóill "
+
+#: wt-status.c:2092
+msgid "HEAD (no branch)"
+msgstr "CEAD (gan aon bhrainse)"
+
+#: wt-status.c:2122
+msgid "gone"
+msgstr "imithe"
+
+#: wt-status.c:2124
+msgid "different"
+msgstr "difriúil"
+
+#: wt-status.c:2126 wt-status.c:2134
+msgid "behind "
+msgstr "taobh thiar "
+
+#: wt-status.c:2129 wt-status.c:2132
+msgid "ahead "
+msgstr "chun tosaigh "
+
+#. TRANSLATORS: the action is e.g. "pull with rebase"
+#: wt-status.c:2674
+#, c-format
+msgid "cannot %s: You have unstaged changes."
+msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+
+#: wt-status.c:2680
+msgid "additionally, your index contains uncommitted changes."
+msgstr "ina theannta sin, tá athruithe neamhthiomanta i d'innéacs."
+
+#: wt-status.c:2682
+#, c-format
+msgid "cannot %s: Your index contains uncommitted changes."
+msgstr "ní féidir %s: Tá athruithe neamhthiomanta ag d'innéacs."

--- a/po/ga.po
+++ b/po/ga.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2025-05-12 22:57+0000\n"
-"PO-Revision-Date: 2025-05-14 13:12+0100\n"
+"PO-Revision-Date: 2025-05-15 22:58+0100\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@gmail.com>\n"
 "Language-Team: none\n"
 "Language: ga\n"
@@ -20,188 +20,182 @@ msgstr ""
 
 #, c-format
 msgid "Huh (%s)?"
-msgstr ""
+msgstr "Huh (%s)?"
 
-#, fuzzy
 msgid "could not read index"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní raibh in ann innéacs a léamh"
 
 msgid "binary"
-msgstr ""
+msgstr "dénártha"
 
 msgid "nothing"
-msgstr ""
+msgstr "rud ar bith"
 
-#, fuzzy
 msgid "unchanged"
-msgstr "Gan aon athruithe"
+msgstr "gan athrú"
 
 msgid "Update"
-msgstr ""
+msgstr "Nuashonraigh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not stage '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a chéim"
 
-#, fuzzy
 msgid "could not write index"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní fhéadfadh innéacs a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
-msgstr[0] "Nuashonraíodh %d cosán ó %s"
-msgstr[1] "Nuashonraíodh %d cosán ó %s"
-msgstr[2] "Nuashonraíodh %d cosán ó %s"
+msgstr[0] "nuashonraithe %d cosán\n"
+msgstr[1] "nuashonraíodh %d cosán\n"
+msgstr[2] "nuashonraíodh %d cosán\n"
 
 #, c-format
 msgid "note: %s is untracked now.\n"
-msgstr ""
+msgstr "nótaí: Tá %s dírianaithe anois.\n"
 
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
 
 msgid "Revert"
-msgstr ""
+msgstr "Aisghabháil"
 
-#, fuzzy
 msgid "Could not parse HEAD^{tree}"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Ní raibh sé in ann HEAD ^ {tree} a pharsáil"
 
 #, c-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "cosán %d aisiompaithe\n"
+msgstr[1] "%d cosán aisiompaithe\n"
+msgstr[2] "%d cosán aisiompaithe\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "No untracked files.\n"
-msgstr "Comhaid neamhrianaithe"
+msgstr "Gan aon chomhaid neamhrianaithe.\n"
 
 msgid "Add untracked"
-msgstr ""
+msgstr "Cuir neamh-rianaithe leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
-msgstr[0] "a chuir siad leis:"
-msgstr[1] "a chuir siad leis:"
-msgstr[2] "a chuir siad leis:"
+msgstr[0] "cuireadh %d cosán leis\n"
+msgstr[1] "%d cosán curtha leis\n"
+msgstr[2] "%d cosán curtha leis\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "ignoring unmerged: %s"
-msgstr "neamhaird a dhéanamh ar iontrálacha"
+msgstr "ag neamhaird a dhéanamh de neamhchumasctha: %s"
 
 #, c-format
 msgid "Only binary files changed.\n"
-msgstr ""
+msgstr "Níor athraigh ach comhaid dénártha.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "No changes.\n"
-msgstr "Gan aon athruithe"
+msgstr "Gan aon athruithe.\n"
 
-#, fuzzy
 msgid "Patch update"
-msgstr "nuashonruithe fórsa"
+msgstr "Nuashonrú paiste"
 
 msgid "Review diff"
-msgstr ""
+msgstr "Athbhreithniú diff"
 
 msgid "show paths with changes"
-msgstr ""
+msgstr "taispeáin cosáin le hathruithe"
 
 msgid "add working tree state to the staged set of changes"
-msgstr ""
+msgstr "cuir stát crann oibre leis an tsraith athruithe céimeádta"
 
 msgid "revert staged set of changes back to the HEAD version"
-msgstr ""
+msgstr "tacar athruithe céime a chur ar ais chuig an leagan HEAD"
 
-#, fuzzy
 msgid "pick hunks and update selectively"
-msgstr "roghnaigh hunks idirghníomhach"
+msgstr "roghnaigh hunks agus nuashonraigh go roghnach"
 
-#, fuzzy
 msgid "view diff between HEAD and index"
-msgstr "athshocraigh HEAD agus innéacs"
+msgstr "féach ar an difríocht idir HEAD agus innéacs"
 
 msgid "add contents of untracked files to the staged set of changes"
-msgstr ""
+msgstr "cuir ábhar comhaid neamhrianaithe leis an tacar athruithe céimeádta"
 
 msgid "Prompt help:"
-msgstr ""
+msgstr "Cabhair pras:"
 
 msgid "select a single item"
-msgstr ""
+msgstr "roghnaigh mír amháin"
 
 msgid "select a range of items"
-msgstr ""
+msgstr "roghnaigh raon earraí"
 
 msgid "select multiple ranges"
-msgstr ""
+msgstr "roghnaigh raonta iomadúla"
 
 msgid "select item based on unique prefix"
-msgstr ""
+msgstr "roghnaigh mír bunaithe ar réimír uathúil"
 
 msgid "unselect specified items"
-msgstr ""
+msgstr "míreanna sonraithe díroghnaigh"
 
 msgid "choose all items"
-msgstr ""
+msgstr "roghnaigh gach earra"
 
 msgid "(empty) finish selecting"
-msgstr ""
+msgstr "(folamh) críochnaigh a roghnú"
 
 msgid "select a numbered item"
-msgstr ""
+msgstr "roghnaigh mír uimhrithe"
 
 msgid "(empty) select nothing"
-msgstr ""
+msgstr "(folamh) roghnaigh aon rud"
 
 msgid "*** Commands ***"
-msgstr ""
+msgstr "*** Orduithe ***"
 
 msgid "What now"
-msgstr ""
+msgstr "Cad anois"
 
 msgid "staged"
-msgstr ""
+msgstr "stáitse"
 
 msgid "unstaged"
-msgstr ""
+msgstr "gan stáitse"
 
 msgid "path"
 msgstr "cosán"
 
-#, fuzzy
 msgid "could not refresh index"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní fhéadfadh innéacs a athnuachan"
 
 #, c-format
 msgid "Bye.\n"
-msgstr ""
+msgstr "Slán..\n"
 
 #, c-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Athrú modh stáitse [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Scriosadh céime [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Breiseán céime [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir an píosa seo ar stáitse [y,n,q,a,d%s,?]? "
 
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "staging."
 msgstr ""
+"Má chuireann an paiste i bhfeidhm go glan, déanfar an hunk eagarthóireachta "
+"a mharcáil láithreach le haghaidh stáitsithe."
 
 msgid ""
 "y - stage this hunk\n"
@@ -210,27 +204,35 @@ msgid ""
 "a - stage this hunk and all later hunks in the file\n"
 "d - do not stage this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - céim an hunk seo\n"
+"n - ná déan an hunk seo a chéile\n"
+"q - scor; ná déan an hunk seo ná aon cheann de na cinn atá fágtha a chéile\n"
+"a - céim an hunk seo agus gach hunc ina dhiaidh sin sa chomhad\n"
+"d - ná déan an hunk seo ná aon cheann de na hunks níos déanaí sa chomhad a "
+"chéile\n"
 
 #, c-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Athrú modh stash [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Scriosadh staise [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Breiseán stash [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "An bhfuil an carachtar seo [y,n,q,a,d%s,?] i bhfolach? "
 
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
 msgstr ""
+"Má chuireann an paiste i bhfeidhm go glan, déanfar an hunk eagarthóireachta "
+"a mharcáil láithreach le haghaidh stórála."
 
 msgid ""
 "y - stash this hunk\n"
@@ -239,27 +241,35 @@ msgid ""
 "a - stash this hunk and all later hunks in the file\n"
 "d - do not stash this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - stash an hunk seo\n"
+"n - ná déan an hunk seo a stóráil\n"
+"q - scor; ná déan an hunk seo ná aon cheann de na cinn atá fágtha a stóráil\n"
+"a - stóráil an hunk seo agus gach hunk ina dhiaidh sin sa chomhad\n"
+"d - ná déan an hunk seo ná aon cheann de na hunks níos déanaí sa chomhad a "
+"stóráil\n"
 
 #, c-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Athrú ar mhodh gan stáitse [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Scriosadh gan stáitse [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Breiseán gan stáitse [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Dí-stáitseáil an píosa beag seo den stáitse [y,n,q,a,d%s,?]? "
 
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
 msgstr ""
+"Má chuireann an paiste i bhfeidhm go glan, déanfar an hunk eagarthóireachta "
+"a mharcáil láithreach le haghaidh dístáisithe."
 
 msgid ""
 "y - unstage this hunk\n"
@@ -268,27 +278,35 @@ msgid ""
 "a - unstage this hunk and all later hunks in the file\n"
 "d - do not unstage this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - déan an hunk seo a dhíchur\n"
+"n - ná déan an hunk seo a dhíchur\n"
+"q - scor; ná déan an hunk seo nó aon cheann de na cinn atá fágtha a dhíchur\n"
+"a - déan an hunk seo a dhíchur agus gach hunk ina dhiaidh sin sa chomhad\n"
+"d - ná déan an hunk seo nó aon cheann de na huncanna níos déanaí sa chomhad "
+"a dhíchur\n"
 
 #, c-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir athrú mód i bhfeidhm ar innéacs [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir scriosadh i bhfeidhm ar innéacs [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir an breiseán i bhfeidhm ar innéacs [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir an píosa seo i bhfeidhm ar innéacs [y,n,q,a,d%s,?]? "
 
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "applying."
 msgstr ""
+"Má chuireann an paiste i bhfeidhm go glan, déanfar an hunk eagarthóireachta "
+"a mharcáil láithreach le haghaidh iarratas a dhéanamh."
 
 msgid ""
 "y - apply this hunk to index\n"
@@ -297,27 +315,37 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - cuir an hunk seo i bhfeidhm ar innéacs\n"
+"n - ná cuir an hunk seo i bhfeidhm ar innéacs\n"
+"q - scor; ná cuir an hunk seo ná aon cheann de na cinn atá fágtha i "
+"bhfeidhm\n"
+"a - cuir an hunk seo agus gach hunk níos déanaí i bhfeidhm sa chomhad\n"
+"d - ná cuir an hunk seo ná aon cheann de na hunks níos déanaí sa chomhad i "
+"bhfeidhm\n"
 
 #, c-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Athrú modh a dhiúscairt ó chrann oibre [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "An scriosadh ón gcrann oibre [y,n,q,a,d%s,?] a sheachaint? "
 
 #, c-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Scrios an breiseán ón gcrann oibre [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"An bhfuil an píosa beag seo le fáil réidh ón gcrann oibre [y,n,q,a,d%s,?]? "
 
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "discarding."
 msgstr ""
+"Má chuireann an paiste i bhfeidhm go glan, déanfar an hunk eagarthóireachta "
+"a mharcáil láithreach lena dhiúscairt."
 
 msgid ""
 "y - discard this hunk from worktree\n"
@@ -326,22 +354,32 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - caitheamh an bonc seo ón gcrann oibre\n"
+"n - ná caitheamh an hunk seo ón gcrann oibre\n"
+"q - scor; ná caith an hunk seo ná aon cheann de na cinn atá fágtha\n"
+"a - caith an hunk seo agus gach hunc ina dhiaidh sin sa chomhad\n"
+"d - ná caith an hunk seo ná aon cheann de na huncanna níos déanaí sa "
+"chomhad\n"
 
 #, c-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"Athrú modh a dhiúscairt ó innéacs agus crann oibre [y, n, q, a, d %s,?]? "
 
 #, c-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"An scriosadh ón innéacs agus ón gcrann oibre [y,n,q,a,d%s,?] a dhíbirt? "
 
 #, c-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Caitheamh breisiú ó innéacs agus crann oibre [y, n, q, a, d %s,?]? "
 
 #, c-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"An bhfuil an píosa beag seo le fáil réidh ón innéacs agus ón gcrann oibre "
+"[y,n,q,a,d%s,?]? "
 
 msgid ""
 "y - discard this hunk from index and worktree\n"
@@ -350,22 +388,35 @@ msgid ""
 "a - discard this hunk and all later hunks in the file\n"
 "d - do not discard this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - caitheamh an hunk seo ón innéacs agus ón gcrann oibre\n"
+"n - ná caith an hunk seo ón innéacs agus ón gcrann oibre\n"
+"q - scor; ná caith an hunk seo ná aon cheann de na cinn atá fágtha\n"
+"a - caith an hunk seo agus gach hunc ina dhiaidh sin sa chomhad\n"
+"d - ná caith an hunk seo ná aon cheann de na huncanna níos déanaí sa "
+"chomhad\n"
 
 #, c-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"Cuir athrú mód i bhfeidhm ar an innéacs agus ar an gcrann oibre "
+"[y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"Cuir scriosadh i bhfeidhm ar innéacs agus crann oibre [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"Cuir an breiseán i bhfeidhm ar an innéacs agus ar an gcrann oibre "
+"[y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
+"Cuir an píosa seo i bhfeidhm ar an innéacs agus ar an gcrann oibre "
+"[y,n,q,a,d%s,?]? "
 
 msgid ""
 "y - apply this hunk to index and worktree\n"
@@ -374,22 +425,29 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - cuir an hunk seo i bhfeidhm ar innéacs agus ar chrann oibre\n"
+"n - ná cuir an hunk seo i bhfeidhm ar innéacs agus crann oibre\n"
+"q - scor; ná cuir an hunk seo ná aon cheann de na cinn atá fágtha i "
+"bhfeidhm\n"
+"a - cuir an hunk seo agus gach hunk níos déanaí i bhfeidhm sa chomhad\n"
+"d - ná cuir an hunk seo ná aon cheann de na hunks níos déanaí sa chomhad i "
+"bhfeidhm\n"
 
 #, c-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir athrú mód i bhfeidhm ar an gcrann oibre [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir scriosadh i bhfeidhm ar chrann oibre [y, n, q, a, d%s,?]? "
 
 #, c-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir an breiseán i bhfeidhm ar an gcrann oibre [y,n,q,a,d%s,?]? "
 
 #, c-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
-msgstr ""
+msgstr "Cuir an píosa seo i bhfeidhm ar an gcrann oibre [y,n,q,a,d%s,?]? "
 
 msgid ""
 "y - apply this hunk to worktree\n"
@@ -398,36 +456,45 @@ msgid ""
 "a - apply this hunk and all later hunks in the file\n"
 "d - do not apply this hunk or any of the later hunks in the file\n"
 msgstr ""
+"y - cuir an hunk seo i bhfeidhm ar chrann oibre\n"
+"n - ná cuir an hunk seo i bhfeidhm ar chrann oibre\n"
+"q - scor; ná cuir an hunk seo ná aon cheann de na cinn atá fágtha i "
+"bhfeidhm\n"
+"a - cuir an hunk seo agus gach hunk níos déanaí i bhfeidhm sa chomhad\n"
+"d - ná cuir an hunk seo ná aon cheann de na hunks níos déanaí sa chomhad i "
+"bhfeidhm\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse hunk header '%.*s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "níorbh fhéidir ceanntásc an bhlúire '%.*s' a pharsáil"
 
-#, fuzzy
 msgid "could not parse diff"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh sé in ann difríocht a pharsáil"
 
-#, fuzzy
 msgid "could not parse colored diff"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh sé in ann difríocht daite a pháirseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to run '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar '%s' a reáchtáil"
 
 msgid "mismatched output from interactive.diffFilter"
-msgstr ""
+msgstr "aschur mí-mheaitseáilte ó interactive.diffFilter"
 
 msgid ""
 "Your filter must maintain a one-to-one correspondence\n"
 "between its input and output lines."
 msgstr ""
+"Caithfidh do scagaire comhfhreagras duine le duine a choinneáil\n"
+"idir a línte ionchuir agus aschuir."
 
 #, c-format
 msgid ""
 "expected context line #%d in\n"
 "%.*s"
 msgstr ""
+"líne comhthéacs a bhfuil súil leo #%d i\n"
+"%.*s"
 
 #, c-format
 msgid ""
@@ -436,9 +503,14 @@ msgid ""
 "\tdoes not end with:\n"
 "%.*s"
 msgstr ""
+"ní fhorluíonn hunks:\n"
+"%.*s\n"
+" ní chríochnaíonn sé le:\n"
+"%.*s"
 
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
 msgstr ""
+"Modh eagarthóireachta hunk láimhe - féach an bun le haghaidh treoir thapa.\n"
 
 #, c-format
 msgid ""
@@ -447,18 +519,26 @@ msgid ""
 "To remove '%c' lines, delete them.\n"
 "Lines starting with %s will be removed.\n"
 msgstr ""
+"---\n"
+"Chun línte '%c' a bhaint, déan línte '' iad (comhthéacs).\n"
+"Chun línte '%c' a bhaint, scrios iad.\n"
+"Bainfear línte a thosaíonn le %s.\n"
 
 msgid ""
 "If it does not apply cleanly, you will be given an opportunity to\n"
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
 "aborted and the hunk is left unchanged.\n"
 msgstr ""
+"Mura bhfuil feidhm aige go glan, tabharfar deis duit\n"
+"cuir in eagar arís. Má bhaintear gach líne den hunk, ansin is é an t-"
+"eagarthóireacht\n"
+"cuireadh isteach agus fágtar an hunk gan athrú.\n"
 
 msgid "could not parse hunk header"
-msgstr ""
+msgstr "ní fhéadfaí ceanntásc hunk a pháirseáil"
 
 msgid "'git apply --cached' failed"
-msgstr ""
+msgstr "Theip ar 'git apply --cached'"
 
 #. TRANSLATORS: do not translate [y/n]
 #. The program will only accept that input at this point.
@@ -469,15 +549,17 @@ msgstr ""
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
+"Ní bhaineann do chuid eagraithe. Cuir in eagar arís (ag rá \"níl\" cuirtear "
+"i leataobh é!) [y/n]? "
 
 msgid "The selected hunks do not apply to the index!"
-msgstr ""
+msgstr "Ní bhaineann na hunks roghnaithe leis an innéacs!"
 
 msgid "Apply them to the worktree anyway? "
-msgstr ""
+msgstr "An gcuirfidh tú i bhfeidhm iad ar an gcrann oibre ar aon nós? "
 
 msgid "Nothing was applied.\n"
-msgstr ""
+msgstr "Ní chuirtear aon rud i bhfeidhm.\n"
 
 msgid ""
 "j - leave this hunk undecided, see next undecided hunk\n"
@@ -491,121 +573,139 @@ msgid ""
 "p - print the current hunk, 'P' to use the pager\n"
 "? - print help\n"
 msgstr ""
+"j - fág an hunk seo gan chinneadh, féach an chéad hunk neamhchinnte eile\n"
+"J - fág an hunk seo gan chinneadh, féach an chéad hunk eile\n"
+"k - fág an hunk seo gan chinneadh, féach an hunk neamhchinnte roimhe seo\n"
+"K - fág an hunk seo gan chinneadh, féach an hunk roimhe seo\n"
+"g - roghnaigh hunk le dul chuig\n"
+"/- cuardaigh hunk a mheaitseann leis an regex a thugtar\n"
+"s - roinn an hunk reatha ina huncanna níos lú\n"
+"e - cuir an hunk reatha in eagar de láimh\n"
+"p - priontáil an hunk reatha, 'P' chun an pager a úsáid\n"
+"? - cabhair priontála\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Only one letter is expected, got '%s'"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "Níl súil leis ach litir amháin, fuair '%s'"
 
 msgid "No previous hunk"
-msgstr ""
+msgstr "Níl aon hunk roimhe seo"
 
 msgid "No next hunk"
-msgstr ""
+msgstr "Níl aon chéad hunk eile"
 
 msgid "No other hunks to goto"
-msgstr ""
+msgstr "Níl aon ghuncanna eile le dul"
 
 msgid "go to which hunk (<ret> to see more)? "
-msgstr ""
+msgstr "téigh chuig cén hunk (<ret> le tuilleadh a fheiceáil)? "
 
 msgid "go to which hunk? "
-msgstr ""
+msgstr "téigh chuig cén hunk? "
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid number: '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "Uimhir neamhbhailí: '%s'"
 
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Tá brón orm, níl ach %d píosa ar fáil."
+msgstr[1] "Tá brón orm, níl ach %d hunks ar fáil."
+msgstr[2] "Tá brón orm, níl ach %d hunks ar fáil."
 
 msgid "No other hunks to search"
-msgstr ""
+msgstr "Níl aon ghuncanna eile le cuardach"
 
 msgid "search for regex? "
-msgstr ""
+msgstr "cuardach a dhéanamh ar regex? "
 
 #, c-format
 msgid "Malformed search regexp %s: %s"
-msgstr ""
+msgstr "Regexp cuardaigh mífheidhmithe %s: %s"
 
 msgid "No hunk matches the given pattern"
-msgstr ""
+msgstr "Níl aon hunk ag teacht leis an bpatrún tugtha"
 
 msgid "Sorry, cannot split this hunk"
-msgstr ""
+msgstr "Tá brón orainn, ní féidir an hunk seo a roinnt"
 
 #, c-format
 msgid "Split into %d hunks."
-msgstr ""
+msgstr "Roinn ina %d hunks."
 
 msgid "Sorry, cannot edit this hunk"
-msgstr ""
+msgstr "Tá brón orainn, ní féidir an hunk seo a chur in eagar"
 
 #, c-format
 msgid "Unknown command '%s' (use '?' for help)"
-msgstr ""
+msgstr "Ordú anaithnid '%s' (bain úsáid as '?' le haghaidh cabhair)"
 
 msgid "'git apply' failed"
-msgstr ""
+msgstr "Theip ar 'git apply'"
 
-#, fuzzy
 msgid "No changes."
-msgstr "Gan aon athruithe"
+msgstr "Gan aon athruithe."
 
 msgid "Only binary files changed."
-msgstr ""
+msgstr "Níor athraigh ach comhaid dénártha."
 
 #, c-format
 msgid ""
 "\n"
 "Disable this message with \"git config set advice.%s false\""
 msgstr ""
+"\n"
+"Díchumasaigh an teachtaireacht seo le \"git config set advice.%s false\""
 
 #, c-format
 msgid "%shint:%s%.*s%s\n"
-msgstr ""
+msgstr "%sleid:%s%.*s%s\n"
 
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
+"Ní féidir piocadh silíní toisc go bhfuil comhaid neamh-chumasaithe agat."
 
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
+"Ní féidir tiomantas a dhéanamh toisc go bhfuil comhaid neamh-"
+"chomhcheangailte agat."
 
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
+"Ní féidir cumasc a dhéanamh toisc go bhfuil comhaid neamh-chumasaithe agat."
 
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
+"Ní féidir tarraingt a tharraingt toisc go bhfuil comhaid neamh-chumasaithe "
+"agat."
 
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
+"Ní féidir aisiompú toisc go bhfuil comhaid neamh-chomhcheangailte agat."
 
 msgid "Rebasing is not possible because you have unmerged files."
 msgstr ""
+"Ní féidir athbhunú a dhéanamh toisc go bhfuil comhaid neamh-chumasaithe agat."
 
-#, fuzzy
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
 msgstr ""
-" (bain úsáid \"git add/rm <comhad>...\" de réir mar is cuí chun réiteach a "
-"mharcáil)"
+"<file>Socraigh iad sa chrann oibre, agus ansin bain úsáid as 'git add/rm '\n"
+"de réir mar is cuí chun réiteach a mharcáil agus tiomantas a dhéanamh."
 
 msgid "Exiting because of an unresolved conflict."
-msgstr ""
+msgstr "Ag imeacht mar gheall ar choimhlint neamhréitithe."
 
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
-msgstr ""
+msgstr "Níor thug tú do chumasc i gcrích (MERGE_HEAD ann)."
 
 msgid "Please, commit your changes before merging."
-msgstr ""
+msgstr "Déan d'athruithe a dhéanamh le do thoil sula ndéanann tú cumasc."
 
 msgid "Exiting because of unfinished merge."
-msgstr ""
+msgstr "Ag imeacht mar gheall ar chumasc críochnaithe."
 
 msgid ""
 "Diverging branches can't be fast-forwarded, you need to either:\n"
@@ -616,9 +716,16 @@ msgid ""
 "\n"
 "\tgit rebase\n"
 msgstr ""
+"Ní féidir brainsí éagsúla a chur ar aghaidh go tapa, ní mór duit:\n"
+"\n"
+" git merge --no-ff\n"
+"\n"
+"nó:\n"
+"\n"
+" git rebase\n"
 
 msgid "Not possible to fast-forward, aborting."
-msgstr ""
+msgstr "Ní féidir dul ar aghaidh go tapa, ag cur isteach."
 
 #, c-format
 msgid ""
@@ -626,12 +733,19 @@ msgid ""
 "outside of your sparse-checkout definition, so will not be\n"
 "updated in the index:\n"
 msgstr ""
+"Meaitseáil na cosáin agus/nó na cosáin seo a leanas cosáin ann\n"
+"lasmuigh de do shainmhíniú seiceála neamhchoitianta, mar sin ní bheidh\n"
+"nuashonraithe san innéacs:\n"
 
 msgid ""
 "If you intend to update such entries, try one of the following:\n"
 "* Use the --sparse option.\n"
 "* Disable or modify the sparsity rules."
 msgstr ""
+"Má tá sé ar intinn agat iontrálacha den sórt sin a nuashonrú, bain triail as "
+"ceann amháin de\n"
+"* Úsáid an rogha --sparse.\n"
+"* Díchumasaigh nó modhnaigh na rialacha neamhghnách."
 
 #, c-format
 msgid ""
@@ -654,6 +768,28 @@ msgid ""
 "false\n"
 "\n"
 msgstr ""
+"Nóta: ag aistriú go '%s'.\n"
+"\n"
+"Tá tú i stát 'CEANN scoite'. Is féidir leat breathnú timpeall, turgnamhach a "
+"dhéanamh\n"
+"athruithe agus iad a dhéanamh, agus féadfaidh tú aon gealltanais a dhéanann "
+"tú san áireamh a dhiúscairt\n"
+"stáit gan dul i bhfeidhm ar aon bhrainsí trí aistriú ar ais chuig brainse.\n"
+"\n"
+"Más mian leat brainse nua a chruthú chun gealltanais a chruthaíonn tú a "
+"choinneáil, féadfaidh tú\n"
+"déan amhlaidh (anois nó níos déanaí) trí úsáid a bhaint as -c leis an ordú "
+"lasc. Sampla:\n"
+"\n"
+"  git switch -c <new-branch-name>\n"
+"\n"
+"Nó cealaigh an oibríocht seo le:\n"
+"\n"
+"  git switch -c <new-branch-name>\n"
+"\n"
+"Múch an chomhairle seo trí chomhairle athróg advice.detachedHead a shocrú go "
+"false\n"
+"\n"
 
 #, c-format
 msgid ""
@@ -661,81 +797,88 @@ msgid ""
 "sparse-checkout definition but are not sparse due to local\n"
 "modifications.\n"
 msgstr ""
+"Tá na cosáin seo a leanas bogadh taobh amuigh den\n"
+"sainmhíniú seiceála neamhchoitianta ach níl siad neamhchoitiúil mar gheall "
+"ar an\n"
+"modhnuithe.\n"
 
 msgid ""
 "To correct the sparsity of these paths, do the following:\n"
 "* Use \"git add --sparse <paths>\" to update the index\n"
 "* Use \"git sparse-checkout reapply\" to apply the sparsity rules"
 msgstr ""
+"Chun neamhghnáth na gcosáin seo a cheartú, déan an méid seo a leanas:\n"
+"* Úsáid “git add --sparse<paths>\" chun an t-innéacs a nuashonrú\n"
+"* Úsáid “git sparse-checkout reapply” chun na rialacha neamhchoitianta a "
+"chur i bhfeidhm"
 
 msgid "cmdline ends with \\"
-msgstr ""
+msgstr "críochnaíonn cmdline le \\"
 
 msgid "unclosed quote"
-msgstr ""
+msgstr "luachan neamhdhúnadh"
 
-#, fuzzy
 msgid "too many arguments"
-msgstr "An iomarca argóintí."
+msgstr "an iomarca argóintí"
 
 #, c-format
 msgid "unrecognized whitespace option '%s'"
-msgstr ""
+msgstr "rogha spás bán gan aithint '%s'"
 
 #, c-format
 msgid "unrecognized whitespace ignore option '%s'"
-msgstr ""
+msgstr "neamhaird ar spás bán gan aithint neamhaird ar rogha '%s'"
 
 #, c-format
 msgid "options '%s' and '%s' cannot be used together"
 msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' outside a repository"
-msgstr "socrú mar stór roinnte"
+msgstr "'%s' lasmuigh de stór"
 
-#, fuzzy
 msgid "failed to read patch"
-msgstr "nach féidir %s a léamh"
+msgstr "theip ar phaiste a léamh"
 
 msgid "patch too large"
-msgstr ""
+msgstr "paiste ró-mhór"
 
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
-msgstr ""
+msgstr "Ní féidir regexp %s aimstampa a ullmhú"
 
 #, c-format
 msgid "regexec returned %d for input: %s"
-msgstr ""
+msgstr "d'fhill regexec %d le haghaidh ionchur: %s"
 
 #, c-format
 msgid "unable to find filename in patch at line %d"
-msgstr ""
+msgstr "ní féidir ainm comhaid a aimsiú i bpaiste ag an líne %d"
 
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
-msgstr ""
+msgstr "git apply: bad git-diff - ag súil le /dev/null, fuair %s ar líne %d"
 
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
+"git apply: bad git-diff - ainm comhaid nua neamhchomhsheasmhach ar líne %d"
 
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
-msgstr ""
+msgstr "git apply: bad git-diff - sean-ainm comhaid neamhréireach ar líne %d"
 
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null on line %d"
-msgstr ""
+msgstr "git apply: bad git-diff - súil leis /dev/null ar líne %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid mode on line %d: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "modh neamhbhailí ar líne %d: %s"
 
 #, c-format
 msgid "inconsistent header lines %d and %d"
-msgstr ""
+msgstr "línte ceanntásc neamhchomhsheasmhach %d agus %d"
 
 #, c-format
 msgid ""
@@ -745,657 +888,672 @@ msgid_plural ""
 "git diff header lacks filename information when removing %d leading pathname "
 "components (line %d)"
 msgstr[0] ""
+"tá easpa eolais ainm comhaid ar cheanntásc git diff nuair a bhaintear %d "
+"comhpháirt ainm cosáin tosaigh (líne %d)"
 msgstr[1] ""
+"tá easpa eolais ainm comhaid ar cheanntásc git diff agus %d comhpháirteanna "
+"ainm cosáin tosaigh á mbaint (líne %d)"
 msgstr[2] ""
+"tá easpa eolais ainm comhaid ar cheanntásc git diff agus %d comhpháirteanna "
+"ainm cosáin tosaigh á mbaint (líne %d)"
 
 #, c-format
 msgid "git diff header lacks filename information (line %d)"
-msgstr ""
+msgstr "tá easpa eolais ainm comhaid ar cheanntásc git diff (líne %d)"
 
 #, c-format
 msgid "recount: unexpected line: %.*s"
-msgstr ""
+msgstr "atháireamh: líne gan choinne: %.*s"
 
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
-msgstr ""
+msgstr "blúirt paiste gan ceanntásc ag an líne %d: %.*s"
 
 msgid "new file depends on old contents"
-msgstr ""
+msgstr "braitheann comhad nua ar shean-ábhar"
 
 msgid "deleted file still has contents"
-msgstr ""
+msgstr "tá ábhar fós ag comhad scriosta"
 
 #, c-format
 msgid "corrupt patch at line %d"
-msgstr ""
+msgstr "paiste truaillithe ag líne %d"
 
 #, c-format
 msgid "new file %s depends on old contents"
-msgstr ""
+msgstr "braitheann an comhad nua %s ar an seanábhar"
 
 #, c-format
 msgid "deleted file %s still has contents"
-msgstr ""
+msgstr "tá ábhar fós ag comhad scriosta %s"
 
 #, c-format
 msgid "** warning: file %s becomes empty but is not deleted"
-msgstr ""
+msgstr "** rabhadh: éiríonn comhad %s folamh ach ní scriostar é"
 
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
-msgstr ""
+msgstr "paiste dénártha truaillithe ag líne %d: %.*s"
 
 #, c-format
 msgid "unrecognized binary patch at line %d"
-msgstr ""
+msgstr "paiste dénártha gan aithint ag an líne %d"
 
 #, c-format
 msgid "patch with only garbage at line %d"
-msgstr ""
+msgstr "paiste gan ach truflais ag an líne %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read symlink %s"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir nasc simtéarach %s a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open or read %s"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir %s a oscailt nó a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid start of line: '%c'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "tús neamhbhailí na líne: '%c'"
 
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "D'éirigh le hunk #%d ag %d (líne fhritháireamh %d)."
+msgstr[1] "D'éirigh le hunk #%d ag %d (%d líne curtha as feidhm)."
+msgstr[2] "D'éirigh le hunk #%d ag %d (%d líne curtha as feidhm)."
 
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
-msgstr ""
+msgstr "Laghdaithe comhthéacs go (%ld/%ld) chun blúire a chur i bhfeidhm ag %d"
 
 #, c-format
 msgid ""
 "while searching for:\n"
 "%.*s"
 msgstr ""
+"agus tú ag cuardach:\n"
+"%.*s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "missing binary patch data for '%s'"
-msgstr "ainm brainse ar iarraidh; iarracht -%c"
+msgstr "sonraí paiste dénártha in easnamh do '%s'"
 
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
+"ní féidir paiste dénártha a chur i bhfeidhm ar ais gan an hunk droim ar ais "
+"chuig '%s'"
 
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr ""
+"ní féidir paiste dénártha a chur i bhfeidhm ar '%s' gan líne innéacs iomlán"
 
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
 msgstr ""
+"baineann an paiste le '%s' (%s), nach bhfuil comhoiriúnach leis an ábhar "
+"reatha."
 
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
-msgstr ""
+msgstr "baineann an paiste le '%s' folamh ach níl sé folamh"
 
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
-msgstr ""
+msgstr "ní féidir an post riachtanach %s le haghaidh '%s' a léamh"
 
 #, c-format
 msgid "binary patch does not apply to '%s'"
-msgstr ""
+msgstr "ní bhaineann paiste dénártha le '%s'"
 
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
+"cruthaíonn paiste dénártha chuig '%s' toradh mícheart (ag súil le %s, fuair "
+"%s)"
 
 #, c-format
 msgid "patch failed: %s:%ld"
-msgstr ""
+msgstr "theip ar phaiste: %s: %ld"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot checkout %s"
-msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
+msgstr "ní féidir %s a sheiceáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to read %s"
-msgstr "nach féidir %s a léamh"
+msgstr "theip ar %s a léamh"
 
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
-msgstr ""
+msgstr "léamh ó '%s' níos faide ná nasc siombalach"
 
 #, c-format
 msgid "path %s has been renamed/deleted"
-msgstr ""
+msgstr "tá conair %s athainmnithe/scriosta"
 
 #, c-format
 msgid "%s: does not exist in index"
-msgstr ""
+msgstr "%s: níl ann san innéacs"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s: does not match index"
-msgstr "src refspec %s ní mheaitseálann aon"
+msgstr "%s: ní mheaitseálann innéacs"
 
 msgid "repository lacks the necessary blob to perform 3-way merge."
-msgstr ""
+msgstr "níl an blob riachtanach ag stór chun cumasc trí bhealach a dhéanamh."
 
 #, c-format
 msgid "Performing three-way merge...\n"
-msgstr ""
+msgstr "Cumaisc trí bhealach a dhéanamh...\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read the current contents of '%s'"
-msgstr "ní féidir comhpháirt amháin a bhaint as url '%s'"
+msgstr "ní féidir ábhar reatha '%s' a léamh"
 
 #, c-format
 msgid "Failed to perform three-way merge...\n"
-msgstr ""
+msgstr "Theip ar chumasc trí bhealach a dhéanamh...\n"
 
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
-msgstr ""
+msgstr "Paiste cuireadh i bhfeidhm ar '%s' le coinbhleachtaí.\n"
 
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
-msgstr ""
+msgstr "Cuireadh paiste i bhfeidhm go '%s' go glan.\n"
 
 #, c-format
 msgid "Falling back to direct application...\n"
-msgstr ""
+msgstr "Ag titim ar ais chuig feidhmchlár díreach...\n"
 
 msgid "removal patch leaves file contents"
-msgstr ""
+msgstr "fágann paiste bainte ábhar an chomhaid"
 
 #, c-format
 msgid "%s: wrong type"
-msgstr ""
+msgstr "%s: cineál mícheart"
 
 #, c-format
 msgid "%s has type %o, expected %o"
-msgstr ""
+msgstr "%s tá cineál %o air, ach bhíothas ag súil le %o"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid path '%s'"
-msgstr "%s neamhbhailí"
+msgstr "cosán neamhbhailí '%s'"
 
 #, c-format
 msgid "%s: already exists in index"
-msgstr ""
+msgstr "%s: ann cheana féin san innéacs"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s: already exists in working directory"
-msgstr "Tá %s ann agus ní eolaire é"
+msgstr "%s: ann cheana féin san eolaire oibre"
 
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
-msgstr ""
+msgstr "ní mheaitseálann modh nua (%o) de %s sean-mhodh (%o)"
 
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
-msgstr ""
+msgstr "ní mheaitseálann modh nua (%o) de %s sean-mhodh (%o) de %s"
 
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
-msgstr ""
+msgstr "tá an comhad tionchair '%s' níos faide ná nasc siombalach"
 
 #, c-format
 msgid "%s: patch does not apply"
-msgstr ""
+msgstr "%s: níl paiste i bhfeidhm"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Checking patch %s..."
-msgstr "Rud a sheiceáil"
+msgstr "Seiceáil paiste %s..."
 
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
-msgstr ""
+msgstr "tá faisnéis sha1 easpa nó gan úsáid le haghaidh fo-mhodúl %s"
 
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
-msgstr ""
+msgstr "athrú modh do %s, nach bhfuil i HEAD reatha"
 
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
-msgstr ""
+msgstr "tá faisnéis sha1 easpa nó gan úsáid (%s)."
 
 #, c-format
 msgid "could not add %s to temporary index"
-msgstr ""
+msgstr "ní fhéadfaí %s a chur le hinnéacs sealadach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write temporary index to %s"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní fhéadfaí innéacs sealadach a scríobh chuig %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to remove %s from index"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir %s a bhaint as innéacs"
 
-#, fuzzy, c-format
+#, c-format
 msgid "corrupt patch for submodule %s"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "paiste truaillithe do fho-mhodúl %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to stat newly created file '%s'"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "nach féidir an comhad nua-chruthaithe '%s' a stáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create backing store for newly created file %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir stór tacaíochta a chruthú do chomhad nua-chruthaithe %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to add cache entry for %s"
-msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+msgstr "nach féidir iontráil taisce a chur le haghaidh %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to write to '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar scríobh chuig '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "closing file '%s'"
-msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
+msgstr "comhad dúnadh '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to write file '%s' mode %o"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "ní féidir an comhad '%s' modh %o a scríobh"
 
 #, c-format
 msgid "Applied patch %s cleanly."
-msgstr ""
+msgstr "Cuireadh paiste %s i bhfeidhm go glan."
 
-#, fuzzy
 msgid "internal error"
-msgstr "earráid inmheánach i dsiúlóid"
+msgstr "earráid inmheánach"
 
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Ag cur paiste %%s i bhfeidhm le %d diúltú..."
+msgstr[1] "Ag cur paiste %%s i bhfeidhm le %d diúltuithe..."
+msgstr[2] "Ag cur paiste %%s i bhfeidhm le %d diúltuithe..."
 
 #, c-format
 msgid "cannot open %s"
-msgstr ""
+msgstr "ní féidir %s a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot unlink '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "ní féidir '%s' a dhínascadh"
 
 #, c-format
 msgid "Hunk #%d applied cleanly."
-msgstr ""
+msgstr "Cuireadh Hunk #%d i bhfeidhm go glan."
 
 #, c-format
 msgid "Rejected hunk #%d."
-msgstr ""
+msgstr "Hunk diúltaithe #%d."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Skipped patch '%s'."
-msgstr "Aistrithe go brainse '%s'\n"
+msgstr "Paiste scipeáilte '%s'."
 
 msgid "No valid patches in input (allow with \"--allow-empty\")"
-msgstr ""
+msgstr "Níl aon paistí bailí san ionchur (cead le “--allow-empty”)"
 
-#, fuzzy
 msgid "unable to read index file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann comhad innéacs a léamh"
 
 #, c-format
 msgid "can't open patch '%s': %s"
-msgstr ""
+msgstr "ní féidir paiste '%s' a oscailt: %s"
 
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "earráid spás bán %d múchta"
+msgstr[1] "%d earráid spás bán múchta"
+msgstr[2] "%d earráid spás bán múchta"
 
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Cuireann %d líne earráidí spás bán leis."
+msgstr[1] "Cuireann %d líne earráidí spás bán leis."
+msgstr[2] "Cuireann %d líne earráidí spás bán leis."
 
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%d líne curtha i bhfeidhm tar éis earráidí spás bán a shocrú."
+msgstr[1] "%d líne curtha i bhfeidhm tar éis earráidí spás bán a shocrú."
+msgstr[2] "%d líne curtha i bhfeidhm tar éis earráidí spás bán a shocrú."
 
-#, fuzzy
 msgid "Unable to write new index file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "Ní féidir comhad innéacs nua a scríobh"
 
 msgid "don't apply changes matching the given path"
-msgstr ""
+msgstr "ná cuir athruithe a mheaitseáil leis an gcosán tugtha"
 
 msgid "apply changes matching the given path"
-msgstr ""
+msgstr "athruithe a chur i bhfeidhm a mheaitseálann"
 
 msgid "num"
-msgstr ""
+msgstr "uimhir"
 
 msgid "remove <num> leading slashes from traditional diff paths"
-msgstr ""
+msgstr "bain <num>slascanna ceannródaíocha ó chosáin difriúla traidisiúnta"
 
 msgid "ignore additions made by the patch"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar bhreiseanna a dhéanann an"
 
 msgid "instead of applying the patch, output diffstat for the input"
-msgstr ""
+msgstr "in ionad an paiste a chur i bhfeidhm, diffstat aschuir don ionchur"
 
 msgid "show number of added and deleted lines in decimal notation"
-msgstr ""
+msgstr "líon na línte breise agus scriosta a thaispeáint i nótaí deachúil"
 
 msgid "instead of applying the patch, output a summary for the input"
-msgstr ""
+msgstr "in ionad an paiste a chur i bhfeidhm, aschur achoimre don ionchur"
 
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
+"in ionad an paiste a chur i bhfeidhm, féach an bhfuil an paiste infheidhme"
 
 msgid "make sure the patch is applicable to the current index"
 msgstr ""
+"déan cinnte go bhfuil an paiste infheidhme maidir leis an innéacs reatha"
 
 msgid "mark new files with `git add --intent-to-add`"
-msgstr ""
+msgstr "comhad nua a mharcáil le `git add --intent-to-add`"
 
 msgid "apply a patch without touching the working tree"
-msgstr ""
+msgstr "cuir paiste i bhfeidhm gan teagmháil leis an gcrann oibre"
 
 msgid "accept a patch that touches outside the working area"
-msgstr ""
+msgstr "glacadh le paiste a théann lasmuigh den limistéar oibre"
 
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr ""
+"cuir an paiste i bhfeidhm freisin (bain úsáid le --stat/--summary/--check)"
 
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
+"iarracht a dhéanamh cumasc trí bhealach, titim ar ais ar ghnáthphaiste má "
+"theipeann"
 
 msgid "for conflicts, use our version"
-msgstr ""
+msgstr "le haghaidh coimhlintí, bain úsáid as ár leagan"
 
 msgid "for conflicts, use their version"
-msgstr ""
+msgstr "le haghaidh coimhlintí, bain úsáid as a leagan"
 
 msgid "for conflicts, use a union version"
-msgstr ""
+msgstr "le haghaidh coimhlintí, bain úsáid as leagan aontais"
 
 msgid "build a temporary index based on embedded index information"
-msgstr ""
+msgstr "innéacs sealadach a thógáil bunaithe ar eolas innéacs leabaithe"
 
 msgid "paths are separated with NUL character"
-msgstr ""
+msgstr "tá cosáin scartha le carachtar NUL"
 
 msgid "ensure at least <n> lines of context match"
-msgstr ""
+msgstr "a chinntiú go mbe <n>adh línte comhthéacsa"
 
 msgid "action"
-msgstr ""
+msgstr "gníomh"
 
 msgid "detect new or modified lines that have whitespace errors"
-msgstr ""
+msgstr "línte nua nó modhnaithe a bhrath a bhfuil earráidí spás bán acu"
 
 msgid "ignore changes in whitespace when finding context"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar athruithe ar spás bán agus comhthéacs á"
 
 msgid "apply the patch in reverse"
-msgstr ""
+msgstr "cuir an paiste i bhfeidhm ar ais"
 
 msgid "don't expect at least one line of context"
-msgstr ""
+msgstr "ná bí ag súil le líne comhthéacs amháin ar a laghad"
 
 msgid "leave the rejected hunks in corresponding *.rej files"
-msgstr ""
+msgstr "fág na hunks diúltaithe i gcomhaide*.rej comhfhreagracha"
 
 msgid "allow overlapping hunks"
-msgstr ""
+msgstr "cead a cheadú do na huncanna"
 
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr ""
+"glacadh le líne nua atá in easnamh a bhraitear go mícheart ag deireadh an "
+"chomhaid"
 
 msgid "do not trust the line counts in the hunk headers"
-msgstr ""
+msgstr "ná bíodh muinín agat as na comhaireamh líne sna ceanntásca hunk"
 
 msgid "root"
-msgstr ""
+msgstr "fréamh"
 
 msgid "prepend <root> to all filenames"
-msgstr ""
+msgstr "cuireadh <root>i bhfeidhm ar gach ainm comhaid"
 
 msgid "don't return error for empty patches"
-msgstr ""
+msgstr "ná tabhair earráid ar ais le haghaidh paistí folamh"
 
 msgid "--ours, --theirs, and --union require --3way"
-msgstr ""
+msgstr "Éilíonn --ours, --theirs, agus --union --3way"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot stream blob %s"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "ní féidir le blob %s a shruthlú"
 
 #, c-format
 msgid "unsupported file mode: 0%o (SHA1: %s)"
-msgstr ""
+msgstr "modh comhad gan tacaíocht: 0%o (SHA1: %s)"
 
 #, c-format
 msgid "deflate error (%d)"
-msgstr ""
+msgstr "earráid dífhabhtaithe (%d)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to start '%s' filter"
-msgstr "theip ar '%s' a stáil"
+msgstr "nach féidir scagaire '%s' a thosú"
 
-#, fuzzy
 msgid "unable to redirect descriptor"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir tuairiscí a atreorú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' filter reported error"
-msgstr "earráid tuairiscithe ar iompar"
+msgstr "Earráid a thuairiscigh scagaire '%s'"
 
 #, c-format
 msgid "path is not valid UTF-8: %s"
-msgstr ""
+msgstr "níl cosán bailí UTF-8: %s"
 
 #, c-format
 msgid "path too long (%d chars, SHA1: %s): %s"
-msgstr ""
+msgstr "cosán rófhada (%d chars, SHA1: %s): %s"
 
 #, c-format
 msgid "timestamp too large for this system: %<PRIuMAX>"
-msgstr ""
+msgstr "stampa ama ró-mhór don chóras seo:%<PRIuMAX>"
 
-#, fuzzy
 msgid "git archive [<options>] <tree-ish> [<path>...]"
-msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+msgstr "git cartlan <options>n [] <tree-ish>[<path>...]"
 
 msgid ""
 "git archive --remote <repo> [--exec <cmd>] [<options>] <tree-ish> [<path>...]"
 msgstr ""
+"<tree-ish><path>git archive --remote <repo>[--exec<cmd>] [] [...<options>]"
 
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
-msgstr ""
+msgstr "<cmd>git archive --remote <repo>[--exec] --list"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir '%s' a léamh"
 
 #, c-format
 msgid "pathspec '%s' matches files outside the current directory"
-msgstr ""
+msgstr "meaitseálann pathspec '%s' comhaid lasmuigh den eolaire reatha"
 
-#, fuzzy, c-format
+#, c-format
 msgid "pathspec '%s' did not match any files"
-msgstr "src refspec %s ní mheaitseálann aon"
+msgstr "níor mheaitseáil pathspec '%s' aon chomhaid"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such ref: %.*s"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "gan aon tagairt den sórt sin: %.*s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a valid object name: %s"
-msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+msgstr "ní ainm réad bailí: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a tree object: %s"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní réad crann: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to unpack tree object %s"
-msgstr "Theip ar chrann %s a aimsiú."
+msgstr "theip ar réad crann %s a dhíphacáil"
 
 #, c-format
 msgid "File not found: %s"
-msgstr ""
+msgstr "Níor aimsíodh an comhad: %s"
 
 #, c-format
 msgid "Not a regular file: %s"
-msgstr ""
+msgstr "Ní comhad rialta: %s"
 
 #, c-format
 msgid "unclosed quote: '%s'"
-msgstr ""
+msgstr "luachan neamhdhúnadh: '%s'"
 
 #, c-format
 msgid "missing colon: '%s'"
-msgstr ""
+msgstr "colon in easnamh: '%s'"
 
 #, c-format
 msgid "empty file name: '%s'"
-msgstr ""
+msgstr "ainm comhaid folamh: '%s'"
 
-#, fuzzy
 msgid "fmt"
-msgstr "formáid"
+msgstr "fmt"
 
-#, fuzzy
 msgid "archive format"
-msgstr "formáid"
+msgstr "formáid cartlann"
 
 msgid "prefix"
-msgstr ""
+msgstr "réimír"
 
 msgid "prepend prefix to each pathname in the archive"
-msgstr ""
+msgstr "réimír a pholadh chuig gach ainm cosán sa chartlann"
 
-#, fuzzy
 msgid "file"
-msgstr "comhad nua:"
+msgstr "comhad"
 
-#, fuzzy
 msgid "add untracked file to archive"
-msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+msgstr "cuir comhad neamhrianaithe leis an gcartlann"
 
 msgid "path:content"
-msgstr ""
+msgstr "bealach:ábhar"
 
 msgid "write the archive to this file"
-msgstr ""
+msgstr "scríobh an cartlann chuig an gcomhad seo"
 
 msgid "read .gitattributes in working directory"
-msgstr ""
+msgstr "léite.gitattributs san eolaire oibre"
 
 msgid "report archived files on stderr"
-msgstr ""
+msgstr "tuairisciú comhaid cartlainne ar stderr"
 
 msgid "time"
 msgstr "am"
 
 msgid "set modification time of archive entries"
-msgstr ""
+msgstr "socraigh am modhnaithe iontrálacha cartlainne"
 
 msgid "set compression level"
-msgstr ""
+msgstr "leibhéal comhbhrú a shocrú"
 
 msgid "list supported archive formats"
-msgstr ""
+msgstr "liosta formáidí cartlainne tacaíochta"
 
 msgid "repo"
 msgstr "stóras"
 
 msgid "retrieve the archive from remote repository <repo>"
-msgstr ""
+msgstr "aisghabháil an cartlann ó stór iargúlta <repo>"
 
 msgid "command"
-msgstr ""
+msgstr "ordú"
 
-#, fuzzy
 msgid "path to the remote git-upload-archive command"
-msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
+msgstr "cosán chuig an ordú iargúlta git-upload-archive"
 
 msgid "Unexpected option --remote"
-msgstr ""
+msgstr "Rogha gan choinne --remote"
 
 #, c-format
 msgid "the option '%s' requires '%s'"
 msgstr "tá %s ag teastáil don rogha '%s'"
 
 msgid "Unexpected option --output"
-msgstr ""
+msgstr "Rogha gan choinne --output"
 
 #, c-format
 msgid "extra command line parameter '%s'"
-msgstr ""
+msgstr "paraiméadar líne ordaithe breise '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Unknown archive format '%s'"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "Formáid cartlainne anaithnid '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Argument not supported for format '%s': -%d"
-msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+msgstr "Argóint nach dtacaítear le haghaidh formáid '%s': -%d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%.*s is not a valid attribute name"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "%.*s ní ainm tréith bailí é"
 
 msgid "unable to add additional attribute"
-msgstr ""
+msgstr "in ann tréith bhreise a chur leis"
 
 #, c-format
 msgid "ignoring overly long attributes line %d"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar líne tréithe ró-fhada %d"
 
 #, c-format
 msgid "%s not allowed: %s:%d"
-msgstr ""
+msgstr "%s ní cheadaítear %s:%d"
 
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
 msgstr ""
+"Déantar neamhaird ar phatrúin dhiúltacha i d\n"
+"Úsáid '\\!' le haghaidh brú ceannródaíoch litriúil."
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot fstat gitattributes file '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir an comhad gitattributeanna '%s' fstat"
 
 #, c-format
 msgid "ignoring overly large gitattributes file '%s'"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar chomhad gitattributs ró-mhór '%s'"
 
 #, c-format
 msgid "ignoring overly large gitattributes blob '%s'"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar ghitattributs ró-mhór blob '%s'"
 
 msgid "cannot use --attr-source or GIT_ATTR_SOURCE without repo"
-msgstr ""
+msgstr "ní féidir --attr-source nó GIT_ATTR_SOURCE a úsáid gan repo"
 
 msgid "bad --attr-source or GIT_ATTR_SOURCE"
-msgstr ""
+msgstr "olc --attr-source nó GIT_ATTR_SOURCE"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to stat '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "ní féidir '%s' a shástáil"
 
 #, c-format
 msgid "unable to read %s"
@@ -1403,33 +1561,39 @@ msgstr "nach féidir %s a léamh"
 
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
-msgstr ""
+msgstr "Ábhar a luaitear go dona sa chomhad '%s': %s"
 
 #, c-format
 msgid "We cannot bisect more!\n"
-msgstr ""
+msgstr "Ní féidir linn níos mó a dhícheangal!\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Not a valid commit name %s"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní ainm tiomanta bailí %s"
 
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
 "This means the bug has been fixed between %s and [%s].\n"
 msgstr ""
+"Tá an bonn cumaisc %s go dona.\n"
+"Ciallaíonn sé seo go bhfuil an fabht socraithe idir %s agus [%s].\n"
 
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
 "The property has changed between %s and [%s].\n"
 msgstr ""
+"Tá an bonn cumaisc %s nua.\n"
+"Tá athrú tagtha ar an maoin idir %s agus [%s].\n"
 
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
 "This means the first '%s' commit is between %s and [%s].\n"
 msgstr ""
+"Is é an bonn cumaisc %s ná %s.\n"
+"Ciallaíonn sé seo go bhfuil an chéad thiomantas '%s' idir %s agus [%s].\n"
 
 #, c-format
 msgid ""
@@ -1437,6 +1601,9 @@ msgid ""
 "git bisect cannot work properly in this case.\n"
 "Maybe you mistook %s and %s revs?\n"
 msgstr ""
+"Ní sinsear an %s rev iad roinnt revs %s\n"
+"Ní féidir le git bisect oibriú i gceart sa chás seo.\n"
+"B'fhéidir gur mheas tú %s agus %s revs?\n"
 
 #, c-format
 msgid ""
@@ -1444,46 +1611,52 @@ msgid ""
 "So we cannot be sure the first %s commit is between %s and %s.\n"
 "We continue anyway."
 msgstr ""
+"caithfear an bonn cumaisc idir %s agus [%s] a scipeáil.\n"
+"Mar sin ní féidir linn a bheith cinnte go bhfuil an chéad thiomantas %s idir "
+"%s agus %s.\n"
+"Leanaimid orainn ar aon nós."
 
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
-msgstr ""
+msgstr "Déroinnt: ní mór bonn cumaisc a thástáil\n"
 
 #, c-format
 msgid "a %s revision is needed"
-msgstr ""
+msgstr "tá athbhreithniú %s ag teastáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create file '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí comhad '%s' a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to start 'show' for object '%s'"
-msgstr "theip ar an iterator a thosú thar '%s'"
+msgstr "ní féidir 'show' a thosú le haghaidh réad '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read file '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann comhad '%s' a léamh"
 
 msgid "reading bisect refs failed"
-msgstr ""
+msgstr "theip ar athbhreithnithe bisect a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s was both %s and %s\n"
-msgstr "Rianann %s %s agus %s araon"
+msgstr "Bhí %s %s agus %s araon\n"
 
 #, c-format
 msgid ""
 "No testable commit found.\n"
 "Maybe you started with bad path arguments?\n"
 msgstr ""
+"Níor aimsíodh aon tiomantas intástála.\n"
+"B'fhéidir gur thosaigh tú le droch-argóintí cosáin?\n"
 
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "(thart ar %d céim)"
+msgstr[1] "(thart ar %d céim)"
+msgstr[2] "(thart ar %d céim)"
 
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
@@ -1491,15 +1664,21 @@ msgstr[2] ""
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
-msgstr[0] ""
+msgstr[0] "Ag trasnú: %d athbhreithniú fágtha le tástáil tar éis an %s seo\n"
 msgstr[1] ""
+"Ag roinnt ina dhá leath: %d athbhreithniú fágtha le tástáil tar éis an %s "
+"seo\n"
 msgstr[2] ""
+"Ag roinnt ina dhá leath: %d athbhreithniú fágtha le tástáil tar éis an %s "
+"seo\n"
 
 msgid "--contents and --reverse do not blend well."
-msgstr ""
+msgstr "Ní chumasc --contents agus --reverse go maith."
 
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
+"Éilíonn --reverse agus --first-parent le chéile an tiomantas sonraithe is "
+"déanaí"
 
 msgid "revision walk setup failed"
 msgstr "theip ar socrú siúlóid ath"
@@ -1507,57 +1686,65 @@ msgstr "theip ar socrú siúlóid ath"
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
+"--reverse --first-parent le chéile, teastaíonn raon feadh an tslabhra first-"
+"parent"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such path %s in %s"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "níl aon chosán den sórt sin %s i %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read blob %s for path %s"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "ní féidir le blob %s a léamh le haghaidh cosán %s"
 
 msgid ""
 "cannot inherit upstream tracking configuration of multiple refs when "
 "rebasing is requested"
 msgstr ""
+"ní féidir cumraíocht rianaithe suas srutha iolracha a oidhreacht nuair a "
+"iarrtar athbhunú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not setting branch '%s' as its own upstream"
-msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+msgstr "gan brainse '%s' a shocrú mar a thuas an sruth féin"
 
 #, c-format
 msgid "branch '%s' set up to track '%s' by rebasing."
-msgstr ""
+msgstr "bunaíodh brainse '%s' chun '%s' a rianú trí athbhunú."
 
-#, fuzzy, c-format
+#, c-format
 msgid "branch '%s' set up to track '%s'."
-msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
+msgstr "bunaíodh brainse '%s' chun '%s' a rianú."
 
 #, c-format
 msgid "branch '%s' set up to track:"
-msgstr ""
+msgstr "bunaíodh brainse '%s' chun rianú:"
 
-#, fuzzy
 msgid "unable to write upstream branch configuration"
-msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+msgstr "in ann cumraíocht brainse suas srutha a scríobh"
 
 msgid ""
 "\n"
 "After fixing the error cause you may try to fix up\n"
 "the remote tracking information by invoking:"
 msgstr ""
+"\n"
+"Tar éis an chúis earráide a shocrú féadfaidh tú iarracht a dhéanamh socrú\n"
+"an fhaisnéis cianrianaithe trí ghairm a dhéanamh ar:"
 
 #, c-format
 msgid "asked to inherit tracking from '%s', but no remote is set"
-msgstr ""
+msgstr "iarradh ar rianú oidhreachta ó '%s', ach níl aon iargúlta socraithe"
 
 #, c-format
 msgid "asked to inherit tracking from '%s', but no merge configuration is set"
 msgstr ""
+"iarrtar ar rianú oidhreachta ó '%s', ach níl aon chumraíocht cumaisc "
+"socraithe"
 
 #, c-format
 msgid "not tracking: ambiguous information for ref '%s'"
-msgstr ""
+msgstr "gan rianú: faisnéis dhébhríoch le haghaidh tagairt '%s'"
 
 #. #-#-#-#-#  branch.c.po  #-#-#-#-#
 #. TRANSLATORS: This is a line listing a remote with duplicate
@@ -1572,7 +1759,7 @@ msgstr ""
 #.
 #, c-format
 msgid "  %s\n"
-msgstr ""
+msgstr "  %s\n"
 
 #. TRANSLATORS: The second argument is a \n-delimited list of
 #. duplicate refspecs, composed above.
@@ -1588,29 +1775,41 @@ msgid ""
 "different remotes' fetch refspecs map into different\n"
 "tracking namespaces."
 msgstr ""
+"Tá iomadúla iargúlta ann a bhfuil a léarscáil athfheidhmithe a fháil chuig "
+"an iargúlta\n"
+"tagairt rianaithe '%s':\n"
+"%s\n"
+"De ghnáth is earráid chumraíochta é seo.\n"
+"\n"
+"Chun tacú le brainsí rianaithe a bhunú, cinntigh go\n"
+"faigheann ciananna éagsúla léarscáil speisiúcháin go difriúil\n"
+"spaisí ainmneacha a rianú."
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid branch name"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní ainm brainse bailí é '%s'"
 
 msgid "See `man git check-ref-format`"
-msgstr ""
+msgstr "Féach `man git check-ref-format`"
 
-#, fuzzy, c-format
+#, c-format
 msgid "a branch named '%s' already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "tá brainse darb ainm '%s' ann cheana"
 
 #, c-format
 msgid "cannot force update the branch '%s' used by worktree at '%s'"
 msgstr ""
+"ní féidir an brainse '%s' a úsáideann crann oibre a nuashonrú a chur i "
+"bhfeidhm ag '%s'"
 
 #, c-format
 msgid "cannot set up tracking information; starting point '%s' is not a branch"
 msgstr ""
+"ní féidir faisnéis rianaithe a chur ar bun; ní brainse é pointe tosaigh '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "the requested upstream branch '%s' does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl an brainse suas srutha iarrtha '%s' ann"
 
 msgid ""
 "\n"
@@ -1622,126 +1821,134 @@ msgid ""
 "will track its remote counterpart, you may want to use\n"
 "\"git push -u\" to set the upstream config as you push."
 msgstr ""
+"\n"
+"Má tá tú ag pleanáil do chuid oibre a bhunú ar an suas sruth\n"
+"brainse atá ann cheana féin ag an iargúlta, b'fhéidir go mbeidh ort\n"
+"reáchtáil “git fetch” chun é a aisghabháil.\n"
+"\n"
+"Má tá tú ag pleanáil brainse áitiúil nua a bhrú amach\n"
+"rianóidh sé a mhacasamhail iargúlta, b'fhéidir gur mhaith leat a úsáid\n"
+"“git push -u” chun an cumraíocht suas sruth a shocrú agus tú ag brú."
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a valid object name: '%s'"
-msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+msgstr "ní ainm réad bailí: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "ambiguous object name: '%s'"
-msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+msgstr "ainm réad débhríoch: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a valid branch point: '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "ní pointe brainse bailí: '%s'"
 
 #, c-format
 msgid "submodule '%s': unable to find submodule"
-msgstr ""
+msgstr "fo-mhodúl '%s': in ann fo-mhodúl a aimsiú"
 
 #, c-format
 msgid ""
 "You may try updating the submodules using 'git checkout --no-recurse-"
 "submodules %s && git submodule update --init'"
 msgstr ""
+"Is féidir leat triail a bhaint as na fo-mhodúil a nuashonrú ag baint úsáide "
+"as 'git checkout --no-recurse-submodules %s && git submodule update --init'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "submodule '%s': cannot create branch '%s'"
-msgstr "Ní féidir '%s' a úsáid le '%s'"
+msgstr "fo-mhodúl '%s': ní féidir brainse '%s' a chruthú"
 
 #, c-format
 msgid "'%s' is already used by worktree at '%s'"
-msgstr ""
+msgstr "Úsáidtear '%s' cheana féin ag an gcrann oibre ag '%s'"
 
-#, fuzzy
 msgid "git add [<options>] [--] <pathspec>..."
-msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+msgstr "git add [<options>] [--]<pathspec>..."
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot chmod %cx '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir chmod %cx '%s'"
 
-#, fuzzy
 msgid "Unstaged changes after refreshing the index:"
-msgstr "Athruithe gan stáitse tar éis athshocrú:"
+msgstr "Athruithe gan stáitse tar éis an t-innéacs a athnuachan:"
 
-#, fuzzy
 msgid "could not read the index"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní raibh in ann an t-innéacs a léamh"
 
-#, fuzzy
 msgid "editing patch failed"
-msgstr "theip ar socrú siúlóid ath"
+msgstr "theip ar paiste eagarthóire"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not stat '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "ní fhéadfaí '%s' a stát"
 
 msgid "empty patch. aborted"
-msgstr ""
+msgstr "paiste folam. a ghabhrú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not apply '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a chur i bhfeidhm"
 
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
+"Déanann ceann de do chomhaid .gitignore neamhaird ar na cosáin seo a "
+"leanas:\n"
 
 msgid "dry run"
 msgstr "rith tirim"
 
 msgid "be verbose"
-msgstr ""
+msgstr "a bheith inearálta"
 
 msgid "interactive picking"
-msgstr ""
+msgstr "piocadh idirghní"
 
 msgid "select hunks interactively"
 msgstr "roghnaigh hunks idirghníomhach"
 
 msgid "edit current diff and apply"
-msgstr ""
+msgstr "athraigh an dif reatha agus cuir i bhfeidhm"
 
 msgid "allow adding otherwise ignored files"
-msgstr ""
+msgstr "ligean comhaid a neamhaird a chur leis"
 
-#, fuzzy
 msgid "update tracked files"
-msgstr "Comhaid neamhrianaithe"
+msgstr "comhaid rianaithe a nuashonrú"
 
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr ""
+"athormalú a dhéanamh ar EOL na gcomhaid rianaithe (tugann le tuiscint -u)"
 
-#, fuzzy
 msgid "record only the fact that the path will be added later"
-msgstr ""
-"ní thaifeadadh ach an fíric go gcuirfear cosáin bainte leis níos déanaí"
+msgstr "ní thaifeadadh ach an fíric go gcuirfear an cosán leis níos déanaí"
 
 msgid "add changes from all tracked and untracked files"
-msgstr ""
+msgstr "cuir athruithe ó gach comhad rianaithe agus neamhrianaithe"
 
-#, fuzzy
 msgid "ignore paths removed in the working tree (same as --no-all)"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr ""
+"neamhaird a dhéanamh ar chosáin a bhaintear sa chrann oibre (mar an gcéanna "
+"le --no-all)"
 
 msgid "don't add, only refresh the index"
-msgstr ""
+msgstr "ná cuir leis, ach an t-innéacs a athnuachan"
 
 msgid "just skip files which cannot be added because of errors"
 msgstr ""
+"ní gá ach comhaid a scipeáil nach féidir a chur leis mar gheall ar earráidí"
 
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
+"seiceáil an ndéantar neamhaird ar chomhaid - fiú ar iarraidh - ar iarraidh"
 
 msgid "allow updating entries outside of the sparse-checkout cone"
-msgstr ""
+msgstr "ligean iontrálacha a nuashonrú lasmuigh den chón seiceála neamh"
 
 msgid "override the executable bit of the listed files"
-msgstr ""
+msgstr "an giotán infhorghníomhaithe de na comhaid liostaithe a sháraigh"
 
-#, fuzzy
 msgid "warn when adding an embedded repository"
-msgstr "stóras lom a chruthú"
+msgstr "rabhadh agus stór leabaithe á chur leis"
 
 #, c-format
 msgid ""
@@ -1759,20 +1966,33 @@ msgid ""
 "\n"
 "See \"git help submodule\" for more information."
 msgstr ""
+"Chuir tú stór git eile leis taobh istigh de do stór reatha.\n"
+"Ní bheidh ábhar i gclóin an stór seachtrach\n"
+"an stór leabaithe agus ní bheidh a fhios acu conas é a fháil.\n"
+"Má bhí sé i gceist agat fo-mhodúl a chur leis, bain úsáid as:\n"
+"\n"
+" <url>Cuir submodule git %s\n"
+"\n"
+"Má chuir tú an cosán seo le botún, is féidir leat é a bhaint as an\n"
+"innéacs le:\n"
+"\n"
+"\tgit rm --cached %s\n"
+"\n"
+"Féach “git help submodule” le haghaidh tuilleadh faisnéise."
 
-#, fuzzy, c-format
+#, c-format
 msgid "adding embedded git repository: %s"
-msgstr "--stdin teastaíonn stórlann git"
+msgstr "stór git leabaithe a chur leis: %s"
 
 msgid "Use -f if you really want to add them."
-msgstr ""
+msgstr "Úsáid -f más mian leat iad a chur leis i ndáiríre."
 
 msgid "adding files failed"
-msgstr ""
+msgstr "theip ar chomhaid a chur leis"
 
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
-msgstr ""
+msgstr "Caithfidh --chmod param '%s' a bheith -x nó +x"
 
 #, c-format
 msgid "'%s' and pathspec arguments cannot be used together"
@@ -1780,10 +2000,10 @@ msgstr "Ní féidir argóintí '%s' agus pathspec a úsáid le chéile"
 
 #, c-format
 msgid "Nothing specified, nothing added.\n"
-msgstr ""
+msgstr "Níl aon rud sonraithe, ní chuir aon rud leis.\n"
 
 msgid "Maybe you wanted to say 'git add .'?"
-msgstr ""
+msgstr "B'fhéidir gur mhaith leat a rá 'git add. '?"
 
 msgid "index file corrupt"
 msgstr "comhad innéacs truaillithe"
@@ -1791,105 +2011,110 @@ msgstr "comhad innéacs truaillithe"
 msgid "unable to write new index file"
 msgstr "in ann comhad innéacs nua a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad action '%s' for '%s'"
-msgstr "tá %s ag teastáil don rogha '%s'"
+msgstr "droch-ghníomh '%s' le haghaidh '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid value for '%s': '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "luach neamhbhailí do '%s': '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann '%s' a léamh"
 
-#, fuzzy
 msgid "could not parse author script"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní raibh sé in ann script údair a pharsáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí %s a pháirseáil"
 
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
-msgstr ""
+msgstr "Scriosadh '%s' ag an crúca applypatch-msg"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Malformed input line: '%s'."
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "Líne ionchuir mífhoirmithe: '%s'."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "Theip ar nótaí a chóipeáil ó '%s' go '%s'"
 
 msgid "fseek failed"
-msgstr ""
+msgstr "theip ar fseek"
 
 #, c-format
 msgid "could not open '%s' for reading"
-msgstr ""
+msgstr "ní fhéadfaí '%s' a oscailt le haghaidh léamh"
 
 #, c-format
 msgid "could not open '%s' for writing"
-msgstr ""
+msgstr "ní féidir '%s' a oscailt le haghaidh scríbhneoireachta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse patch '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní raibh sé in ann paiste '%s' a pháirseáil"
 
 msgid "Only one StGIT patch series can be applied at once"
 msgstr ""
+"Ní féidir ach sraith paiste STGit amháin a chur i bhfeidhm ag an am céanna"
 
-#, fuzzy
 msgid "invalid timestamp"
-msgstr "%s neamhbhailí"
+msgstr "stampa ama neamhbhailí"
 
-#, fuzzy
 msgid "invalid Date line"
-msgstr "sonraíocht cosáin nebhail"
+msgstr "líne dáta neamhbhailí"
 
 msgid "invalid timezone offset"
-msgstr ""
+msgstr "fhritháireamh crios ama neamh"
 
 msgid "Patch format detection failed."
-msgstr ""
+msgstr "Theip ar bhrath formáid paiste."
 
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "theip ar eolaire '%s' a chruthú"
 
-#, fuzzy
 msgid "Failed to split patches."
-msgstr "theip ar '%s' a stáil"
+msgstr "Theip ar phaistí a roinnt."
 
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\".\n"
 msgstr ""
+"Nuair a bheidh an fhadhb seo réitithe agat, reáchtáil “%s --continue”.\n"
 
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead.\n"
 msgstr ""
+"Más fearr leat an paiste seo a scipeáil, reáchtáil “%s --skip” ina ionad.\n"
 
 #, c-format
 msgid ""
 "To record the empty patch as an empty commit, run \"%s --allow-empty\".\n"
 msgstr ""
+"Chun an paiste folamh a thaifeadadh mar thiomantas folamh, reáchtáil “%s --"
+"allow-empty”.\n"
 
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
+"Chun an brainse bunaidh a chur ar ais agus stopadh le patáil, reáchtáil “%s "
+"--abort”."
 
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
+"Seoladh paiste le formáid = sreabhadh; d'fhéadfaí spás ag deireadh na línte "
+"a chailleadh."
 
-#, fuzzy, c-format
+#, c-format
 msgid "missing author line in commit %s"
-msgstr "brainse ar iarraidh nó argóint a dhéanamh"
+msgstr "líne údair ar iarraidh i dtiomantas %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid ident line: %.*s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "líne aitheantais neamhbhailí: %.*s"
 
 #, c-format
 msgid "unable to parse commit %s"
@@ -1897,38 +2122,40 @@ msgstr "nach féidir le tiomantas %s a pharsáil"
 
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
+"Níl na blobanna riachtanacha ag an stór chun titim siar ar chumasc trí "
+"bhealach."
 
 msgid "Using index info to reconstruct a base tree..."
-msgstr ""
+msgstr "Eolas innéacs a úsáid chun bonn crann a athchóiriú..."
 
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
 msgstr ""
+"Ar chuir tú do phaiste in eagar de láimh?\n"
+"Ní bhaineann sé le blobs a taifeadtar ina innéacs."
 
 msgid "Falling back to patching base and 3-way merge..."
-msgstr ""
+msgstr "Ag titim ar ais go bonn paiste agus cumasc trí bhealach..."
 
-#, fuzzy
 msgid "Failed to merge in the changes."
-msgstr "Theip ar chrann %s a aimsiú."
+msgstr "Theip ar na hathruithe a chumasc."
 
 msgid "git write-tree failed to write a tree"
-msgstr ""
+msgstr "theip ar git write-tree crann a scríobh"
 
 msgid "applying to an empty history"
-msgstr ""
+msgstr "iarratas a dhéanamh ar stair folamh"
 
-#, fuzzy
 msgid "failed to write commit object"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "theip ar réad tiomanta a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot resume: %s does not exist."
-msgstr "níl an stóras '%s' ann"
+msgstr "ní féidir atosú: níl %s ann."
 
 msgid "Commit Body is:"
-msgstr ""
+msgstr "Is é an Comhlacht Tiomanta:"
 
 #. TRANSLATORS: Make sure to include [y], [n], [e], [v] and [a]
 #. in your translation. The program will only accept English
@@ -1937,50 +2164,54 @@ msgstr ""
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
+"Cuir i bhfeidhm?[y]es/[n]o/[e]dit/[v]iew patch/[a]glacadh le gach rud: "
 
-#, fuzzy
 msgid "unable to write index file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann comhad innéacs a scríobh"
 
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
-msgstr ""
+msgstr "Innéacs salach: ní féidir paistí a chur i bhfeidhm (salach: %s)"
 
 #, c-format
 msgid "Skipping: %.*s"
-msgstr ""
+msgstr "Scipeáil: %.*s"
 
 #, c-format
 msgid "Creating an empty commit: %.*s"
-msgstr ""
+msgstr "Tiomantas folamh a chruthú: %.*s"
 
-#, fuzzy
 msgid "Patch is empty."
-msgstr "Tá an paiste reatha folamh."
+msgstr "Tá paiste folamh."
 
 #, c-format
 msgid "Applying: %.*s"
-msgstr ""
+msgstr "Iarratas a dhéanamh: %.*s"
 
 msgid "No changes -- Patch already applied."
-msgstr ""
+msgstr "Gan aon athruithe - paiste curtha i bhfeidhm cheana féin."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Patch failed at %s %.*s"
-msgstr "theip ar '%s' a stáil"
+msgstr "Theip ar phaiste ag %s%.*s"
 
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
+"Úsáid 'git am --show-current-patch=diff' chun an paiste theip a fheiceáil"
 
-#, fuzzy
 msgid "No changes - recorded it as an empty commit."
-msgstr "níl aon athruithe curtha le tiomantas\n"
+msgstr "Gan aon athruithe - taifeadadh é mar thiomantas folamh."
 
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
 "already introduced the same changes; you might want to skip this patch."
 msgstr ""
+"Gan aon athruithe - ar ndearna tú dearmad 'git add' a úsáid?\n"
+"Mura bhfuil aon rud fágtha chun na céime, tá seans ann go bhfuil rud éigin "
+"eile\n"
+"tugadh na hathruithe céanna isteach cheana féin; b'fhéidir gur mhaith leat "
+"an paiste seo a scipeáil."
 
 msgid ""
 "You still have unmerged paths in your index.\n"
@@ -1988,275 +2219,281 @@ msgid ""
 "such.\n"
 "You might run `git rm` on a file to accept \"deleted by them\" for it."
 msgstr ""
+"Tá cosáin neamh-chumasaithe agat fós i d'innéacs.\n"
+"Ba chóir duit gach comhad a 'chur leis 'git' le coinbhleachtaí réitithe chun "
+"iad a mharcáil mar sin.\n"
+"D'fhéadfá `git rm` a reáchtáil ar chomhad chun glacadh le “scriosta ag siad” "
+"dó."
 
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
 
-#, fuzzy
 msgid "failed to clean index"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar innéacs a ghlanadh"
 
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
 msgstr ""
+"Is cosúil gur bhogadh tú HEAD ón teip 'am' deireanach.\n"
+"Gan athfhillte chuig ORIG_HEAD"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to read '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar '%s' a léamh"
 
-#, fuzzy
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git am [<options>] [(<mbox> | <Maildir>)...]"
 
 msgid "git am [<options>] (--continue | --skip | --abort)"
-msgstr ""
+msgstr "git am [<options>] (--continue | --skip | --abort)"
 
-#, fuzzy
 msgid "run interactively"
-msgstr "roghnaigh hunks idirghníomhach"
+msgstr "rith idirghníomhach"
 
 msgid "bypass pre-applypatch and applypatch-msg hooks"
-msgstr ""
+msgstr "seachbhóthar crúcaí réamh-applypatch agus applypatch-msg"
 
 msgid "historical option -- no-op"
-msgstr ""
+msgstr "rogha stairiúil  -- no-op"
 
 msgid "allow fall back on 3way merging if needed"
-msgstr ""
+msgstr "ligean titim siar ar chumasc 3bhealach más gá"
 
 msgid "be quiet"
-msgstr ""
+msgstr "a bheith ciúin"
 
 msgid "add a Signed-off-by trailer to the commit message"
-msgstr ""
+msgstr "cuir leantóir sínithe amach leis an teachtaireacht tiomanta"
 
-#, fuzzy
 msgid "recode into utf8 (default)"
-msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
+msgstr "athchóiriú isteach i utf8 (réamhshocraithe)"
 
 msgid "pass -k flag to git-mailinfo"
-msgstr ""
+msgstr "pas bratach -k chuig git-mailinfo"
 
 msgid "pass -b flag to git-mailinfo"
-msgstr ""
+msgstr "pas bratach -b chuig git-mailinfo"
 
 msgid "pass -m flag to git-mailinfo"
-msgstr ""
+msgstr "pas bratach -m chuig git-mailinfo"
 
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
-msgstr ""
+msgstr "pas bratach --keep-cr go git-mailsplit le haghaidh formáid mbox"
 
 msgid "strip everything before a scissors line"
-msgstr ""
+msgstr "gach rud a tharraingt roimh líne siosúr"
 
 msgid "pass it through git-mailinfo"
-msgstr ""
+msgstr "cuir ar aghaidh trí git-mailinfo"
 
 msgid "pass it through git-apply"
-msgstr ""
+msgstr "cuir isteach é trí git-apply"
 
 msgid "n"
-msgstr ""
+msgstr "n"
 
 msgid "format"
 msgstr "formáid"
 
 msgid "format the patch(es) are in"
-msgstr ""
+msgstr "formáid atá na paistea/na paiste iontu"
 
 msgid "override error message when patch failure occurs"
-msgstr ""
+msgstr "teachtaireacht earráide a shárú nuair a tharlaíonn teip"
 
 msgid "continue applying patches after resolving a conflict"
-msgstr ""
+msgstr "leanúint ar aghaidh ag cur paistí a chur i bhfeidhm tar"
 
 msgid "synonyms for --continue"
-msgstr ""
+msgstr "comhchiallaigh do --continue"
 
-#, fuzzy
 msgid "skip the current patch"
-msgstr "Tá an paiste reatha folamh."
+msgstr "scipeáil an paiste reatha"
 
 msgid "restore the original branch and abort the patching operation"
 msgstr ""
+"an bhrainse bunaidh a chur ar ais agus cuir deireadh leis an oibríocht paiste"
 
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr ""
+"déan deireadh leis an oibríocht paisteála ach coinnigh CEAD san áit a bhfuil "
+"sé"
 
 msgid "show the patch being applied"
-msgstr ""
+msgstr "taispeáin an paiste atá á chur i bhfeidhm"
 
 msgid "try to apply current patch again"
-msgstr ""
+msgstr "déan iarracht paiste reatha a chur i bhfeidhm"
 
-#, fuzzy
 msgid "record the empty patch as an empty commit"
-msgstr ""
-" (bain úsáid as “git am --allow-empty” chun an paiste seo a thaifeadadh mar "
-"thiomantas folamh)"
+msgstr "taifeadadh an paiste folamh mar thiomantas folamh"
 
 msgid "lie about committer date"
-msgstr ""
+msgstr "bréag faoi dháta an choimisiúnaithe"
 
 msgid "use current timestamp for author date"
-msgstr ""
+msgstr "bain úsáid as stampa ama reatha le haghaidh dáta an údair"
 
 msgid "key-id"
-msgstr ""
+msgstr "id eochair"
 
-#, fuzzy
 msgid "GPG-sign commits"
-msgstr "tiomantais nua, "
+msgstr "Tiomanta comhartha GPG-Comhartha"
 
 msgid "how to handle empty patches"
-msgstr ""
+msgstr "conas paistí folamh a láimhseáil"
 
 msgid "(internal use for git-rebase)"
-msgstr ""
+msgstr "(úsáid inmheánach le haghaidh git-rebase)"
 
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
 msgstr ""
+"Tá an rogha -b/--binary neamh-op le fada an lá, agus\n"
+"bainfear é. Ná húsáid é níos mó le do thoil."
 
-#, fuzzy
 msgid "failed to read the index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "theip ar an t-innéacs a léamh"
 
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
-msgstr ""
+msgstr "eolaire rebase roimhe seo %s ann fós ach tugadh mbox."
 
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
 "Use \"git am --abort\" to remove it."
 msgstr ""
+"Fuarthas eolaire %s stray.\n"
+"Úsáid “git am --abort” chun é a bhaint."
 
 msgid "Resolve operation not in progress, we are not resuming."
-msgstr ""
+msgstr "Réiteach oibríocht nach bhfuil ar siúl, níl muid ag atosú."
 
 msgid "interactive mode requires patches on the command line"
-msgstr ""
+msgstr "éilíonn modh idirghníomhach paistí ar an líne ordaithe"
 
-#, fuzzy
 msgid "git apply [<options>] [<patch>...]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git feidhm [<options>] [<patch>...]"
 
-#, fuzzy
 msgid "could not redirect output"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí aschur a atreorú"
 
 msgid "git archive: expected ACK/NAK, got a flush packet"
-msgstr ""
+msgstr "cartlann git: ag súil le ACK/NAK, fuair sé paicéad sruthán"
 
 #, c-format
 msgid "git archive: NACK %s"
-msgstr ""
+msgstr "git archive: NACK %s"
 
 msgid "git archive: protocol error"
-msgstr ""
+msgstr "git cartlann: earráid prótacal"
 
-#, fuzzy
 msgid "git archive: expected a flush"
-msgstr "nár bhfuair sé réad ag súil leis %s"
+msgstr "git archive: bhíothas ag súil le sruthlú"
 
 msgid "git backfill [--min-batch-size=<n>] [--[no-]sparse]"
-msgstr ""
+msgstr "git backfill [--min-batch-size=<n>] [-- [no-] neart]"
 
-#, fuzzy
 msgid "problem loading sparse-checkout"
-msgstr "Tá tú i seiceáil neamhchoitianta."
+msgstr "fadhb ag luchtú seiceáil neamhchoiti"
 
 msgid "Minimum number of objects to request at a time"
-msgstr ""
+msgstr "Líon íosta rudaí le iarraidh ag an am"
 
 msgid "Restrict the missing objects to the current sparse-checkout"
-msgstr ""
+msgstr "Cuir srian ar na rudaí atá in easnamh don tseiceáil neamhchoitianta"
 
 msgid ""
 "git bisect start [--term-(new|bad)=<term> --term-(old|good)=<term>]    [--no-"
 "checkout] [--first-parent] [<bad> [<good>...]] [--]    [<pathspec>...]"
 msgstr ""
+"git bisect start [--term-(new|bad)=<term> --term-(old|good)=<term>]    [--no-"
+"checkout] [--first-parent] [<bad> [<good>...]] [--]    [<pathspec>...]"
 
 msgid "git bisect (good|bad) [<rev>...]"
-msgstr ""
+msgstr "<rev>git bisect (maith|olc) [...]"
 
 msgid "git bisect skip [(<rev>|<range>)...]"
-msgstr ""
+msgstr "git bisect skip [(<rev>|<range>)...]"
 
 msgid "git bisect reset [<commit>]"
-msgstr ""
+msgstr "<commit>athshocrú git bisect []"
 
 msgid "git bisect replay <logfile>"
-msgstr ""
+msgstr "athsheinm git bisect <logfile>"
 
 msgid "git bisect run <cmd> [<arg>...]"
-msgstr ""
+msgstr "git bisect a rith <cmd>[<arg>...]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open file '%s' in mode '%s'"
-msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
+msgstr "ní féidir comhad '%s' a oscailt sa mhodh '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write to file '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní fhéadfaí scríobh chuig comhad '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open file '%s' for reading"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir comhad '%s' a oscailt le haghaidh léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid term"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní téarma bailí é '%s'"
 
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
-msgstr ""
+msgstr "ní féidir an t-ordú bunaithe '%s' a úsáid mar théarma"
 
 #, c-format
 msgid "can't change the meaning of the term '%s'"
-msgstr ""
+msgstr "ní féidir le brí an téarma '%s' a athrú"
 
 msgid "please use two different terms"
-msgstr ""
+msgstr "bain úsáid as dhá théarma éagsúla"
 
-#, fuzzy, c-format
+#, c-format
 msgid "We are not bisecting.\n"
-msgstr "Tá tú ag déileáil faoi láthair."
+msgstr "Nílimid ag déileáil.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid commit"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní gealltanas bailí é '%s'"
 
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
 msgstr ""
+"ní fhéadfaí an HEAD bunaidh '%s' a sheiceáil. <commit>Bain triail as 'git "
+"bisect reset '."
 
 #, c-format
 msgid "Bad bisect_write argument: %s"
-msgstr ""
+msgstr "Droch-argóint bisect_write: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "couldn't get the oid of the rev '%s'"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "ní raibh in ann oid an rev '%s' a fháil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "couldn't open the file '%s'"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "ní raibh in ann an comhad '%s' a oscailt"
 
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
-msgstr ""
+msgstr "Ordú neamhbhailí: tá tú i mbeagán %s/%s faoi láthair"
 
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
 "You can use \"git bisect %s\" and \"git bisect %s\" for that."
 msgstr ""
+"Ní mór duit athbhreithniú %s agus %s amháin ar a laghad a thabhairt dom.\n"
+"Is féidir leat “git bisect %s” agus “git bisect %s” a úsáid chuige sin."
 
 #, c-format
 msgid ""
@@ -2264,288 +2501,297 @@ msgid ""
 "You then need to give me at least one %s and %s revision.\n"
 "You can use \"git bisect %s\" and \"git bisect %s\" for that."
 msgstr ""
+"Ní mór duit tosú ag “git bisect start”.\n"
+"Ansin ní mór duit athbhreithniú %s agus %s amháin ar a laghad a thabhairt "
+"dom.\n"
+"Is féidir leat “git bisect %s” agus “git bisect %s” a úsáid chuige sin."
 
 #, c-format
 msgid "bisecting only with a %s commit"
-msgstr ""
+msgstr "ag déileáil ach amháin le tiomantas %s"
 
 #. TRANSLATORS: Make sure to include [Y] and [n] in your
 #. translation. The program will only accept English input
 #. at this point.
 #.
 msgid "Are you sure [Y/n]? "
-msgstr ""
+msgstr "An bhfuil tú cinnte [Y/n]? "
 
 msgid "status: waiting for both good and bad commits\n"
-msgstr ""
+msgstr "stádas: ag fanacht le tiomáintí mhaith agus tiomáintí dona\n"
 
 #, c-format
 msgid "status: waiting for bad commit, %d good commit known\n"
 msgid_plural "status: waiting for bad commit, %d good commits known\n"
-msgstr[0] ""
+msgstr[0] "stádas: ag fanacht le droch-thiomnadh, %d dea-thiomnadh ar eolas\n"
 msgstr[1] ""
+"stádas: ag fanacht le droch-thiomantas, %d dea-thiomantas ar eolas\n"
 msgstr[2] ""
+"stádas: ag fanacht le droch-thiomantas, %d dea-thiomantas ar eolas\n"
 
 msgid "status: waiting for good commit(s), bad commit known\n"
-msgstr ""
+msgstr "stádas: ag fanacht le tiomáintí maith, droch-tiomantas ar eolas\n"
 
 msgid "no terms defined"
-msgstr ""
+msgstr "aon téarmaí sainmhínithe"
 
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
 "and %s for the new state.\n"
 msgstr ""
+"Is iad na téarmaí reatha %s don seanstát\n"
+"agus %s don stát nua.\n"
 
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
 "Supported options are: --term-good|--term-old and --term-bad|--term-new."
 msgstr ""
+"argóint neamhbhailí %s le haghaidh 'git bisect terms'.\n"
+"Is iad na roghanna tacaithe ná: --term-good|--term-old agus --term-bad|--"
+"term-new."
 
 #, c-format
 msgid "could not open '%s' for appending"
-msgstr ""
+msgstr "ní fhéadfaí '%s' a oscailt le haghaidh cur isteach"
 
-#, fuzzy
 msgid "'' is not a valid term"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "'' ní téarma bailí é"
 
 #, c-format
 msgid "unrecognized option: '%s'"
-msgstr ""
+msgstr "rogha gan aithint: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' does not appear to be a valid revision"
-msgstr "níl a leagan ag cosán '%s'"
+msgstr "Ní cosúil gur athbhreithniú bailí é '%s'"
 
 msgid "bad HEAD - I need a HEAD"
-msgstr ""
+msgstr "droch HEAD - Teastaíonn HEAD uaim"
 
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
+"theip ar '%s' a sheiceáil. <valid-branch>Bain triail as 'git bisect start '."
 
 msgid "bad HEAD - strange symbolic ref"
-msgstr ""
+msgstr "bad HEAD - tagairt siombalach aisteach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid ref: '%s'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "tagairt neamhbhailí: '%s'"
 
 msgid "You need to start by \"git bisect start\"\n"
-msgstr ""
+msgstr "Ní mór duit tosú ag “git bisect start”\n"
 
 #. TRANSLATORS: Make sure to include [Y] and [n] in your
 #. translation. The program will only accept English input
 #. at this point.
 #.
 msgid "Do you want me to do it for you [Y/n]? "
-msgstr ""
+msgstr "An dteastaíonn uait go ndéanfaidh mé é duit [Y/n]? "
 
 msgid "Please call `--bisect-state` with at least one argument"
-msgstr ""
+msgstr "Glaoigh ar `--bisect-state` le do thoil le argóint amháin ar a laghad"
 
 #, c-format
 msgid "'git bisect %s' can take only one argument."
-msgstr ""
+msgstr "Ní féidir le 'git bisect %s' ach argóint amháin a ghlacadh."
 
 #, c-format
 msgid "Bad rev input: %s"
-msgstr ""
+msgstr "Droch-ionchur rev: %s"
 
 #, c-format
 msgid "Bad rev input (not a commit): %s"
-msgstr ""
+msgstr "Droch-ionchur rev (ní tiomantas): %s"
 
-#, fuzzy
 msgid "We are not bisecting."
-msgstr "Tá tú ag déileáil faoi láthair."
+msgstr "Nílimid ag déileáil."
 
 #, c-format
 msgid "'%s'?? what are you talking about?"
-msgstr ""
+msgstr "'%s'?? cad atá tú ag caint faoi?"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read file '%s' for replaying"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir comhad '%s' a léamh le haghaidh athsheinm"
 
-#, fuzzy, c-format
+#, c-format
 msgid "running %s\n"
-msgstr "Ag brú chuig %s\n"
+msgstr "ag rith %s\n"
 
 msgid "bisect run failed: no command provided."
-msgstr ""
+msgstr "theip ar rith bioctha: níl aon ordú curtha ar fáil."
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to verify %s on good revision"
-msgstr "Theip ar '%s' a réiteach mar athbhreithniú bailí."
+msgstr "nach féidir %s a fhíorú ar athbhreithniú maith"
 
 #, c-format
 msgid "bogus exit code %d for good revision"
-msgstr ""
+msgstr "cód imeachta bréagach %d le haghaidh athbhreithniú maith"
 
 #, c-format
 msgid "bisect run failed: exit code %d from %s is < 0 or >= 128"
-msgstr ""
+msgstr "< 0 or >Theip ar rith bioctha: is é an cód imeachta %d ó %s = 128"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open file '%s' for writing"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir comhad '%s' a oscailt le haghaidh scríobh"
 
 msgid "bisect run cannot continue any more"
-msgstr ""
+msgstr "ní féidir le rith bisect leanúint ar aghaidh níos mó"
 
 msgid "bisect run success"
-msgstr ""
+msgstr "rath reatha dhéagsúil"
 
 msgid "bisect found first bad commit"
-msgstr ""
+msgstr "fuarthas bisect an chéad droch-thiomantas"
 
 #, c-format
 msgid "bisect run failed: 'git bisect %s' exited with error code %d"
-msgstr ""
+msgstr "theip ar rith bisect: D'éirigh 'git bisect %s' le cód earráide %d"
 
 #, c-format
 msgid "'%s' requires either no argument or a commit"
-msgstr ""
+msgstr "Ní éilíonn '%s' aon argóint ná tiomantas"
 
 #, c-format
 msgid "'%s' requires 0 or 1 argument"
-msgstr ""
+msgstr "Éilíonn '%s' argóint 0 nó 1"
 
 #, c-format
 msgid "'%s' requires 0 arguments"
-msgstr ""
+msgstr "Éilíonn '%s' 0 argóint"
 
 msgid "no logfile given"
-msgstr ""
+msgstr "níl aon logfile tugtha"
 
 #, c-format
 msgid "'%s' failed: no command provided."
-msgstr ""
+msgstr "Theip ar '%s': níl aon ordú curtha ar fáil."
 
 msgid "need a command"
-msgstr ""
+msgstr "teastaíonn ordú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown command: '%s'"
-msgstr "stíl choimhlinte anaithnid '%s'"
+msgstr "ordú anaithnid: '%s'"
 
-#, fuzzy
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git an mille <options>án [<rev-opts>] [<rev>] [] [--] <file>"
 
-#, fuzzy
 msgid "git annotate [<options>] [<rev-opts>] [<rev>] [--] <file>"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git annotate [<options>] [] [<rev-opts><rev>] [--] <file>"
 
 msgid "<rev-opts> are documented in git-rev-list(1)"
-msgstr ""
+msgstr "<rev-opts>iad doiciméadaithe i git-rev-list (1)"
 
 #, c-format
 msgid "expecting a color: %s"
-msgstr ""
+msgstr "ag súil le dath: %s"
 
 msgid "must end with a color"
-msgstr ""
+msgstr "caithfidh deireadh a chur le dath"
 
 #, c-format
 msgid "cannot find revision %s to ignore"
-msgstr ""
+msgstr "ní féidir athbhreithniú %s a fháil le neamhair"
 
 msgid "show blame entries as we find them, incrementally"
-msgstr ""
+msgstr "taispeáint iontrálacha milleán de réir mar a aimsímid iad, go chéile"
 
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr ""
+"ná taispeáin ainmneacha réada na ngealltanais teorann (Réamhshocraithe: as)"
 
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr ""
+"ná déileáil le gealltanais fréimhe mar theorainneacha (Réamhshocraithe: as)"
 
 msgid "show work cost statistics"
-msgstr ""
+msgstr "taispeáin staitisticí costas oibre"
 
 msgid "force progress reporting"
 msgstr "tuairisciú dul chun cinn"
 
 msgid "show output score for blame entries"
-msgstr ""
+msgstr "taispeáin scór aschuir d'iontrálacha mille"
 
 msgid "show original filename (Default: auto)"
-msgstr ""
+msgstr "taispeáin ainm comhaid bunaidh (Réamhshocraithe: auto)"
 
 msgid "show original linenumber (Default: off)"
-msgstr ""
+msgstr "taispeáin uimhir líne bunaidh (Réamhshocraithe: as)"
 
 msgid "show in a format designed for machine consumption"
-msgstr ""
+msgstr "taispeáint i bhformáid atá deartha le haghaidh tomhaltas meaisín"
 
 msgid "show porcelain format with per-line commit information"
-msgstr ""
+msgstr "formáid poircealláin a thaispeáint le faisnéis tiomanta"
 
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr ""
+"bain úsáid as an modh aschuir céanna le git-annotate (Réamhshocraithe: as)"
 
 msgid "show raw timestamp (Default: off)"
-msgstr ""
+msgstr "taispeáin ama amh (Réamhshocraithe: as)"
 
 msgid "show long commit SHA1 (Default: off)"
-msgstr ""
+msgstr "taispeáin tiomantas fada SHA1 (Réamhshocraithe: as)"
 
 msgid "suppress author name and timestamp (Default: off)"
-msgstr ""
+msgstr "ainm an údair agus stampa ama a chur faoi chois (Réamhshocraithe: as)"
 
 msgid "show author email instead of name (Default: off)"
-msgstr ""
+msgstr "taispeáin ríomhphost an údair in ionad ainm (Réamhshocraithe: as)"
 
 msgid "ignore whitespace differences"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar dhifríochtaí spás b"
 
 msgid "rev"
 msgstr "rev"
 
 msgid "ignore <rev> when blaming"
-msgstr ""
+msgstr "neamhaird a <rev>dhéanamh agus an milleán"
 
 msgid "ignore revisions from <file>"
-msgstr ""
+msgstr "neamhaird ar athbhreithnithe <file>"
 
 msgid "color redundant metadata from previous line differently"
-msgstr ""
+msgstr "meiteashonraí iomarcach dath ó líne roimhe seo ar bheal"
 
 msgid "color lines by age"
-msgstr ""
+msgstr "línte datha de réir aois"
 
 msgid "spend extra cycles to find better match"
-msgstr ""
+msgstr "timthriallta breise a chaitheamh chun meaitseáil níos fearr"
 
 msgid "use revisions from <file> instead of calling git-rev-list"
-msgstr ""
+msgstr "athbhreithnithe a úsáid as in <file>ionad glaoch ar git-rev-list"
 
 msgid "use <file>'s contents as the final image"
-msgstr ""
+msgstr "úsáid <file>ábhar mar an íomhá deiridh"
 
 msgid "score"
-msgstr ""
+msgstr "scór"
 
 msgid "find line copies within and across files"
-msgstr ""
+msgstr "faigh cóipeanna líne laistigh de chomhaid agus trasna"
 
 msgid "find line movements within and across files"
-msgstr ""
+msgstr "faigh gluaiseachtaí líne laistigh de chomhaid agus trasna"
 
 msgid "range"
-msgstr ""
+msgstr "raon"
 
 msgid "process only line range <start>,<end> or function :<funcname>"
-msgstr ""
+msgstr "ach raon líne, nó feidh <start>m a <end>phróiseáil: <funcname>"
 
-#, fuzzy
 msgid "--progress can't be used with --incremental or porcelain formats"
-msgstr ""
-"clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
+msgstr "Ní féidir --progress a úsáid le formáidí --incremental nó poircealláin"
 
 #. TRANSLATORS: This string is used to tell us the
 #. maximum display width for a relative timestamp in
@@ -2556,166 +2802,166 @@ msgstr ""
 #. columns.
 #.
 msgid "4 years, 11 months ago"
-msgstr ""
+msgstr "4 bliana, 11 mhí ó shin"
 
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "comhad %s níl ach %lu líne"
+msgstr[1] "comhad %s níl ach %lu línte"
+msgstr[2] "comhad %s níl ach %lu línte"
 
 msgid "Blaming lines"
-msgstr ""
+msgstr "An milleán ar línte"
 
 msgid "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
-msgstr ""
+msgstr "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
 
 msgid ""
 "git branch [<options>] [-f] [--recurse-submodules] <branch-name> [<start-"
 "point>]"
 msgstr ""
+"git branch [<options>] [-f] [--recurse-submodules] <branch-name> [<start-"
+"point>]"
 
-#, fuzzy
 msgid "git branch [<options>] [-l] [<pattern>...]"
-msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+msgstr "git branch [<options>] [-l] [<pattern>...]"
 
-#, fuzzy
 msgid "git branch [<options>] [-r] (-d | -D) <branch-name>..."
-msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+msgstr "git branch [<options>] [-r] (-d | -D) <branch-name>..."
 
-#, fuzzy
 msgid "git branch [<options>] (-m | -M) [<old-branch>] <new-branch>"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git branch [<options>] (-m | -M) [<old-branch>] <new-branch>"
 
-#, fuzzy
 msgid "git branch [<options>] (-c | -C) [<old-branch>] <new-branch>"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git branch [<options>] (-c | -C) [<old-branch>] <new-branch>"
 
-#, fuzzy
 msgid "git branch [<options>] [-r | -a] [--points-at]"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git branch [<options>] [-r | -a] [--points-at]"
 
-#, fuzzy
 msgid "git branch [<options>] [-r | -a] [--format]"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git branch [<options>] [-r | -a] [--format]"
 
 #, c-format
 msgid ""
 "deleting branch '%s' that has been merged to\n"
 "         '%s', but not yet merged to HEAD"
 msgstr ""
+"brainse '%s' a bhfuil cumasc orthu a scriosadh\n"
+" '%s', ach níor chumasc le HEAD go fóill"
 
 #, c-format
 msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
 "         '%s', even though it is merged to HEAD"
 msgstr ""
+"gan brainse '%s' a scriosadh nach bhfuil cumasc fós leis\n"
+" '%s', cé go ndéantar é a chumasc le HEAD"
 
 #, c-format
 msgid "couldn't look up commit object for '%s'"
-msgstr ""
+msgstr "ní raibh in ann réad tiomanta a lorg suas le haghaidh '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "the branch '%s' is not fully merged"
-msgstr "tá cosán '%s' neamh-chomhcheangailte"
+msgstr "níl an brainse '%s' cumaisc go hiomlán"
 
 #, c-format
 msgid "If you are sure you want to delete it, run 'git branch -D %s'"
 msgstr ""
+"Má tá tú cinnte gur mhaith leat é a scriosadh, reáchtáil 'git branch -D %s'"
 
 msgid "update of config-file failed"
-msgstr ""
+msgstr "theip ar nuashonrú comhad config-file"
 
-#, fuzzy
 msgid "cannot use -a with -d"
-msgstr "Ní féidir '%s' a úsáid le '%s'"
+msgstr "ní féidir -a a úsáid le -d"
 
 #, c-format
 msgid "cannot delete branch '%s' used by worktree at '%s'"
-msgstr ""
+msgstr "ní féidir brainse '%s' a úsáideann crann oibre ag '%s' a scriosadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "remote-tracking branch '%s' not found"
-msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+msgstr "níor aimsíodh brainse cianrianaithe '%s'"
 
 #, c-format
 msgid ""
 "branch '%s' not found.\n"
 "Did you forget --remote?"
 msgstr ""
+"níor aimsíodh brainse '%s'.\n"
+"Ar ndearna tú dearmad ar --remote?"
 
-#, fuzzy, c-format
+#, c-format
 msgid "branch '%s' not found"
-msgstr "níl aon iargúlta ag brainse '%s' chun brú"
+msgstr "níor aimsíodh brainse '%s'"
 
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
-msgstr ""
+msgstr "Brainse cianrianaithe scriosta %s (bhí %s).\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Deleted branch %s (was %s).\n"
-msgstr "Athshocraigh brainse '%s'\n"
+msgstr "Brainse %s scriosta (%s ba é).\n"
 
-#, fuzzy
 msgid "unable to parse format string"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "in ann teaghrán formáide a pháirseáil"
 
-#, fuzzy
 msgid "could not resolve HEAD"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí HEAD a réiteach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
-msgstr "Ní fhaightear CEAD thíos na refs/heads!"
+msgstr "Pointí HEAD (%s) lasmuigh de refs/heads/"
 
-#, fuzzy, c-format
+#, c-format
 msgid "branch %s is being rebased at %s"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "tá brainse %s á athbhunú ag %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "branch %s is being bisected at %s"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "tá brainse %s á dhíscaoileadh ag %s"
 
 #, c-format
 msgid "HEAD of working tree %s is not updated"
-msgstr ""
+msgstr "Níl CEANN an chrainn oibre %s nuashonraithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid branch name: '%s'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "ainm brainse neamhbhailí: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no commit on branch '%s' yet"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "níl aon gealltanas ar bhrainse '%s' go fóill"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no branch named '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "níl aon bhrainse darb ainm '%s'"
 
 msgid "branch rename failed"
-msgstr ""
+msgstr "theip ar athainmniú brainse"
 
 msgid "branch copy failed"
-msgstr ""
+msgstr "theip ar chóip brainse"
 
-#, fuzzy, c-format
+#, c-format
 msgid "created a copy of a misnamed branch '%s'"
-msgstr "cruthú agus aistrigh go brainse nua"
+msgstr "chruthaigh cóip de bhrainse mí-ainmnithe '%s'"
 
 #, c-format
 msgid "renamed a misnamed branch '%s' away"
-msgstr ""
+msgstr "athainmnigh brainse mí-ainmnithe '%s' ar shiúl"
 
 #, c-format
 msgid "branch renamed to %s, but HEAD is not updated"
-msgstr ""
+msgstr "athainmníodh brainse go %s, ach níl HEAD nuashonraithe"
 
 msgid "branch is renamed, but update of config-file failed"
-msgstr ""
+msgstr "athainmnítear brainse, ach theip ar nuashonrú ar chomhad config-file"
 
 msgid "branch is copied, but update of config-file failed"
-msgstr ""
+msgstr "cóipeáiltear brainse, ach theip ar nuashonrú comhad config-file"
 
 #, c-format
 msgid ""
@@ -2723,117 +2969,114 @@ msgid ""
 "  %s\n"
 "Lines starting with '%s' will be stripped.\n"
 msgstr ""
+"Cuir an tuairisc don bhrainse in eagar\n"
+" %s\n"
+"Déanfar línte a thosaíonn le '%s' a scriosadh.\n"
 
 msgid "Generic options"
-msgstr ""
+msgstr "Roghanna cineálacha"
 
 msgid "show hash and subject, give twice for upstream branch"
-msgstr ""
+msgstr "taispeáin hash agus ábhar, tabhair faoi dhó don bhrainse suas srutha"
 
 msgid "suppress informational messages"
-msgstr ""
+msgstr "teachtaireachtaí faisnéise a chur"
 
 msgid "set branch tracking configuration"
 msgstr "cumraíocht rianaithe brainse a shoc"
 
 msgid "do not use"
-msgstr ""
+msgstr "ná húsáid"
 
 msgid "upstream"
-msgstr ""
+msgstr "suas sruth"
 
 msgid "change the upstream info"
-msgstr ""
+msgstr "athraigh an fhaisnéis suas sruth"
 
 msgid "unset the upstream info"
-msgstr ""
+msgstr "díshocraigh an fhaisnéis suas sruth"
 
 msgid "use colored output"
-msgstr ""
+msgstr "úsáid aschur daite"
 
-#, fuzzy
 msgid "act on remote-tracking branches"
-msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
+msgstr "gníomhú ar bhrainsí cianrianaithe"
 
 msgid "print only branches that contain the commit"
-msgstr ""
+msgstr "ach brainsí a phriontáil ina bhfuil an tiomantas"
 
 msgid "print only branches that don't contain the commit"
-msgstr ""
+msgstr "ach brainsí a phriontáil nach bhfuil an tiomantas"
 
 msgid "Specific git-branch actions:"
-msgstr ""
+msgstr "Gníomhartha sonracha git-branch:"
 
 msgid "list both remote-tracking and local branches"
-msgstr ""
+msgstr "liostáil brainsí cianrianaithe agus áitiúla araon"
 
 msgid "delete fully merged branch"
-msgstr ""
+msgstr "scrios brainse lánchumaisc"
 
 msgid "delete branch (even if not merged)"
-msgstr ""
+msgstr "brainse a scriosadh (fiú mura bhfuil sé cumasaithe)"
 
 msgid "move/rename a branch and its reflog"
-msgstr ""
+msgstr "brainse a bhogadh/athainmniú agus a athainmniú"
 
 msgid "move/rename a branch, even if target exists"
-msgstr ""
+msgstr "brainse a bhogadh/athainmniú, fiú má tá sprioc ann"
 
 msgid "do not output a newline after empty formatted refs"
-msgstr ""
+msgstr "ná aschur líne nua tar éis aifeanna formáidithe folamh"
 
 msgid "copy a branch and its reflog"
-msgstr ""
+msgstr "cóipeáil brainse agus a reflog"
 
 msgid "copy a branch, even if target exists"
-msgstr ""
+msgstr "cóipeáil brainse, fiú má tá sprioc ann"
 
-#, fuzzy
 msgid "list branch names"
-msgstr "Athshocraigh brainse '%s'\n"
+msgstr "liosta ainmneacha brainse"
 
-#, fuzzy
 msgid "show current branch name"
-msgstr "Níl sé ar aon bhrainse faoi láthair."
+msgstr "taispeáin ainm brainse reatha"
 
 msgid "create the branch's reflog"
-msgstr ""
+msgstr "athbhreithniú na brainse a chruthú"
 
-#, fuzzy
 msgid "edit the description for the branch"
-msgstr "cruthú reflog do bhrainse nua"
+msgstr "cuir an tuairisc don bhrainse a chur in eagar"
 
 msgid "force creation, move/rename, deletion"
-msgstr ""
+msgstr "cruthú fórsa, gluaise/athainmniú, scriosadh"
 
 msgid "print only branches that are merged"
-msgstr ""
+msgstr "ach brainsí a chumasc a phriontáil"
 
 msgid "print only branches that are not merged"
-msgstr ""
+msgstr "ach brainsí nach ndéantar cumasc a phriontáil"
 
 msgid "list branches in columns"
-msgstr ""
+msgstr "liostáil brainsí i gcolúin"
 
 msgid "object"
-msgstr ""
+msgstr "réad"
 
 msgid "print only branches of the object"
-msgstr ""
+msgstr "ach brainsí den réad a phriontáil"
 
 msgid "sorting and filtering are case insensitive"
-msgstr ""
+msgstr "tá sórtáil agus scagadh neamh-íogair ó thaobh cásanna de"
 
-#, fuzzy
 msgid "recurse through submodules"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "athshlánú trí fho-mhodúil"
 
 msgid "format to use for the output"
-msgstr ""
+msgstr "formáid le húsáid don aschur"
 
-#, fuzzy
 msgid "failed to resolve HEAD as a valid ref"
-msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+msgstr "theip ar HEAD a réiteach mar thagartha bailí"
 
 msgid "HEAD not found below refs/heads!"
 msgstr "Ní fhaightear CEAD thíos na refs/heads!"
@@ -2842,86 +3085,97 @@ msgid ""
 "branch with --recurse-submodules can only be used if "
 "submodule.propagateBranches is enabled"
 msgstr ""
+"ní féidir brainse le --recurse-submodules a úsáid ach amháin má tá "
+"submodule.propagateBranches cumasaithe"
 
 msgid "--recurse-submodules can only be used to create branches"
-msgstr ""
+msgstr "Ní féidir --recurse-submodules a úsáid ach chun brainsí a chruthú"
 
 msgid "branch name required"
-msgstr ""
+msgstr "ainm brainse ag teastáil"
 
 msgid "cannot give description to detached HEAD"
-msgstr ""
+msgstr "ní féidir cur síos a thabhairt ar HEAD scoite"
 
 msgid "cannot edit description of more than one branch"
-msgstr ""
+msgstr "ní féidir cur síos ar níos mó ná brainse amháin a chur in eagar"
 
 msgid "cannot copy the current branch while not on any"
-msgstr ""
+msgstr "ní féidir leis an mbrainse reatha a chóipeáil cé nach bhfuil ar aon"
 
 msgid "cannot rename the current branch while not on any"
-msgstr ""
+msgstr "ní féidir leis an mbrainse reatha a athainmniú cé nach bhfuil ar aon"
 
 msgid "too many branches for a copy operation"
-msgstr ""
+msgstr "an iomarca brainsí le haghaidh oibríocht cóipeála"
 
 msgid "too many arguments for a rename operation"
-msgstr ""
+msgstr "an iomarca argóintí maidir le hoibríocht athainmnithe"
 
 msgid "too many arguments to set new upstream"
-msgstr ""
+msgstr "an iomarca argóintí chun suas an sruth nua a shocrú"
 
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch"
 msgstr ""
+"ní fhéadfaí suas sruth de HEAD a shocrú go %s nuair nach dtugann sé in iúl "
+"go dtí aon bhrainse"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such branch '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "níl brainse den sórt sin '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "branch '%s' does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl brainse '%s' ann"
 
-#, fuzzy
 msgid "too many arguments to unset upstream"
-msgstr "An iomarca argóintí."
+msgstr "an iomarca argóintí le díshocrú suas an sruth"
 
-#, fuzzy
 msgid "could not unset upstream of HEAD when it does not point to any branch"
-msgstr "Ní chuireann HEAD in iúl do bhrainse"
+msgstr ""
+"ní fhéadfaí a dhíshuiteáil suas an sruth den HEAD nuair nach dtugann sé in "
+"iúl d'aon bhrainse"
 
-#, fuzzy, c-format
+#, c-format
 msgid "branch '%s' has no upstream information"
-msgstr "níl aon iargúlta ag brainse '%s' chun brú"
+msgstr "níl aon fhaisnéis suas sruth ag brainse '%s'"
 
 msgid ""
 "the -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
 msgstr ""
+"ní ghlacann na roghanna -a, agus -r, le 'git branch' ainm brainse.\n"
+"<pattern>An raibh sé i gceist agat úsáid a bhaint as: -a|-r --list?"
 
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead"
 msgstr ""
+"ní thacaítear leis an rogha '--set-upstream' a thuilleadh. Úsáid '--track' "
+"nó '--set-upstream-to' ina ionad"
 
 msgid "git version:\n"
-msgstr ""
+msgstr "leagan git:\n"
 
 msgid "compiler info: "
-msgstr ""
+msgstr "eolas tiomsaitheora: "
 
 msgid "libc info: "
-msgstr ""
+msgstr "eolas libc: "
 
 msgid "not run from a git repository - no hooks to show\n"
-msgstr ""
+msgstr "gan rith ó stór git - gan aon chrúcaí le taispeáint\n"
 
 msgid ""
 "git bugreport [(-o | --output-directory) <path>]\n"
 "              [(-s | --suffix) <format> | --no-suffix]\n"
 "              [--diagnose[=<mode>]]"
 msgstr ""
+"<path>git bugreport [(-o | --output-directory)]\n"
+" <format>[(-s | --iarmhír) | --no-iarmhír]\n"
+" [--diagnóis [=<mode>]]"
 
 msgid ""
 "Thank you for filling out a Git bug report!\n"
@@ -2940,138 +3194,159 @@ msgid ""
 "Please review the rest of the bug report below.\n"
 "You can delete any lines you don't wish to share.\n"
 msgstr ""
+"Go raibh maith agat as tuarascáil fabht Git a líonadh!\n"
+"Freagair na ceisteanna seo a leanas le do thoil chun cabhrú linn do cheist a "
+"thuiscint\n"
+"\n"
+"Cad a rinne tú sular tharla an fabht? (Céimeanna chun d'eisiúint a "
+"atáirgeadh)\n"
+"\n"
+"Cad a bhí tú ag súil go dtarlódh? (Iompar ag súil leis)\n"
+"\n"
+"Cad a tharla ina ionad sin? (Iompar iarbhír)\n"
+"\n"
+"Cad atá difriúil idir an méid a bhí súil agat leis agus cad a tharla i "
+"ndáiríre\n"
+"\n"
+"Aon rud eile a theastaíonn uait a chur leis:\n"
+"\n"
+"Déan athbhreithniú ar an chuid eile den tuarascáil fabht thíos.\n"
+"Is féidir leat aon línte nach dteastaíonn uait a roinnt a scriosadh.\n"
 
 msgid "mode"
-msgstr ""
+msgstr "mód"
 
 msgid ""
 "create an additional zip archive of detailed diagnostics (default 'stats')"
 msgstr ""
+"cruthú cartlann zip breise de dhiagnóiseach mionsonraithe ('stats' "
+"réamhshocraithe)"
 
 msgid "specify a destination for the bugreport file(s)"
-msgstr ""
+msgstr "sonraigh ceann scríbe don chomhad (í) bugreport"
 
 msgid "specify a strftime format suffix for the filename(s)"
-msgstr ""
+msgstr "sonraigh iarmhír formáid strftime don ainm (í) comhaid"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown argument `%s'"
-msgstr "algartam hais anaithnid '%s'"
+msgstr "argóint anaithnid `%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create leading directories for '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolairí tosaigh a chruthú do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create diagnostics archive %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir cartlann diagnóiseach %s a chruthú"
 
 msgid "System Info"
-msgstr ""
+msgstr "Eolas Córais"
 
 msgid "Enabled Hooks"
-msgstr ""
+msgstr "Crúcaí Cumasaithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to write to %s"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir a scríobh chuig %s"
 
 #, c-format
 msgid "Created new report at '%s'.\n"
-msgstr ""
+msgstr "Cruthaíodh tuarascáil nua ag '%s'.\n"
 
 msgid ""
 "git bundle create [-q | --quiet | --progress]\n"
 "                  [--version=<version>] <file> <git-rev-list-args>"
 msgstr ""
+"cruthaigh bonn git [-q | --quiet | --progress]\n"
+" <version>[--leagan =] <file><git-rev-list-args>"
 
 msgid "git bundle verify [-q | --quiet] <file>"
-msgstr ""
+msgstr "fíorú beartán git [-q | --quiet] <file>"
 
 msgid "git bundle list-heads <file> [<refname>...]"
-msgstr ""
+msgstr "<refname>ceannairí liosta bonn git <file>[...]"
 
 msgid "git bundle unbundle [--progress] <file> [<refname>...]"
-msgstr ""
+msgstr "<refname>díbhuntáil bonn git [--progress] <file>[...]"
 
 msgid "need a <file> argument"
-msgstr ""
+msgstr "teastaíonn ar <file>góint"
 
 msgid "do not show progress meter"
-msgstr ""
+msgstr "ná taispeáin méadar dul chun cinn"
 
-#, fuzzy
 msgid "show progress meter"
-msgstr "tuairisciú dul chun cinn"
+msgstr "taispeáin méadar dul chun cinn"
 
 msgid "historical; same as --progress"
-msgstr ""
+msgstr "stairiúil; mar an gcéanna le --progress"
 
 msgid "historical; does nothing"
-msgstr ""
+msgstr "stairiúil; ní dhéanann aon rud"
 
 msgid "specify bundle format version"
-msgstr ""
+msgstr "leagan formáid beartán a shonrú"
 
 msgid "Need a repository to create a bundle."
-msgstr ""
+msgstr "Teastaíonn stór chun beartán a chruthú."
 
 msgid "do not show bundle details"
-msgstr ""
+msgstr "ná taispeáin sonraí beartán"
 
 msgid "need a repository to verify a bundle"
-msgstr ""
+msgstr "teastaíonn stór chun beartán a fhíorú"
 
 #, c-format
 msgid "%s is okay\n"
-msgstr ""
+msgstr "%s ceart go leor\n"
 
-#, fuzzy
 msgid "Need a repository to unbundle."
-msgstr "Ní mór duit stór a shonrú le clónú."
+msgstr "Teastaíonn stór chun dícheangail a dhícheangal."
 
-#, fuzzy
 msgid "Unbundling objects"
-msgstr "Rudaí innéacsála"
+msgstr "Rudaí a dhícheangal"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read object %s '%s'"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "ní féidir réad %s '%s' a léamh"
 
 msgid "flush is only for --buffer mode"
-msgstr ""
+msgstr "níl sruth ach le haghaidh mód --buffer"
 
 msgid "empty command in input"
-msgstr ""
+msgstr "ordú folamh san ionchur"
 
 #, c-format
 msgid "whitespace before command: '%s'"
-msgstr ""
+msgstr "spás bán roimh an ordú: '%s'"
 
 #, c-format
 msgid "%s requires arguments"
-msgstr ""
+msgstr "Teastaíonn argóintí %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s takes no arguments"
-msgstr "An iomarca argóintí."
+msgstr "Ní ghlacann %s aon argóintí"
 
 msgid "only one batch option may be specified"
-msgstr ""
+msgstr "ní féidir ach rogha baisc amháin a shonrú"
 
 msgid "git cat-file <type> <object>"
-msgstr ""
+msgstr "git cat-file <type> <object>"
 
 msgid "git cat-file (-e | -p) <object>"
-msgstr ""
+msgstr "git cat-file (-e | -p) <object>"
 
 msgid "git cat-file (-t | -s) [--allow-unknown-type] <object>"
-msgstr ""
+msgstr "git cat-file (-t | -s) [--leis-cineál gan eolas] <object>"
 
 msgid ""
 "git cat-file (--textconv | --filters)\n"
 "             [<rev>:<path|tree-ish> | --path=<path|tree-ish> <rev>]"
 msgstr ""
+"git cat-file (--textconv | --filters)\n"
+"             [<rev>:<path|tree-ish> | --path=<path|tree-ish> <rev>]"
 
 msgid ""
 "git cat-file (--batch | --batch-check | --batch-command) [--batch-all-"
@@ -3079,240 +3354,245 @@ msgid ""
 "             [--buffer] [--follow-symlinks] [--unordered]\n"
 "             [--textconv | --filters] [-Z]"
 msgstr ""
+"git cat-file (--batch | --batch-check | --batch-command) [--batch-all-"
+"objects]\n"
+"             [--buffer] [--follow-symlinks] [--unordered]\n"
+"             [--textconv | --filters] [-Z]"
 
 msgid "Check object existence or emit object contents"
-msgstr ""
+msgstr "Seiceáil go bhfuil réad ann nó astaigh ábhar réad"
 
-#, fuzzy
 msgid "check if <object> exists"
-msgstr "Rud a sheiceáil"
+msgstr "seiceáil an bhfuil <object> ann"
 
 msgid "pretty-print <object> content"
-msgstr ""
+msgstr "<object> ábhar priontáil álainn"
 
 msgid "Emit [broken] object attributes"
-msgstr ""
+msgstr "Easaigh tréithe réada [briste]"
 
 msgid "show object type (one of 'blob', 'tree', 'commit', 'tag', ...)"
 msgstr ""
+"taispeáint cineál réad (ceann de 'blob', 'crann', 'tiomantas', 'tag',...)"
 
 msgid "show object size"
-msgstr ""
+msgstr "taispeáin méid an réad"
 
 msgid "allow -s and -t to work with broken/corrupt objects"
-msgstr ""
+msgstr "ligean do -s agus -t oibriú le rudaí briste/truaillithe"
 
 msgid "use mail map file"
-msgstr ""
+msgstr "úsáid comhad léarscáil ríomhphoist"
 
 msgid "Batch objects requested on stdin (or --batch-all-objects)"
-msgstr ""
+msgstr "Baisc rudaí a iarrtar ar stdin (nó --batch-all-objects)"
 
 msgid "show full <object> or <rev> contents"
-msgstr ""
+msgstr "taispeáin iomlán <object>nó á <rev>bhar"
 
 msgid "like --batch, but don't emit <contents>"
-msgstr ""
+msgstr "cosúil le --batch, ach ná astaíonn <contents>"
 
 msgid "stdin is NUL-terminated"
-msgstr ""
+msgstr "tá stdin foirceanta ag NUL"
 
 msgid "stdin and stdout is NUL-terminated"
-msgstr ""
+msgstr "tá stdin agus stdout foirceannta NUL"
 
-#, fuzzy
 msgid "read commands from stdin"
-msgstr "Níl aon orduithe fágtha."
+msgstr "léigh orduithe ó stdin"
 
 msgid "with --batch[-check]: ignores stdin, batches all known objects"
 msgstr ""
+"le --batch [-check]: déanann neamhaird ar stdin, déanann baisceanna gach rud "
+"aitheanta"
 
 msgid "Change or optimize batch output"
-msgstr ""
+msgstr "Athraigh nó barrfheabhsú aschur baisc"
 
 msgid "buffer --batch output"
-msgstr ""
+msgstr "maolán --batch baisc"
 
 msgid "follow in-tree symlinks"
-msgstr ""
+msgstr "lean naisc shiombailí in-chrann"
 
 msgid "do not order objects before emitting them"
-msgstr ""
+msgstr "ná ordaigh rudaí sula n-astaíonn tú iad"
 
 msgid ""
 "Emit object (blob or tree) with conversion or filter (stand-alone, or with "
 "batch)"
 msgstr ""
+"Rud a astaíonn (blob nó crann) le comhshó nó scagaire (neamhspleách, nó le "
+"baisc)"
 
 msgid "run textconv on object's content"
-msgstr ""
+msgstr "reáchtáil textconv ar ábhar an réad"
 
 msgid "run filters on object's content"
-msgstr ""
+msgstr "reáchtáil scagairí ar ábhar an rud"
 
 msgid "blob|tree"
-msgstr ""
+msgstr "blob | crann"
 
 msgid "use a <path> for (--textconv | --filters); Not with 'batch'"
-msgstr ""
+msgstr "úsáid a le <path>haghaidh (--textconv | --filters); Ní le 'baisc'"
 
 msgid "objects filter only supported in batch mode"
-msgstr ""
+msgstr "ní thacaítear scagaire rudaí ach i mód baisc"
 
 #, c-format
 msgid "objects filter not supported: '%s'"
-msgstr ""
+msgstr "ní thacaítear le scagaire réadanna: '%s'"
 
 #, c-format
 msgid "'%s=<%s>' needs '%s' or '%s'"
-msgstr ""
+msgstr "'%s=<%s>' teastaíonn '%s' nó '%s'"
 
 msgid "path|tree-ish"
-msgstr ""
+msgstr "cosán | crann-ish"
 
 #, c-format
 msgid "'%s' requires a batch mode"
-msgstr ""
+msgstr "Éilíonn '%s' modh baisc"
 
 #, c-format
 msgid "'-%c' is incompatible with batch mode"
-msgstr ""
+msgstr "Níl '-%c' comhoiriúnach le mód baisc"
 
 msgid "batch modes take no arguments"
-msgstr ""
+msgstr "ní ghlacann modhanna baisc aon argóintí"
 
 #, c-format
 msgid "<rev> required with '%s'"
-msgstr ""
+msgstr "<rev>ag teastáil le '%s'"
 
 #, c-format
 msgid "<object> required with '-%c'"
-msgstr ""
+msgstr "<object>ag teastáil le '-%c'"
 
 #, c-format
 msgid "only two arguments allowed in <type> <object> mode, not %d"
-msgstr ""
+msgstr "ní cheadaítear ach dhá argóint <type><object>sa mhodh, ní %d"
 
 msgid ""
 "git check-attr [--source <tree-ish>] [-a | --all | <attr>...] [--] "
 "<pathname>..."
 msgstr ""
+"git check-attr [--source <tree-ish>] [-a | --all | <attr>...] [--] "
+"<pathname>..."
 
-#, fuzzy
 msgid ""
 "git check-attr --stdin [-z] [--source <tree-ish>] [-a | --all | <attr>...]"
-msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+msgstr ""
+"git check-attr --stdin [-z] [--source <tree-ish>] [-a | --all | <attr>...]"
 
 msgid "report all attributes set on file"
-msgstr ""
+msgstr "tuairisc a thabhairt ar gach tréithe atá leagtha síos"
 
 msgid "use .gitattributes only from the index"
-msgstr ""
+msgstr "bain úsáid as .gitattributs ach ón innéacs"
 
 msgid "read file names from stdin"
-msgstr ""
+msgstr "léigh ainmneacha comhaid ó stdin"
 
 msgid "terminate input and output records by a NUL character"
-msgstr ""
+msgstr "taifid ionchuir agus aschuir a fhoirceannadh le carachtar NUL"
 
 msgid "<tree-ish>"
-msgstr ""
+msgstr "<tree-ish>"
 
-#, fuzzy
 msgid "which tree-ish to check attributes at"
-msgstr "cén crainn le seiceáil uaidh"
+msgstr "cén crainn le tréithe a sheiceáil ag"
 
 msgid "suppress progress reporting"
 msgstr "cur chun cinn tuairiscithe"
 
 msgid "show non-matching input paths"
-msgstr ""
+msgstr "cosáin ionchuir neamh-mheaitseála"
 
 msgid "ignore index when checking"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar innéacs agus"
 
 msgid "cannot specify pathnames with --stdin"
-msgstr ""
+msgstr "ní féidir ainmneacha cosáin a shonrú le --stdin"
 
 msgid "-z only makes sense with --stdin"
-msgstr ""
+msgstr "Ní dhéanann -z ciall ach le --stdin"
 
-#, fuzzy
 msgid "no path specified"
-msgstr "sonraíocht cosáin nebhail"
+msgstr "níl aon chosán sonraithe"
 
 msgid "--quiet is only valid with a single pathname"
-msgstr ""
+msgstr "Níl --quiet bailí ach le ainm cosán amháin"
 
 msgid "cannot have both --quiet and --verbose"
-msgstr ""
+msgstr "ní féidir --quiet agus --verbose araon a bheith agat"
 
 msgid "--non-matching is only valid with --verbose"
-msgstr ""
+msgstr "Níl --non-matching bailí ach le --verbose"
 
-#, fuzzy
 msgid "git check-mailmap [<options>] <contact>..."
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git check-mailmap [<options>] <contact>..."
 
 msgid "also read contacts from stdin"
-msgstr ""
+msgstr "léigh teagmhálacha ó stdin freisin"
 
 msgid "read additional mailmap entries from file"
-msgstr ""
+msgstr "léigh iontrálacha ríomhphoist breise ón gcomhad"
 
 msgid "blob"
-msgstr ""
+msgstr "blob"
 
 msgid "read additional mailmap entries from blob"
-msgstr ""
+msgstr "léigh iontrálacha ríomhphoist breise ó blob"
 
 msgid "no contacts specified"
-msgstr ""
+msgstr "aon teagmhálacha sonraithe"
 
-#, fuzzy
 msgid "git checkout--worker [<options>]"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git checkout--worker [<options>]"
 
 msgid "string"
-msgstr ""
+msgstr "teaghrán"
 
 msgid "when creating files, prepend <string>"
-msgstr ""
+msgstr "agus comhaid á gcruthú agat, déan iarracht <string>"
 
-#, fuzzy
 msgid "git checkout-index [<options>] [--] [<file>...]"
-msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+msgstr "git checkout-index [<options>] [--] [<file>...]"
 
 msgid "stage should be between 1 and 3 or all"
-msgstr ""
+msgstr "ba chóir go mbeadh an chéim idir 1 agus 3 nó gach ceann"
 
 msgid "check out all files in the index"
-msgstr ""
+msgstr "seiceáil gach comhad san innéacs"
 
 msgid "do not skip files with skip-worktree set"
-msgstr ""
+msgstr "ná scipeáil comhaid le tacar scip-work tree"
 
 msgid "force overwrite of existing files"
-msgstr ""
+msgstr "athscríobh fórsa na gcomhaid atá ann cheana"
 
 msgid "no warning for existing files and files not in index"
 msgstr ""
+"gan aon rabhadh maidir le comhaid agus comhaid atá ann cheana nach bhfuil "
+"san innéacs"
 
 msgid "don't checkout new files"
-msgstr ""
+msgstr "ná seiceáil comhaid nua"
 
-#, fuzzy
 msgid "update stat information in the index file"
-msgstr "Nuashonraíodh %d cosán ón innéacs"
+msgstr "faisnéis stat a nuashonrú sa chomhad innéacs"
 
 msgid "read list of paths from the standard input"
-msgstr ""
+msgstr "léigh liosta na gcosáin ón ionchur caighdeánach"
 
 msgid "write the content to temporary files"
-msgstr ""
+msgstr "scríobh an t-ábhar chuig comhaid sealadacha"
 
 msgid "copy out the files from named stage"
-msgstr ""
+msgstr "cóipeáil amach na comhaid ón gcéim ainmnithe"
 
 msgid "git checkout [<options>] <branch>"
 msgstr "git checkout [<roghanna>] <brainse>"
@@ -3612,7 +3892,7 @@ msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
 msgstr ""
-"ní féidir brainse a athrú agus tú ag roghnú brainse nua\n"
+"ní féidir brainse a athrú agus tú ag cherry-picking\n"
 "Smaoinigh ar \"git cherry-pick --quit\" nó \"git worktree add\"."
 
 msgid ""
@@ -3778,37 +4058,38 @@ msgid ""
 "git clean [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] "
 "[<pathspec>...]"
 msgstr ""
+"<pathspec>git glan [-d] [-f] [-i] [-n] [-q] [-e] [- <pattern>x | -X] [--] "
+"[...]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Removing %s\n"
-msgstr "Deltas a réiteach"
+msgstr "Ag baint %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Would remove %s\n"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "Bainfeadh %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Skipping repository %s\n"
-msgstr "droch-stóras '%s'"
+msgstr "Ag scipeáil an stóras %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Would skip repository %s\n"
-msgstr "droch-stóras '%s'"
+msgstr "Scaipfeadh stóras %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to remove %s"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar %s a bhaint"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not lstat %s\n"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí lstat %s\n"
 
 msgid "Refusing to remove current working directory\n"
-msgstr ""
+msgstr "Ag diúltú an t-eolaire oibre reatha a bhaint\n"
 
-#, fuzzy
 msgid "Would refuse to remove current working directory\n"
-msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
+msgstr "Dhiúltódh sé/sí an t-eolaire oibre reatha a bhaint\n"
 
 #, c-format
 msgid ""
@@ -3817,6 +4098,10 @@ msgid ""
 "foo        - select item based on unique prefix\n"
 "           - (empty) select nothing\n"
 msgstr ""
+"Cabhair pras:\n"
+"1 - roghnaigh mír uimhrithe\n"
+"foo - roghnaigh mír bunaithe ar réimír uathúil\n"
+" - (folamh) roghnaigh aon rud\n"
 
 #, c-format
 msgid ""
@@ -3829,26 +4114,34 @@ msgid ""
 "*          - choose all items\n"
 "           - (empty) finish selecting\n"
 msgstr ""
+"Cabhair pras:\n"
+"1 - roghnaigh mír amháin\n"
+"3-5 - roghnaigh raon earraí\n"
+"2-3,6-9 - roghnaigh raonta iolracha\n"
+"foo - roghnaigh mír bunaithe ar réimír uathúil\n"
+"-... - míreanna sonraithe a dhíroghnú\n"
+"* - roghnaigh gach earra\n"
+" - (folamh) bailchríoch a roghnú\n"
 
 #, c-format
 msgid "Huh (%s)?\n"
-msgstr ""
+msgstr "Huh (%s)?\n"
 
 #, c-format
 msgid "Input ignore patterns>> "
-msgstr ""
+msgstr "Patrúin neamhaird ionchuir >> "
 
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
-msgstr ""
+msgstr "RABHADH: Ní féidir míreanna a mheaitseáil le: %s a aimsiú"
 
 msgid "Select items to delete"
-msgstr ""
+msgstr "Roghnaigh míreanna le scriosadh"
 
 #. TRANSLATORS: Make sure to keep [y/N] as is
 #, c-format
 msgid "Remove %s [y/N]? "
-msgstr ""
+msgstr "Bain %s [y/N]? "
 
 msgid ""
 "clean               - start cleaning\n"
@@ -3859,44 +4152,49 @@ msgid ""
 "help                - this screen\n"
 "?                   - help for prompt selection"
 msgstr ""
+"glan - tosú ag glanadh\n"
+"scagadh de réir patrún - eisiamh míreanna ó scriosadh\n"
+"roghnaigh de réir uimhreacha - roghnaigh míreanna atá le scriosadh de réir\n"
+"fiafraigh gach ceann - deimhnigh gach scriosadh (cosúil le “rm -i”)\n"
+"scor - stop glanadh\n"
+"cabhair - an scáileán seo\n"
+"? - cabhair le haghaidh roghnú pras"
 
 msgid "Would remove the following item:"
 msgid_plural "Would remove the following items:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Bhainfeadh sé an mhír seo a leanas:"
+msgstr[1] "Bainfí na míreanna seo a leanas:"
+msgstr[2] "Bainfí na míreanna seo a leanas:"
 
 msgid "No more files to clean, exiting."
-msgstr ""
+msgstr "Níl aon níos mó comhaid le glanadh, ag imeacht amach."
 
 msgid "do not print names of files removed"
-msgstr ""
+msgstr "ná priontáil ainmneacha na gcomhaid a bhaintear"
 
 msgid "force"
-msgstr ""
+msgstr "fórsa"
 
 msgid "interactive cleaning"
-msgstr ""
+msgstr "glanadh idirghní"
 
 msgid "remove whole directories"
-msgstr ""
+msgstr "bain eolairí iomlána"
 
 msgid "pattern"
-msgstr ""
+msgstr "patrún"
 
 msgid "add <pattern> to ignore rules"
-msgstr ""
+msgstr "cuir leis <pattern>na rialacha a neamhaird"
 
-#, fuzzy
 msgid "remove ignored files, too"
-msgstr "Comhaid neamhaird"
+msgstr "bain comhaid a neamhaird orthu, freisin"
 
-#, fuzzy
 msgid "remove only ignored files"
-msgstr "Comhaid neamhaird"
+msgstr "bain ach comhaid a neamhaird orthu"
 
 msgid "clean.requireForce is true and -f not given: refusing to clean"
-msgstr ""
+msgstr "tá clean.requireForce fíor agus ní thugtar -f: diúltú glanadh"
 
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
@@ -4221,38 +4519,38 @@ msgstr "Ní aimsíodh athbhreithniú iargúlta %s i suas sruth %s"
 msgid "You appear to have cloned an empty repository."
 msgstr "Is cosúil gur chlónaigh tú stór folamh."
 
-#, fuzzy
 msgid "git column [<options>]"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "colún git [<options>]"
 
 msgid "lookup config vars"
-msgstr ""
+msgstr "earraí cumraíochta cuardaigh"
 
 msgid "layout to use"
-msgstr ""
+msgstr "leagan amach le húsáid"
 
 msgid "maximum width"
-msgstr ""
+msgstr "leithead uasta"
 
 msgid "padding space on left border"
-msgstr ""
+msgstr "spás padding ar an teorainn chlé"
 
 msgid "padding space on right border"
-msgstr ""
+msgstr "spás padding ar an teorainn dheis"
 
 msgid "padding space between columns"
-msgstr ""
+msgstr "spás padding idir colúin"
 
 #, c-format
 msgid "%s must be non-negative"
-msgstr ""
+msgstr "Caithfidh %s a bheith neamh-diúltach"
 
 msgid "--command must be the first argument"
-msgstr ""
+msgstr "Ní mór gurb é --command an chéad argóint"
 
 msgid ""
 "git commit-graph verify [--object-dir <dir>] [--shallow] [--[no-]progress]"
 msgstr ""
+"git commit-graph verify [--object-dir <dir>] [--shallow] [--[no-]progress]"
 
 msgid ""
 "git commit-graph write [--object-dir <dir>] [--append]\n"
@@ -4262,125 +4560,135 @@ msgid ""
 "[no-]progress]\n"
 "                       <split-options>"
 msgstr ""
+"git commit-graph write [--object-dir <dir>] [--append]\n"
+"                       [--split[=<strategy>]] [--reachable | --stdin-packs | "
+"--stdin-commits]\n"
+"                       [--changed-paths] [--[no-]max-new-filters <n>] [--"
+"[no-]progress]\n"
+"                       <split-options>"
 
-#, fuzzy
 msgid "dir"
-msgstr "gitdir"
+msgstr "redir"
 
 msgid "the object directory to store the graph"
-msgstr ""
+msgstr "an eolaire réada chun an graf a stóráil"
 
 msgid "if the commit-graph is split, only verify the tip file"
-msgstr ""
+msgstr "má tá an graf coimite scoilte, ní fhíoraigh ach an comhad leid"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not open commit-graph '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Níor féidir graf coimisiúnaithe '%s' a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not open commit-graph chain '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí slabhra coimisi-graf '%s' a oscailt"
 
 #, c-format
 msgid "unrecognized --split argument, %s"
-msgstr ""
+msgstr "argóint --split gan aithint, %s"
 
 #, c-format
 msgid "unexpected non-hex object ID: %s"
-msgstr ""
+msgstr "id réada neamh-heicsidheachúlach gan choinne: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid object: %s"
-msgstr "réad blob neamhbhailí %s"
+msgstr "réad neamhbhailí: %s"
 
 #, c-format
 msgid "option `%s' expects a numerical value"
-msgstr ""
+msgstr "tá rogha `%s' ag súil le luach uimhriúil"
 
 msgid "start walk at all refs"
-msgstr ""
+msgstr "tosú ag siúl ag gach ceann"
 
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr ""
+"scanadh innéacsanna pacáiste atá liostaithe ag stdin le haghaidh gealltanais"
 
 msgid "start walk at commits listed by stdin"
-msgstr ""
+msgstr "tosú ag siúl ag gealltanais atá liostaithe ag stdin"
 
 msgid "include all commits already in the commit-graph file"
 msgstr ""
+"áireamh na gealltanais go léir cheana féin sa chomhad gráf coimisiúnaithe"
 
 msgid "enable computation for changed paths"
-msgstr ""
+msgstr "ríomh a chumasú le haghaidh cosáin athraithe"
 
 msgid "allow writing an incremental commit-graph file"
-msgstr ""
+msgstr "ligean comhad gráf choimisiúnaithe a scríobh"
 
 msgid "maximum number of commits in a non-base split commit-graph"
-msgstr ""
+msgstr "uaslíon na ngealltanais i ngráf coiste scoilte neamh-bhonn"
 
 msgid "maximum ratio between two levels of a split commit-graph"
-msgstr ""
+msgstr "cóimheas uasta idir dhá leibhéal de ghraf coimiste scoilte"
 
 msgid "only expire files older than a given date-time"
-msgstr ""
+msgstr "ní rachaidh in éag ach comhaid níos sine ná dáta-am ar leith"
 
 msgid "maximum number of changed-path Bloom filters to compute"
-msgstr ""
+msgstr "líon uasta scagairí Bloom cosáin athraithe le ríomh"
 
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
+"bain úsáid as ceann de --reachable, --stdin-commits, nó --stdin-packs ar a "
+"mhéad"
 
 msgid "Collecting commits from input"
-msgstr ""
+msgstr "Gealltanais a bhailiú ó ionchur"
 
 msgid "git commit-tree <tree> [(-p <parent>)...]"
-msgstr ""
+msgstr "<parent>git commit-tree <tree>[(-p)...]"
 
 msgid ""
 "git commit-tree [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
 "                [(-F <file>)...] <tree>"
 msgstr ""
+"<parent>git commit-tree [(-p)...] [-S [<keyid>]] [(-m<message>)...]\n"
+" [(-F<file>)...] <tree>"
 
 #, c-format
 msgid "duplicate parent %s ignored"
-msgstr ""
+msgstr "neamhaird déanta ar thuismitheoir dúblach %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a valid object name %s"
-msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+msgstr "ní ainm réad bailí %s"
 
 #, c-format
 msgid "git commit-tree: failed to read '%s'"
-msgstr ""
+msgstr "git commit-tree: theip ar '%s' a léamh"
 
 #, c-format
 msgid "git commit-tree: failed to close '%s'"
-msgstr ""
+msgstr "git commit-tree: theip ar '%s' a dhúnadh"
 
 msgid "parent"
-msgstr ""
+msgstr "tuismitheoir"
 
 msgid "id of a parent commit object"
-msgstr ""
+msgstr "id réad tiomanta tuismitheora"
 
 msgid "message"
-msgstr ""
+msgstr "teachtaireacht"
 
 msgid "commit message"
-msgstr ""
+msgstr "teachtaireacht a thabhairt"
 
 msgid "read commit log message from file"
-msgstr ""
+msgstr "léigh teachtaireacht logála tiomanta ón gcomhad"
 
-#, fuzzy
 msgid "GPG sign commit"
-msgstr "Síníonn GPG an brú"
+msgstr "Tiomantas comhartha GPG"
 
 msgid "must give exactly one tree"
-msgstr ""
+msgstr "caithfidh crann amháin a thabhairt go díreach"
 
 msgid "git commit-tree: failed to read"
-msgstr ""
+msgstr "git commit-tree: theip ar léamh"
 
 msgid ""
 "git commit [-a | --interactive | --patch] [-s] [-v] [-u[<mode>]] [--amend]\n"
@@ -4393,16 +4701,28 @@ msgid ""
 "           [(--trailer <token>[(=|:)<value>])...] [-S[<keyid>]]\n"
 "           [--] [<pathspec>...]"
 msgstr ""
+"git commit [-a | --interactive | --patch] [-s] [-v] [-u[<mode>]] [--amend]\n"
+"           [--dry-run] [(-c | -C | --squash) <commit> | --fixup [(amend|"
+"reword):]<commit>]\n"
+"           [-F <file> | -m <msg>] [--reset-author] [--allow-empty]\n"
+"           [--allow-empty-message] [--no-verify] [-e] [--author=<author>]\n"
+"           [--date=<date>] [--cleanup=<mode>] [--[no-]status]\n"
+"           [-i | -o] [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"           [(--trailer <token>[(=|:)<value>])...] [-S[<keyid>]]\n"
+"           [--] [<pathspec>...]"
 
-#, fuzzy
 msgid "git status [<options>] [--] [<pathspec>...]"
-msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+msgstr "stádas git [<options>] [--] [<pathspec>...]"
 
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
 "remove the commit entirely with \"git reset HEAD^\".\n"
 msgstr ""
+"D'iarr tú an gealltanas is déanaí a leasú, ach déanfaí amhlaidh a dhéanamh\n"
+"folamh é. Is féidir leat d'ordú a athdhéanamh le --allow-empty, nó is féidir "
+"leat\n"
+"bain an tiomantas go hiomlán le “git reset HEAD^”.\n"
 
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
@@ -4411,12 +4731,18 @@ msgid ""
 "    git commit --allow-empty\n"
 "\n"
 msgstr ""
+"Tá an pioc silíní roimhe seo folamh anois, b'fhéidir mar gheall ar réiteach "
+"coinbhleachta.\n"
+"Más mian leat é a dhéanamh ar aon nós, bain úsáid as:\n"
+"\n"
+"    git commit --allow-empty\n"
+"\n"
 
 msgid "Otherwise, please use 'git rebase --skip'\n"
-msgstr ""
+msgstr "Seachas sin, bain úsáid as 'git rebase --skip'\n"
 
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
-msgstr ""
+msgstr "Seachas sin, bain úsáid as 'git cherry-pick --skip'\n"
 
 msgid ""
 "and then use:\n"
@@ -4429,120 +4755,132 @@ msgid ""
 "    git cherry-pick --skip\n"
 "\n"
 msgstr ""
+"agus ansin bain úsáid as:\n"
+"\n"
+"    git cherry-pick --continue\n"
+"\n"
+"chun na gealltanais atá fágtha a atosú ag piocadh silíní.\n"
+"Más mian leat an tiomantas seo a scipeáil, bain úsáid as:\n"
+"\n"
+" git cherry-pick --skip\n"
 
-#, fuzzy
 msgid "updating files failed"
-msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
+msgstr "theip ar nuashonrú comhaid"
 
 msgid "failed to unpack HEAD tree object"
-msgstr ""
+msgstr "theip orthu réad crann HEAD a dhíphacáil"
 
 msgid "No paths with --include/--only does not make sense."
-msgstr ""
+msgstr "Níl ciall ag aon chosáin le --include/--only."
 
-#, fuzzy
 msgid "unable to create temporary index"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "in ann innéacs sealadach a chruthú"
 
 msgid "interactive add failed"
-msgstr ""
+msgstr "theip ar chur idirghníomh"
 
-#, fuzzy
 msgid "unable to update temporary index"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "in ann innéacs sealadach a nuashonrú"
 
 msgid "Failed to update main cache tree"
-msgstr ""
+msgstr "Theip ar phríomhchrann taisce a nuashonrú"
 
-#, fuzzy
 msgid "cannot do a partial commit during a merge."
-msgstr "Ní féidir athshocrú %s a dhéanamh i lár cumaisc."
+msgstr "ní féidir le tiomantas páirteach a dhéanamh le linn cumaisc."
 
 msgid "cannot do a partial commit during a cherry-pick."
-msgstr ""
+msgstr "ní féidir le tiomantas páirteach a dhéanamh le linn pioc silíní."
 
-#, fuzzy
 msgid "cannot do a partial commit during a rebase."
-msgstr "Tá tú ag eagarthóireacht tiomanta faoi láthair le linn athbhunaithe."
+msgstr "ní féidir le tiomantas páirteach a dhéanamh le linn athbhunaithe."
 
-#, fuzzy
 msgid "cannot read the index"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "ní féidir leis an innéacs a léamh"
 
-#, fuzzy
 msgid "unable to write temporary index file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann comhad innéacs sealadach a scríobh"
 
 #, c-format
 msgid "commit '%s' lacks author header"
-msgstr ""
+msgstr "níl ceannteideal údair ag comhoiriú '%s'"
 
 #, c-format
 msgid "commit '%s' has malformed author line"
-msgstr ""
+msgstr "comtal tá líne údair mífhoirmithe ag '%s'"
 
 msgid "malformed --author parameter"
-msgstr ""
+msgstr "paraiméadar --author mífhoirmithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid date format: %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "formáid dáta neamhbhailí: %s"
 
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
 msgstr ""
+"nach féidir carachtar tráchta a roghnú nach n-úsáidtear\n"
+"sa teachtaireacht tiomanta reatha"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not lookup commit '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí cuardach a dhéanamh ar '%s'"
 
 #, c-format
 msgid "(reading log message from standard input)\n"
-msgstr ""
+msgstr "(teachtaireacht log a léamh ó ionchur caighdeánach)\n"
 
 msgid "could not read log from standard input"
-msgstr ""
+msgstr "ní raibh in ann log a léamh ó ionchur caighdeánach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read log file '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann comhad logála '%s' a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "options '%s' and '%s:%s' cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr "ní féidir roghanna '%s' agus '%s: %s' a úsáid le chéile"
 
 msgid "could not read SQUASH_MSG"
-msgstr ""
+msgstr "ní raibh in ann SQUASH_MSG a léamh"
 
 msgid "could not read MERGE_MSG"
-msgstr ""
+msgstr "ní raibh in ann MERGE_MSG a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not open '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a oscailt"
 
-#, fuzzy
 msgid "could not write commit template"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní raibh sé in ann teimpléad tiomanta a"
 
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
 "with '%s' will be ignored.\n"
 msgstr ""
+"Cuir isteach an teachtaireacht tiomanta le haghaidh d'athruithe. Línte ag "
+"tosú\n"
+"déanfar neamhaird le '%s'.\n"
 
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
 "with '%s' will be ignored, and an empty message aborts the commit.\n"
 msgstr ""
+"Cuir isteach an teachtaireacht tiomanta le haghaidh d'athruithe. Línte ag "
+"tosú\n"
+"déanfar neamhaird le '%s', agus déanfar teachtaireacht folamh deireadh leis "
+"an tiomantas.\n"
 
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
 "with '%s' will be kept; you may remove them yourself if you want to.\n"
 msgstr ""
+"Cuir isteach an teachtaireacht tiomanta le haghaidh d'athruithe. Línte ag "
+"tosú\n"
+"coimeádfar le '%s'; féadfaidh tú iad a bhaint féin más mian leat.\n"
 
 #, c-format
 msgid ""
@@ -4550,6 +4888,10 @@ msgid ""
 "with '%s' will be kept; you may remove them yourself if you want to.\n"
 "An empty message aborts the commit.\n"
 msgstr ""
+"Cuir isteach an teachtaireacht tiomanta le haghaidh d'athruithe. Línte ag "
+"tosú\n"
+"coimeádfar le '%s'; féadfaidh tú iad a bhaint féin más mian leat.\n"
+"Déanann teachtaireacht folamh deireadh leis an tiomantas.\n"
 
 msgid ""
 "\n"
@@ -4558,6 +4900,11 @@ msgid ""
 "\tgit update-ref -d MERGE_HEAD\n"
 "and try again.\n"
 msgstr ""
+"\n"
+"Is cosúil go bhfuil tú ag déanamh cumasc.\n"
+"Mura bhfuil sé seo ceart, rith\n"
+"git update-ref -d MERGE_HEAD\n"
+"agus déan iarracht arís.\n"
 
 msgid ""
 "\n"
@@ -4566,440 +4913,457 @@ msgid ""
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "and try again.\n"
 msgstr ""
+"\n"
+"Is cosúil go bhfuil tú ag déanamh rogha neamhghnách.\n"
+"Mura bhfuil sé seo ceart, rith\n"
+"\tgit update-ref -d CHERRY_PICK_HEAD\n"
+"agus déan iarracht arís.\n"
 
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
-msgstr ""
+msgstr "%sÚdar:    %.*s <%.*s>"
 
 #, c-format
 msgid "%sDate:      %s"
-msgstr ""
+msgstr "%sDáta: %s"
 
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
-msgstr ""
+msgstr "%sCeannasaí: %.*s <%.*s>"
 
-#, fuzzy
 msgid "Cannot read index"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "Ní féidir innéacs a léamh"
 
-#, fuzzy
 msgid "unable to pass trailers to --trailers"
-msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+msgstr "nach féidir leantóirí a chur chuig --trailers"
 
 msgid "Error building trees"
-msgstr ""
+msgstr "Earráid ag tógáil crainn"
 
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr ""
+"Soláthair an teachtaireacht le do thoil ag baint úsáide as rogha -m nó -F.\n"
 
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
+"Ní 'Ainm' é --author '%s' agus ní mheaitseálann <email>aon údar atá ann "
+"cheana"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid ignored mode '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "Modh neamhbhailí neamhaird '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid untracked files mode '%s'"
-msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+msgstr "Modh comhaid neamhrianaithe neamhbhailí '%s'"
 
-#, fuzzy
 msgid "You are in the middle of a merge -- cannot reword."
-msgstr "Tá tú i lár seisiún am."
+msgstr "Tá tú i lár cumaisc - ní féidir athfhocal a athfhocal."
 
-#, fuzzy
 msgid "You are in the middle of a cherry-pick -- cannot reword."
-msgstr "Tá tú i lár seisiún am."
+msgstr "Tá tú i lár pioc silíní - ní féidir athfhocal a athfhocal."
 
-#, fuzzy, c-format
+#, c-format
 msgid "reword option of '%s' and path '%s' cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr "ní féidir rogha athfhocal de '%s' agus cosán '%s' a úsáid le chéile"
 
-#, fuzzy, c-format
+#, c-format
 msgid "reword option of '%s' and '%s' cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr "ní féidir rogha athfhocal de '%s' agus '%s' a úsáid le chéile"
 
 msgid "You have nothing to amend."
-msgstr ""
+msgstr "Níl aon rud le leasú agat."
 
-#, fuzzy
 msgid "You are in the middle of a merge -- cannot amend."
-msgstr "Tá tú i lár seisiún am."
+msgstr "Tá tú i lár cumaisc - ní féidir leat leasú."
 
-#, fuzzy
 msgid "You are in the middle of a cherry-pick -- cannot amend."
-msgstr "Tá tú i lár seisiún am."
+msgstr "Tá tú i lár rogha silíní - ní féidir leat leasú."
 
-#, fuzzy
 msgid "You are in the middle of a rebase -- cannot amend."
-msgstr "Tá tú i lár seisiún am."
+msgstr "Tá tú i lár athbhunaithe - ní féidir leat leasú."
 
-#, fuzzy
 msgid "--reset-author can be used only with -C, -c or --amend."
-msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+msgstr "Ní féidir --reset-author a úsáid ach le -C, -c nó --amend."
 
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
-msgstr ""
+msgstr "rogha anaithnid: --fixup=%s:%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "paths '%s ...' with -a does not make sense"
-msgstr "níl ár leagan ag cosán '%s'"
+msgstr "ní chiallaíonn cosáin '%s... 'le -a"
 
 msgid "show status concisely"
-msgstr ""
+msgstr "taispeáin stádas go hachomair"
 
-#, fuzzy
 msgid "show branch information"
-msgstr "cumraíocht rianaithe brainse a shoc"
+msgstr "taispeáin faisnéis bhrainse"
 
 msgid "show stash information"
-msgstr ""
+msgstr "taispeáin faisnéis stash"
 
 msgid "compute full ahead/behind values"
-msgstr ""
+msgstr "luachanna iomlána/taobh thiar de na luachanna a ríomh"
 
 msgid "version"
-msgstr ""
+msgstr "leagan"
 
 msgid "machine-readable output"
 msgstr "aschur inléite meaisín"
 
 msgid "show status in long format (default)"
-msgstr ""
+msgstr "stádas taispeáint i bhformáid fhada (réamhshocraithe)"
 
 msgid "terminate entries with NUL"
-msgstr ""
+msgstr "foirceannadh na hiontrálacha"
 
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
+"taispeáin comhaid neamhrianaithe, modhanna roghnacha: gach, gnáth, níl. "
+"(Réamhshocraithe: gach)"
 
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
 msgstr ""
+"taispeáint comhaid neamhaird orthu, modhanna roghnacha: traidisiúnta, "
+"meaitseáil, (Réamhshocraithe: traidisiúnta)"
 
 msgid "when"
-msgstr ""
+msgstr "nuair a"
 
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
 msgstr ""
+"neamhaird a dhéanamh ar athruithe ar fho-mhodúil, roghnach nuair a bhíonn: "
+"gach, salach, gan rianú. (Réamhshocraithe: gach)"
 
-#, fuzzy
 msgid "list untracked files in columns"
-msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+msgstr "liostáil comhaid neamhrianaithe i gcolúin"
 
 msgid "do not detect renames"
-msgstr ""
+msgstr "ná athainmneacha a bhrath"
 
 msgid "detect renames, optionally set similarity index"
-msgstr ""
+msgstr "athainmneacha a bhrath, innéacs cosúlachta a shocrú go ro"
 
 msgid "Unsupported combination of ignored and untracked-files arguments"
-msgstr ""
+msgstr "Teaglaim gan tacaíocht d'argóintí comhaid a neamhaird agus gan rianú"
 
 msgid "suppress summary after successful commit"
-msgstr ""
+msgstr "achoimre a chur faoi chois tar éis tiomantas"
 
 msgid "show diff in commit message template"
-msgstr ""
+msgstr "taispeáin diff i teimpléad teachtaireachta tiomanta"
 
 msgid "Commit message options"
-msgstr ""
+msgstr "Tiomanta roghanna teachtaire"
 
 msgid "read message from file"
-msgstr ""
+msgstr "léigh teachtaireacht ón gcomhad"
 
 msgid "author"
-msgstr ""
+msgstr "údar"
 
 msgid "override author for commit"
-msgstr ""
+msgstr "an t-údar a shárú le haghaidh tiomantas"
 
 msgid "date"
-msgstr ""
+msgstr "dáta"
 
 msgid "override date for commit"
-msgstr ""
+msgstr "dáta athsháraithe le haghaidh tiomanta"
 
-#, fuzzy
 msgid "commit"
-msgstr "tiomantais nua, "
+msgstr "tiomantas"
 
 msgid "reuse and edit message from specified commit"
-msgstr ""
+msgstr "teachtaireacht a athúsáid agus a chur in eagar ó thiomantas"
 
 msgid "reuse message from specified commit"
-msgstr ""
+msgstr "teachtaireacht athúsáid ó thiomantas sonraithe"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
 msgid "[(amend|reword):]commit"
-msgstr ""
+msgstr "[(leaso|athfhocal):] comhartha"
 
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
+"úsáid teachtaireacht fhormáidithe autosquash chun gealltanas sonraithe a "
+"shocrú nó a leasú/athfhocal"
 
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
+"úsáid teachtaireacht fhormáidithe autosquash chun tiomantas sonraithe squash"
 
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
-msgstr ""
+msgstr "tá an gealltanas údar agam anois (úsáidtear le -C/-c/--amend)"
 
 msgid "trailer"
-msgstr ""
+msgstr "leantóir"
 
 msgid "add custom trailer(s)"
-msgstr ""
+msgstr "cuir leantóir (í) saincheaptha"
 
 msgid "add a Signed-off-by trailer"
-msgstr ""
+msgstr "cuir leantóir sínithe as"
 
 msgid "use specified template file"
-msgstr ""
+msgstr "úsáid comhad teimpléad sonraithe"
 
-#, fuzzy
 msgid "force edit of commit"
-msgstr "níl aon athruithe curtha le tiomantas\n"
+msgstr "eagarthóireacht fórsa ar thiomantas"
 
 msgid "include status in commit message template"
-msgstr ""
+msgstr "áireamh stádas i dteimpléad teachtaireachta"
 
 msgid "Commit contents options"
-msgstr ""
+msgstr "Tiomnaigh roghanna ábhair"
 
 msgid "commit all changed files"
-msgstr ""
+msgstr "gach comhad athraithe a thiomnú"
 
 msgid "add specified files to index for commit"
-msgstr ""
+msgstr "cuir comhaid sonraithe leis an innéacs le haghaidh tiomanta"
 
-#, fuzzy
 msgid "interactively add files"
-msgstr "Comhaid neamhrianaithe"
+msgstr "cuir comhaid idirghníomhach"
 
 msgid "interactively add changes"
-msgstr ""
+msgstr "cuir athruithe idirghníomhach"
 
 msgid "commit only specified files"
-msgstr ""
+msgstr "ach comhaid shonraithe a dhéanamh"
 
 msgid "bypass pre-commit and commit-msg hooks"
-msgstr ""
+msgstr "seachbhóthar crúcaí réamh-thiomanta agus comh-msg"
 
-#, fuzzy
 msgid "show what would be committed"
-msgstr "Athruithe atá le déanamh:"
+msgstr "taispeáint cad a bheadh tiomanta"
 
 msgid "amend previous commit"
-msgstr ""
+msgstr "leasú a leasú"
 
-#, fuzzy
 msgid "bypass post-rewrite hook"
-msgstr "seachbhóthar crúca réamh"
+msgstr "seachbhóthar crúca iar-athsc"
 
 msgid "ok to record an empty change"
-msgstr ""
+msgstr "ceart go leor chun athrú folamh a thaifeadadh"
 
 msgid "ok to record a change with an empty message"
-msgstr ""
+msgstr "ceart go leor chun athrú a thaifeadadh le teachtaireacht folamh"
 
-#, fuzzy
 msgid "could not parse HEAD commit"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "ní fhéadfadh sé gealltanas HEAD a pharsáil"
 
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
-msgstr ""
+msgstr "Comhad truaillithe MERGE_HEAD (%s)"
 
 msgid "could not read MERGE_MODE"
-msgstr ""
+msgstr "ní raibh in ann MERGE_MODE a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read commit message: %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní féidir teachtaireacht tiomanta a léamh: %s"
 
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
-msgstr ""
+msgstr "Tiomantas a ghabháil mar gheall ar theachtaireacht tiomanta folamh\n"
 
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
-msgstr ""
+msgstr "Tiomantas a ghearradh; níor chuir tú an teachtaireacht in eagar.\n"
 
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr ""
+"Tiomantas a ghabháil mar gheall ar chorp teachtaireachta tiomanta folamh.\n"
 
 msgid ""
 "repository has been updated, but unable to write\n"
 "new index file. Check that disk is not full and quota is\n"
 "not exceeded, and then \"git restore --staged :/\" to recover."
 msgstr ""
+"nuashonraíodh an stór, ach ní féidir scríobh\n"
+"comhad innéacs nua. Seiceáil nach bhfuil an diosca \n"
+"lán agus nach bhfuil an cuóta sáraithe, agus ansin \"git restore --staged :/"
+"\" chun é a aisghabháil."
 
 msgid "git config list [<file-option>] [<display-option>] [--includes]"
-msgstr ""
+msgstr "liosta config git [<file-option>] [<display-option>] [--include]"
 
 msgid ""
 "git config get [<file-option>] [<display-option>] [--includes] [--all] [--"
 "regexp] [--value=<value>] [--fixed-value] [--default=<default>] <name>"
 msgstr ""
+"<value><default>git config a fháil [<file-option>] [] [--include<display-"
+"option>] [--all] [--regexp] [--value=] [--luach seasta] [--default=] <name>"
 
 msgid ""
 "git config set [<file-option>] [--type=<type>] [--all] [--value=<value>] [--"
 "fixed-value] <name> <value>"
 msgstr ""
+"<value>git config set [<file-option>] [--type =] [--all] [--value=<type>] [--"
+"luach seasta] <name><value>"
 
 msgid ""
 "git config unset [<file-option>] [--all] [--value=<value>] [--fixed-value] "
 "<name>"
 msgstr ""
+"<value>git config gan socrú [] [--gach<file-option>] [--value=] [--luach "
+"seasta] <name>"
 
 msgid "git config rename-section [<file-option>] <old-name> <new-name>"
-msgstr ""
+msgstr "<file-option>roinn athainmnithe git config [] <old-name><new-name>"
 
 msgid "git config remove-section [<file-option>] <name>"
-msgstr ""
+msgstr "<file-option>roinn aistrithe git config [] <name>"
 
 msgid "git config edit [<file-option>]"
-msgstr ""
+msgstr "<file-option>Eagarthóireacht config git []"
 
 msgid "git config [<file-option>] --get-colorbool <name> [<stdout-is-tty>]"
-msgstr ""
+msgstr "<name><stdout-is-tty>git config [<file-option>] --get-colorbool []"
 
 msgid ""
 "git config get [<file-option>] [<display-option>] [--includes] [--all] [--"
 "regexp=<regexp>] [--value=<value>] [--fixed-value] [--default=<default>] "
 "<name>"
 msgstr ""
+"<value><default>git config a fháil [<file-option>] [] [--include<display-"
+"option>] [--all] [--regexp=] [-- <regexp>value=] [--luach seasta] [--"
+"default=] <name>"
 
 msgid ""
 "git config set [<file-option>] [--type=<type>] [--comment=<message>] [--all] "
 "[--value=<value>] [--fixed-value] <name> <value>"
 msgstr ""
+"<value>git config set [<file-option>] [--type =] [--comment =<type>] [--all] "
+"[--value=<message>] [--luach seasta] <name><value>"
 
 msgid "Config file location"
-msgstr ""
+msgstr "Suíomh comhad Config"
 
 msgid "use global config file"
-msgstr ""
+msgstr "bain úsáid as comhad cumraíochta domhanda"
 
 msgid "use system config file"
-msgstr ""
+msgstr "bain úsáid as comhad cumraíochta córais"
 
-#, fuzzy
 msgid "use repository config file"
-msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+msgstr "bain úsáid as comhad cumraíochta stórais"
 
-#, fuzzy
 msgid "use per-worktree config file"
-msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+msgstr "bain úsáid as comhad cumraíochta in aghaidh an chrann oibre"
 
 msgid "use given config file"
-msgstr ""
+msgstr "bain úsáid as comhad cumraíochta tugtha"
 
 msgid "blob-id"
-msgstr ""
+msgstr "blob-id"
 
 msgid "read config from given blob object"
-msgstr ""
+msgstr "léigh cumraíocht ó réad blob a thugtar"
 
 msgid "Type"
-msgstr ""
+msgstr "Cineál"
 
 msgid "type"
-msgstr ""
+msgstr "cineál"
 
 msgid "value is given this type"
-msgstr ""
+msgstr "tugtar luach an cineál seo"
 
 msgid "value is \"true\" or \"false\""
-msgstr ""
+msgstr "tá luach “fíor” nó “bréagach”"
 
 msgid "value is decimal number"
-msgstr ""
+msgstr "is é luach uimhir deachúil"
 
 msgid "value is --bool or --int"
-msgstr ""
+msgstr "is é luach --bool nó --int"
 
 msgid "value is --bool or string"
-msgstr ""
+msgstr "is é luach --bool nó teaghrán"
 
 msgid "value is a path (file or directory name)"
-msgstr ""
+msgstr "is cosán é luach (ainm comhad nó eolaire)"
 
 msgid "value is an expiry date"
-msgstr ""
+msgstr "is dáta éaga é luach"
 
 msgid "Display options"
-msgstr ""
+msgstr "Roghanna taispeána"
 
 msgid "terminate values with NUL byte"
-msgstr ""
+msgstr "foirceannadh luachanna le nóta NUL"
 
 msgid "show variable names only"
-msgstr ""
+msgstr "taispeáin ainmneacha athróg amháin"
 
 msgid "show origin of config (file, standard input, blob, command line)"
 msgstr ""
+"taispeáint bunús an chumraíochta (comhad, ionchur caighdeánach, blob, líne "
+"ordaithe)"
 
 msgid "show scope of config (worktree, local, global, system, command)"
 msgstr ""
+"taispeáin raon feidhme an chumraíochta (crann oibre, áitiúil, domhanda, "
+"córas, ordú)"
 
 msgid "show config keys in addition to their values"
-msgstr ""
+msgstr "taispeáin eochracha cumraithe i dteannta lena luachanna"
 
 #, c-format
 msgid "unrecognized --type argument, %s"
-msgstr ""
+msgstr "argóint --type gan aithint, %s"
 
 msgid "only one type at a time"
-msgstr ""
+msgstr "ach cineál amháin ag an am"
 
 #, c-format
 msgid "wrong number of arguments, should be %d"
-msgstr ""
+msgstr "líon mícheart na n-argóintí, ba chóir go mbeadh %d"
 
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
-msgstr ""
+msgstr "ba chóir go mbeadh líon mícheart na n-argóintí ó %d go %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid key pattern: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "patrún eochair neamhbhailí: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid pattern: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "patrún neamhbhailí: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to format default config value: %s"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar luach cumraíochta réamhshocraithe a fhormáidiú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot parse color '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir dath '%s' a pháirseáil"
 
-#, fuzzy
 msgid "unable to parse default color value"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "in ann luach dath réamhshocraithe a pharsáil"
 
-#, fuzzy
 msgid "not in a git directory"
-msgstr "Tá %s ann agus ní eolaire é"
+msgstr "nach bhfuil i eolaire git"
 
 msgid "writing to stdin is not supported"
-msgstr ""
+msgstr "ní thacaítear le scríobh chuig stdin"
 
 msgid "writing config blobs is not supported"
-msgstr ""
+msgstr "ní thacaítear le blobs cumraíochta a scríobh"
 
 #, c-format
 msgid ""
@@ -5009,194 +5373,202 @@ msgid ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 msgstr ""
+"# Seo comhad cumraíochta Git in aghaidh an úsáideora.\n"
+"[úsáideoir]\n"
+"# Oiriúnaigh agus bain trácht de na línte seo a leanas le do thoil:\n"
+"#\tainm = %s\n"
+"#\tríomhphost = %s\n"
 
 msgid "only one config file at a time"
-msgstr ""
+msgstr "ach comhad cumraithe amháin ag an am"
 
-#, fuzzy
 msgid "--local can only be used inside a git repository"
-msgstr "--stdin teastaíonn stórlann git"
+msgstr "Ní féidir --local a úsáid ach taobh istigh de stór git"
 
-#, fuzzy
 msgid "--blob can only be used inside a git repository"
-msgstr "--stdin teastaíonn stórlann git"
+msgstr "Ní féidir --blob a úsáid ach taobh istigh de stór git"
 
-#, fuzzy
 msgid "--worktree can only be used inside a git repository"
-msgstr "--stdin teastaíonn stórlann git"
+msgstr "Ní féidir --worktree a úsáid ach taobh istigh de stór git"
 
 msgid "$HOME not set"
-msgstr ""
+msgstr "Níl $HOME socraithe"
 
 msgid ""
 "--worktree cannot be used with multiple working trees unless the config\n"
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
 "section in \"git help worktree\" for details"
 msgstr ""
+"Ní féidir --worktree a úsáid le crainn oibre iolracha mura bhfuil an "
+"cumraíocht\n"
+"Tá síneadh WorkTreeConfig cumasaithe. Léigh “COMHAD CUMRAÍOCHTA”\n"
+"roinn i “git help worktree” le haghaidh sonraí"
 
 msgid "Other"
-msgstr ""
+msgstr "Eile"
 
 msgid "respect include directives on lookup"
-msgstr ""
+msgstr "meas lena n-áirítear treoracha maidir le cuardach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read config file '%s'"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir an comhad cumraithe '%s' a léamh"
 
-#, fuzzy
 msgid "error processing config file(s)"
-msgstr "earráid agus comhad pacáiste á dúnadh"
+msgstr "comhad (í) cumraíochta próiseála earráide"
 
 msgid "Filter options"
-msgstr ""
+msgstr "Roghanna scagaire"
 
 msgid "return all values for multi-valued config options"
 msgstr ""
+"gach luach a thabhairt ar ais le haghaidh roghanna cumraithe illuachmhara"
 
 msgid "interpret the name as a regular expression"
-msgstr ""
+msgstr "léirmhíniú an t-ainm mar abairt rialta"
 
 msgid "show config with values matching the pattern"
-msgstr ""
+msgstr "taispeáin cumraíocht le luachanna a mheaitseann an phatrún"
 
 msgid "use string equality when comparing values to value pattern"
-msgstr ""
+msgstr "bain úsáid as comhionannas sreangán agus luachanna á gcomparáid"
 
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 msgid "show config matching the given URL"
-msgstr ""
+msgstr "taispeáin configí a mheaitseáil leis an URL tugtha"
 
-#, fuzzy
 msgid "value"
-msgstr "eochair=luach"
+msgstr "luach"
 
 msgid "use default value when missing entry"
-msgstr ""
+msgstr "bain úsáid as luach réamhshocraithe agus iontráil"
 
 msgid "--fixed-value only applies with 'value-pattern'"
-msgstr ""
+msgstr "Ní bhaineann --fixed-value ach le 'patrún luacha'"
 
-#, fuzzy
 msgid "--default= cannot be used with --all or --url="
-msgstr ""
-"clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
+msgstr "Ní féidir --default= a úsáid le --all nó --url ="
 
-#, fuzzy
 msgid "--url= cannot be used with --all, --regexp or --value"
-msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+msgstr "Ní féidir --url = a úsáid le --all, --regexp nó --value"
 
 msgid "Filter"
-msgstr ""
+msgstr "Scagaire"
 
 msgid "replace multi-valued config option with new value"
-msgstr ""
+msgstr "luach nua a chur in ionad rogha cumraíochta illuachmhara"
 
 msgid "human-readable comment string (# will be prepended as needed)"
 msgstr ""
+"teaghrán tráchtaireachta inléite don duine (déanfar # a ullmhú de réir mar "
+"is gá)"
 
 msgid "add a new line without altering any existing values"
-msgstr ""
+msgstr "líne nua a chur leis gan aon luachanna atá ann cheana a athrú"
 
 msgid "--fixed-value only applies with --value=<pattern>"
-msgstr ""
+msgstr "ní bhaineann --fixed-value ach le --value=<pattern>"
 
-#, fuzzy
 msgid "--append cannot be used with --value=<pattern>"
-msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+msgstr "Ní féidir --append a úsáid le --value=<pattern>"
 
 #, c-format
 msgid ""
 "cannot overwrite multiple values with a single value\n"
 "       Use a regexp, --add or --replace-all to change %s."
 msgstr ""
+"ní féidir luachanna iolracha a fhorscríobh le luach amháin\n"
+" Úsáid regexp, --add nó --replace-all chun %s a athrú."
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such section: %s"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "gan aon chuid den sórt sin: %s"
 
 msgid "editing stdin is not supported"
-msgstr ""
+msgstr "ní thacaítear le stdin eagarthóireachta"
 
 msgid "editing blobs is not supported"
-msgstr ""
+msgstr "ní thacaítear le blobs eagarthóireachta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot create configuration file %s"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir comhad cumraíochta %s a chruthú"
 
 msgid "Action"
-msgstr ""
+msgstr "Gníomhaíocht"
 
 msgid "get value: name [<value-pattern>]"
-msgstr ""
+msgstr "luach a fháil: ainm [<value-pattern>]"
 
 msgid "get all values: key [<value-pattern>]"
-msgstr ""
+msgstr "faigh na luachanna go léir: eochair [<value-pattern>]"
 
 msgid "get values for regexp: name-regex [<value-pattern>]"
-msgstr ""
+msgstr "<value-pattern>luachanna a fháil do regexp: ainm-regex []"
 
 msgid "get value specific for the URL: section[.var] URL"
-msgstr ""
+msgstr "faigh luach sonrach don URL: rannán [.var] URL"
 
 msgid "replace all matching variables: name value [<value-pattern>]"
-msgstr ""
+msgstr "athróg meaitseála go léir in ionad: luach ainm [<value-pattern>]"
 
 msgid "add a new variable: name value"
-msgstr ""
+msgstr "cuir athróg nua leis: luach ainm"
 
 msgid "remove a variable: name [<value-pattern>]"
-msgstr ""
+msgstr "bhaint athróg: ainm [<value-pattern>]"
 
 msgid "remove all matches: name [<value-pattern>]"
-msgstr ""
+msgstr "bhaint gach cluiche: ainm [<value-pattern>]"
 
 msgid "rename section: old-name new-name"
-msgstr ""
+msgstr "athainmnigh an chuid: sean-ainm nua-ainm"
 
 msgid "remove a section: name"
-msgstr ""
+msgstr "cuid a bhaint: ainm"
 
 msgid "list all"
-msgstr ""
+msgstr "liostáil go léir"
 
 msgid "open an editor"
-msgstr ""
+msgstr "eagarthóir a oscailt"
 
 msgid "find the color configured: slot [<default>]"
-msgstr ""
+msgstr "faigh an dath cumraithe: sliotán [<default>]"
 
 msgid "find the color setting: slot [<stdout-is-tty>]"
-msgstr ""
+msgstr "faigh an socrú dath: sliotán [<stdout-is-tty>]"
 
 msgid "with --get, use default value when missing entry"
-msgstr ""
+msgstr "le --get, bain úsáid as luach réamhshocraithe agus iontráil in easnamh"
 
 msgid "--get-color and variable type are incoherent"
-msgstr ""
+msgstr "Tá --get-color agus cineál athraitheach neamhchomhtháite"
 
 msgid "no action specified"
-msgstr ""
+msgstr "aon ghníomh sonraithe"
 
 msgid "--name-only is only applicable to --list or --get-regexp"
-msgstr ""
+msgstr "Níl --name-only infheidhme ach le --list nó --get-regexp"
 
 msgid ""
 "--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
 "list"
 msgstr ""
+"Níl --show-origin infheidhme ach le --get, --get-all, --get-regexp, agus --"
+"list"
 
 msgid "--default is only applicable to --get"
-msgstr ""
+msgstr "Níl --default infheidhme ach le --get"
 
 msgid "--comment is only applicable to add/set/replace operations"
 msgstr ""
+"Níl --comment infheidhme ach le hoibríochtaí a chur leis /socraí/athsholáthar"
 
 msgid "print sizes in human readable format"
-msgstr ""
+msgstr "méideanna priontála i bhformáid inléite don duine"
 
 #, c-format
 msgid ""
@@ -5205,498 +5577,511 @@ msgid ""
 "\n"
 "\tchmod 0700 %s"
 msgstr ""
+"Tá na ceadanna ar d'eolaire soicéad ró-scaoilte; eile\n"
+"b'fhéidir go mbeidh úsáideoirí in ann do dhintiúir taiscéadaithe a léamh. "
+"Smaoinigh ar rith:\n"
+"\n"
+" chmod 0700 %s"
 
 msgid "print debugging messages to stderr"
-msgstr ""
+msgstr "teachtaireachtaí dífhabhtaithe a phriontáil chuig stderr"
 
 msgid "credential-cache--daemon unavailable; no unix socket support"
-msgstr ""
+msgstr "credential-cache--daemon ar fáil; gan aon tacaíocht soicéad unix"
 
 msgid "credential-cache unavailable; no unix socket support"
-msgstr ""
+msgstr "taisce creidiúnaithe ar fáil; gan aon tacaíocht soicéad unix"
 
 #, c-format
 msgid "unable to get credential storage lock in %d ms"
-msgstr ""
+msgstr "in ann glas stórála creidiúnaithe a fháil in %d ms"
 
 msgid ""
 "git describe [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]"
 msgstr ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]"
 
 msgid ""
 "git describe [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]"
 msgstr ""
+"git describe [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]"
 
 msgid "git describe <blob>"
-msgstr ""
+msgstr "git cur síos <blob>"
 
-#, fuzzy
 msgid "head"
-msgstr "chun tosaigh "
+msgstr "ceann"
 
 msgid "lightweight"
-msgstr ""
+msgstr "éadrom"
 
 msgid "annotated"
-msgstr ""
+msgstr "anótáilte"
 
 #, c-format
 msgid "annotated tag %s not available"
-msgstr ""
+msgstr "níl clib anótáilte %s ar fáil"
 
 #, c-format
 msgid "tag '%s' is externally known as '%s'"
-msgstr ""
+msgstr "tugtar '%s' ar an gclib '%s' go seachtrach"
 
 #, c-format
 msgid "no tag exactly matches '%s'"
-msgstr ""
+msgstr "níl aon chlib ag teacht go díreach le '%s'"
 
 #, c-format
 msgid "No exact match on refs or tags, searching to describe\n"
 msgstr ""
+"Níl aon mheaitseáil cruinn ar thaifeanna nó clibeanna, ag cuardach chun cur "
+"síos\n"
 
 #, c-format
 msgid "finished search at %s\n"
-msgstr ""
+msgstr "cuardach críochnaithe ag %s\n"
 
 #, c-format
 msgid ""
 "No annotated tags can describe '%s'.\n"
 "However, there were unannotated tags: try --tags."
 msgstr ""
+"Ní féidir le haon chlibeanna anótaithe cur síos a dhéanamh ar '%s'.\n"
+"Mar sin féin, bhí clibeanna gan anótáil ann: triail as --tags."
 
 #, c-format
 msgid ""
 "No tags can describe '%s'.\n"
 "Try --always, or create some tags."
 msgstr ""
+"Ní féidir le clibeanna cur síos a dhéanamh ar '%s'.\n"
+"Bain triail as --always, nó cruthaigh roinnt clibeanna."
 
 #, c-format
 msgid "traversed %lu commits\n"
-msgstr ""
+msgstr "gealltanais %lu a thrasnaíodh\n"
 
 #, c-format
 msgid "found %i tags; gave up search at %s\n"
-msgstr ""
+msgstr "fuarthas %i clibeanna; thréig an cuardach ag %s\n"
 
 #, c-format
 msgid "describe %s\n"
-msgstr ""
+msgstr "déan cur síos ar %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Not a valid object name %s"
-msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+msgstr "Ní ainm réad bailí %s"
 
 #, c-format
 msgid "%s is neither a commit nor blob"
-msgstr ""
+msgstr "Ní gealltanas ná blob é %s"
 
 msgid "find the tag that comes after the commit"
-msgstr ""
+msgstr "faigh an chlib a thagann tar éis an tiomanta"
 
 msgid "debug search strategy on stderr"
-msgstr ""
+msgstr "straitéis cuardaigh dífhabhtú ar stderr"
 
 msgid "use any ref"
-msgstr ""
+msgstr "bain úsáid as aon tagairt"
 
 msgid "use any tag, even unannotated"
-msgstr ""
+msgstr "úsáid aon chlib, fiú gan anótáil"
 
 msgid "always use long format"
-msgstr ""
+msgstr "úsáid formáid fada i gcónaí"
 
 msgid "only follow first parent"
-msgstr ""
+msgstr "lean ach an chéad thuismitheoir"
 
 msgid "only output exact matches"
-msgstr ""
+msgstr "ach cluichí cruinne aschuir"
 
 msgid "consider <n> most recent tags (default: 10)"
-msgstr ""
+msgstr "machnamh <n>ar na clibeanna is déanaí (réamhshocraithe: 10)"
 
 msgid "only consider tags matching <pattern>"
-msgstr ""
+msgstr "ní mheas ach meaitseáil clibeanna <pattern>"
 
 msgid "do not consider tags matching <pattern>"
-msgstr ""
+msgstr "ná smaoinigh ar mheaitseáil clibeanna <pattern>"
 
 msgid "show abbreviated commit object as fallback"
-msgstr ""
+msgstr "taispeáint réad tiomanta giorraithe mar fhilleadh"
 
 msgid "mark"
-msgstr ""
+msgstr "marc"
 
-#, fuzzy
 msgid "append <mark> on dirty working tree (default: \"-dirty\")"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr "cuir isteach <mark>ar chrann oibre salach (réamhshocraithe: “-salach”)"
 
 msgid "append <mark> on broken working tree (default: \"-broken\")"
-msgstr ""
+msgstr "cuir isteach <mark>ar chrann oibre briste (réamhshocraithe: “-broken”)"
 
 msgid "No names found, cannot describe anything."
 msgstr ""
+"Níor aimsíodh aon ainmneacha, ní féidir cur síos a dhéanamh ar aon rud."
 
-#, fuzzy, c-format
+#, c-format
 msgid "option '%s' and commit-ishes cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr "ní féidir rogha '%s' agus coimistí a úsáid le chéile"
 
 msgid ""
 "git diagnose [(-o | --output-directory) <path>] [(-s | --suffix) <format>]\n"
 "             [--mode=<mode>]"
 msgstr ""
+"<format>git diagnosis [(-o | --output-directory)] [(-s | -- <path>suffix)]\n"
+" <mode>[--mód =]"
 
 msgid "specify a destination for the diagnostics archive"
-msgstr ""
+msgstr "sonraigh ceann scríbe don chartlann diagnóisic"
 
 msgid "specify a strftime format suffix for the filename"
-msgstr ""
+msgstr "sonraigh iarmhír formáid strftime don ainm comhaid"
 
 msgid "specify the content of the diagnostic archive"
-msgstr ""
+msgstr "sonraigh ábhar an chartlann dhiagnóiseach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse mode: %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir modh a pháirseáil: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse object id: %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir id réad a pháirseáil: %s"
 
 msgid "git diff-pairs -z [<diff-options>]"
-msgstr ""
+msgstr "git diff-pairs -z [<diff-options>]"
 
 #, c-format
 msgid "unrecognized argument: %s"
-msgstr ""
+msgstr "argóint gan aithint: %s"
 
 msgid "working without -z is not supported"
-msgstr ""
+msgstr "ní thacaítear le bheith ag obair gan -z"
 
-#, fuzzy
 msgid "pathspec arguments not supported"
-msgstr "Ní féidir argóintí '%s' agus pathspec a úsáid le chéile"
+msgstr "argóintí pathspec nach dtacaítear leis"
 
-#, fuzzy
 msgid "revision arguments not allowed"
-msgstr "theip ar socrú siúlóid ath"
+msgstr "argóintí athbhreithnithe nach"
 
 msgid "invalid raw diff input"
-msgstr ""
+msgstr "ionchur diff amh neamhbhailí"
 
 msgid "tree objects not supported"
-msgstr ""
+msgstr "rudaí crann nach dtacaítear leis"
 
 msgid "got EOF while reading path"
-msgstr ""
+msgstr "fuair EOF agus tú ag léamh cosán"
 
 msgid "got EOF while reading destination path"
-msgstr ""
+msgstr "fuair EOF agus tú ag léamh cosán ceann scríbe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse rename/copy score: %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir scór athainmniú/cóipeáil a pháirseáil: %s"
 
 #, c-format
 msgid "unknown diff status: %c"
-msgstr ""
+msgstr "stádas diff anaithnid: %c"
 
 msgid "--merge-base only works with two commits"
-msgstr ""
+msgstr "Ní oibríonn --merge-base ach le dhá thiomantas"
 
 #, c-format
 msgid "'%s': not a regular file or symlink"
-msgstr ""
+msgstr "'%s': ní comhad rialta nó comhnasc"
 
 msgid "no merge given, only parents."
-msgstr ""
+msgstr "ní thugtar aon chumasc, tuismitheoirí amháin."
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid option: %s"
-msgstr "%s neamhbhailí"
+msgstr "rogha neamhbhailí: %s"
 
 #, c-format
 msgid "%s...%s: no merge base"
-msgstr ""
+msgstr "%s... %s: gan aon bhonn cumaisc"
 
-#, fuzzy
 msgid "Not a git repository"
-msgstr "stóras lom a chruthú"
+msgstr "Ní stór git"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid object '%s' given."
-msgstr "réad blob neamhbhailí %s"
+msgstr "réad neamhbhailí '%s' tugtha."
 
 #, c-format
 msgid "more than two blobs given: '%s'"
-msgstr ""
+msgstr "níos mó ná dhá bhlob a thugtar: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unhandled object '%s' given."
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "réad neamh-láimhseáilte '%s' tugtha."
 
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
-msgstr ""
+msgstr "%s... %s: bonn cumaisc iolracha, ag baint úsáide as %s"
 
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
-msgstr ""
+msgstr "git difftool [[<options>]] <commit>[[<commit>]] [--] [<path>...]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read symlink %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí nasc simtéarach %s a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read symlink file %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann comhad simnasc %s a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read object %s for symlink %s"
-msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+msgstr "ní raibh in ann réad %s a léamh le haghaidh nasc simtéarach %s"
 
 msgid ""
 "combined diff formats ('-c' and '--cc') are not supported in\n"
 "directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
+"ní thacaítear le formáidí diff comhcheangailte ('-c' agus '--cc') i\n"
+"modh diff eolaire ('-d' agus '--dir-diff')."
 
 #, c-format
 msgid "both files modified: '%s' and '%s'."
-msgstr ""
+msgstr "modhnaigh an dá chomhad: '%s' agus '%s'."
 
-#, fuzzy
 msgid "working tree file has been left."
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "tá comhad crann oibre fágtha."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not copy '%s' to '%s'"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "ní fhéadfaí '%s' a chóipeáil chuig '%s'"
 
 #, c-format
 msgid "temporary files exist in '%s'."
-msgstr ""
+msgstr "tá comhaid shealadacha ann i '%s'."
 
 msgid "you may want to cleanup or recover these."
-msgstr ""
+msgstr "b'fhéidir gur mhaith leat iad seo a ghlanadh nó a aisghabháil."
 
 #, c-format
 msgid "failed: %d"
-msgstr ""
+msgstr "theip ar: %d"
 
 msgid "use `diff.guitool` instead of `diff.tool`"
-msgstr ""
+msgstr "bain úsáid as `diff.guitool` in ionad `diff.tool`"
 
 msgid "perform a full-directory diff"
-msgstr ""
+msgstr "éagsúlacht eolaire lán-eolaire a dhéanamh"
 
 msgid "do not prompt before launching a diff tool"
-msgstr ""
+msgstr "ná spreag sula seolann tú uirlis diff"
 
 msgid "use symlinks in dir-diff mode"
-msgstr ""
+msgstr "bain úsáid as naisc siombailte i mód dir-diff"
 
 msgid "tool"
-msgstr ""
+msgstr "uirlis"
 
 msgid "use the specified diff tool"
-msgstr ""
+msgstr "bain úsáid as an uirlis diff sonraithe"
 
 msgid "print a list of diff tools that may be used with `--tool`"
-msgstr ""
+msgstr "liosta d'uirlisí diff is féidir a úsáid le `--tool` a phriontáil"
 
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
 msgstr ""
+"imeacht 'git-difftool' a dhéanamh nuair a fhilleann uirlis diff a ghairmtear "
+"cód imeachta neamh-nialasach"
 
 msgid "specify a custom command for viewing diffs"
-msgstr ""
+msgstr "sonraigh ordú saincheaptha chun féachaint ar dhifríochtaí"
 
 msgid "passed to `diff`"
-msgstr ""
+msgstr "cuireadh chuig `diff`"
 
 msgid "difftool requires worktree or --no-index"
-msgstr ""
+msgstr "éilíonn difftool crann oibre nó --no-index"
 
 msgid "no <tool> given for --tool=<tool>"
-msgstr ""
+msgstr "níl aon tu <tool> gadh le haghaidh --tool=<tool>"
 
 msgid "no <cmd> given for --extcmd=<cmd>"
-msgstr ""
+msgstr "níl <cmd> tugtha do --extcmd=<cmd>"
 
 msgid "git fast-export [<rev-list-opts>]"
-msgstr ""
+msgstr "git fast-export [<rev-list-opts>]"
 
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
+"Earráid: Ní féidir clibeanna neadaithe a onnmhairiú mura sonraítear --mark-"
+"tags."
 
 msgid "--anonymize-map token cannot be empty"
-msgstr ""
+msgstr "Ní féidir le comhartha --anonymize-map a bheith folamh"
 
 msgid "show progress after <n> objects"
-msgstr ""
+msgstr "dhul chun cinn a thaispe <n>áint"
 
 msgid "select handling of signed tags"
-msgstr ""
+msgstr "roghnaigh láimhseáil na clibeanna"
 
 msgid "select handling of signed commits"
-msgstr ""
+msgstr "roghnaigh láimhseáil tiomantas sínithe"
 
 msgid "select handling of tags that tag filtered objects"
-msgstr ""
+msgstr "roghnaigh láimhseáil clibeanna a ligeann rudaí"
 
 msgid "select handling of commit messages in an alternate encoding"
-msgstr ""
+msgstr "roghnaigh láimhseáil teachtaireachtaí tiomanta i ionchódú"
 
 msgid "dump marks to this file"
-msgstr ""
+msgstr "marcanna dumpáil chuig an gcomhad seo"
 
 msgid "import marks from this file"
-msgstr ""
+msgstr "marcanna iompórtáil ón gcomhad seo"
 
 msgid "import marks from this file if it exists"
-msgstr ""
+msgstr "marcanna a iompórtáil ón gcomhad seo má tá sé ann"
 
 msgid "fake a tagger when tags lack one"
-msgstr ""
+msgstr "clibeoir bréige nuair nach bhfuil ceann ag clibeanna"
 
 msgid "output full tree for each commit"
-msgstr ""
+msgstr "aschur crann iomlán do gach tiomantas"
 
 msgid "use the done feature to terminate the stream"
-msgstr ""
+msgstr "úsáid an ghné déanta chun an sruth a fhoirceannadh"
 
 msgid "skip output of blob data"
-msgstr ""
+msgstr "scipeáil aschur sonraí blob"
 
 msgid "refspec"
-msgstr ""
+msgstr "refspec"
 
 msgid "apply refspec to exported refs"
-msgstr ""
+msgstr "refspec a chur i bhfeidhm ar thaifeanna onnmhair"
 
 msgid "anonymize output"
-msgstr ""
+msgstr "aschur gan ainm"
 
 msgid "from:to"
-msgstr ""
+msgstr "ó:go"
 
 msgid "convert <from> to <to> in anonymized output"
-msgstr ""
+msgstr "tiontaigh <from>go <to>in aschur gan ainm"
 
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
+"tuismitheoirí tagartha nach bhfuil i sruth tapa onnmhairithe de réir id réad"
 
 msgid "show original object ids of blobs/commits"
-msgstr ""
+msgstr "taispeáin id réad bunaidh de bhlobanna/gealltanna"
 
 msgid "label tags with mark ids"
-msgstr ""
+msgstr "clibeanna lipéad le id marc"
 
 #, c-format
 msgid "Missing from marks for submodule '%s'"
-msgstr ""
+msgstr "Ar iarraidh ó mharcanna don fho-mhodúl '%s'"
 
 #, c-format
 msgid "Missing to marks for submodule '%s'"
-msgstr ""
+msgstr "Ar iarraidh marcanna don fho-mhodúl '%s'"
 
 #, c-format
 msgid "Expected 'mark' command, got %s"
-msgstr ""
+msgstr "Táthar ag súil leis an ordú 'marc', fuair %s"
 
 #, c-format
 msgid "Expected 'to' command, got %s"
-msgstr ""
+msgstr "Táthar ag súil leis an ordú 'to', fuair %s"
 
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr ""
+"Ainm formáid a bhfuil súil leis ainm comhaid don rogha athscríobh fo-mhodúil"
 
 #, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
-msgstr ""
+msgstr "feature '%s' forbidden in input without --allow-unsafe-features"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Lockfile created but not reported: %s"
-msgstr "Fo-mhodúil athraithe ach gan nuashonrú:"
+msgstr "Cruthaíodh comhad Lockfile ach nár tuairiscigh: %s"
 
-#, fuzzy
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
-msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+msgstr "git fetch [<options>] [<repository> [<refspec>...]]"
 
-#, fuzzy
 msgid "git fetch [<options>] <group>"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git fetch [<options>] <group>"
 
-#, fuzzy
 msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
-msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+msgstr "git fetch --multiple [<options>] [(<repository> | <group>)...]"
 
-#, fuzzy
 msgid "git fetch --all [<options>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git fetch --all [<options>]"
 
 msgid "fetch.parallel cannot be negative"
-msgstr ""
+msgstr "ní féidir fetch.parallel a bheith diúltach"
 
-#, fuzzy
 msgid "couldn't find remote ref HEAD"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "ní raibh in ann ciantagartha HEAD a fháil"
 
 #, c-format
 msgid "From %.*s\n"
-msgstr ""
+msgstr "Ó %.*s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object %s not found"
-msgstr "réad %s: súil leis an gcineál %s, aimsíodh %s"
+msgstr "níor aimsíodh réad %s"
 
 msgid "[up to date]"
-msgstr ""
+msgstr "[cothrom le dáta]"
 
 msgid "[rejected]"
-msgstr ""
+msgstr "[diúltaithe]"
 
-#, fuzzy
 msgid "can't fetch into checked-out branch"
-msgstr "cruthaigh/athshocraigh agus seiceáil amach brainse"
+msgstr "ní féidir teacht isteach i mbrainse seiceáilte"
 
 msgid "[tag update]"
-msgstr ""
+msgstr "[Nuashonrú tag]"
 
-#, fuzzy
 msgid "unable to update local ref"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "in ann tagairt áitiúil a nuashonrú"
 
 msgid "would clobber existing tag"
-msgstr ""
+msgstr "chuirfeadh an chlib atá ann cheana"
 
 msgid "[new tag]"
-msgstr ""
+msgstr "[tag nua]"
 
-#, fuzzy
 msgid "[new branch]"
-msgstr "brainse-nua"
+msgstr "[brainse nua]"
 
 msgid "[new ref]"
-msgstr ""
+msgstr "[tagartha nua]"
 
-#, fuzzy
 msgid "forced update"
-msgstr "nuashonruithe fórsa"
+msgstr "nuashonrú éigeant"
 
 msgid "non-fast-forward"
-msgstr ""
+msgstr "neamh-tapa ar aghaidh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir '%s' a oscailt"
 
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
 "flag or run 'git config fetch.showForcedUpdates true'"
 msgstr ""
+"is gnách go léiríonn teacht na brainsí a raibh nuashonrú éigeantach orthu,\n"
+"ach tá an seiceáil sin díchumasaithe; chun athchumasú, bain úsáid as '--show-"
+"forced-updates'\n"
+"bratach nó rith 'git config fetch.showForcedUpdates true'"
 
 #, c-format
 msgid ""
@@ -5705,55 +6090,61 @@ msgid ""
 "false'\n"
 "to avoid this check\n"
 msgstr ""
+"thóg sé %.2f soicind chun nuashonruithe éigeantacha a sheiceáil; is féidir "
+"leat úsáid\n"
+"'--no-show-forced-updates 'nó rith 'git config fetch.showForcedUpdates "
+"bréaga'\n"
+"chun an seiceáil seo a sheachaint\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s did not send all necessary objects"
-msgstr "níor sheol iargúlta gach rud riachtanach"
+msgstr "Níor sheol %s na rudaí riachtanacha go léir"
 
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
-msgstr ""
+msgstr "dhiúltaigh %s toisc nach gceadaítear fréamhacha éadmhara a nuashonrú"
 
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
 " 'git remote prune %s' to remove any old, conflicting branches"
 msgstr ""
+"ní fhéadfaí roinnt fios áitiúla a nuashonrú; déan iarracht rith\n"
+" 'git remote prune%s' chun aon bhrainsí sean-fhrithsheasmhach a bhaint"
 
 #, c-format
 msgid "   (%s will become dangling)"
-msgstr ""
+msgstr "   (beidh %s ag crochadh)"
 
 #, c-format
 msgid "   (%s has become dangling)"
-msgstr ""
+msgstr "   (%s has become dangling)"
 
-#, fuzzy
 msgid "[deleted]"
-msgstr "scriosta:"
+msgstr "[scriosta]"
 
 msgid "(none)"
-msgstr ""
+msgstr "(níl aon)"
 
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
-msgstr ""
+msgstr "ag diúltú teacht isteach i mbrainse '%s' a sheiceáil amach ag '%s'"
 
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
-msgstr ""
+msgstr "níl an rogha “%s” luach “%s” bailí do %s"
 
 #, c-format
 msgid "option \"%s\" is ignored for %s"
-msgstr ""
+msgstr "déantar neamhaird ar rogha “%s” do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s is not a valid object"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní réad bailí é %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "the object %s does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl an réad %s ann"
 
 #, c-format
 msgid ""
@@ -5763,443 +6154,447 @@ msgid ""
 "'git config set remote.%s.followRemoteHEAD warn-if-not-branch-%s'\n"
 "will disable the warning until the remote changes HEAD to something else."
 msgstr ""
+"Rith 'git remote set-head %s %s' chun an t-athrú a leanúint, nó socraigh\n"
+"rogha cumraíochta 'remote.%s.followRemoteHEAD' go luach difriúil\n"
+"mura mian leat an teachtaireacht seo a fheiceáil. Go sonrach, má ritheann "
+"tú\n"
+"'git config set remote.%s.followRemoteHEAD warn-if-not-branch-%s'\n"
+"díchumasófar an rabhadh go dtí go n-athraíonn an cianda HEAD go rud éigin "
+"eile."
 
 msgid "multiple branches detected, incompatible with --set-upstream"
-msgstr ""
+msgstr "brainsí iolracha brainsí braite, gan oiriúint le --set-upstream"
 
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
 "any branch."
 msgstr ""
+"ní fhéadfaí suas sruth de HEAD a shocrú go '%s' ó '%s' nuair nach dtugann sé "
+"in iúl go dtí aon bhrainse."
 
-#, fuzzy
 msgid "not setting upstream for a remote remote-tracking branch"
-msgstr "brainse suas srutha '%s' nach stóráiltear mar bhrainse cianrianaithe"
+msgstr "gan socrú suas sruth do bhrainse cianrianaithe"
 
-#, fuzzy
 msgid "not setting upstream for a remote tag"
-msgstr "socraigh suas sruth le haghaidh tarraing/stádas git"
+msgstr "gan a shocrú suas sruth le haghaidh clib iargúlta"
 
-#, fuzzy
 msgid "unknown branch type"
-msgstr "cineál réad anaithnid %d"
+msgstr "cineál brainse anaithnid"
 
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
 msgstr ""
+"ní bhfuarthas aon bhrainse foinse;\n"
+"ní mór duit brainse amháin a shonrú go díreach leis an rogha --set-upstream"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Fetching %s\n"
-msgstr "Ag brú chuig %s\n"
+msgstr "Ag tarraingt %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not fetch %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí %s a fháil"
 
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
-msgstr ""
+msgstr "níorbh fhéidir '%s' a fháil (cód scoir: %d)\n"
 
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
 msgstr ""
+"níl aon stór iargúlta sonraithe; sonraigh URL nó a\n"
+"ainm iargúlta ar chóir athbhreithnithe nua a fháil"
 
 msgid "you need to specify a tag name"
-msgstr ""
+msgstr "ní mór duit ainm clib a shonrú"
 
 msgid "fetch from all remotes"
-msgstr ""
+msgstr "faigh ó gach iargúlta"
 
-#, fuzzy
 msgid "set upstream for git pull/fetch"
-msgstr "socraigh suas sruth le haghaidh tarraing/stádas git"
+msgstr "socraigh suas sruth le haghaidh git pull/fetch"
 
 msgid "append to .git/FETCH_HEAD instead of overwriting"
-msgstr ""
+msgstr "cuir chuig .git/FETCH_HEAD in ionad athscríobh"
 
-#, fuzzy
 msgid "use atomic transaction to update references"
-msgstr "iarraidh idirbheart adamach ar an taobh iargúl"
+msgstr "úsáid idirbheart adamach chun tagairtí a nuashonrú"
 
-#, fuzzy
 msgid "path to upload pack on remote end"
-msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
+msgstr "cosán chun pacáiste a uaslódáil ar iargúlta"
 
 msgid "force overwrite of local reference"
-msgstr ""
+msgstr "tagairt áitiúil a fhorscríobh"
 
 msgid "fetch from multiple remotes"
-msgstr ""
+msgstr "a fháil ó iomadúla iargúlta"
 
 msgid "fetch all tags and associated objects"
-msgstr ""
+msgstr "gach clib agus rudaí gaolmhara a fháil"
 
 msgid "do not fetch all tags (--no-tags)"
-msgstr ""
+msgstr "ná faigh gach clib (--no-tags)"
 
-#, fuzzy
 msgid "number of submodules fetched in parallel"
-msgstr "líon na bhfo-mhodúil atá clónaithe go comhthreomhar"
+msgstr "líon na bhfo-mhodúil a fuarthas go comhthreomhar"
 
 msgid "modify the refspec to place all refs within refs/prefetch/"
-msgstr ""
+msgstr "an refspec a mhodhnú chun gach refs a chur laistigh de refs/prefetch/"
 
 msgid "prune remote-tracking branches no longer on remote"
-msgstr ""
+msgstr "brainsí cianrianaithe a ghearradh nach bhfuil ar iargúlta a"
 
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
+"clibeanna áitiúla a ghearradh nach bhfuil ar chlibeanna iargúlta agus "
+"athraithe clobber"
 
 msgid "on-demand"
-msgstr ""
+msgstr "ar éileamh"
 
-#, fuzzy
 msgid "control recursive fetching of submodules"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "tógáil athfhillteach fo-mhodúil a rialú"
 
 msgid "write fetched references to the FETCH_HEAD file"
-msgstr ""
+msgstr "scríobh tagairtí faighte don chomhad FETCH_HEAD"
 
 msgid "keep downloaded pack"
-msgstr ""
+msgstr "pacáiste íoslódáilte"
 
 msgid "allow updating of HEAD ref"
-msgstr ""
+msgstr "cead a thabhairt do nuashonrú HEAD ref"
 
-#, fuzzy
 msgid "deepen history of shallow clone"
-msgstr "stair an chlóin éadomhain a dhoimhniú, gan tagairt"
+msgstr "stair clón éadomhain a dhoimhniú"
 
-#, fuzzy
 msgid "deepen history of shallow repository based on time"
-msgstr "stair an chlóin éadomhain a dhoimhniú, gan tagairt"
+msgstr "stair stór éadomhain a dhoimhniú bunaithe ar am"
 
-#, fuzzy
 msgid "convert to a complete repository"
-msgstr "a chlónú ó stór áitiúil"
+msgstr "tiontaigh go stór iomlán"
 
 msgid "re-fetch without negotiating common commits"
-msgstr ""
+msgstr "athghabháil gan gealltanais choiteanna a chaibidliú"
 
 msgid "prepend this to submodule path output"
-msgstr ""
+msgstr "é seo a chur ar aghaidh chuig aschur cosán fo-mhodúil"
 
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
 msgstr ""
+"réamhshocraithe maidir le fo-mhodúil a fháil athshlánach (tosaíocht níos "
+"ísle ná comhaid chumraithe)"
 
 msgid "accept refs that update .git/shallow"
-msgstr ""
+msgstr "glacadh le hiarrachtaí a nuashonraíonn .git/shalach"
 
 msgid "refmap"
-msgstr ""
+msgstr "athléarscáil"
 
 msgid "specify fetch refmap"
-msgstr ""
+msgstr "sonraigh refmap a fháil"
 
 msgid "revision"
-msgstr ""
+msgstr "athbhreithiú"
 
 msgid "report that we have only objects reachable from this object"
-msgstr ""
+msgstr "tuairisciú nach bhfuil ach rudaí inrochtana againn ón réad seo"
 
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
+"ná faigh comhad pacáiste; ina ionad sin, priontáil sinsear leideanna "
+"idirbheartaíochta"
 
 msgid "run 'maintenance --auto' after fetching"
-msgstr ""
+msgstr "reáchtáil 'cothabháil --auto' tar éis a fháil"
 
 msgid "check for forced-updates on all updated branches"
-msgstr ""
+msgstr "seiceáil ar nuashonruithe éigeantacha ar gach brainse nuashonraithe"
 
 msgid "write the commit-graph after fetching"
-msgstr ""
+msgstr "scríobh an graf coimisiúnaithe tar éis a fháil"
 
 msgid "accept refspecs from stdin"
-msgstr ""
+msgstr "glacadh le refspecs ó stdin"
 
 msgid "--negotiate-only needs one or more --negotiation-tip=*"
 msgstr ""
+"--negotiate-only teastaíonn ceann amháin nó níos mó --negotiation-tip=*"
 
 msgid "negative depth in --deepen is not supported"
-msgstr ""
+msgstr "ní thacaítear le doimhneacht dhiúltach i --deepen"
 
 msgid "--unshallow on a complete repository does not make sense"
-msgstr ""
+msgstr "níl ciall le --unshallow ar stórlann iomlán"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to fetch bundles from '%s'"
-msgstr "theip ar rudaí a fháil ó URI '%s'"
+msgstr "theip ar bhaclaí a fháil ó '%s'"
 
-#, fuzzy
 msgid "fetch --all does not take a repository argument"
-msgstr "git checkout: --detach ní ghlacann argóint cosáin '%s'"
+msgstr "ní ghlacann fetch --all argóint stór"
 
-#, fuzzy
 msgid "fetch --all does not make sense with refspecs"
-msgstr "--delete níl ciall leis gan aon réiteoirí"
+msgstr "ní bhíonn ciall ag teacht --all le refspecs"
 
 #, c-format
 msgid "no such remote or remote group: %s"
-msgstr ""
+msgstr "gan aon ghrúpa iargúlta nó cianda den sórt sin: %s"
 
 msgid "fetching a group and specifying refspecs does not make sense"
-msgstr ""
+msgstr "níl ciall grúpa a fháil agus refspecs a shonrú"
 
 msgid "must supply remote when using --negotiate-only"
-msgstr ""
+msgstr "ní mór iargúlta a sholáthar agus tú ag úsáid --negotiate-only"
 
 msgid "protocol does not support --negotiate-only, exiting"
-msgstr ""
+msgstr "ní thacaíonn an prótacal le --negotiate-only, ag scoir"
 
 msgid ""
 "--filter can only be used with the remote configured in "
 "extensions.partialclone"
 msgstr ""
+"--filter Ní féidir ach an scagaire a úsáid ach leis an iargúlta cumraithe in "
+"extensions.partialclone"
 
-#, fuzzy
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
-"a URI chun cuachtaí a íoslódáil sula n-iarrtar iad ó chianchéim tionscnaimh"
+"--atomic ní féidir ach adamhach a úsáid ach amháin nuair a bhíonn sé á fháil "
+"ó chianrialtán amháin"
 
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
+"Ní féidir --stdin a úsáid ach amháin nuair a bhfaightear é ó iargúlta amháin"
 
 msgid ""
 "git fmt-merge-msg [-m <message>] [--log[=<n>] | --no-log] [--file <file>]"
 msgstr ""
+"<n><file>git fmt-merge-msg [-m<message>] [--log [=] | --no-log] [--comhad]"
 
 msgid "populate log with at most <n> entries from shortlog"
-msgstr ""
+msgstr "logáil a chomhlánú le hiontrálacha is mó <n>ó ghearrlog"
 
 msgid "alias for --log (deprecated)"
-msgstr ""
+msgstr "alias le haghaidh --log (mísheasmhach)"
 
 msgid "text"
-msgstr ""
+msgstr "téacs"
 
 msgid "use <text> as start of message"
-msgstr ""
+msgstr "úsáid <text> mar thús na teachtaireachta"
 
-#, fuzzy
 msgid "use <name> instead of the real target branch"
-msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+msgstr "úsáid in <name> ionad na fíor-spriocbhrainse"
 
-#, fuzzy
 msgid "file to read from"
-msgstr "nach féidir %s a léamh"
+msgstr "comhad le léamh ó"
 
-#, fuzzy
 msgid "git for-each-ref [<options>] [<pattern>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git for-each-ref [<options>] [<pattern>]"
 
 msgid "git for-each-ref [--points-at <object>]"
-msgstr ""
+msgstr "git for-each-ref [--points-at <object>]"
 
 msgid "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
-msgstr ""
+msgstr "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
 
 msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
-msgstr ""
+msgstr "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
 
 msgid "quote placeholders suitably for shells"
-msgstr ""
+msgstr "sealbhóirí áiteanna a luachan go oiriúnach do"
 
 msgid "quote placeholders suitably for perl"
-msgstr ""
+msgstr "sealbhóirí áiteanna a luachan go oiriúnach do perl"
 
 msgid "quote placeholders suitably for python"
-msgstr ""
+msgstr "sealbhóirí áiteanna a luaigh go oiriúnach do python"
 
 msgid "quote placeholders suitably for Tcl"
-msgstr ""
+msgstr "sealbhóirí áiteanna a luachan go oiriúnach do Tcl"
 
 msgid "show only <n> matched refs"
-msgstr ""
+msgstr "taispeáin ach sonraí com <n>hoiriúnaithe"
 
 msgid "respect format colors"
-msgstr ""
+msgstr "meas dathanna formáid"
 
 msgid "print only refs which points at the given object"
-msgstr ""
+msgstr "ní phriontáil ach téacsanna a phointíonn ar an réad a thugtar"
 
 msgid "print only refs that are merged"
-msgstr ""
+msgstr "ní phriontáil ach scríbhneoireachtaí atá cumasaithe"
 
 msgid "print only refs that are not merged"
-msgstr ""
+msgstr "priontáil ach scríbhinní nach bhfuil cumasc"
 
 msgid "print only refs which contain the commit"
-msgstr ""
+msgstr "ní phriontáil ach téifeanna ina bhfuil an tiomantas"
 
 msgid "print only refs which don't contain the commit"
-msgstr ""
+msgstr "ní phriontáil ach scríbhneoirí nach bhfuil an tiomantas"
 
 msgid "read reference patterns from stdin"
-msgstr ""
+msgstr "léigh patrúin tagartha ó stdin"
 
 msgid "also include HEAD ref and pseudorefs"
-msgstr ""
+msgstr "san áireamh freisin HEAD ref agus pseudorefs"
 
 msgid "unknown arguments supplied with --stdin"
-msgstr ""
+msgstr "argóintí anaithnid a sholáthraítear le --stdin"
 
 msgid "git for-each-repo --config=<config> [--] <arguments>"
-msgstr ""
+msgstr "git for-each-repo --config=<config> [--] <arguments>"
 
 msgid "config"
-msgstr ""
+msgstr "cumraíocht"
 
 msgid "config key storing a list of repository paths"
-msgstr ""
+msgstr "eochair chumraithe a stóráil liosta de chosáin stórais"
 
 msgid "keep going even if command fails in a repository"
-msgstr ""
+msgstr "coinnigh ort fiú má theipeann an t-ordú i stóras"
 
 msgid "missing --config=<config>"
-msgstr ""
+msgstr "ar iarraidh --config=<config>"
 
 #, c-format
 msgid "got bad config --config=%s"
-msgstr ""
+msgstr "fuair go dona cumraíocht --config=%s"
 
-#, fuzzy
 msgid "unknown"
-msgstr "anaithnid:"
+msgstr "anaithnid"
 
 #. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
 #, c-format
 msgid "error in %s %s: %s"
-msgstr ""
+msgstr "earráid i %s %s: %s"
 
 #. TRANSLATORS: e.g. warning in tree 01bfda: <more explanation>
 #, c-format
 msgid "warning in %s %s: %s"
-msgstr ""
+msgstr "rabhadh i %s %s: %s"
 
 #, c-format
 msgid "broken link from %7s %s"
-msgstr ""
+msgstr "nasc briste ó %7s %s"
 
-#, fuzzy
 msgid "wrong object type in link"
-msgstr "cineál réad anaithnid %d"
+msgstr "cineál réad mícheart i nasc"
 
 #, c-format
 msgid ""
 "broken link from %7s %s\n"
 "              to %7s %s"
 msgstr ""
+"nasc briste ó %7s %s\n"
+" chuig %7s %s"
 
-#, fuzzy
 msgid "Checking connectivity"
-msgstr "Rud a sheiceáil"
+msgstr "Nascacht a sheiceáil"
 
 #, c-format
 msgid "missing %s %s"
-msgstr ""
+msgstr "%s %s ar iarraidh"
 
 #, c-format
 msgid "unreachable %s %s"
-msgstr ""
+msgstr "%s %s neamh-inrochtana"
 
 #, c-format
 msgid "dangling %s %s"
-msgstr ""
+msgstr "ag crochadh %s %s"
 
-#, fuzzy
 msgid "could not create lost-found"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí a chruthú a aimsíodh caillte"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not finish '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh '%s' in ann a chríochnú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Checking %s"
-msgstr "Rud a sheiceáil"
+msgstr "Seiceáil %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Checking connectivity (%d objects)"
-msgstr "Rud a sheiceáil"
+msgstr "Ag seiceáil nascachta (%d réad)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Checking %s %s"
-msgstr "Rud a sheiceáil"
+msgstr "Seiceáil %s %s"
 
 msgid "broken links"
-msgstr ""
+msgstr "naisc briste"
 
 #, c-format
 msgid "root %s"
-msgstr ""
+msgstr "fréamh %s"
 
 #, c-format
 msgid "tagged %s %s (%s) in %s"
-msgstr ""
+msgstr "clib %s %s (%s) i %s"
 
 #, c-format
 msgid "%s: object corrupt or missing"
-msgstr ""
+msgstr "%s: réad truaillithe nó ar iarraidh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s: invalid reflog entry %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "%s: iontráil reflog neamhbhailí %s"
 
 #, c-format
 msgid "Checking reflog %s->%s"
-msgstr ""
+msgstr "Seiceáil reflog %s->%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s: invalid sha1 pointer %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "%s: pointeoir sha1 neamhbhailí %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s: not a commit"
-msgstr "Tiomantas tosaigh"
+msgstr "%s: ní gealltanas"
 
 msgid "notice: No default references"
-msgstr ""
+msgstr "fógra: Gan aon tagairtí réamhshocraithe"
 
 #, c-format
 msgid "%s: hash-path mismatch, found at: %s"
-msgstr ""
+msgstr "%s: míchomhoiriúnú hash-path, le fáil ag: %s"
 
 #, c-format
 msgid "%s: object corrupt or missing: %s"
-msgstr ""
+msgstr "%s: réad truaillithe nó ar iarraidh: %s"
 
 #, c-format
 msgid "%s: object is of unknown type '%s': %s"
-msgstr ""
+msgstr "%s: tá réad de chineál anaithnid '%s': %s"
 
 #, c-format
 msgid "%s: object could not be parsed: %s"
-msgstr ""
+msgstr "%s: ní fhéadfaí réad a pháirseáil: %s"
 
 #, c-format
 msgid "bad sha1 file: %s"
-msgstr ""
+msgstr "comhad sha1 olc: %s"
 
-#, fuzzy
 msgid "Checking object directory"
-msgstr "Rud a sheiceáil"
+msgstr "Seiceáil eolaire réada"
 
-#, fuzzy
 msgid "Checking object directories"
-msgstr "Rud a sheiceáil"
+msgstr "Seiceáil eolairí réada"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Checking %s link"
-msgstr "Rud a sheiceáil"
+msgstr "Nasc %s a sheiceáil"
 
 #, c-format
 msgid "invalid %s"
@@ -6207,42 +6602,41 @@ msgstr "%s neamhbhailí"
 
 #, c-format
 msgid "%s points to something strange (%s)"
-msgstr ""
+msgstr "Léiríonn %s rud éigin aisteach (%s)"
 
 #, c-format
 msgid "%s: detached HEAD points at nothing"
-msgstr ""
+msgstr "%s: pointí HEAD scoite ag aon rud"
 
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
-msgstr ""
+msgstr "fógra: Díríonn %s chuig brainse neamhbhreithe (%s)"
 
 #, c-format
 msgid "Checking cache tree of %s"
-msgstr ""
+msgstr "Crann taisce de %s a sheiceáil"
 
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree of %s"
-msgstr ""
+msgstr "%s: pointeoir sha1 neamhbhailí i gcrann cache-%s"
 
 msgid "non-tree in cache-tree"
-msgstr ""
+msgstr "neamh-chrann i gcrann cache-"
 
 #, c-format
 msgid "%s: invalid sha1 pointer in resolve-undo of %s"
-msgstr ""
+msgstr "%s: pointeoir sha1 neamhbhailí i réiteach a chealú de %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to load rev-index for pack '%s'"
-msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+msgstr "in ann innéacs rev-innéacs a luchtú do phacáiste '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid rev-index for pack '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "innéacs rev-neamhbhailí do phacáiste '%s'"
 
-#, fuzzy
 msgid "Checking ref database"
-msgstr "Rud a sheiceáil"
+msgstr "Seiceáil bunachar sonraí tagairt"
 
 msgid ""
 "git fsck [--tags] [--root] [--unreachable] [--cache] [--no-reflogs]\n"
@@ -6250,167 +6644,166 @@ msgid ""
 "         [--[no-]dangling] [--[no-]progress] [--connectivity-only]\n"
 "         [--[no-]name-objects] [--[no-]references] [<object>...]"
 msgstr ""
+"git fsck [--tags] [--root] [--inrochtana] [--cache] [--no-reflogs]\n"
+" [-- [no-] iomlán] [--dian] [--verbose] [--caillte]\n"
+" [-- [gan-] ag crochadh] [-- [gan-] dul chun cinn] [--nascacht amháin]\n"
+" <object>[-- [no-] ainm-rudaí] [-- [aon-] tagairtí] [...]"
 
 msgid "show unreachable objects"
-msgstr ""
+msgstr "taispeáint rudaí dochreidte"
 
-#, fuzzy
 msgid "show dangling objects"
-msgstr "Rud a sheiceáil"
+msgstr "taispeáin rudaí crochtanacha"
 
 msgid "report tags"
-msgstr ""
+msgstr "clibeanna tuarascála"
 
 msgid "report root nodes"
-msgstr ""
+msgstr "nóid fréimhe a thuairisc"
 
 msgid "make index objects head nodes"
-msgstr ""
+msgstr "nóid ceann rudaí innéacs a dhéanamh"
 
-#, fuzzy
 msgid "make reflogs head nodes (default)"
-msgstr "úsáid modh forleagtha (réamhshocraithe)"
+msgstr "nóid ceann reflogs a dhéanamh (réamhshocraithe)"
 
 msgid "also consider packs and alternate objects"
-msgstr ""
+msgstr "smaoinigh freisin ar phacáistí agus rudaí"
 
 msgid "check only connectivity"
-msgstr ""
+msgstr "seiceáil ach nascacht"
 
 msgid "enable more strict checking"
-msgstr ""
+msgstr "cumasú seiceáil níos docht"
 
 msgid "write dangling objects in .git/lost-found"
-msgstr ""
+msgstr "scríobh rudaí crochta in .git/lost-found"
 
 msgid "show progress"
-msgstr ""
+msgstr "taispeáin dul chun cinn"
 
 msgid "show verbose names for reachable objects"
-msgstr ""
+msgstr "taispeáint ainmneacha fabhracha do rudaí inrochtana"
 
 msgid "check reference database consistency"
-msgstr ""
+msgstr "seiceáil comhsheasmhacht bunachair"
 
 msgid "Checking objects"
 msgstr "Rud a sheiceáil"
 
 #, c-format
 msgid "%s: object missing"
-msgstr ""
+msgstr "%s: réad ar iarraidh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "paraiméadar neamhbhailí: súil le sha1, fuair '%s'"
 
 msgid "git fsmonitor--daemon start [<options>]"
-msgstr ""
+msgstr "git fsmonitor--daemon start [<options>]"
 
 msgid "git fsmonitor--daemon run [<options>]"
-msgstr ""
+msgstr "git fsmonitor--daemon run [<options>]"
 
 #, c-format
 msgid "value of '%s' out of range: %d"
-msgstr ""
+msgstr "luach '%s' lasmuigh den raon: %d"
 
 #, c-format
 msgid "value of '%s' not bool or int: %d"
-msgstr ""
+msgstr "luach '%s' gan bool nó int: %d"
 
 #, c-format
 msgid "fsmonitor-daemon is watching '%s'\n"
-msgstr ""
+msgstr "tá fsmonitor-daemon ag féachaint ar '%s'\n"
 
 #, c-format
 msgid "fsmonitor-daemon is not watching '%s'\n"
-msgstr ""
+msgstr "níl fsmonitor-daemon ag féachaint ar '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create fsmonitor cookie '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí fianán fsmonitor '%s' a chruthú"
 
 #, c-format
 msgid "fsmonitor: cookie_result '%d' != SEEN"
-msgstr ""
+msgstr "fsmonitor: cookie_result  '%d' != SEEN"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not start IPC thread pool on '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí linn snáithe IPC a thosú ar '%s'"
 
 msgid "could not start fsmonitor listener thread"
-msgstr ""
+msgstr "ní fhéadfaí snáithe éisteora fsmonitor a thosú"
 
 msgid "could not start fsmonitor health thread"
-msgstr ""
+msgstr "ní fhéadfaí snáithe sláinte fsmonitor a thosú"
 
 msgid "could not initialize listener thread"
-msgstr ""
+msgstr "ní fhéadfadh snáithe éisteora a thionscnamh"
 
 msgid "could not initialize health thread"
-msgstr ""
+msgstr "ní fhéadfaí snáithe sláinte a thionscnamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not cd home '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí cd baile '%s'"
 
 #, c-format
 msgid "fsmonitor--daemon is already running '%s'"
-msgstr ""
+msgstr "tá fsmonitor--daemon ag rith '%s' cheana féin"
 
 #, c-format
 msgid "running fsmonitor-daemon in '%s'\n"
-msgstr ""
+msgstr "ag rith fsmonitor-daemon i '%s'\n"
 
 #, c-format
 msgid "starting fsmonitor-daemon in '%s'\n"
-msgstr ""
+msgstr "ag tosú fsmonitor-daemon i '%s'\n"
 
-#, fuzzy
 msgid "daemon failed to start"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar daemon a thosú"
 
 msgid "daemon not online yet"
-msgstr ""
+msgstr "daemon nach bhfuil ar líne fós"
 
 msgid "daemon terminated"
-msgstr ""
+msgstr "deireadh le déemon"
 
-#, fuzzy
 msgid "detach from console"
-msgstr "CEANN scartha ó "
+msgstr "dícheangal ón gconsól"
 
 msgid "use <n> ipc worker threads"
-msgstr ""
+msgstr "úsáid snái <n>theanna oibrithe ipc"
 
 msgid "max seconds to wait for background daemon startup"
-msgstr ""
+msgstr "soicind uasta chun fanacht le tosú daemon cúlra"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid 'ipc-threads' value (%d)"
-msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
+msgstr "luach 'ipc-snáitheanna' neamhbhailí (%d)"
 
 #, c-format
 msgid "Unhandled subcommand '%s'"
-msgstr ""
+msgstr "Foordú neamh-láimhseáilte '%s'"
 
 msgid "fsmonitor--daemon not supported on this platform"
-msgstr ""
+msgstr "fsmonitor--daemon  nach dtacaíonn sé ar an ardán seo"
 
-#, fuzzy
 msgid "git gc [<options>]"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git gc [<options>]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to fstat %s: %s"
-msgstr "theip ar '%s' a stáil"
+msgstr "Theip ar fstat %s: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to parse '%s' value '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar luach '%s' a pharsáil '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot stat '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "ní féidir '%s' a stát"
 
 #, c-format
 msgid ""
@@ -6420,226 +6813,230 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Tuairiscigh an rith gc deireanach an méid seo a leanas Ceartaigh an bunchúis "
+"le do thoil\n"
+"agus bain %s\n"
+"Ní dhéanfar glantachán uathoibríoch go dtí go mbainfear an comhad.\n"
+"\n"
+"%s"
 
-#, fuzzy
 msgid "prune unreferenced objects"
-msgstr "níl ach tagairt amháin ag súil leis"
+msgstr "rudaí gan tagairt a ghearradh"
 
 msgid "pack unreferenced objects separately"
-msgstr ""
+msgstr "rudaí gan tagairt a phacáil ar leithligh"
 
 msgid "with --cruft, limit the size of new cruft packs"
-msgstr ""
+msgstr "le --cruft, teorainn le méid pacáistí cruft nua"
 
 msgid "be more thorough (increased runtime)"
-msgstr ""
+msgstr "a bheith níos críochnúla (tréimhse méadaithe)"
 
 msgid "enable auto-gc mode"
-msgstr ""
+msgstr "mód auto-gc a chumasú"
 
 msgid "perform garbage collection in the background"
-msgstr ""
+msgstr "bailiú truflais a dhéanamh sa chúlra"
 
 msgid "force running gc even if there may be another gc running"
-msgstr ""
+msgstr "fórsa ag rith gc fiú má d'fhéadfadh gc eile a bheith ag rith"
 
 msgid "repack all other packs except the largest pack"
-msgstr ""
+msgstr "gach pacáiste eile a athphacáil ach amháin an pacáiste is mó"
 
 msgid "pack prefix to store a pack containing pruned objects"
-msgstr ""
+msgstr "réimír pacáiste chun pacáiste ina bhfuil rudaí gearrtha a stóráil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to parse gc.logExpiry value %s"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar luach gc.logExpiry %s a pháirseáil"
 
 #, c-format
 msgid "failed to parse prune expiry value %s"
-msgstr ""
+msgstr "theip ar luach éaga brúite %s a pharsáil"
 
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
-msgstr ""
+msgstr "Pacáil uathoibríoch an stór sa chúlra chun an fheidhmíocht is fearr\n"
 
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
-msgstr ""
+msgstr "Pacáil uathoibríoch an stór chun an fheidhmíocht is fearr\n"
 
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
-msgstr ""
+msgstr "Féach \"git help gc\" le haghaidh obair tí láimhe.\n"
 
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
 msgstr ""
+"tá gc ag rith cheana féin ar mheaisín '%s' pid%<PRIuMAX>(bain úsáid as --"
+"force mura bhfuil)"
 
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
+"Tá an iomarca rudaí scaoilte neamh-inrochtana ann; reáchtáil 'git prune' "
+"chun iad a bhaint."
 
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr ""
+"<task>rith cothabhála git [--auto] [-- [no-] ciúin] [--task=] [--schedule]"
 
 msgid "--no-schedule is not allowed"
-msgstr ""
+msgstr "Ní cheadaítear --no-schedule"
 
 #, c-format
 msgid "unrecognized --schedule argument '%s'"
-msgstr ""
+msgstr "argóint --schedule gan aithint '%s'"
 
-#, fuzzy
 msgid "failed to write commit-graph"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "theip orthu graf coimisiúnaithe a scríobh"
 
-#, fuzzy
 msgid "failed to prefetch remotes"
-msgstr "theip orthu beartáin fógraithe a fháil"
+msgstr "theip ar iargúlta iargúlta a réamhghabháil"
 
-#, fuzzy
 msgid "failed to start 'git pack-objects' process"
-msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+msgstr "theip ar phróiseas 'git pack-objects' a thosú"
 
-#, fuzzy
 msgid "failed to finish 'git pack-objects' process"
-msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+msgstr "theip ar phróiseas 'git pack-objects' a chríochnú"
 
 msgid "failed to write multi-pack-index"
-msgstr ""
+msgstr "theip ar innéacs il-phacáiste a scríobh"
 
 msgid "'git multi-pack-index expire' failed"
-msgstr ""
+msgstr "Theip ar 'git multi-pack-index in éag'"
 
 msgid "'git multi-pack-index repack' failed"
-msgstr ""
+msgstr "Theip ar 'git multi-pack-index repack'"
 
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
+"tasc athphacáil fáis a scipeáil toisc go bhfuil core.multiPackIndex "
+"díchumasaithe"
 
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
-msgstr ""
+msgstr "tá comhad glasála '%s' ann, ag scipeáil cothabháil"
 
 #, c-format
 msgid "task '%s' failed"
-msgstr ""
+msgstr "theip ar thasc '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid task"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní tasc bailí é '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "task '%s' cannot be selected multiple times"
-msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
+msgstr "ní féidir tasc '%s' a roghnú arís agus arís eile"
 
 msgid "run tasks based on the state of the repository"
-msgstr ""
+msgstr "tascanna a reáchtáil bunaithe ar staid an stór"
 
 msgid "perform maintenance in the background"
-msgstr ""
+msgstr "cothabháil a dhéanamh sa chúlra"
 
 msgid "frequency"
-msgstr ""
+msgstr "minicíocht"
 
 msgid "run tasks based on frequency"
-msgstr ""
+msgstr "tascanna a rith bunaithe ar mhinicíocht"
 
 msgid "do not report progress or other information over stderr"
-msgstr ""
+msgstr "ná tuairiscigh dul chun cinn nó faisnéis eile faoi stderr"
 
 msgid "task"
-msgstr ""
+msgstr "tasc"
 
 msgid "run a specific task"
-msgstr ""
+msgstr "tasc ar leith a reáchtáil"
 
 msgid "use at most one of --auto and --schedule=<frequency>"
-msgstr ""
+msgstr "bain úsáid as --auto agus --schedule=<frequency> ar a mhéad"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to add '%s' value of '%s'"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "nach féidir luach '%s' de '%s' a chur leis"
 
 msgid "return success even if repository was not registered"
-msgstr ""
+msgstr "rath ar ais fiú mura raibh stór cláraithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to unset '%s' value of '%s'"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "nach féidir luach '%s' de '%s' a dhíshocrú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "repository '%s' is not registered"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl stór '%s' cláraithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to expand path '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar an gcosán '%s' a leathnú"
 
-#, fuzzy
 msgid "failed to start launchctl"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar launchctl a thosú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to create directories for '%s'"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar eolairí a chruthú do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to bootstrap service %s"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar sheirbhís bootstrap %s"
 
-#, fuzzy
 msgid "failed to create temp xml file"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar chomhad xml temp a chruthú"
 
-#, fuzzy
 msgid "failed to start schtasks"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar schasks a thosú"
 
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
+"theip ar 'crontab -l' a reáchtáil; b'fhéidir nach dtacaíonn do chóras le "
+"'cron'"
 
-#, fuzzy
 msgid "failed to create crontab temporary file"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar chomhad sealadach crontab a chruthú"
 
-#, fuzzy
 msgid "failed to open temporary file"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar chomhad sealadach a oscailt"
 
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
+"theip ar 'crontab' a reáchtáil; b'fhéidir nach dtacaíonn do chóras le 'cron'"
 
 msgid "'crontab' died"
-msgstr ""
+msgstr "Fuair 'crontab' bás"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to delete '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar '%s' a scriosadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to flush '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar '%s' a shruthlú"
 
-#, fuzzy
 msgid "failed to start systemctl"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar systemctl a thosú"
 
-#, fuzzy
 msgid "failed to run systemctl"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar systemctl a reáchtáil"
 
 #, c-format
 msgid "unrecognized --scheduler argument '%s'"
-msgstr ""
+msgstr "argóint --scheduler gan aithint '%s'"
 
 msgid "neither systemd timers nor crontab are available"
-msgstr ""
+msgstr "níl uaireoirí systemd ná crontab ar fáil"
 
 #, c-format
 msgid "%s scheduler is not available"
-msgstr ""
+msgstr "Níl sceidealóir %s ar fáil"
 
 #, c-format
 msgid ""
@@ -6650,39 +7047,48 @@ msgid ""
 "then try again. If it still fails, a git-maintenance(1) process may have\n"
 "crashed in this repository earlier: remove the file manually to continue."
 msgstr ""
+"nach féidir '%s.lock' a chruthú: %s.\n"
+"\n"
+"Is cosúil go bhfuil próiseas sceidealaithe eile git-maintenance(1) ag rith "
+"sa\n"
+"stórlann seo\n"
+"Déan cinnte go bhfuil aon phróisis chothabhála eile ag rith agus\n"
+"ansin déan iarracht arís. Má theipeann air fós, d'fhéadfadh go mbeadh "
+"próiseas cothabhála git-maintenance (1)\n"
+"tháinig isteach sa stór seo níos luaithe: bain an comhad de láimh chun "
+"leanúint ar aghaidh."
 
 msgid "cannot acquire lock for scheduled background maintenance"
-msgstr ""
+msgstr "ní féidir glas a fháil le haghaidh cothabháil sceidealta cúlra"
 
 msgid "git maintenance start [--scheduler=<scheduler>]"
-msgstr ""
+msgstr "<scheduler>tús cothabhála git [--scheduler=]"
 
 msgid "scheduler"
-msgstr ""
+msgstr "sceidealóir"
 
 msgid "scheduler to trigger git maintenance run"
-msgstr ""
+msgstr "sceidealóir chun rith cothabhála git a spreagadh"
 
 msgid "failed to set up maintenance schedule"
-msgstr ""
+msgstr "theip ar sceideal cothabhála a chur ar bun"
 
 msgid "failed to add repo to global config"
-msgstr ""
+msgstr "theip ar repo a chur le cumraíocht domhanda"
 
 msgid "git maintenance <subcommand> [<options>]"
-msgstr ""
+msgstr "cothabháil git <subcommand>[<options>]"
 
-#, fuzzy
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
-msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+msgstr "git grep [<options>] [-e] <pattern>[<rev>...] [[--]<path>...]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "grep: failed to create thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "grep: theip ar shnáithe a chruthú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid number of threads specified (%d) for %s"
-msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
+msgstr "líon neamhbhailí na snáitheanna a shonraítear (%d) do %s"
 
 #. #-#-#-#-#  grep.c.po  #-#-#-#-#
 #. TRANSLATORS: %s is the configuration
@@ -6693,339 +7099,347 @@ msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
 msgid "no threads support, ignoring %s"
 msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read tree %s"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "nach féidir crann %s a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to grep from object of type %s"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "in ann grep ó réad de chineál %s"
 
 #, c-format
 msgid "switch `%c' expects a numerical value"
-msgstr ""
+msgstr "tá an lasc `%c' ag súil le luach uimhriúil"
 
-#, fuzzy
 msgid "search in index instead of in the work tree"
-msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+msgstr "cuardaigh san innéacs in ionad sa chrann oibre"
 
 msgid "find in contents not managed by git"
-msgstr ""
+msgstr "aimsigh in ábhar nach mbainistíonn git"
 
-#, fuzzy
 msgid "search in both tracked and untracked files"
-msgstr " (bain úsáid as an rogha -u chun comhaid neamhrianaithe a thaispeáint)"
+msgstr "cuardach i gcomhaid rianaithe agus neamhrianaithe araon"
 
 msgid "ignore files specified via '.gitignore'"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar chomhaid a shonraítear trí '.gitignore'"
 
-#, fuzzy
 msgid "recursively search in each submodule"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "cuardach athshlánach i ngach fo-mhodúl"
 
 msgid "show non-matching lines"
-msgstr ""
+msgstr "línte neamh-mheaitseála a"
 
 msgid "case insensitive matching"
-msgstr ""
+msgstr "meaitseáil cás neamhíogair"
 
 msgid "match patterns only at word boundaries"
-msgstr ""
+msgstr "patrúin a mheaitseáil ach ag teorainneacha focal"
 
 msgid "process binary files as text"
-msgstr ""
+msgstr "comhaid dénártha a phróiseáil mar th"
 
 msgid "don't match patterns in binary files"
-msgstr ""
+msgstr "ná meaitseáil patrúin i gcomhaid dénártha"
 
 msgid "process binary files with textconv filters"
-msgstr ""
+msgstr "comhaid dénártha a phróiseáil le scagairí textconv"
 
 msgid "search in subdirectories (default)"
-msgstr ""
+msgstr "cuardaigh i bhfo-eolairí (réamhshocrú)"
 
 msgid "descend at most <n> levels"
-msgstr ""
+msgstr "síos ag an bhformhór na <n>leibh"
 
 msgid "use extended POSIX regular expressions"
-msgstr ""
+msgstr "bain úsáid as nathanna rialta POSIX leathnaithe"
 
 msgid "use basic POSIX regular expressions (default)"
-msgstr ""
+msgstr "úsáid abairtí rialta bunúsacha POSIX (réamhshocraithe)"
 
 msgid "interpret patterns as fixed strings"
-msgstr ""
+msgstr "patrúin a léiriú mar teaghráin seasta"
 
 msgid "use Perl-compatible regular expressions"
-msgstr ""
+msgstr "úsáid abairtí rialta atá comhoiriúnach le PERL"
 
 msgid "show line numbers"
-msgstr ""
+msgstr "taispeáin uimhreacha líne"
 
 msgid "show column number of first match"
-msgstr ""
+msgstr "taispeáin uimhir cholún an chéad chluiche"
 
 msgid "don't show filenames"
-msgstr ""
+msgstr "ná taispeáin ainmneacha comhaid"
 
 msgid "show filenames"
-msgstr ""
+msgstr "taispeáin ainmneacha comhaid"
 
 msgid "show filenames relative to top directory"
-msgstr ""
+msgstr "ainmneacha comhaid a thaispeáint i gcoibhneas"
 
 msgid "show only filenames instead of matching lines"
-msgstr ""
+msgstr "taispeáint ach ainmneacha comhaid in ionad línte meaitseála"
 
 msgid "synonym for --files-with-matches"
-msgstr ""
+msgstr "comhchiallach do --files-with-matches"
 
 msgid "show only the names of files without match"
-msgstr ""
+msgstr "taispeáint ach ainmneacha na gcomhaid gan meaitseáil"
 
 msgid "print NUL after filenames"
-msgstr ""
+msgstr "priontáil NUL tar éis ainmneacha comhaid"
 
 msgid "show only matching parts of a line"
-msgstr ""
+msgstr "taispeáin ach codanna de líne a mheaitseáil"
 
 msgid "show the number of matches instead of matching lines"
-msgstr ""
+msgstr "taispeáint líon na gcluichí in ionad línte meaitseála"
 
 msgid "highlight matches"
-msgstr ""
+msgstr "cluichí aibhsithe"
 
 msgid "print empty line between matches from different files"
-msgstr ""
+msgstr "priontáil líne folamh idir cluichí ó chomhaid éagsúla"
 
 msgid "show filename only once above matches from same file"
 msgstr ""
+"taispeáin ainm comhaid ach uair amháin thuas na cluichí ón gcomhad céanna"
 
 msgid "show <n> context lines before and after matches"
-msgstr ""
+msgstr "<n>línte comhthéacs a thaispeáint roimh agus tar"
 
 msgid "show <n> context lines before matches"
-msgstr ""
+msgstr "<n>línte comhthéacs a thaispeáint"
 
 msgid "show <n> context lines after matches"
-msgstr ""
+msgstr "<n>línte comhthéacs a thaispeáint"
 
 msgid "use <n> worker threads"
-msgstr ""
+msgstr "úsáid sná <n>itheanna oibrithe"
 
 msgid "shortcut for -C NUM"
-msgstr ""
+msgstr "aicearra le haghaidh -C NUM"
 
 msgid "show a line with the function name before matches"
-msgstr ""
+msgstr "taispeáint líne leis an ainm feidhme roimh mheaitseálacha"
 
 msgid "show the surrounding function"
-msgstr ""
+msgstr "taispeáin an fheidhm máguaird"
 
 msgid "read patterns from file"
-msgstr ""
+msgstr "patrúin a léamh ón gcomhad"
 
 msgid "match <pattern>"
-msgstr ""
+msgstr "comhoiriúnú <pattern>"
 
 msgid "combine patterns specified with -e"
-msgstr ""
+msgstr "comhcheangal patrúin a shonraítear le -e"
 
 msgid "indicate hit with exit status without output"
-msgstr ""
+msgstr "léirigh bualadh le stádas imeachta gan aschur"
 
 msgid "show only matches from files that match all patterns"
-msgstr ""
+msgstr "taispeáin ach cluichí ó chomhaid a mheaitseálann gach patrún"
 
 msgid "pager"
-msgstr ""
+msgstr "pager"
 
 msgid "show matching files in the pager"
-msgstr ""
+msgstr "taispeáint comhaid mheaitseála sa pager"
 
 msgid "allow calling of grep(1) (ignored by this build)"
-msgstr ""
+msgstr "cead a ghlaoch grep (1) (neamhaird ag an tógáil seo)"
 
 msgid "maximum number of results per file"
-msgstr ""
+msgstr "líon uasta na dtorthaí in aghaidh an chomhad"
 
 msgid "no pattern given"
-msgstr ""
+msgstr "aon phatrún a thugtar"
 
-#, fuzzy
 msgid "--no-index or --untracked cannot be used with revs"
-msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
+msgstr "Ní féidir --no-index nó --untracked a úsáid le hathairí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to resolve revision: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir athbhreithniú a réiteach: %s"
 
 msgid "--untracked not supported with --recurse-submodules"
-msgstr ""
+msgstr "--untracked nach dtacaítear le --recurse-submodules"
 
 msgid "invalid option combination, ignoring --threads"
-msgstr ""
+msgstr "teaglaim roghanna neamhbhailí, ag neamhaird --threads"
 
-#, fuzzy
 msgid "no threads support, ignoring --threads"
-msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
+msgstr "níl aon tacaíocht do shnáitheanna, ag déanamh neamhaird ar --threads"
 
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
 
 msgid "--open-files-in-pager only works on the worktree"
-msgstr ""
+msgstr "Ní oibríonn --open-files-in-pager ach ar an gcrann oibre"
 
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
+"- ní féidir caighdeán eisiach [no-] a úsáid le haghaidh ábhar rianaithe"
 
 msgid "both --cached and trees are given"
-msgstr ""
+msgstr "tugtar --cached agus crainn araon"
 
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file> | --no-filters]\n"
 "                [--stdin [--literally]] [--] <file>..."
 msgstr ""
+"git hash-object [-t <type>] [-w] [--path=<file> | --no-filters]\n"
+"                [--stdin [--literally]] [--] <file>..."
 
 msgid "git hash-object [-t <type>] [-w] --stdin-paths [--no-filters]"
-msgstr ""
+msgstr "git hash-object [-t <type>] [-w] --stdin-paths [--no-filters]"
 
-#, fuzzy
 msgid "object type"
-msgstr "cineál réad anaithnid %d"
+msgstr "cineál réad"
 
 msgid "write the object into the object database"
-msgstr ""
+msgstr "scríobh an réad isteach sa bhunachar sonraí réad"
 
 msgid "read the object from stdin"
-msgstr ""
+msgstr "léigh an réad ó stdin"
 
 msgid "store file as is without filters"
-msgstr ""
+msgstr "comhad a stóráil mar atá gan scagairí"
 
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr ""
+"ní gá ach aon truflais randamach a chur chun rudaí truaillithe a chruthú le "
+"haghaidh dífhab"
 
 msgid "process file as it were from this path"
-msgstr ""
+msgstr "comhad próiseála mar a bhí sé ón gcosán seo"
 
 msgid "print all available commands"
-msgstr ""
+msgstr "gach ordú atá ar fáil a phriontáil"
 
 msgid "show external commands in --all"
-msgstr ""
+msgstr "taispeáint orduithe seachtracha i --all"
 
 msgid "show aliases in --all"
-msgstr ""
+msgstr "taispeáin ainmneacha in --all"
 
 msgid "exclude guides"
-msgstr ""
+msgstr "treoracha a eisiamh"
 
 msgid "show man page"
-msgstr ""
+msgstr "taispeáin leathanach fear"
 
 msgid "show manual in web browser"
-msgstr ""
+msgstr "taispeáin lámhleabhar sa bhrabhsála"
 
 msgid "show info page"
-msgstr ""
+msgstr "taispeáin leathanach faisnéise"
 
 msgid "print command description"
-msgstr ""
+msgstr "cur síos ordaithe priontála"
 
 msgid "print list of useful guides"
-msgstr ""
+msgstr "liosta priontáil de threoracha úsáideacha"
 
 msgid "print list of user-facing repository, command and file interfaces"
 msgstr ""
+"liosta priontála de stór, comhéadain ordaithe agus comhad atá os comhair "
+"úsáideora"
 
 msgid "print list of file formats, protocols and other developer interfaces"
 msgstr ""
+"liosta priontála formáidí comhaid, prótacail agus comhéadain forbróra eile"
 
 msgid "print all configuration variable names"
-msgstr ""
+msgstr "priontáil gach ainm athróg cumraíochta"
 
 msgid "git help [[-i|--info] [-m|--man] [-w|--web]] [<command>|<doc>]"
-msgstr ""
+msgstr "<command><doc>git help [[-i|--eolas] [-m|--fear] [-w|--gréasáin]] [|]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized help format '%s'"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "formáid cabhrach gan aithint '%s'"
 
-#, fuzzy
 msgid "Failed to start emacsclient."
-msgstr "theip ar '%s' a stáil"
+msgstr "Theip ar emacsclient a thosú."
 
-#, fuzzy
 msgid "Failed to parse emacsclient version."
-msgstr "Theip ar '%s' a réiteach mar athbhreithniú bailí."
+msgstr "Theip ar leagan emacsclient a pháirseáil."
 
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
-msgstr ""
+msgstr "leagan imacsclient '%d' ró-sean (< 22)."
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to exec '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar '%s' a fheidhmiú"
 
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
 "Please consider using 'man.<tool>.cmd' instead."
 msgstr ""
+"'%s': cosán do lucht féachana fear gan tacaíocht.\n"
+"Smaoinigh ar 'fear a úsáid le do thoil. <tool>.cmd' ina ionad."
 
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
 "Please consider using 'man.<tool>.path' instead."
 msgstr ""
+"'%s': cmd do lucht féachana fear tacaithe.\n"
+"Smaoinigh ar 'fear a úsáid le do thoil. <tool>.path' ina ionad sin."
 
 #, c-format
 msgid "'%s': unknown man viewer."
-msgstr ""
+msgstr "'%s': féachtóir fear anaithnid."
 
 msgid "no man viewer handled the request"
-msgstr ""
+msgstr "níl aon fhéachtóir fear ar an iarraidh"
 
 msgid "no info viewer handled the request"
-msgstr ""
+msgstr "níl aon fhéachtóir faisnéise ag láimhseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is aliased to '%s'"
-msgstr "Ní féidir '%s' a úsáid le '%s'"
+msgstr "Tá '%s' aistrithe go '%s'"
 
 #, c-format
 msgid "bad alias.%s string: %s"
-msgstr ""
+msgstr "droch-ainm. Teagán %s: %s"
 
 #, c-format
 msgid "the '%s' option doesn't take any non-option arguments"
-msgstr ""
+msgstr "ní ghlacann an rogha '%s' aon argóintí neamh-rogha"
 
 msgid ""
 "the '--no-[external-commands|aliases]' options can only be used with '--all'"
 msgstr ""
+"ní féidir na roghanna '--no- [external-commands|aliases] 'a úsáid ach le' --"
+"all '"
 
 #, c-format
 msgid "usage: %s%s"
-msgstr ""
+msgstr "úsáid: %s%s"
 
 msgid "'git help config' for more information"
-msgstr ""
+msgstr "'git help config' le haghaidh tuilleadh faisnéise"
 
 msgid ""
 "git hook run [--ignore-missing] [--to-stdin=<path>] <hook-name> [-- <hook-"
 "args>]"
 msgstr ""
+"<path><hook-name><hook-args>git hook run [--ignore-missing] [--to-stdin =] "
+"[--]"
 
 msgid "silently ignore missing requested <hook-name>"
-msgstr ""
+msgstr "neamhaird go ciúin a iarrtar ar <hook-name>"
 
-#, fuzzy
 msgid "file to read into hooks' stdin"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "comhad le léamh isteach i stdin na hracaí"
 
 #, c-format
 msgid "object type mismatch at %s"
@@ -7273,1598 +7687,1619 @@ msgid ""
 "         [-b <branch-name> | --initial-branch=<branch-name>]\n"
 "         [--shared[=<permissions>]] [<directory>]"
 msgstr ""
+"git init [-q | --quiet] [--bare] [--template=<template-directory>]\n"
+"         [--separate-git-dir <git-dir>] [--object-format=<format>]\n"
+"         [--ref-format=<format>]\n"
+"         [-b <branch-name> | --initial-branch=<branch-name>]\n"
+"         [--shared[=<permissions>]] [<directory>]"
 
 msgid "permissions"
-msgstr ""
+msgstr "ceadanna"
 
 msgid "specify that the git repository is to be shared amongst several users"
-msgstr ""
+msgstr "sonraigh go bhfuil an stór git le roinnt i measc roinnt úsáideoirí"
 
 msgid "override the name of the initial branch"
-msgstr ""
+msgstr "ainm na brainse tosaigh a shárú"
 
 msgid "hash"
-msgstr ""
+msgstr "hash"
 
-#, fuzzy
 msgid "specify the hash algorithm to use"
-msgstr "sonraigh an fhormáid tagartha le húsáid"
+msgstr "sonraigh an algartam hash le húsáid"
 
 #, c-format
 msgid "cannot mkdir %s"
-msgstr ""
+msgstr "ní féidir teacht ar %s"
 
 #, c-format
 msgid "cannot chdir to %s"
-msgstr ""
+msgstr "ní féidir teacht chuig %s"
 
 #, c-format
 msgid ""
 "%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
 "dir=<directory>)"
 msgstr ""
+"%s (or --work-tree=<directory>) ní cheadaítear gan sonrú %s (or --git-"
+"dir=<directory>)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Cannot access work tree '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "Ní féidir rochtain a fháil ar chrann oibre '%s'"
 
-#, fuzzy
 msgid "--separate-git-dir incompatible with bare repository"
-msgstr "Ní cheadaítear athshocrú %s i stóras lom"
+msgstr "--separate-git-dir neamhoiriúnach le stór lom"
 
 msgid ""
 "git interpret-trailers [--in-place] [--trim-empty]\n"
 "                       [(--trailer (<key>|<key-alias>)[(=|:)<value>])...]\n"
 "                       [--parse] [<file>...]"
 msgstr ""
+"git interpret-trailers [--in-place] [--trim-empty]\n"
+"                       [(--trailer (<key>|<key-alias>)[(=|:)<value>])...]\n"
+"                       [--parse] [<file>...]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not stat %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh ann %s a shástáil"
 
 #, c-format
 msgid "file %s is not a regular file"
-msgstr ""
+msgstr "ní comhad rialta é comhad %s"
 
 #, c-format
 msgid "file %s is not writable by user"
-msgstr ""
+msgstr "ní féidir an t-úsáideoir comhad %s a scríobh"
 
-#, fuzzy
 msgid "could not open temporary file"
-msgstr "ní féidir le comhad malartacha sealadacha a dhínascadh"
+msgstr "ní fhéadfadh comhad sealadach a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read input file '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann comhad ionchuir '%s' a léamh"
 
-#, fuzzy
 msgid "could not read from stdin"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí léamh ó stdin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not rename temporary file to %s"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "ní fhéadfaí comhad sealadach a athainmniú go %s"
 
 msgid "edit files in place"
-msgstr ""
+msgstr "comhaid in áit a chur in eagar"
 
 msgid "trim empty trailers"
-msgstr ""
+msgstr "leantóirí folamh a ghear"
 
 msgid "placement"
-msgstr ""
+msgstr "socrúcháin"
 
 msgid "where to place the new trailer"
-msgstr ""
+msgstr "cá háit a chuirfear an leantóir nua"
 
-#, fuzzy
 msgid "action if trailer already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "gníomh má tá leantóir ann cheana féin"
 
 msgid "action if trailer is missing"
-msgstr ""
+msgstr "gníomh má tá leantóir ar iarraidh"
 
 msgid "output only the trailers"
-msgstr ""
+msgstr "aschur ach na leantóirí"
 
 msgid "do not apply trailer.* configuration variables"
-msgstr ""
+msgstr "ná cuir leantóir i bhfeidhm.* athróga cumraíochta"
 
 msgid "reformat multiline trailer values as single-line values"
-msgstr ""
+msgstr "luachanna leantóra illíne a athfhormáidiú mar luachanna aon-líne"
 
 msgid "alias for --only-trailers --only-input --unfold"
-msgstr ""
+msgstr "ainm le haghaidh --only-trailers --only-input --unfold"
 
 msgid "do not treat \"---\" as the end of input"
-msgstr ""
+msgstr "ná déileáil le “---” mar dheireadh an ionchuir"
 
 msgid "trailer(s) to add"
-msgstr ""
+msgstr "leantóir (í) le cur leis"
 
 msgid "--trailer with --only-input does not make sense"
-msgstr ""
+msgstr "níl ciall le --trailer le --only-input"
 
 msgid "no input file given for in-place editing"
-msgstr ""
+msgstr "níl aon chomhad ionchuir a thugtar le haghaidh eagarthóireachta"
 
-#, fuzzy
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
-msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+msgstr "logáil git [<options>] [<revision-range>] [[--]<path>...]"
 
-#, fuzzy
 msgid "git show [<options>] <object>..."
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git show [<options>]<object>..."
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid --decorate option: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "rogha neamhbhailí --decorate: %s"
 
 msgid "suppress diff output"
-msgstr ""
+msgstr "aschur diff a chur faoi chois"
 
 msgid "show source"
-msgstr ""
+msgstr "foinse taispeáin"
 
 msgid "clear all previously-defined decoration filters"
-msgstr ""
+msgstr "glan na scagairí maisiúcháin atá sainmhínithe roimhe seo"
 
 msgid "only decorate refs that match <pattern>"
-msgstr ""
+msgstr "ní mhaisigh ach na cinn a mheaitseálann <pattern>"
 
 msgid "do not decorate refs that match <pattern>"
-msgstr ""
+msgstr "ná maisigh na cinn a mheaitseálann <pattern>"
 
 msgid "decorate options"
-msgstr ""
+msgstr "roghanna maisiú"
 
 msgid ""
 "trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
-msgstr ""
+msgstr "éabhlóid raon líne<start>, <end>nó feidhm <funcname>a rianú: i <file>"
 
-#, fuzzy
 msgid "-L<range>:<file> cannot be used with pathspec"
-msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+msgstr "-L<range>: ní <file>féidir é a úsáid le pathspec"
 
 #, c-format
 msgid "Final output: %d %s\n"
-msgstr ""
+msgstr "Aschur deiridh: %d %s\n"
 
 #, c-format
 msgid "git show %s: bad file"
-msgstr ""
+msgstr "git show %s: droch-chomhad"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read object %s"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní raibh in ann réad %s a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown type: %d"
-msgstr "cineál réad anaithnid %d"
+msgstr "cineál anaithnid: %d"
 
 #, c-format
 msgid "%s: invalid cover from description mode"
-msgstr ""
+msgstr "%s: clúdach neamhbhailí ó mhodh tuairisc"
 
 msgid "format.headers without value"
-msgstr ""
+msgstr "format.headers gan luach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open patch file %s"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "ní féidir comhad paiste %s a oscailt"
 
 msgid "need exactly one range"
-msgstr ""
+msgstr "teastaíonn raon amháin díreach"
 
 msgid "not a range"
-msgstr ""
+msgstr "ní raon"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read branch description file '%s'"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "nach féidir an comhad tuairisc brainse '%s' a léamh"
 
 msgid "cover letter needs email format"
-msgstr ""
+msgstr "teastaíonn formáid ríomhphoist ó litir"
 
-#, fuzzy
 msgid "failed to create cover-letter file"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar chomhad litir chlúdaigh a chruthú"
 
 #, c-format
 msgid "insane in-reply-to: %s"
-msgstr ""
+msgstr "in-fhreagairt daingniúil: %s"
 
-#, fuzzy
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git format-patch [<roghanna>] [<ó> | <raon-athbhreithnithe>]"
 
 msgid "two output directories?"
-msgstr ""
+msgstr "dhá eolaire aschuir?"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown commit %s"
-msgstr "stíl choimhlinte anaithnid '%s'"
+msgstr "tiomantas anaithnid %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to resolve '%s' as a valid ref"
-msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+msgstr "theip ar '%s' a réiteach mar thagartha bailí"
 
-#, fuzzy
 msgid "could not find exact merge base"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "ní fhéadfaí bonn cumaisc cruinn a fháil"
 
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
 "Or you could specify base commit by --base=<base-commit-id> manually"
 msgstr ""
+"theip ar an dul suas sruth, más mian leat an gealltanas bonn a thaifeadadh "
+"go huathoibríoch,\n"
+"bain úsáid as git branch --set-upstream-to chun brainse iargúlta a rianú.\n"
+"Nó d'fhéadfá an gealltanas bonn a shonrú trí --base=<base-commit-id> de láimh"
 
-#, fuzzy
 msgid "failed to find exact merge base"
-msgstr "Theip ar chrann %s a aimsiú."
+msgstr "theip orthu bonn cumaisc cruinn a fháil"
 
 msgid "base commit should be the ancestor of revision list"
-msgstr ""
+msgstr "ba cheart gurb é bonn tiomantas ina sinsear an liosta athbhrei"
 
 msgid "base commit shouldn't be in revision list"
-msgstr ""
+msgstr "níor cheart go mbeadh tiomantas bonn sa liosta athbhrei"
 
-#, fuzzy
 msgid "cannot get patch id"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "ní féidir id paiste a fháil"
 
 msgid "failed to infer range-diff origin of current series"
-msgstr ""
+msgstr "theip ar thionscnamh raon difriúil na sraithe reatha a thabhairt amach"
 
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
-msgstr ""
+msgstr "ag baint úsáide as '%s' mar bhunús diff raon na sraithe reatha"
 
 msgid "use [PATCH n/m] even with a single patch"
-msgstr ""
+msgstr "bain úsáid as [PATCH n/m] fiú le paiste amháin"
 
 msgid "use [PATCH] even with multiple patches"
-msgstr ""
+msgstr "bain úsáid as [PATCH] fiú le paistí iolracha"
 
 msgid "print patches to standard out"
-msgstr ""
+msgstr "paistí a phriontáil chun caighdeánach"
 
 msgid "generate a cover letter"
-msgstr ""
+msgstr "litir chlúdaigh a ghiniúint"
 
 msgid "use simple number sequence for output file names"
-msgstr ""
+msgstr "úsáid seicheamh uimhreacha simplí d'ainmneacha comhaid aschu"
 
 msgid "sfx"
-msgstr ""
+msgstr "sfx"
 
 msgid "use <sfx> instead of '.patch'"
-msgstr ""
+msgstr "úsáid <sfx>in ionad '.patch'"
 
 msgid "start numbering patches at <n> instead of 1"
-msgstr ""
+msgstr "tosú ag uimhriú paistí ag <n>seachas 1"
 
 msgid "reroll-count"
-msgstr ""
+msgstr "comhaireamh ath-rollta"
 
 msgid "mark the series as Nth re-roll"
-msgstr ""
+msgstr "marcáil an tsraith mar Nú ath-rolla"
 
 msgid "max length of output filename"
-msgstr ""
+msgstr "fad uasta ainm an chomhaid aschuir"
 
-#, fuzzy
 msgid "rfc"
-msgstr "tagairt"
+msgstr "rfc"
 
 msgid "add <rfc> (default 'RFC') before 'PATCH'"
-msgstr ""
+msgstr "cuir <rfc>(réamhshocraithe 'RFC') roimh 'PATCH'"
 
 msgid "cover-from-description-mode"
-msgstr ""
+msgstr "modh clúdaigh ó-tuairiscríbhinní"
 
 msgid "generate parts of a cover letter based on a branch's description"
-msgstr ""
+msgstr "codanna de litir chlúdaigh a ghiniúint bunaithe ar thuairisc brainse"
 
 msgid "use branch description from file"
-msgstr ""
+msgstr "úsáid cur síos brainse ón gcomhad"
 
 msgid "use [<prefix>] instead of [PATCH]"
-msgstr ""
+msgstr "úsáid [<prefix>] in ionad [PATCH]"
 
 msgid "store resulting files in <dir>"
-msgstr ""
+msgstr "comhaid mar thoradh air a stóráil i <dir>"
 
 msgid "don't strip/add [PATCH]"
-msgstr ""
+msgstr "ná stiall/cuir [PATCH] leis"
 
 msgid "don't output binary diffs"
-msgstr ""
+msgstr "ná aschur difríochtaí dénártha"
 
 msgid "output all-zero hash in From header"
-msgstr ""
+msgstr "aschur hash uile-nialas i Ó cheanntásc"
 
 msgid "don't include a patch matching a commit upstream"
-msgstr ""
+msgstr "ná cuir paiste a mheaitseann le tiomantas suas an sruth"
 
 msgid "show patch format instead of default (patch + stat)"
-msgstr ""
+msgstr "taispeáin formáid paiste in ionad réamhshocraithe (paiste + stat)"
 
 msgid "Messaging"
-msgstr ""
+msgstr "Teachtaireachtaí"
 
-#, fuzzy
 msgid "header"
-msgstr "chun tosaigh "
+msgstr "ceanntásc"
 
 msgid "add email header"
-msgstr ""
+msgstr "ceanntásc ríomhphoist leis"
 
 msgid "email"
-msgstr ""
+msgstr "ríomhphost"
 
 msgid "add To: header"
-msgstr ""
+msgstr "cuir Le: ceanntásc"
 
 msgid "add Cc: header"
-msgstr ""
+msgstr "cuir Cc leis: ceanntásc"
 
 msgid "ident"
-msgstr ""
+msgstr "idirghníomhaire"
 
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
+"socraigh Ó sheoladh go dtí <ident>(nó aitheantas an tiomantais mura bhfuil "
+"sé ann)"
 
 msgid "message-id"
-msgstr ""
+msgstr "id teachtaireachta"
 
 msgid "make first mail a reply to <message-id>"
-msgstr ""
+msgstr "déan freagra ar an gcéad phost <message-id>"
 
 msgid "boundary"
-msgstr ""
+msgstr "teorainn"
 
 msgid "attach the patch"
-msgstr ""
+msgstr "ceangail an paiste"
 
 msgid "inline the patch"
-msgstr ""
+msgstr "inlíne an paiste"
 
 msgid "enable message threading, styles: shallow, deep"
-msgstr ""
+msgstr "cumasú snáithe teachtaireachta, stíleanna: éadomhain, domhain"
 
 msgid "signature"
-msgstr ""
+msgstr "síniú"
 
 msgid "add a signature"
-msgstr ""
+msgstr "cuir síniú"
 
 msgid "base-commit"
-msgstr ""
+msgstr "bun-tiomantas"
 
 msgid "add prerequisite tree info to the patch series"
-msgstr ""
+msgstr "cuir faisnéis rainn réamhriachtanais leis an tsraith paiste"
 
 msgid "add a signature from a file"
-msgstr ""
+msgstr "cuir síniú ó chomhad"
 
 msgid "don't print the patch filenames"
-msgstr ""
+msgstr "ná priontáil na hainmneacha comhaid paiste"
 
 msgid "show progress while generating patches"
-msgstr ""
+msgstr "dul chun cinn a thaispeáint agus paistí"
 
 msgid "show changes against <rev> in cover letter or single patch"
-msgstr ""
+msgstr "athruithe a thaispeá <rev>int i gcoinne i litir chlúdaigh nó"
 
 msgid "show changes against <refspec> in cover letter or single patch"
-msgstr ""
+msgstr "athruithe a thaispeá <refspec>int i gcoinne i litir chlúdaigh nó"
 
 msgid "percentage by which creation is weighted"
-msgstr ""
+msgstr "céatadán faoina n-ualaítear an cruthú"
 
 msgid "show in-body From: even if identical to the e-mail header"
 msgstr ""
+"taispeáin in-chorp Ó: fiú más comhionann leis an gceannteideal ríomhphoist"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid ident line: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "líne aitheantais neamhbhailí: %s"
 
 msgid "--name-only does not make sense"
-msgstr ""
+msgstr "Ní bhíonn ciall ag --name-only"
 
 msgid "--name-status does not make sense"
-msgstr ""
+msgstr "Ní bhíonn ciall ag --name-status"
 
 msgid "--check does not make sense"
-msgstr ""
+msgstr "Ní bhíonn ciall ag --check"
 
 msgid "--remerge-diff does not make sense"
-msgstr ""
+msgstr "Ní bhíonn ciall ag --remerge-diff"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create directory '%s'"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire '%s' a chruthú"
 
 msgid "--interdiff requires --cover-letter or single patch"
-msgstr ""
+msgstr "éilíonn --interdiff --cover-letter nó paiste singil"
 
 msgid "Interdiff:"
-msgstr ""
+msgstr "Interdiff:"
 
 #, c-format
 msgid "Interdiff against v%d:"
-msgstr ""
+msgstr "Interdiff i gcoinne v%d:"
 
 msgid "--range-diff requires --cover-letter or single patch"
-msgstr ""
+msgstr "Éilíonn --range-diff --cover-letter nó paiste aonair"
 
 msgid "Range-diff:"
-msgstr ""
+msgstr "Difríocht raon:"
 
 #, c-format
 msgid "Range-diff against v%d:"
-msgstr ""
+msgstr "Difríocht raon i gcoinne v%d:"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read signature file '%s'"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "nach féidir an comhad sínithe '%s' a léamh"
 
-#, fuzzy
 msgid "Generating patches"
-msgstr "Cosáin neamh-chumasaithe:"
+msgstr "Giniúint paistí"
 
-#, fuzzy
 msgid "failed to create output files"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar chomhaid aschuir a chruthú"
 
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
-msgstr ""
+msgstr "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
 msgstr ""
+"Níor féidir brainse iargúlta rianaithe a fháil, sonraigh de láimh le do th "
+"<upstream>oil.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not get object info about '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí faisnéis réada a fháil faoi '%s'"
 
-#, fuzzy
 msgid "git ls-files [<options>] [<file>...]"
-msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+msgstr "git ls-files [<options>] [<file>...]"
 
 msgid "separate paths with the NUL character"
-msgstr ""
+msgstr "cosáin ar leithligh leis an carachtar NUL"
 
 msgid "identify the file status with tags"
-msgstr ""
+msgstr "stádas an chomhaid a aithint le clibeanna"
 
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr ""
+"bain úsáid as litreacha beaga le haghaidh comhaid 'glacadh leis gan "
+"athraithe'"
 
 msgid "use lowercase letters for 'fsmonitor clean' files"
-msgstr ""
+msgstr "bain úsáid as litreacha beaga le haghaidh comhaid 'fsmonitor clean'"
 
 msgid "show cached files in the output (default)"
-msgstr ""
+msgstr "taispeáint comhaid taispeána san aschur (réamhshocraithe)"
 
 msgid "show deleted files in the output"
-msgstr ""
+msgstr "taispeáint comhaid scriosta san aschur"
 
 msgid "show modified files in the output"
-msgstr ""
+msgstr "taispeáint comhaid modhnaithe san aschur"
 
 msgid "show other files in the output"
-msgstr ""
+msgstr "taispeáint comhaid eile san aschur"
 
 msgid "show ignored files in the output"
-msgstr ""
+msgstr "taispeáint comhaid a neamhaird san aschur"
 
 msgid "show staged contents' object name in the output"
-msgstr ""
+msgstr "taispeáin ainm réad ábhair stáitseáilte san aschur"
 
 msgid "show files on the filesystem that need to be removed"
-msgstr ""
+msgstr "taispeáint comhaid ar an gcóras comhaid is gá a bhaint"
 
 msgid "show 'other' directories' names only"
-msgstr ""
+msgstr "taispeáin ainmneacha 'eile' amháin"
 
 msgid "show line endings of files"
-msgstr ""
+msgstr "taispeáint deireadh líne na gcomhaid"
 
 msgid "don't show empty directories"
-msgstr ""
+msgstr "ná taispeáin eolairí folamh"
 
 msgid "show unmerged files in the output"
-msgstr ""
+msgstr "taispeáint comhaid neamh-chumhdaithe san aschur"
 
 msgid "show resolve-undo information"
-msgstr ""
+msgstr "taispeáin faisnéis réitigh a chealú"
 
 msgid "skip files matching pattern"
-msgstr ""
+msgstr "patrún meaitseála comhaid scipeála"
 
 msgid "read exclude patterns from <file>"
-msgstr ""
+msgstr "léigh patrúin eisiamh ó <file>"
 
 msgid "read additional per-directory exclude patterns in <file>"
-msgstr ""
+msgstr "léigh patrúin breise in aghaidh eolaire a eisiamh i <file>"
 
 msgid "add the standard git exclusions"
-msgstr ""
+msgstr "cuir na heisiaimh caighdeánacha git"
 
 msgid "make the output relative to the project top directory"
-msgstr ""
+msgstr "déan an t-aschur i gcoibhneas le barr-eolaire an tion"
 
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr ""
+"mura <file>bhfuil aon cheann san innéacs, déileáil leis seo mar earráid"
 
 msgid "tree-ish"
-msgstr ""
+msgstr "crainn"
 
 msgid "pretend that paths removed since <tree-ish> are still present"
-msgstr ""
+msgstr "ligean go bhfuil cosáin a bhain <tree-ish>tear ó shin fós i láthair"
 
 msgid "show debugging data"
-msgstr ""
+msgstr "taispeáin sonraí dífhabhtaithe"
 
 msgid "suppress duplicate entries"
-msgstr ""
+msgstr "iontrálacha dúbailte a chur"
 
 msgid "show sparse directories in the presence of a sparse index"
-msgstr ""
+msgstr "taispeáint eolairí neamhchoitianta i láthair innéacs neamhchoitianta"
 
 msgid ""
 "--format cannot be used with -s, -o, -k, -t, --resolve-undo, --deduplicate, "
 "--eol"
 msgstr ""
+"Ní féidir --format a úsáid le -s, -o, -k, -t, --resolve-undo, --deduplicate, "
+"--eol"
 
 msgid ""
 "git ls-remote [--branches] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "              [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
 "              [--symref] [<repository> [<patterns>...]]"
 msgstr ""
+"git ls-remote [--branches] [--tags] [--refs] [--upload-pack=<exec>]\n"
+"              [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
+"              [--symref] [<repository> [<patterns>...]]"
 
 msgid "do not print remote URL"
-msgstr ""
+msgstr "ná priontáil URL iargúlta"
 
 msgid "exec"
-msgstr ""
+msgstr "feidhmiúcháin"
 
-#, fuzzy
 msgid "path of git-upload-pack on the remote host"
-msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
+msgstr "cosán git-upload-pack ar an óstach cianda"
 
 msgid "limit to tags"
-msgstr ""
+msgstr "teorainn le clibeanna"
 
-#, fuzzy
 msgid "limit to branches"
-msgstr "Aistrithe go brainse '%s'\n"
+msgstr "teorainn le brainsí"
 
 msgid "deprecated synonym for --branches"
-msgstr ""
+msgstr "comhchiallach scoite do --branches"
 
 msgid "do not show peeled tags"
-msgstr ""
+msgstr "ná taispeáin clibeanna scáilte"
 
 msgid "take url.<base>.insteadOf into account"
-msgstr ""
+msgstr "glacadh url. <base>.insteadOf san áireamh"
 
 msgid "exit with exit code 2 if no matching refs are found"
-msgstr ""
+msgstr "imeacht le cód imeachta 2 mura bhfaightear aon aifeanna meaitseála"
 
 msgid "show underlying ref in addition to the object pointed by it"
-msgstr ""
+msgstr "taispeáint an tagairt bhunúsach i dteannta leis an réad a thug sé"
 
-#, fuzzy
 msgid "git ls-tree [<options>] <tree-ish> [<path>...]"
-msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+msgstr "<path>git ls-tree [<options>] [...<tree-ish>]"
 
 msgid "only show trees"
-msgstr ""
+msgstr "ach crainn a thaispeáint"
 
 msgid "recurse into subtrees"
-msgstr ""
+msgstr "athshlánú isteach i bhfo-chrainn"
 
 msgid "show trees when recursing"
-msgstr ""
+msgstr "crainn a thaispeáint agus tú ag athf"
 
 msgid "terminate entries with NUL byte"
-msgstr ""
+msgstr "foirceannadh iontrálacha le bait NUL"
 
-#, fuzzy
 msgid "include object size"
-msgstr "réad blob neamhbhailí %s"
+msgstr "méid an rud san áireamh"
 
 msgid "list only filenames"
-msgstr ""
+msgstr "ainmneacha comhaid amháin a liostáil"
 
-#, fuzzy
 msgid "list only objects"
-msgstr "réad blob neamhbhailí %s"
+msgstr "rudaí amháin a liostáil"
 
 msgid "use full path names"
-msgstr ""
+msgstr "úsáid ainmneacha cosáin iomlána"
 
 msgid "list entire tree; not just current directory (implies --full-name)"
 msgstr ""
+"liostáil crann iomlán; ní hamháin eolaire reatha (tugann le tuiscint --full-"
+"name)"
 
-#, fuzzy
 msgid "--format can't be combined with other format-altering options"
-msgstr "--mirror ní féidir é a chomhcheangal le refspecs"
+msgstr ""
+"Ní féidir --format a chomhcheangal le roghanna eile a athraíonn formáidí"
 
 #. TRANSLATORS: keep <> in "<" mail ">" info.
 msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
-msgstr ""
+msgstr "git mailinfo [<options>] <msg> <patch> < mail >info"
 
 msgid "keep subject"
-msgstr ""
+msgstr "coinnigh ábhar"
 
 msgid "keep non patch brackets in subject"
-msgstr ""
+msgstr "coinnigh lúibíní gan paiste san ábhar"
 
 msgid "copy Message-ID to the end of commit message"
 msgstr ""
+"cóipeáil ID teachtaireachtaí go dtí deireadh na teachtaireachta tiomanta"
 
 msgid "re-code metadata to i18n.commitEncoding"
-msgstr ""
+msgstr "meiteashonraí a athchódú chuig i18N.CommitEncoding"
 
 msgid "disable charset re-coding of metadata"
-msgstr ""
+msgstr "díchumasú ath-chódú charset meiteashonraí"
 
 msgid "encoding"
-msgstr ""
+msgstr "ionchódú"
 
 msgid "re-code metadata to this encoding"
-msgstr ""
+msgstr "athchódú meiteashonraí don ionchódú seo"
 
 msgid "use scissors"
-msgstr ""
+msgstr "siosúr a úsáid"
 
 msgid "<action>"
-msgstr ""
+msgstr "<action>"
 
 msgid "action when quoted CR is found"
-msgstr ""
+msgstr "gníomh nuair a aimsítear CR a luaitear"
 
 msgid "use headers in message's body"
-msgstr ""
+msgstr "ceanntásca a úsáid i gcorp na teachtaireachta"
 
 msgid "reading patches from stdin/tty..."
-msgstr ""
+msgstr "paistí a léamh ó stdin/tty..."
 
 #, c-format
 msgid "empty mbox: '%s'"
-msgstr ""
+msgstr "mbox folamh: '%s'"
 
 msgid "git merge-base [-a | --all] <commit> <commit>..."
-msgstr ""
+msgstr "git merge-base [-a | --all] <commit> <commit>..."
 
 msgid "git merge-base [-a | --all] --octopus <commit>..."
-msgstr ""
+msgstr "git merge-base [-a | --all] --octopus <commit>..."
 
 msgid "git merge-base --is-ancestor <commit> <commit>"
-msgstr ""
+msgstr "git merge-base --is-ancestor <commit> <commit>"
 
 msgid "git merge-base --independent <commit>..."
-msgstr ""
+msgstr "git merge-base --independent <commit>..."
 
 msgid "git merge-base --fork-point <ref> [<commit>]"
-msgstr ""
+msgstr "git merge-base --fork-point <ref> [<commit>]"
 
 msgid "output all common ancestors"
-msgstr ""
+msgstr "aschur gach sinsear coitianta"
 
 msgid "find ancestors for a single n-way merge"
-msgstr ""
+msgstr "aimsigh sinsear le haghaidh cumasc n-bhealach amháin"
 
 msgid "list revs not reachable from others"
-msgstr ""
+msgstr "liosta revs nach féidir teacht ó dhaoine eile"
 
 msgid "is the first one ancestor of the other?"
-msgstr ""
+msgstr "an é an chéad sinsear amháin den duine eile?"
 
 msgid "find where <commit> forked from reflog of <ref>"
-msgstr ""
+msgstr "faigh cén áit a <commit> bhforcáladh ó athbhreithniú <ref>"
 
 msgid ""
 "git merge-file [<options>] [-L <name1> [-L <orig> [-L <name2>]]] <file1> "
 "<orig-file> <file2>"
 msgstr ""
+"git merge-file [<options>] [-L <name1> [-L <orig> [-L <name2>]]] <file1> "
+"<orig-file> <file2>"
 
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 msgstr ""
+"glacann difr-algartam rogha le “myers”, “íosta”, “foighne” agus “histogram”"
 
 msgid "send results to standard output"
-msgstr ""
+msgstr "torthaí a sheoladh chuig aschur caigh"
 
 msgid "use object IDs instead of filenames"
-msgstr ""
+msgstr "úsáid ID réad in ionad ainmneacha comhaid"
 
 msgid "use a diff3 based merge"
-msgstr ""
+msgstr "bain úsáid as cumaisc atá bunaithe ar diff3"
 
 msgid "use a zealous diff3 based merge"
-msgstr ""
+msgstr "bain úsáid as cumaisc díograiseach bunaithe ar diff3"
 
 msgid "<algorithm>"
-msgstr ""
+msgstr "<algorithm>"
 
 msgid "choose a diff algorithm"
-msgstr ""
+msgstr "roghnaigh algartam diff"
 
 msgid "for conflicts, use this marker size"
-msgstr ""
+msgstr "le haghaidh coinbhleachtaí, bain úsáid as an méid marcóra"
 
 msgid "do not warn about conflicts"
-msgstr ""
+msgstr "ná tabhair rabhadh faoi choimhlintí"
 
 msgid "set labels for file1/orig-file/file2"
-msgstr ""
+msgstr "lipéid a shocrú le haghaidh comhad1/orig-file/file2"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object '%s' does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl réad '%s' ann"
 
-#, fuzzy
 msgid "Could not write object file"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "Ní fhéadfaí comhad réad a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown option %s"
-msgstr "cineál réad anaithnid %d"
+msgstr "rogha anaithnid %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse object '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí réad '%s' a pháirseáil"
 
 #, c-format
 msgid "cannot handle more than %d base. Ignoring %s."
 msgid_plural "cannot handle more than %d bases. Ignoring %s."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "ní féidir níos mó ná %d bonn a láimhseáil. Ag neamhaird de %s."
+msgstr[1] "ní féidir níos mó ná %d bonn a láimhseáil. Ag neamhaird de %s."
+msgstr[2] "ní féidir níos mó ná %d bonn a láimhseáil. Ag neamhaird de %s."
 
 msgid "not handling anything other than two heads merge."
-msgstr ""
+msgstr "gan láimhseáil aon rud seachas dhá cheann a chumasc."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not resolve ref '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí tagairt '%s' a réiteach"
 
 #, c-format
 msgid "Merging %s with %s\n"
-msgstr ""
+msgstr "Cumasc %s le %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse as tree '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí parsáil mar chrann '%s'"
 
 msgid "not something we can merge"
-msgstr ""
+msgstr "ní rud is féidir linn a chumasc"
 
 msgid "refusing to merge unrelated histories"
-msgstr ""
+msgstr "diúltú stair neamhghaolmhara a chumasc"
 
 msgid "failure to merge"
-msgstr ""
+msgstr "teip a chumasc"
 
 msgid "git merge-tree [--write-tree] [<options>] <branch1> <branch2>"
-msgstr ""
+msgstr "git merge-tree [--write-tree] [<options>] <branch1> <branch2>"
 
 msgid "git merge-tree [--trivial-merge] <base-tree> <branch1> <branch2>"
-msgstr ""
+msgstr "git merge-tree [--trivial-cumaisc] <base-tree><branch1><branch2>"
 
 msgid "do a real merge instead of a trivial merge"
-msgstr ""
+msgstr "déan fíor-chumasc in ionad cumaisc triobháideach"
 
 msgid "do a trivial merge only"
-msgstr ""
+msgstr "déan cumaisc thréimhseach amháin"
 
 msgid "also show informational/conflict messages"
-msgstr ""
+msgstr "taispeáin teachtaireachtaí faisnéis/coinbhleachta freisin"
 
 msgid "list filenames without modes/oids/stages"
-msgstr ""
+msgstr "ainmneacha comhaid a liostáil gan modhair/oids/céimeanna"
 
 msgid "allow merging unrelated histories"
-msgstr ""
+msgstr "ligean stair neamhghaolmhara a chumasc"
 
 msgid "perform multiple merges, one per line of input"
-msgstr ""
+msgstr "cumaisc iolracha a dhéanamh, ceann in aghaidh an líne ionchuir"
 
-#, fuzzy
 msgid "specify a merge-base for the merge"
-msgstr "sonraigh an fhormáid tagartha le húsáid"
+msgstr "sonraigh bonn cumaisc don chumasc"
 
 msgid "option=value"
-msgstr ""
+msgstr "rogha = luach"
 
 msgid "option for selected merge strategy"
-msgstr ""
+msgstr "rogha do straitéis cumaisc roghnaithe"
 
 msgid "--trivial-merge is incompatible with all other options"
-msgstr ""
+msgstr "Tá --trivial-merge neamhoiriúnach le gach rogha eile"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown strategy option: -X%s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "rogha straitéise anaithnid: -X%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed input line: '%s'."
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "líne ionchuir mífhoirmithe: '%s'."
 
-#, fuzzy
 msgid "git merge [<options>] [<commit>...]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git cumaisc [<options>] [<commit>...]"
 
 msgid "switch `m' requires a value"
-msgstr ""
+msgstr "teastaíonn luach ag lasc `m'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "option `%s' requires a value"
-msgstr "tá %s ag teastáil don rogha '%s'"
+msgstr "teastaíonn luach ag rogha `%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not find merge strategy '%s'.\n"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "Níorbh fhéidir straitéis cumaisc '%s' a fháil.\n"
 
 #, c-format
 msgid "Available strategies are:"
-msgstr ""
+msgstr "Is iad straitéisí atá ar fáil:"
 
 #, c-format
 msgid "Available custom strategies are:"
-msgstr ""
+msgstr "Is iad seo a leanas na straitéisí saincheaptha atá ar fáil:"
 
 msgid "do not show a diffstat at the end of the merge"
-msgstr ""
+msgstr "ná taispeáin diffstat ag deireadh an chumaisc"
 
 msgid "show a diffstat at the end of the merge"
-msgstr ""
+msgstr "taispeáin diffstat ag deireadh an chumaisc"
 
 msgid "(synonym to --stat)"
-msgstr ""
+msgstr "(Comhchiallach le --stat)"
 
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
+"cuir iontrálacha (ar a mh <n>éad) ó gearrlog chun teachtaireacht tiomanta a "
+"chumasc"
 
 msgid "create a single commit instead of doing a merge"
-msgstr ""
+msgstr "tiomantas amháin a chruthú in ionad cumaisc a dhéanamh"
 
 msgid "perform a commit if the merge succeeds (default)"
-msgstr ""
+msgstr "tiomantas a dhéanamh má éireoidh leis an gcumasc (réamhshocraithe)"
 
-#, fuzzy
 msgid "edit message before committing"
-msgstr "Athruithe nach ndearnadh a chur ar stáitse le haghaidh tiomantais:"
+msgstr "teachtaireacht in eagar sula ndéanann"
 
 msgid "allow fast-forward (default)"
-msgstr ""
+msgstr "ligean go tapa ar aghaidh (réamhshocraithe)"
 
 msgid "abort if fast-forward is not possible"
-msgstr ""
+msgstr "déan deireadh a chur ar aghaidh mura féidir go tapa ar aghaidh"
 
 msgid "verify that the named commit has a valid GPG signature"
-msgstr ""
+msgstr "fíorú go bhfuil síniú bailí GPG ag an tiomantas ainmnithe"
 
 msgid "strategy"
-msgstr ""
+msgstr "straitéis"
 
 msgid "merge strategy to use"
-msgstr ""
+msgstr "straitéis a chumasc le húsáid"
 
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr ""
+"teachtaireacht tiomanta a chumasc (le haghaidh cumaisc neamh-tapa ar aghaidh)"
 
-#, fuzzy
 msgid "use <name> instead of the real target"
-msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+msgstr "úsáid in <name>ionad an sprioc fíor"
 
-#, fuzzy
 msgid "abort the current in-progress merge"
-msgstr "Ar ais atá ar siúl faoi láthair."
+msgstr "deireadh a chur leis an gcumasc reatha atá ar siúl"
 
-#, fuzzy
 msgid "--abort but leave index and working tree alone"
-msgstr "athshocraigh HEAD, innéacs agus crann oibre"
+msgstr "--abort ach fág an t-innéacs agus an crann oibre ina n-aonar"
 
-#, fuzzy
 msgid "continue the current in-progress merge"
-msgstr "Ar ais atá ar siúl faoi láthair."
+msgstr "leanúint leis an gcumasc atá ar siúl reatha"
 
 msgid "bypass pre-merge-commit and commit-msg hooks"
-msgstr ""
+msgstr "seachbhóthar crúcaí réamh-chumaisc-tiomantas agus comh-msg"
 
-#, fuzzy
 msgid "could not run stash."
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfadh stash a reáchtáil."
 
 msgid "stash failed"
-msgstr ""
+msgstr "theip ar stash"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a valid object: %s"
-msgstr "réad blob neamhbhailí %s"
+msgstr "ní réad bailí: %s"
 
 msgid "read-tree failed"
-msgstr ""
+msgstr "theip ar chrann léitheoireachta"
 
 msgid "Already up to date. (nothing to squash)"
-msgstr ""
+msgstr "Cothrom le dáta cheana féin. (rud ar bith le squash)"
 
 msgid "Already up to date."
-msgstr ""
+msgstr "Cothrom le dáta cheana féin."
 
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
-msgstr ""
+msgstr "Tiomantas Squash - gan HEAD a nuashonrú\n"
 
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
-msgstr ""
+msgstr "Gan aon teachtaireacht cumaisc - gan HEAD a nuashonrú\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' does not point to a commit"
-msgstr "Ní chuireann HEAD in iúl do bhrainse"
+msgstr "Ní thugann '%s' in iúl do thiomantas"
 
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
-msgstr ""
+msgstr "Drochbhrainse. %s.mergeoptions teaghrán: %s"
 
-#, fuzzy
 msgid "Unable to write index."
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "Ní féidir innéacs a scríobh."
 
 msgid "Not handling anything other than two heads merge."
-msgstr ""
+msgstr "Gan aon rud a láimhseáil seachas dhá cheann cumasc."
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to write %s"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir %s a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not read from '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Ní féidir léamh ó '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
-msgstr "  (bain úsáid as “git commit” chun cumasc a thabhairt i gcrích)"
+msgstr ""
+"Gan cumasc a dhéanamh; bain úsáid as 'git commit' chun an cumaisc a chur i "
+"gcrích.\n"
 
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
 "\n"
 msgstr ""
+"Cuir isteach teachtaireacht tiomanta le do thoil chun a mhíniú cén fáth go "
+"bhfuil gá leis\n"
+"go háirithe má chomhcheanglaíonn sé nuashonraithe suas sruth i mbrainse "
+"ábhair.\n"
 
 msgid "An empty message aborts the commit.\n"
-msgstr ""
+msgstr "Cuireann teachtaireacht fholamh deireadh leis an tiomantas.\n"
 
 #, c-format
 msgid ""
 "Lines starting with '%s' will be ignored, and an empty message aborts\n"
 "the commit.\n"
 msgstr ""
+"Déanfar neamhaird ar línte a thosaíonn le '%s', \n"
+"agus cuirfidh teachtaireacht fholamh deireadh leis an tiomantas.\n"
 
 msgid "Empty commit message."
-msgstr ""
+msgstr "Teachtaireacht tiomanta folamh."
 
 #, c-format
 msgid "Wonderful.\n"
-msgstr ""
+msgstr "Iontach.\n"
 
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
+"Theip ar chumasc uathoibríoch; coimhlintí a shocrú agus ansin an toradh\n"
 
-#, fuzzy
 msgid "No current branch."
-msgstr "Níl sé ar aon bhrainse faoi láthair."
+msgstr "Níl aon bhrainse reatha."
 
-#, fuzzy
 msgid "No remote for the current branch."
-msgstr "Níl sé ar aon bhrainse faoi láthair."
+msgstr "Níl aon iargúlta don bhrainse reatha."
 
 msgid "No default upstream defined for the current branch."
-msgstr ""
+msgstr "Níl aon réamhshocraithe suas sruth sainithe don bhrainse reatha."
 
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
-msgstr ""
+msgstr "Gan aon bhrainse cianrianaithe do %s ó %s"
 
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
-msgstr ""
+msgstr "Drochluach '%s' sa timpeallacht '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not close '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a dhúnadh"
 
 #, c-format
 msgid "not something we can merge in %s: %s"
-msgstr ""
+msgstr "ní rud is féidir linn a chumasc i %s: %s"
 
 msgid "--abort expects no arguments"
-msgstr ""
+msgstr "--abort ag súil nach bhfuil aon argóintí"
 
 msgid "There is no merge to abort (MERGE_HEAD missing)."
-msgstr ""
+msgstr "Níl aon chumasc ann chun deireadh a chur (MERGE_HEAD ar iarraidh)."
 
 msgid "--quit expects no arguments"
-msgstr ""
+msgstr "Tá --quit ag súil nach bhfuil aon argóintí"
 
 msgid "--continue expects no arguments"
-msgstr ""
+msgstr "--continue gan aon argóintí ag súil leo"
 
 msgid "There is no merge in progress (MERGE_HEAD missing)."
-msgstr ""
+msgstr "Níl aon chumasc ar siúl (MERGE_HEAD ar iarraidh)."
 
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
 msgstr ""
+"Níor thug tú do chumasc i gcrích (MERGE_HEAD ann).\n"
+"Déan do chuid athruithe a dhéanamh sula ndéanann tú cumasc."
 
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
 msgstr ""
+"Níor thug tú do phiocadh silíní i gcrích (CHERRY_PICK_HEAD ann).\n"
+"Déan do chuid athruithe a dhéanamh sula ndéanann tú cumasc."
 
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
-msgstr ""
+msgstr "Níor thug tú do phiocadh silíní i gcrích (CHERRY_PICK_HEAD ann)."
 
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
+"Níl aon tiomantas sonraithe agus níl merge.defaultToUpstream socraithe."
 
 msgid "Squash commit into empty head not supported yet"
-msgstr ""
+msgstr "Tiomann squash isteach i gceann folamh nach dtacaítear go fóill"
 
-#, fuzzy
 msgid "Non-fast-forward commit does not make sense into an empty head"
-msgstr "--delete níl ciall leis gan aon réiteoirí"
+msgstr "Níl ciall ar thiomantas neamh-thapa ar aghaidh i gceann folamh"
 
 #, c-format
 msgid "%s - not something we can merge"
-msgstr ""
+msgstr "%s - ní rud is féidir linn a chumasc"
 
 msgid "Can merge only exactly one commit into empty head"
-msgstr ""
+msgstr "Ní féidir ach tiomantas amháin a chumasc i gceann folamh"
 
 #, c-format
 msgid "Updating %s..%s\n"
-msgstr ""
+msgstr "Ag nuashonrú %s..%s\n"
 
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "  %s"
 msgstr ""
+"Déanfaí d'athruithe áitiúla ar na comhaid seo a leanas a fhorscríobh trí "
+"chumasc:\n"
+" %s"
 
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
-msgstr ""
+msgstr "Ag triail a dhéanamh cumasc in-innéacs fíor-thrá\n"
 
 #, c-format
 msgid "Nope.\n"
-msgstr ""
+msgstr "Ní hea..\n"
 
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
-msgstr ""
+msgstr "Ag athchasadh an chrainn go dtí go mbeidh sé foirfe...\n"
 
 #, c-format
 msgid "Trying merge strategy %s...\n"
-msgstr ""
+msgstr "Ag iarraidh straitéis cumaisc %s...\n"
 
 #, c-format
 msgid "No merge strategy handled the merge.\n"
-msgstr ""
+msgstr "Níor láimhseáil aon straitéis chumaisc an cumasc.\n"
 
 #, c-format
 msgid "Merge with strategy %s failed.\n"
-msgstr ""
+msgstr "Theip ar chumasc le straitéis %s.\n"
 
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
-msgstr ""
+msgstr "Ag baint úsáide as straitéis %s chun réiteach a ullmhú de láimh.\n"
 
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
-msgstr ""
+msgstr "Chuaigh cumaisc uathoibríoch go maith; stad sula ndearna sé tiomanta\n"
 
 #, c-format
 msgid "When finished, apply stashed changes with `git stash pop`\n"
 msgstr ""
+"Nuair a bheidh críochnaithe, cuir athruithe stashed i bhfeidhm le `git stash "
+"pop`\n"
 
 #, c-format
 msgid "warning: tag input does not pass fsck: %s"
-msgstr ""
+msgstr "rabhadh: ní théann ionchur clib ar fsck: %s"
 
 #, c-format
 msgid "error: tag input does not pass fsck: %s"
-msgstr ""
+msgstr "earráid: ní théann ionchur clib ar fsck: %s"
 
 #, c-format
 msgid "%d (FSCK_IGNORE?) should never trigger this callback"
-msgstr ""
+msgstr "%d (FSCK_IGNORE?) níor cheart go spreagfadh an t-aisghlaoch seo"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read tagged object '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí réad clibeáilte '%s' a léamh"
 
 #, c-format
 msgid "object '%s' tagged as '%s', but is a '%s' type"
-msgstr ""
+msgstr "réad '%s' clibeáilte mar '%s', ach is cineál '%s' é"
 
 msgid "tag on stdin did not pass our strict fsck check"
-msgstr ""
+msgstr "níor rith tag ar stdin ár seiceáil dhian fsck"
 
 msgid "tag on stdin did not refer to a valid object"
-msgstr ""
+msgstr "níor thagraigh an chlib ar stdin do réad bailí"
 
-#, fuzzy
 msgid "unable to write tag file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann comhad clib a scríobh"
 
 msgid "input is NUL terminated"
-msgstr ""
+msgstr "cuirtear deireadh le hionchur NUL"
 
-#, fuzzy
 msgid "allow missing objects"
-msgstr "Rudaí a fháil"
+msgstr "cead a cheadú rudaí"
 
 msgid "allow creation of more than one tree"
-msgstr ""
+msgstr "cead níos mó ná crann amháin a chruthú"
 
 msgid ""
 "git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
 "snapshot=<path>]"
 msgstr ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
 
 msgid "git multi-pack-index [<options>] verify"
-msgstr ""
+msgstr "git multi-pack-index [<options>] verify"
 
-#, fuzzy
 msgid "git multi-pack-index [<options>] expire"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git multi-pack-index [<options>] expire"
 
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
-msgstr ""
+msgstr "git multi-pack-index [<options>] repack [--batch-size=<size>]"
 
-#, fuzzy
 msgid "directory"
-msgstr "eolaire teimpléad"
+msgstr "eolaire"
 
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
+"eolaire réada ina bhfuil tacar de phéirí pacáiste agus innéacs pacáiste"
 
 msgid "preferred-pack"
-msgstr ""
+msgstr "pacáiste is fearr leat"
 
 msgid "pack for reuse when computing a multi-pack bitmap"
-msgstr ""
+msgstr "pacáiste le húsáid agus bitmap il-phacáiste á ríomh"
 
 msgid "write multi-pack bitmap"
-msgstr ""
+msgstr "scríobh bitmap il-phacáiste"
 
 msgid "write a new incremental MIDX"
-msgstr ""
+msgstr "scríobh MIDX incrementach nua"
 
 msgid "write multi-pack index containing only given indexes"
-msgstr ""
+msgstr "scríobh innéacs il-phacáiste nach bhfuil ach innéacsanna ar leith"
 
 msgid "refs snapshot for selecting bitmap commits"
-msgstr ""
+msgstr "léargas refs chun gealltanais bitmap a roghnú"
 
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
+"le linn athphacáil, bailigh comhaid pacáiste de mhéid níos lú i mbaisc atá "
+"níos mó ná an méid seo"
 
 msgid "git mv [-v] [-f] [-n] [-k] <source> <destination>"
-msgstr ""
+msgstr "git mv [-v] [-f] [-n] [-k] <source><destination>"
 
 msgid "git mv [-v] [-f] [-n] [-k] <source>... <destination-directory>"
-msgstr ""
+msgstr "<source>git mv [-v] [-f] [-n] [-k]... <destination-directory>"
 
 #, c-format
 msgid "Directory %s is in index and no submodule?"
-msgstr ""
+msgstr "Tá eolaire %s in innéacs agus níl aon fho-mhodúl ann?"
 
 msgid "Please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
+"Cuir do chuid athruithe ar .gitmodules nó iad a stóráil chun dul ar aghaidh"
 
 #, c-format
 msgid "%.*s is in index"
-msgstr ""
+msgstr "%.*s atá san innéacs"
 
 msgid "force move/rename even if target exists"
-msgstr ""
+msgstr "aistriúin/athainmniú a fhorbairt fiú má tá sprioc ann"
 
 msgid "skip move/rename errors"
-msgstr ""
+msgstr "scipeáil earráidí a bhogadh/athainmniú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "destination '%s' is not a directory"
-msgstr "Tá %s ann agus ní eolaire é"
+msgstr "ní eolaire é ceann scríbe '%s'"
 
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
-msgstr ""
+msgstr "Seiceáil athainmniú '%s' go '%s'\n"
 
-#, fuzzy
 msgid "bad source"
-msgstr "droch %s"
+msgstr "droch-fhoinse"
 
 msgid "destination exists"
-msgstr ""
+msgstr "ceann scríbe ann"
 
 msgid "can not move directory into itself"
-msgstr ""
+msgstr "ní féidir eolaire a bhogadh isteach ina féin"
 
-#, fuzzy
 msgid "destination already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "ceann scríbe ann cheana féin"
 
 msgid "source directory is empty"
-msgstr ""
+msgstr "tá eolaire foinse folamh"
 
 msgid "not under version control"
-msgstr ""
+msgstr "nach bhfuil faoi rialú leagan"
 
 msgid "conflicted"
-msgstr ""
+msgstr "coimhlinneach"
 
 #, c-format
 msgid "overwriting '%s'"
-msgstr ""
+msgstr "athscríobh '%s'"
 
 msgid "Cannot overwrite"
-msgstr ""
+msgstr "Ní féidir athscríobh"
 
 msgid "multiple sources for the same target"
-msgstr ""
+msgstr "foinsí iolracha don sprioc chéanna"
 
-#, fuzzy
 msgid "destination directory does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl eolaire ceann scríbe ann"
 
-#, fuzzy
 msgid "destination exists in the index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "ceann scríbe ann san innéacs"
 
 #, c-format
 msgid "%s, source=%s, destination=%s"
-msgstr ""
+msgstr "%s, foinse = %s, ceann scríbe = %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot move both '%s' and its parent directory '%s'"
-msgstr "Ní féidir %s agus %s a fháil chuig %s"
+msgstr "ní féidir '%s' agus a eolaire tuismitheora '%s' a bhogadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Renaming %s to %s\n"
-msgstr "Ag brú chuig %s\n"
+msgstr "Athainmniú %s go %s\n"
 
 #, c-format
 msgid "renaming '%s' failed"
-msgstr ""
+msgstr "theip ar athainmniú '%s'"
 
-#, fuzzy
 msgid "git name-rev [<options>] <commit>..."
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git name-rev [<options>] <commit>..."
 
-#, fuzzy
 msgid "git name-rev [<options>] --all"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git name-rev [<options>] --all"
 
 msgid "git name-rev [<options>] --annotate-stdin"
-msgstr ""
+msgstr "git name-rev [<options>] --annotate-stdin"
 
 msgid "print only ref-based names (no object names)"
-msgstr ""
+msgstr "ainmneacha ref-bhunaithe amháin a phriontáil (gan ainmneacha réada)"
 
 msgid "only use tags to name the commits"
-msgstr ""
+msgstr "ní húsáid ach clibeanna chun na gealltanais a ainmniú"
 
 msgid "only use refs matching <pattern>"
-msgstr ""
+msgstr "ní úsáideann ach meaitseáil refs <pattern>"
 
 msgid "ignore refs matching <pattern>"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar mheaitseáil <pattern>"
 
 msgid "list all commits reachable from all refs"
-msgstr ""
+msgstr "liostáil na gealltanais go léir atá inrochtana ó gach ceann"
 
 msgid "deprecated: use --annotate-stdin instead"
-msgstr ""
+msgstr "díscríofa: bain úsáid as --annotate-stdin ina ionad"
 
 msgid "annotate text from stdin"
-msgstr ""
+msgstr "téacs a anótáil ó stdin"
 
 msgid "allow to print `undefined` names (default)"
 msgstr ""
+"cead a thabhairt d'ainmneacha “neamhshainithe” a phriontáil (réamhshocrú"
 
 msgid "dereference tags in the input (internal use)"
-msgstr ""
+msgstr "clibeanna dereference san ionchur (úsáid inmheánach)"
 
 msgid "git notes [--ref <notes-ref>] [list [<object>]]"
-msgstr ""
+msgstr "git notes [--ref <notes-ref>] [list [<object>]]"
 
 msgid ""
 "git notes [--ref <notes-ref>] add [-f] [--allow-empty] [--[no-]separator|--"
 "separator=<paragraph-break>] [--[no-]stripspace] [-m <msg> | -F <file> | (-c "
 "| -C) <object>] [<object>] [-e]"
 msgstr ""
+"git notes [--ref <notes-ref>] add [-f] [--allow-empty] [--[no-]separator|--"
+"separator=<paragraph-break>] [--[no-]stripspace] [-m <msg> | -F <file> | (-c "
+"| -C) <object>] [<object>] [-e]"
 
 msgid "git notes [--ref <notes-ref>] copy [-f] <from-object> <to-object>"
-msgstr ""
+msgstr "git notes [--ref<notes-ref>] cóipeáil [-f] <from-object><to-object>"
 
 msgid ""
 "git notes [--ref <notes-ref>] append [--allow-empty] [--[no-]separator|--"
 "separator=<paragraph-break>] [--[no-]stripspace] [-m <msg> | -F <file> | (-c "
 "| -C) <object>] [<object>] [-e]"
 msgstr ""
+"git notes [--ref <notes-ref>] append [--allow-empty] [--[no-]separator|--"
+"separator=<paragraph-break>] [--[no-]stripspace] [-m <msg> | -F <file> | (-c "
+"| -C) <object>] [<object>] [-e]"
 
 msgid "git notes [--ref <notes-ref>] edit [--allow-empty] [<object>]"
-msgstr ""
+msgstr "git notes [--ref <notes-ref>] edit [--allow-empty] [<object>]"
 
 msgid "git notes [--ref <notes-ref>] show [<object>]"
-msgstr ""
+msgstr "git notes [--ref <notes-ref>] show [<object>]"
 
 msgid ""
 "git notes [--ref <notes-ref>] merge [-v | -q] [-s <strategy>] <notes-ref>"
 msgstr ""
+"git notes [--ref <notes-ref>] merge [-v | -q] [-s <strategy>] <notes-ref>"
 
 msgid "git notes [--ref <notes-ref>] remove [<object>...]"
-msgstr ""
+msgstr "git notes [--ref <notes-ref>] remove [<object>...]"
 
 msgid "git notes [--ref <notes-ref>] prune [-n] [-v]"
-msgstr ""
+msgstr "git notes [--ref <notes-ref>] prune [-n] [-v]"
 
 msgid "git notes [--ref <notes-ref>] get-ref"
-msgstr ""
+msgstr "git notes [--ref <notes-ref>] get-ref"
 
 msgid "git notes [list [<object>]]"
-msgstr ""
+msgstr "git notes [list [<object>]]"
 
-#, fuzzy
 msgid "git notes add [<options>] [<object>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git notes add [<options>] [<object>]"
 
 msgid "git notes copy [<options>] <from-object> <to-object>"
-msgstr ""
+msgstr "git notes copy [<options>] <from-object> <to-object>"
 
 msgid "git notes copy --stdin [<from-object> <to-object>]..."
-msgstr ""
+msgstr "git notes copy --stdin [<from-object> <to-object>]..."
 
-#, fuzzy
 msgid "git notes append [<options>] [<object>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git notes append [<options>] [<object>]"
 
 msgid "git notes edit [<object>]"
-msgstr ""
+msgstr "nótaí git a chur in eagar [<object>]"
 
 msgid "git notes show [<object>]"
-msgstr ""
+msgstr "taispeánann nótaí git [<object>]"
 
-#, fuzzy
 msgid "git notes merge [<options>] <notes-ref>"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "cumaisc nótaí git [<options>] <notes-ref>"
 
 msgid "git notes merge --commit [<options>]"
-msgstr ""
+msgstr "git notes merge --commit [<options>]"
 
 msgid "git notes merge --abort [<options>]"
-msgstr ""
+msgstr "git notes merge --abort [<options>]"
 
 msgid "git notes remove [<object>]"
-msgstr ""
+msgstr "git notes remove [<object>]"
 
-#, fuzzy
 msgid "git notes prune [<options>]"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git notes prune [<options>]"
 
 msgid "Write/edit the notes for the following object:"
-msgstr ""
+msgstr "Scríobh/cuir in eagar na nótaí don réad seo a leanas:"
 
-#, fuzzy
 msgid "could not read 'show' output"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann aschur 'taispeáin' a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to finish 'show' for object '%s'"
-msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+msgstr "theip ar 'show' a chríochnú le haghaidh réad '%s'"
 
 msgid "please supply the note contents using either -m or -F option"
-msgstr ""
+msgstr "soláthar ábhar an nóta le do thoil ag baint úsáide as rogha -m nó -F"
 
-#, fuzzy
 msgid "unable to write note object"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann réad nótaí a scríobh"
 
 #, c-format
 msgid "the note contents have been left in %s"
-msgstr ""
+msgstr "tá ábhar an nóta fágtha i %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not open or read '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí '%s' a oscailt nó a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to resolve '%s' as a valid ref."
-msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+msgstr "theip ar '%s' a réiteach mar thagartha bailí."
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to read object '%s'."
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar réad '%s' a léamh."
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read note data from non-blob object '%s'."
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "ní féidir sonraí nótaí a léamh ó réad neamh-blob '%s'."
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to copy notes from '%s' to '%s'"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar nótaí a chóipeáil ó '%s' go '%s'"
 
 #. TRANSLATORS: the first %s will be replaced by a git
 #. notes command: 'add', 'merge', 'remove', etc.
 #.
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
-msgstr ""
+msgstr "diúltú do %s nótaí i %s (lasmuigh de refs/notes/)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no note found for object %s."
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní bhfuarthas aon nóta do réad %s."
 
 msgid "note contents as a string"
-msgstr ""
+msgstr "tabhair faoi deara ábhar mar shreang"
 
 msgid "note contents in a file"
-msgstr ""
+msgstr "tabhair faoi deara ábhar i gcomhad"
 
 msgid "reuse and edit specified note object"
-msgstr ""
+msgstr "réad nóta sonraithe a úsáid agus a chur in eagar"
 
 msgid "edit note message in editor"
-msgstr ""
+msgstr "teachtaireacht nóta in eagar san eagarthóir"
 
 msgid "reuse specified note object"
-msgstr ""
+msgstr "réad nóta sonraithe a athúsáid"
 
 msgid "allow storing empty note"
-msgstr ""
+msgstr "ligean nóta folamh a stóráil"
 
-#, fuzzy
 msgid "replace existing notes"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "nótaí atá ann cheana in ionad"
 
 msgid "<paragraph-break>"
-msgstr ""
+msgstr "<paragraph-break>"
 
 msgid "insert <paragraph-break> between paragraphs"
-msgstr ""
+msgstr "cuir isteach <paragraph-break>idir míreanna"
 
 msgid "remove unnecessary whitespace"
-msgstr ""
+msgstr "bain spás bán neamhriachtanach"
 
 #, c-format
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
+"Ní féidir nótaí a chur leis. Fuarthas nótaí atá ann cheana don réad %s. "
+"Úsáid '-f' chun nótaí atá ann cheana a fhorscríobh"
 
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
-msgstr ""
+msgstr "Athscríobh nótaí atá ann cheana don réad %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Removing note for object %s\n"
-msgstr "Rudaí a fháil"
+msgstr "Nóta a bhaint le haghaidh réad %s\n"
 
 msgid "read objects from stdin"
-msgstr ""
+msgstr "léigh rudaí ó stdin"
 
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr ""
+"cumraíocht athscríbhneoireachta ualaigh le haghaidh <command>(tugann le "
+"tuiscint --stdin)"
 
-#, fuzzy
 msgid "too few arguments"
-msgstr "An iomarca argóintí."
+msgstr "ró-bheag argóintí"
 
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
+"Ní féidir nótaí a chóipeáil. Fuarthas nótaí atá ann cheana don réad %s. "
+"Úsáid '-f' chun nótaí atá ann cheana a fhorscríobh"
 
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
-msgstr ""
+msgstr "nótaí in easnamh ar réad foinse %s. Ní féidir cóipeáil."
 
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
 "Please use 'git notes add -f -m/-F/-c/-C' instead.\n"
 msgstr ""
+"Tá na roghanna -M/-f/-c/-c curtha as an bhfo-ordú 'eagarthóireach'.\n"
+"Úsáid le do thoil 'git notes add -f -m/-f/-c/-C' ina ionad.\n"
 
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
-msgstr ""
+msgstr "theip ar an tagairt NOTES_MERGE_PARTIAL a scriosadh"
 
 msgid "failed to delete ref NOTES_MERGE_REF"
-msgstr ""
+msgstr "theip ar an ref a scriosadh NOTES_MERGE_REF"
 
 msgid "failed to remove 'git notes merge' worktree"
-msgstr ""
+msgstr "theip ar chrann oibre 'git notes merge' a bhaint"
 
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
-msgstr ""
+msgstr "theip ar an tagairt NOTES_MERGE_PARTIAL a léamh"
 
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
-msgstr ""
+msgstr "ní raibh sé in ann tiomantas a fháil ó NOTES_MERGE_PARTIAL."
 
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
-msgstr ""
+msgstr "ní raibh sé in ann tiomantas a pharsáil ó NOTES_MERGE_PARTIAL."
 
 msgid "failed to resolve NOTES_MERGE_REF"
-msgstr ""
+msgstr "theip orthu NOTES_MERGE_REF a réiteach"
 
-#, fuzzy
 msgid "failed to finalize notes merge"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "theip orthu nótaí a chumasc a chur i gcrích"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown notes merge strategy %s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "straitéis cumaisc nótaí anaithnid %s"
 
 msgid "General options"
-msgstr ""
+msgstr "Roghanna ginearálta"
 
 msgid "Merge options"
-msgstr ""
+msgstr "Roghanna cumaisc"
 
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
 msgstr ""
+"coimhlintí nótaí a réiteach ag baint úsáide as an straitéis a thugtar "
+"(lámhleabhair/innir/a nd/union/cat_sort_uniq)"
 
-#, fuzzy
 msgid "Committing unmerged notes"
-msgstr "neamhaird a dhéanamh ar iontrálacha"
+msgstr "Nótaí neamh-mheánaithe a dhéanamh"
 
 msgid "finalize notes merge by committing unmerged notes"
-msgstr ""
+msgstr "cumasc nótaí a chríochnú trí nótaí neamh-chumasaithe a dhéanamh"
 
 msgid "Aborting notes merge resolution"
-msgstr ""
+msgstr "Rún cumasc le nótaí a ghearradh"
 
-#, fuzzy
 msgid "abort notes merge"
-msgstr "cosán '%s': ní féidir a chumasc"
+msgstr "cumaisc nótaí abort"
 
 msgid "cannot mix --commit, --abort or -s/--strategy"
-msgstr ""
+msgstr "ní féidir --commit, --abort nó -s/--strategy a mheascadh"
 
-#, fuzzy
 msgid "must specify a notes ref to merge"
-msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
+msgstr "ní mór tagairt nótaí a shonrú chun cumasc"
 
 #, c-format
 msgid "unknown -s/--strategy: %s"
-msgstr ""
+msgstr "anaithnid -s/--strategy: %s"
 
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
-msgstr ""
+msgstr "tá nótaí a chumasc i %s ar siúl cheana féin ag %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to store link to current notes ref (%s)"
-msgstr "theip ar an iterator a thosú thar '%s'"
+msgstr "theip ar nasc a stóráil le nótaí reatha tagairt (%s)"
 
 #, c-format
 msgid ""
@@ -8872,427 +9307,427 @@ msgid ""
 "'git notes merge --commit', or abort the merge with 'git notes merge --"
 "abort'.\n"
 msgstr ""
+"Theip ar chumasc nótaí uathoibríoch Socraigh coinbhleachtaí i %s agus déan "
+"an toradh a dhéanamh le 'git notes merge --commit', nó cuir deireadh leis an "
+"cumasc le 'git notes merge --abort'.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to resolve '%s' as a valid ref."
-msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+msgstr "Theip ar '%s' a réiteach mar thagartha bailí."
 
 #, c-format
 msgid "Object %s has no note\n"
-msgstr ""
+msgstr "Níl aon nóta ag réad %s\n"
 
 msgid "attempt to remove non-existent note is not an error"
-msgstr ""
+msgstr "ní earráid é iarracht nóta nach bhfuil ann a bhaint"
 
 msgid "read object names from the standard input"
-msgstr ""
+msgstr "léigh ainmneacha réada ón ionchur caighdeánach"
 
 msgid "do not remove, show only"
-msgstr ""
+msgstr "ná bain, taispeáin amháin"
 
 msgid "report pruned notes"
-msgstr ""
+msgstr "nótaí gearrtha a thuairisciú"
 
 msgid "notes-ref"
-msgstr ""
+msgstr "nótairea-tagairt"
 
 msgid "use notes from <notes-ref>"
-msgstr ""
+msgstr "úsáid nótaí ó <notes-ref>"
 
 #, c-format
 msgid "unknown subcommand: `%s'"
-msgstr ""
+msgstr "fo-ordú anaithnid: `%s'"
 
 msgid "git pack-objects --stdout [<options>] [< <ref-list> | < <object-list>]"
-msgstr ""
+msgstr "git pack-objects --stdout [<options>] [< <ref-list> | < <object-list>]"
 
 msgid ""
 "git pack-objects [<options>] <base-name> [< <ref-list> | < <object-list>]"
 msgstr ""
+"git pack-objects [<options>] <base-name> [< <ref-list> | < <object-list>]"
 
 #, c-format
 msgid "invalid --name-hash-version option: %d"
-msgstr ""
+msgstr "rogha neamhbhailí --name-hash-version: %d"
 
 msgid "currently, --write-bitmap-index requires --name-hash-version=1"
-msgstr ""
+msgstr "faoi láthair, teastaíonn --write-bitmap-index --name-hash-version=1"
 
 #, c-format
 msgid ""
 "write_reuse_object: could not locate %s, expected at offset %<PRIuMAX> in "
 "pack %s"
 msgstr ""
+"write_reuse_object: níorbh fhéidir %s a aimsiú, bhíothas ag súil leis ag an "
+"bhfritháireamh %<PRIuMAX> sa phacáiste %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad packed object CRC for %s"
-msgstr "droch --pack_header: %s"
+msgstr "réad pacáilte dona CRC le haghaidh %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "corrupt packed object for %s"
-msgstr "earráid fsck i réad pacáilte"
+msgstr "réad pacáilte truaillithe do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "recursive delta detected for object %s"
-msgstr "nár bhfuair sé réad ag súil leis %s"
+msgstr "braithíodh delta athfhillteach do réad %s"
 
 #, c-format
 msgid "ordered %u objects, expected %<PRIu32>"
-msgstr ""
+msgstr "rudaí %u ordaithe, súil leis% <PRIu32>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "expected object at offset %<PRIuMAX> in pack %s"
-msgstr "tá réad lochtach sa phacáiste ag an bhfritháireamh %<PRIuMAX>: %s"
+msgstr ""
+"réad a bhíothas ag súil leis ag an bhfritháireamh %<PRIuMAX> sa phacáiste %s"
 
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
+"scríobh bitmap a dhíchumasú, roinntear pacáistí mar gheall ar "
+"pack.packSizeLimit"
 
-#, fuzzy
 msgid "Writing objects"
-msgstr "Rudaí a fháil"
+msgstr "Rudaí a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to stat %s"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar stát %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed utime() on %s"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar utime () ar %s"
 
-#, fuzzy
 msgid "failed to write bitmap index"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "theip ar innéacs bitmap a scríobh"
 
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
-msgstr ""
+msgstr "scríobh %<PRIu32> rudaí agus iad ag súil leis %<PRIu32>"
 
 msgid "disabling bitmap writing, as some objects are not being packed"
-msgstr ""
+msgstr "scríobh bitmap a dhíchumasú, toisc nach bhfuil roinnt rudaí á phacáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "delta base offset overflow in pack for %s"
-msgstr "tá fhritháireamh bonn delta as ceangailte"
+msgstr "forsreabhadh fhritháireamh bonn delta i bpacáiste do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "delta base offset out of bound for %s"
-msgstr "tá fhritháireamh bonn delta as ceangailte"
+msgstr "bonn delta a fhritháireamh as ceangailte do %s"
 
-#, fuzzy
 msgid "Counting objects"
-msgstr "Rud a sheiceáil"
+msgstr "Rud a chomhaireamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get size of %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir méid %s a fháil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse object header of %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir ceanntásc réad %s a pháirseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object %s cannot be read"
-msgstr "cosán '%s': ní féidir a chumasc"
+msgstr "ní féidir réad %s a léamh"
 
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
-msgstr ""
+msgstr "fad réada neamhréireach réad %s (%<PRIuMAX> vs %<PRIuMAX>)"
 
 msgid "suboptimal pack - out of memory"
-msgstr ""
+msgstr "pacáiste suboptimal - as cuimhne"
 
 #, c-format
 msgid "Delta compression using up to %d threads"
-msgstr ""
+msgstr "Comhbhrú Delta ag úsáid suas le snáitheanna %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to pack objects reachable from tag %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir rudaí a phacáil inrochtana ó chlib %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get type of object %s"
-msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+msgstr "nach féidir cineál réada %s a fháil"
 
-#, fuzzy
 msgid "Compressing objects"
-msgstr "Rud a sheiceáil"
+msgstr "Rudaí comhbhrúite"
 
 msgid "inconsistency with delta count"
-msgstr ""
+msgstr "neamhréireacht le comhaireamh delta"
 
 #, c-format
 msgid "invalid pack.allowPackReuse value: '%s'"
-msgstr ""
+msgstr "luach pack.allowPackReuse neamhbhailí: '%s'"
 
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
 "hash> <uri>' (got '%s')"
 msgstr ""
+"<object-hash><pack-hash><uri>caithfidh luach uploadpack.blobpackfileuri a "
+"bheith den fhoirm '' (fuair '%s')"
 
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
 msgstr ""
+"réad cumraithe cheana féin i uploadpack.blobpackfileuri eile (fuair '%s')"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not get type of object %s in pack %s"
-msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+msgstr "ní fhéadfaí cineál réada %s a fháil i bpacáiste %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not find pack '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní raibh an pacáiste '%s' in ann a aimsiú"
 
 #, c-format
 msgid "packfile %s cannot be accessed"
-msgstr ""
+msgstr "ní féidir teacht ar chomhad pacáiste %s"
 
-#, fuzzy
 msgid "Enumerating cruft objects"
-msgstr "Rudaí innéacsála"
+msgstr "Ag áireamh rudaí cruft"
 
-#, fuzzy
 msgid "unable to add cruft objects"
-msgstr "nach féidir %s a léamh"
+msgstr "in ann rudaí cruft a chur leis"
 
-#, fuzzy
 msgid "Traversing cruft objects"
-msgstr "Rud a sheiceáil"
+msgstr "Ag trasnú ar rudaí cruth"
 
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
 " %s"
 msgstr ""
+"ag súil le haitheantas réada imeall, fuarthas bruscar:\n"
+"%s"
 
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
 " %s"
 msgstr ""
+"aitheantas réada a bhfuil súil leis, fuair truflais:\n"
+" %s"
 
 msgid "could not load cruft pack .mtimes"
-msgstr ""
+msgstr "ní fhéadfaí pacáiste cruft a luchtú .mtimes"
 
-#, fuzzy
 msgid "cannot open pack index"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "ní féidir innéacs pacáiste a osc"
 
 #, c-format
 msgid "loose object at %s could not be examined"
-msgstr ""
+msgstr "ní fhéadfaí réad scaoilte ag %s a scrúdú"
 
-#, fuzzy
 msgid "unable to force loose object"
-msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+msgstr "in ann rud scaoilte a chur i bhfeidhm"
 
 #, c-format
 msgid "not a rev '%s'"
-msgstr ""
+msgstr "ní rev '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad revision '%s'"
-msgstr "droch-stóras '%s'"
+msgstr "droch-athbhreithniú '%s'"
 
-#, fuzzy
 msgid "unable to add recent objects"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "in ann rudaí le déanaí a chur leis"
 
 #, c-format
 msgid "unsupported index version %s"
-msgstr ""
+msgstr "leagan innéacs neamhthacaithe %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad index version '%s'"
-msgstr "droch-stóras '%s'"
+msgstr "droch-leagan innéacs '%s'"
 
 msgid "show progress meter during object writing phase"
-msgstr ""
+msgstr "méadar dul chun cinn a thaispeáint le linn céim sc"
 
 msgid "similar to --all-progress when progress meter is shown"
-msgstr ""
+msgstr "cosúil le --all-progress nuair a thaispeántar méadar dul chun cinn"
 
 msgid "<version>[,<offset>]"
-msgstr ""
+msgstr "<version>[,<offset>]"
 
 msgid "write the pack index file in the specified idx format version"
-msgstr ""
+msgstr "scríobh an comhad innéacs pacáiste sa leagan formáid idx sonraithe"
 
 msgid "maximum size of each output pack file"
-msgstr ""
+msgstr "uasmhéid gach comhad pacáiste aschuir"
 
 msgid "ignore borrowed objects from alternate object store"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar rudaí atá ar iasacht ó stór"
 
-#, fuzzy
 msgid "ignore packed objects"
-msgstr "earráid fsck i réad pacáilte"
+msgstr "neamhaird a dhéanamh ar earraí"
 
 msgid "limit pack window by objects"
-msgstr ""
+msgstr "teorainn fuinneog pacáiste de réir rudaí"
 
 msgid "limit pack window by memory in addition to object limit"
-msgstr ""
+msgstr "teorainn le fuinneog pacáiste de réir chuimhne i dteannta le teorainn"
 
 msgid "maximum length of delta chain allowed in the resulting pack"
-msgstr ""
+msgstr "fad uasta an slabhra delta a cheadaítear sa phacáiste mar thoradh air"
 
-#, fuzzy
 msgid "reuse existing deltas"
-msgstr "Deltas a réiteach"
+msgstr "déltaí atá ann cheana a athúsáid"
 
-#, fuzzy
 msgid "reuse existing objects"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "athúsáid rudaí atá ann cheana"
 
 msgid "use OFS_DELTA objects"
-msgstr ""
+msgstr "bain úsáid as rudaí OFS_DELTA"
 
 msgid "use threads when searching for best delta matches"
-msgstr ""
+msgstr "úsáid snáitheanna agus tú ag cuardach na cluichí delta is fearr"
 
-#, fuzzy
 msgid "do not create an empty pack output"
-msgstr "ná cruthaigh seiceáil"
+msgstr "ná cruthaigh aschur pacáiste folamh"
 
 msgid "read revision arguments from standard input"
-msgstr ""
+msgstr "léigh argóintí athbhreithnithe ó ionchur"
 
 msgid "limit the objects to those that are not yet packed"
-msgstr ""
+msgstr "teorainn leis na rudaí dóibh siúd nach bhfuil pacáilte fós"
 
 msgid "include objects reachable from any reference"
-msgstr ""
+msgstr "áireamh rudaí atá inrochtana ó aon tagairt"
 
 msgid "include objects referred by reflog entries"
-msgstr ""
+msgstr "áireamh rudaí a dtagraítear ag iontrálacha reflog"
 
 msgid "include objects referred to by the index"
-msgstr ""
+msgstr "áireamh rudaí dá dtagraíonn an t-innéacs"
 
 msgid "read packs from stdin"
-msgstr ""
+msgstr "léigh pacáistí ó stdin"
 
 msgid "output pack to stdout"
-msgstr ""
+msgstr "pacáiste aschuir go stdout"
 
 msgid "include tag objects that refer to objects to be packed"
-msgstr ""
+msgstr "áireamh rudaí clibeanna a thagraíonn do rudaí atá le pacáil"
 
 msgid "keep unreachable objects"
-msgstr ""
+msgstr "rudaí nach féidir a choinneáil"
 
 msgid "pack loose unreachable objects"
-msgstr ""
+msgstr "rudaí scaoilte nach féidir a phacáil"
 
 msgid "unpack unreachable objects newer than <time>"
-msgstr ""
+msgstr "rudaí nach féidir a dhíphacáil níos nuaí ná <time>"
 
 msgid "create a cruft pack"
-msgstr ""
+msgstr "cruthaigh pacáiste cruft"
 
 msgid "expire cruft objects older than <time>"
-msgstr ""
+msgstr "dul in éag rudaí cruft níos sine ná <time>"
 
 msgid "use the sparse reachability algorithm"
-msgstr ""
+msgstr "úsáid an algartam inrochtaineachta neamhchoitianta"
 
-#, fuzzy
 msgid "create thin packs"
-msgstr "bain úsáid as pacáiste tanaí"
+msgstr "cruthaigh pacáistí tanaí"
 
 msgid "create packs suitable for shallow fetches"
-msgstr ""
+msgstr "pacáistí a chruthú atá oiriúnach le haghaidh tógá"
 
 msgid "ignore packs that have companion .keep file"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar phacáistí a bhfuil comhad compánach"
 
-#, fuzzy
 msgid "ignore this pack"
-msgstr "bain úsáid as pacáiste tanaí"
+msgstr "neamhaird a dhéanamh ar an b"
 
 msgid "pack compression level"
-msgstr ""
+msgstr "leibhéal comhbhrú pacáiste"
 
 msgid "do not hide commits by grafts"
-msgstr ""
+msgstr "ná déan gealltanais ag grafts i bhfolach"
 
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
+"úsáid innéacs bitmap má tá sé ar fáil chun rudaí a chomhaireamh a bhrostú"
 
 msgid "write a bitmap index together with the pack index"
-msgstr ""
+msgstr "scríobh innéacs bitmap in éineacht leis an innéacs pacáiste"
 
 msgid "write a bitmap index if possible"
-msgstr ""
+msgstr "scríobh innéacs bitmap más féidir"
 
-#, fuzzy
 msgid "handling for missing objects"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "láimhseáil le haghaidh rudaí atá"
 
 msgid "do not pack objects in promisor packfiles"
-msgstr ""
+msgstr "ná pacáil rudaí i gcomhaid pacáiste gealltanais"
 
 msgid "implies --missing=allow-any"
-msgstr ""
+msgstr "tugann le tuiscint --missing=allow-any"
 
 msgid "respect islands during delta compression"
-msgstr ""
+msgstr "meas ar oileáin le linn comhbhrúite delta"
 
 msgid "protocol"
-msgstr ""
+msgstr "prótacal"
 
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
-msgstr ""
+msgstr "eisiamh aon uploadpack.blobpackfileuri cumraithe leis an bprótacal seo"
 
 msgid "use the specified name-hash function to group similar objects"
 msgstr ""
+"bain úsáid as an bhfeidhm sonraithe ainm-hash chun rudaí den chineál céanna a"
 
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr ""
+"tá doimhneacht slabhra delta %d ró-dhomhain, rud a chuireann iallach ar %d"
 
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
-msgstr ""
+msgstr "pack.deltaCacheLimit ró-ard, ag cur %d i bhfeidhm"
 
 #, c-format
 msgid "bad pack compression level %d"
-msgstr ""
+msgstr "leibhéal comhbhrúite droch-phacáiste %d"
 
-#, fuzzy
 msgid "--max-pack-size cannot be used to build a pack for transfer"
-msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+msgstr "Ní féidir --max-pack-size a úsáid chun pacáiste a thógáil le haistriú"
 
 msgid "minimum pack size limit is 1 MiB"
-msgstr ""
+msgstr "is é teorainn íosta méid an phacáiste ná 1 MiB"
 
-#, fuzzy
 msgid "--thin cannot be used to build an indexable pack"
-msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
+msgstr "Ní féidir --thin a úsáid chun pacáiste innéacsaithe a thógáil"
 
 msgid "cannot use --filter with --stdin-packs"
-msgstr ""
+msgstr "ní féidir --filter a úsáid le --stdin-packs"
 
 msgid "cannot use internal rev list with --stdin-packs"
-msgstr ""
+msgstr "ní féidir liosta rev inmheánach a úsáid le --stdin-packs"
 
 msgid "cannot use internal rev list with --cruft"
-msgstr ""
+msgstr "ní féidir liosta rev inmheánach a úsáid le --cruft"
 
 msgid "cannot use --stdin-packs with --cruft"
-msgstr ""
+msgstr "ní féidir --stdin-packs a úsáid le --cruft"
 
-#, fuzzy
 msgid "Enumerating objects"
-msgstr "Rudaí innéacsála"
+msgstr "Rudaí a chur san áireamh"
 
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
 "reused %<PRIu32> (from %<PRIuMAX>)"
 msgstr ""
+"%<PRIu32> iomlán (delta %<PRIu32>), %<PRIu32> athúsáidte (delta %<PRIu32>), "
+"%<PRIu32> athúsáidte sa phacáiste (ó %<PRIuMAX>)"
 
-#, fuzzy
 msgid ""
 "'git pack-redundant' is nominated for removal.\n"
 "If you still use this command, please add an extra\n"
@@ -9300,121 +9735,119 @@ msgid ""
 "and let us know you still use it by sending an e-mail\n"
 "to <git@vger.kernel.org>.  Thanks.\n"
 msgstr ""
-"léamh iargúlta ó \"%s/%s\", atá ainmnithe lena bhaint.\n"
-"\n"
-"Má úsáideann tú an eolaire “iargúlta/” fós moltar\n"
-"aistriú chuig iargúlta bunaithe ar chumraíocht:\n"
-"\n"
-" git iargúlta a athainmniú %s %s\n"
-"\n"
-"Mura féidir leat, cuir in iúl dúinn le do thoil cén fáth a gcaithfidh tú\n"
-"é a úsáid fós trí ríomhphost a sheoladh chuig <git@vger.kernel.org>."
+"Tá 'git pack-redundant' ainmnithe le baint.\n"
+"Má úsáideann tú an t-ordú seo fós, cuir rogha b\n"
+"hreise, '--i-still-use-this', leis an líne ordaithe \n"
+"agus cuir in iúl dúinn go n-úsáideann tú fós é trí ríomhphost \n"
+"a sheoladh chuig <git@vger.kernel.org>.  Go raibh maith agat.\n"
 
 msgid "refusing to run without --i-still-use-this"
-msgstr ""
+msgstr "ag diúltú rith gan --i-still-use-this fós"
 
 msgid ""
 "git pack-refs [--all] [--no-prune] [--auto] [--include <pattern>] [--exclude "
 "<pattern>]"
 msgstr ""
+"<pattern><pattern>git pack-refs [--all] [--no-prunes] [--auto] [--include] "
+"[--eisiamh]"
 
 msgid "pack everything"
-msgstr ""
+msgstr "pacáil gach rud"
 
-#, fuzzy
 msgid "prune loose refs (default)"
-msgstr "úsáid modh forleagtha (réamhshocraithe)"
+msgstr "briseadh scaoilte (réamhshocraithe)"
 
 msgid "auto-pack refs as needed"
-msgstr ""
+msgstr "tuairiscintí uathoibríoch pacáiste"
 
 msgid "references to include"
-msgstr ""
+msgstr "tagairtí lena n-áirítear"
 
-#, fuzzy
 msgid "references to exclude"
-msgstr "ní crann é tagairt: %s"
+msgstr "tagairtí chun eisiamh"
 
 msgid "git patch-id [--stable | --unstable | --verbatim]"
-msgstr ""
+msgstr "git patch-id [--seasmhach | --éagobhsaí | --verbatim]"
 
 msgid "use the unstable patch-id algorithm"
-msgstr ""
+msgstr "bain úsáid as an algartam paith-id éagobhsaí"
 
 msgid "use the stable patch-id algorithm"
-msgstr ""
+msgstr "bain úsáid as an algartam paith-id cobhsaí"
 
 msgid "don't strip whitespace from the patch"
-msgstr ""
+msgstr "ná tarraingt spás bán ón bpaiste"
 
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
-msgstr ""
+msgstr "<head>git plum [-n] [-v] [--progress] [--dul in éag] [<time>--] [...]"
 
 msgid "report pruned objects"
-msgstr ""
+msgstr "tuairisciú rudaí gearrtha"
 
 msgid "expire objects older than <time>"
-msgstr ""
+msgstr "dul in éag rudaí níos sine ná <time>"
 
 msgid "limit traversal to objects outside promisor packfiles"
-msgstr ""
+msgstr "teorainn a chur ar thrasú le rudaí lasmuigh de phacáiste gealltan"
 
-#, fuzzy
 msgid "cannot prune in a precious-objects repo"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "ní féidir le bearradh i repo rudaí luachmhara"
 
-#, fuzzy
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
-msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+msgstr "git pull [<options>] [<repository>[<refspec>...]]"
 
-#, fuzzy
 msgid "control for recursive fetching of submodules"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "rialú maidir le fo-mhodúil a fháil athshlánach"
 
 msgid "Options related to merging"
-msgstr ""
+msgstr "Roghanna a bhaineann le cumasc"
 
 msgid "incorporate changes by rebasing rather than merging"
-msgstr ""
+msgstr "athruithe a ionchorprú trí athbhunú seachas cumasc"
 
 msgid "allow fast-forward"
-msgstr ""
+msgstr "ligean go tapa ar aghaidh"
 
 msgid "control use of pre-merge-commit and commit-msg hooks"
-msgstr ""
+msgstr "úsáid crúcaí réamh-chumaisc agus comh-msg a rialú"
 
 msgid "automatically stash/stash pop before and after"
-msgstr ""
+msgstr "pop a stash/stash go huathoibríoch roimh agus tar éis"
 
 msgid "Options related to fetching"
-msgstr ""
+msgstr "Roghanna a bhaineann le tarraingt"
 
 msgid "force overwrite of local branch"
-msgstr ""
+msgstr "forscríobh fórsa ar bhrainse áitiúil"
 
-#, fuzzy
 msgid "number of submodules pulled in parallel"
-msgstr "líon na bhfo-mhodúil atá clónaithe go comhthreomhar"
+msgstr "líon na bhfo-mhodúil tarraingthe go comhthreom"
 
 msgid "use IPv4 addresses only"
-msgstr ""
+msgstr "bain úsáid as seoltaí IPv4 amháin"
 
 msgid "use IPv6 addresses only"
-msgstr ""
+msgstr "bain úsáid as seoltaí IPv6 amháin"
 
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
 msgstr ""
+"Níl aon iarrthóir ann chun athbhreithniú i measc na n-airíonna a fuair tú "
+"díreach."
 
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
+"Níl aon iarrthóirí ann chun cumasc i measc na gcomharthaí a fuair tú díreach."
 
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
 msgstr ""
+"Go ginearálta ciallaíonn sé seo gur sholáthraíonn tú refspec cárta fiáin "
+"nach raibh aon\n"
+"cluichí ar an gceann iargúlta."
 
 #, c-format
 msgid ""
@@ -9422,50 +9855,55 @@ msgid ""
 "a branch. Because this is not the default configured remote\n"
 "for your current branch, you must specify a branch on the command line."
 msgstr ""
+"D'iarr tú tarraingt ón iargúlta '%s', ach níor shonraigh tú\n"
+"brainse. Toisc nach é seo an cianda cumraithe réamhshocraithe\n"
+"do bhrainse reatha, ní mór duit brainse a shonrú ar an líne ordaithe."
 
-#, fuzzy
 msgid "You are not currently on a branch."
-msgstr "Níl sé ar aon bhrainse faoi láthair."
+msgstr "Níl tú ar bhrainse faoi láthair."
 
 msgid "Please specify which branch you want to rebase against."
-msgstr ""
+msgstr "Sonraigh le do thoil cén brainse is mian leat a athbhunú ina choinne."
 
 msgid "Please specify which branch you want to merge with."
-msgstr ""
+msgstr "Sonraigh le do thoil cén brainse is mian leat a chumasc leis."
 
 msgid "See git-pull(1) for details."
-msgstr ""
+msgstr "Féach git-pull (1) le haghaidh sonraí."
 
 msgid "<remote>"
-msgstr ""
+msgstr "<remote>"
 
-#, fuzzy
 msgid "<branch>"
-msgstr "brainse"
+msgstr "<branch>"
 
 msgid "There is no tracking information for the current branch."
-msgstr ""
+msgstr "Níl aon fhaisnéis rianaithe don bhrainse reatha."
 
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
+"Más mian leat faisnéis rianaithe a shocrú don bhrainse seo is féidir leat é "
+"sin a dhéanamh le:"
 
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
 "from the remote, but no such ref was fetched."
 msgstr ""
+"Sonraíonn do chumraíocht a chumasc leis an tagairt '%s'\n"
+"ón iargúlta, ach níor faightear aon tagairt den sórt sin."
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to access commit %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir teacht ar thiomantas %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid refspec '%s'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "refspec neamhbhailí '%s'"
 
 msgid "ignoring --verify-signatures for rebase"
-msgstr ""
+msgstr "ag neamhaird --verify-signatures le haghaidh athbhunú"
 
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
@@ -9482,15 +9920,31 @@ msgid ""
 "or --ff-only on the command line to override the configured default per\n"
 "invocation.\n"
 msgstr ""
+"Tá brainsí éagsúla agat agus ní mór duit a shonrú conas iad a réiteach.\n"
+"Is féidir leat é sin a dhéanamh trí cheann de na horduithe seo a leanas a "
+"reáchtáil rud éigin\n"
+"do chéad tarraingt eile:\n"
+"\n"
+"  git config pull.rebase false   # cumaisc\n"
+"  git config pull.rebase true    # rebase\n"
+"  git config pull.ff only      # tapa ar aghaidh amháin\n"
+"\n"
+"Is féidir leat “git config --global” a chur in ionad “git config” chun "
+"réamhshocrú a shocrú\n"
+"rogha do gach stórais. Is féidir leat pas a chur freisin --rebase, --no-"
+"rebase,\n"
+"nó --ff-only ar an líne ordaithe chun an réamhshocrú cumraithe in aghaidh a "
+"shárú\n"
+"ionghairm.\n"
 
 msgid "Updating an unborn branch with changes added to the index."
-msgstr ""
+msgstr "Brainse breithe a nuashonrú le hathruithe curtha leis an innéacs."
 
 msgid "pull with rebase"
-msgstr ""
+msgstr "tarraing le rebase"
 
 msgid "Please commit or stash them."
-msgstr ""
+msgstr "Déan iad a thiomantas nó a stóráil le do thoil."
 
 #, c-format
 msgid ""
@@ -9498,6 +9952,9 @@ msgid ""
 "fast-forwarding your working tree from\n"
 "commit %s."
 msgstr ""
+"nuashonraigh teacht ceann an bhrainse reatha.\n"
+"do chrann oibre a chur ar aghaidh go tapa ó\n"
+"tiomantas %s."
 
 #, c-format
 msgid ""
@@ -9508,21 +9965,27 @@ msgid ""
 "$ git reset --hard\n"
 "to recover."
 msgstr ""
+"Ní féidir do chrann oibre a chur ar aghaidh a thosú.\n"
+"Tar éis duit a chinntiú gur shábháil tú aon rud luachmhar ó\n"
+"$ git diff %s\n"
+"aschur, rith\n"
+"$ git reset --hard\n"
+"chun aisghabháil."
 
 msgid "Cannot merge multiple branches into empty head."
-msgstr ""
+msgstr "Ní féidir brainsí iomadúla a chumasc i gceann folamh."
 
 msgid "Cannot rebase onto multiple branches."
-msgstr ""
+msgstr "Ní féidir athbhunú ar iliomad brainsí."
 
 msgid "Cannot fast-forward to multiple branches."
-msgstr ""
+msgstr "Ní féidir dul ar aghaidh go tapa go brainsí iolracha."
 
 msgid "Need to specify how to reconcile divergent branches."
-msgstr ""
+msgstr "Ní mór a shonrú conas brainsí éagsúla a réiteach."
 
 msgid "cannot rebase with locally recorded submodule modifications"
-msgstr ""
+msgstr "ní féidir athbhunú le modhnuithe fo-mhodúil atá taifeadta"
 
 msgid "git push [<options>] [<repository> [<refspec>...]]"
 msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
@@ -9813,44 +10276,43 @@ msgid "push options must not have new line characters"
 msgstr "ní chóir go mbeadh carachtair líne nua ag roghanna brú"
 
 msgid "git range-diff [<options>] <old-base>..<old-tip> <new-base>..<new-tip>"
-msgstr ""
+msgstr "git range-diff [<options>] <old-base>..<old-tip> <new-base>..<new-tip>"
 
 msgid "git range-diff [<options>] <old-tip>...<new-tip>"
-msgstr ""
+msgstr "git range-diff [<options>] <old-base>..<old-tip> <new-base>..<new-tip>"
 
 msgid "git range-diff [<options>] <base> <old-tip> <new-tip>"
-msgstr ""
+msgstr "git range-diff [<options>] <base> <old-tip> <new-tip>"
 
 msgid "use simple diff colors"
-msgstr ""
+msgstr "bain úsáid as dathanna diff simplí"
 
 msgid "notes"
-msgstr ""
+msgstr "nótaí"
 
 msgid "passed to 'git log'"
-msgstr ""
+msgstr "cuireadh chuig 'git log'"
 
 msgid "only emit output related to the first range"
-msgstr ""
+msgstr "ní scaoileann ach aschur a bhaineann leis an gcéad raon"
 
 msgid "only emit output related to the second range"
-msgstr ""
+msgstr "ní scaoileann ach aschur a bhaineann leis an dara raon"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a revision: '%s'"
-msgstr "droch-stóras '%s'"
+msgstr "ní athbhreithniú: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a commit range: '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "ní raon tiomanta: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a symmetric range: '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "ní raon siméadrach: '%s'"
 
-#, fuzzy
 msgid "need two commit ranges"
-msgstr "tiomantais nua, "
+msgstr "dhá raon tiomanta ag teastáil"
 
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
@@ -9858,114 +10320,113 @@ msgid ""
 "              [-u | -i]] [--index-output=<file>] [--no-sparse-checkout]\n"
 "              (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
+"git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
+"prefix=<prefix>)\n"
+"              [-u | -i]] [--index-output=<file>] [--no-sparse-checkout]\n"
+"              (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
 
 msgid "write resulting index to <file>"
-msgstr ""
+msgstr "scríobh innéacs mar thoradh air go <file>"
 
-#, fuzzy
 msgid "only empty the index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "ach an t-innéacs a fholmhú"
 
 msgid "Merging"
-msgstr ""
+msgstr "Cumaisc"
 
-#, fuzzy
 msgid "perform a merge in addition to a read"
-msgstr "cumasc 3 bhealach a dhéanamh leis an mbrainse nua"
+msgstr "cumaisc a dhéanamh i dteannta le léamh"
 
 msgid "3-way merge if no file level merging required"
-msgstr ""
+msgstr "Cumaisc trí bhealach mura gá cumasc leibhéal comhaid"
 
 msgid "3-way merge in presence of adds and removes"
-msgstr ""
+msgstr "Cumaisc 3 bhealach i láthair breiseanna agus bainteanna"
 
-#, fuzzy
 msgid "same as -m, but discard unmerged entries"
-msgstr "neamhaird a dhéanamh ar iontrálacha"
+msgstr "mar an gcéanna le -m, ach caith iontrálacha neamh-chumhdaithe"
 
 msgid "<subdirectory>/"
-msgstr ""
+msgstr "<subdirectory>/"
 
 msgid "read the tree into the index under <subdirectory>/"
-msgstr ""
+msgstr "léigh an crann isteach san innéacs faoi<subdirectory>/"
 
 msgid "update working tree with merge result"
-msgstr ""
+msgstr "crann oibre a nuashonrú le toradh cumaisc"
 
 msgid "gitignore"
-msgstr ""
+msgstr "gignor"
 
 msgid "allow explicitly ignored files to be overwritten"
-msgstr ""
+msgstr "ligean do chomhaid a dhéantar neamhaird air go sainrá"
 
-#, fuzzy
 msgid "don't check the working tree after merging"
-msgstr "in ann crann oibre a sheiceáil"
+msgstr "ná seiceáil an crann oibre tar éis a chumasc"
 
 msgid "don't update the index or the work tree"
-msgstr ""
+msgstr "ná nuashonraigh an t-innéacs nó an crann oibre"
 
-#, fuzzy
 msgid "skip applying sparse checkout filter"
-msgstr "Tá tú i seiceáil neamhchoitianta."
+msgstr "scipeáil scagaire seiceála neamhchoitianta a"
 
 msgid "debug unpack-trees"
-msgstr ""
+msgstr "crainn díphacáilte a dhífhabhtú"
 
 msgid "suppress feedback messages"
-msgstr ""
+msgstr "teachtaireachtaí aiseolais"
 
-#, fuzzy
 msgid "You need to resolve your current index first"
-msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
+msgstr "Ní mór duit d'innéacs reatha a réiteach ar dtús"
 
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase> | --keep-base] "
 "[<upstream> [<branch>]]"
 msgstr ""
+"<upstream><branch>git rebase [-i] [roghanna] [--exec<cmd>] [--onto "
+"<newbase>| --keep-base] [[]]"
 
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] --root [<branch>]"
 msgstr ""
+"<newbase><branch>git rebase [-i] [roghanna] [--exec] [-- <cmd>onto] --root []"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read '%s'."
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh '%s' in ann a léamh."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create temporary %s"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí %s sealadach a chruthú"
 
-#, fuzzy
 msgid "could not mark as interactive"
-msgstr "roghnaigh hunks idirghníomhach"
+msgstr "ní fhéadfaí marcáil mar idirghníomh"
 
-#, fuzzy
 msgid "could not generate todo list"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann liosta todo a ghiniúint"
 
 msgid "a base commit must be provided with --upstream or --onto"
-msgstr ""
+msgstr "caithfear gealltanas bonn a sholáthar le --upstream nó --onto"
 
 #, c-format
 msgid "%s requires the merge backend"
-msgstr ""
+msgstr "Teastaíonn %s an cúltaca cumaisc"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid onto: '%s'"
-msgstr "%s neamhbhailí"
+msgstr "neamhbhailí ar: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid orig-head: '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "orig-head neamhbhailí: '%s'"
 
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
-msgstr ""
+msgstr "neamhaird a dhéanamh de allow_rerere_autoupdate neamhbhailí: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not remove '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a bhaint"
 
 #, c-format
 msgid ""
@@ -9977,36 +10438,44 @@ msgid ""
 "\n"
 "As a result, git cannot rebase them."
 msgstr ""
+"\n"
+"Bhí earráid ag git agus é ag ullmhú na paistí chun athsheinm\n"
+"na hathbhreithnithe seo:\n"
+"\n"
+" %s\n"
+"\n"
+"Mar thoradh air sin, ní féidir le git iad a athbhunú."
 
 #, c-format
 msgid "Unknown rebase-merges mode: %s"
-msgstr ""
+msgstr "Modh rebase-chumaisc anaithnid: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not switch to %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí aistriú go %s"
 
-#, fuzzy
 msgid "apply options and merge options cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr "roghanna i bhfeidhm agus ní féidir roghanna cumaisc a úsáid le chéile"
 
-#, fuzzy
 msgid "--empty=ask is deprecated; use '--empty=stop' instead."
-msgstr ""
-"--mixed le cosáin imithe i léig; bain úsáid as 'git reset -- <cosáin>' ina "
-"ionad."
+msgstr "Tá --empty=ask díscríofa; bain úsáid as '--empty=stop' ina ionad."
 
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and "
 "\"stop\"."
 msgstr ""
+"cineál folamh gan aithint '%s'; is iad na luachanna bailí ná “drop”, “keep”, "
+"agus “stop”."
 
 msgid ""
 "--rebase-merges with an empty string argument is deprecated and will stop "
 "working in a future version of Git. Use --rebase-merges without an argument "
 "instead, which does the same thing."
 msgstr ""
+"Tá --rebase-merges le argóint teaghrán folamh míshuanta agus stopfaidh sé ag "
+"obair i leagan amach anseo de Git. Úsáid --rebase-merges gan argóint ina "
+"ionad sin, a dhéanann an rud céanna."
 
 #, c-format
 msgid ""
@@ -10017,176 +10486,191 @@ msgid ""
 "    git rebase '<branch>'\n"
 "\n"
 msgstr ""
+"%s\n"
+"Sonraigh le do thoil cén brainse ar mhaith leat athbhunú ina choinne.\n"
+"Féach git-rebase(1) le haghaidh sonraí.\n"
+"\n"
+"git rebase '<brainse>'\n"
+"\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
 "\n"
 "    git branch --set-upstream-to=%s/<branch> %s\n"
 "\n"
 msgstr ""
-"Más mian leat é a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-"
-"am é seo chun é sin a dhéanamh le:\n"
+"Más mian leat faisnéis rianaithe a shocrú don bhrainse seo is féidir leat é "
+"sin a dhéanamh le:\n"
 "\n"
-"git branch <ainm-brainse-nua> %s\n"
+"    git branch --set-upstream-to=%s/<branch> %s\n"
+"\n"
 
 msgid "exec commands cannot contain newlines"
-msgstr ""
+msgstr "ní féidir línte nua a bheith ag orduithe exec"
 
 msgid "empty exec command"
-msgstr ""
+msgstr "ordú exec folamh"
 
 msgid "rebase onto given branch instead of upstream"
-msgstr ""
+msgstr "athbhunú ar an mbrainse ar leith in ionad suas an sruth"
 
 msgid "use the merge-base of upstream and branch as the current base"
-msgstr ""
+msgstr "bain úsáid as bonn cumaisc suas sruth agus brainse mar an bonn reatha"
 
 msgid "allow pre-rebase hook to run"
-msgstr ""
+msgstr "ligean do chrúca réamh-athbhunaithe rith"
 
 msgid "be quiet. implies --no-stat"
-msgstr ""
+msgstr "a bheith ciúin. tugann le tuiscint --no-stat"
 
 msgid "display a diffstat of what changed upstream"
-msgstr ""
+msgstr "taispeáint diffstat den rud a d'athraigh suas an sruth"
 
 msgid "do not show diffstat of what changed upstream"
-msgstr ""
+msgstr "ná taispeáin diffstat den mhéid a d'athraigh suas an sruth"
 
 msgid "add a Signed-off-by trailer to each commit"
-msgstr ""
+msgstr "cuir leantóir sínithe le gach tiomantas"
 
 msgid "make committer date match author date"
-msgstr ""
+msgstr "dáta an údair comhoiriúnaithe dáta a dhéanamh"
 
 msgid "ignore author date and use current date"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar dháta údair agus bain úsáid as"
 
 msgid "synonym of --reset-author-date"
-msgstr ""
+msgstr "comhchiallach de --reset-author-date"
 
 msgid "passed to 'git apply'"
-msgstr ""
+msgstr "cuireadh chuig 'git apply'"
 
 msgid "ignore changes in whitespace"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar athruithe i spás bán"
 
 msgid "cherry-pick all commits, even if unchanged"
-msgstr ""
+msgstr "roghnaigh silíní gach gealltanas, fiú mura bhfuil gan athrú"
 
 msgid "continue"
-msgstr ""
+msgstr "leanúint"
 
 msgid "skip current patch and continue"
-msgstr ""
+msgstr "scipeáil an paiste reatha agus lean ar aghaidh"
 
-#, fuzzy
 msgid "abort and check out the original branch"
-msgstr ""
-" (bain úsáid as “git rebase --abort” chun an bhrainse bunaidh a sheiceáil)"
+msgstr "déan deireadh a chur agus seiceáil ar an mbrainse bunaidh"
 
 msgid "abort but keep HEAD where it is"
-msgstr ""
+msgstr "déan deireadh ach coinnigh CEAD san áit a bhfuil sé"
 
 msgid "edit the todo list during an interactive rebase"
-msgstr ""
+msgstr "cuir an liosta todo in eagar le linn athbhunú idirghníomhach"
 
 msgid "show the patch file being applied or merged"
-msgstr ""
+msgstr "taispeáin an comhad paiste atá á chur i bhfeidhm nó á chumas"
 
 msgid "use apply strategies to rebase"
-msgstr ""
+msgstr "úsáid straitéisí i bhfeidhm chun athbhunú"
 
 msgid "use merging strategies to rebase"
-msgstr ""
+msgstr "straitéisí cumaisc a úsáid chun athbhunú"
 
 msgid "let the user edit the list of commits to rebase"
-msgstr ""
+msgstr "lig don úsáideoir liosta na dtiomantas a athbhunú a chur in eagar"
 
 msgid "(REMOVED) was: try to recreate merges instead of ignoring them"
 msgstr ""
+"(Bainte) a bhí: déan iarracht cumaisc a athchruthú in ionad neamhaird a "
+"dhéanamh orthu"
 
 msgid "how to handle commits that become empty"
-msgstr ""
+msgstr "conas gealltanais a éiríonn folamh a láimhseáil"
 
 msgid "keep commits which start empty"
-msgstr ""
+msgstr "coinnigh gealltanais a thosaíonn folamh"
 
 msgid "move commits that begin with squash!/fixup! under -i"
-msgstr ""
+msgstr "gealltanna gluaiseachta a thosaíonn le squash! /socrú! faoi -i"
 
 msgid "update branches that point to commits that are being rebased"
-msgstr ""
+msgstr "brainsí a nuashonrú a thugann in iúl do ghealltanais atá á athbhunú"
 
 msgid "add exec lines after each commit of the editable list"
 msgstr ""
+"línte exec a chur leis tar éis gach tiomantas den liosta in-eagarthóireachta"
 
 msgid "allow rebasing commits with empty messages"
-msgstr ""
+msgstr "ligean do thiomantas a athbhunú le teachtaireachtaí folamh"
 
 msgid "try to rebase merges instead of skipping them"
-msgstr ""
+msgstr "déan iarracht cumaisc a athbhunú in ionad iad a scipeáil"
 
-#, fuzzy
 msgid "use 'merge-base --fork-point' to refine upstream"
-msgstr "úsáid in <name> ionad 'origin' chun suas an sruth a rianú"
+msgstr "bain úsáid as 'merge-base --fork-point' chun suas an sruth a bheachtú"
 
 msgid "use the given merge strategy"
-msgstr ""
+msgstr "bain úsáid as an straitéis cumaisc tugtha"
 
 msgid "option"
-msgstr ""
+msgstr "rogha"
 
 msgid "pass the argument through to the merge strategy"
-msgstr ""
+msgstr "an argóint a chur ar aghaidh chuig an straitéis cumaisc"
 
 msgid "rebase all reachable commits up to the root(s)"
 msgstr ""
+"athbhunú gach gealltanas inrochtana suas go dtí an fhréamh/na fréamhacha"
 
 msgid "automatically re-schedule any `exec` that fails"
-msgstr ""
+msgstr "athsceidealú go huathoibríoch aon `executaithe' a the"
 
 msgid "apply all changes, even those already present upstream"
-msgstr ""
+msgstr "gach athrú a chur i bhfeidhm, fiú iad siúd atá i láthair suas an"
 
 msgid "It looks like 'git am' is in progress. Cannot rebase."
-msgstr ""
+msgstr "Is cosúil go bhfuil 'git am' ar siúl. Ní féidir athbhunú."
 
 msgid ""
 "`rebase --preserve-merges` (-p) is no longer supported.\n"
 "Use `git rebase --abort` to terminate current rebase.\n"
 "Or downgrade to v2.33, or earlier, to complete the rebase."
 msgstr ""
+"Ní thacaítear le `rebase --preserve-merges` (-p) a thuilleadh.\n"
+"Úsáid `git rebase --abort` chun rebase reatha a fhoirceannadh.\n"
+"Nó íosghrádú go v2.33, nó níos luaithe, chun an athbhunú a chur i gcrích."
 
 msgid ""
 "--preserve-merges was replaced by --rebase-merges\n"
 "Note: Your `pull.rebase` configuration may also be set to 'preserve',\n"
 "which is no longer supported; use 'merges' instead"
 msgstr ""
+"Cuireadh --preserve-merges in ionad --rebase-merges\n"
+"Nóta: Féadfar do chumraíocht `pull.rebase` a shocrú chun 'caomhnú' freisin,\n"
+"nach dtacaítear leis a thuilleadh; bain úsáid as 'cumaisc' ina ionad"
 
-#, fuzzy
 msgid "no rebase in progress"
-msgstr "athbhunú atá ar siúl; ar "
+msgstr "níl aon athbhunú ar siúl"
 
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
+"Ní féidir an gníomh --edit-todo a úsáid ach le linn athbhunú idirghníomhach."
 
 msgid "Cannot read HEAD"
-msgstr ""
+msgstr "Ní féidir HEAD a léamh"
 
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
 msgstr ""
+"Ní mór duit gach coinbhleacht cumaisc a chur in eagar agus ansin\n"
+"iad a mharcáil mar réitigh ag úsáid git add"
 
-#, fuzzy
 msgid "could not discard worktree changes"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfadh athruithe crann oibre a dhiúscairt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not move back to %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí bogadh ar ais chuig %s"
 
 #, c-format
 msgid ""
@@ -10199,100 +10683,108 @@ msgid ""
 "and run me again.  I am stopping in case you still have something\n"
 "valuable there.\n"
 msgstr ""
+"Dealraíonn sé go bhfuil eolaire %s ann cheana féin, agus\n"
+"N'fheadar an bhfuil tú i lár athbhunaithe eile. Más é sin an\n"
+"cás, déan iarracht\n"
+" %s\n"
+"Mura bhfuil sé sin an cás, le do thoil\n"
+" %s\n"
+"agus rith mé arís. Táim ag stopadh i gcás go bhfuil rud éigin agat fós\n"
+"luachmhar ansin.\n"
 
 msgid "switch `C' expects a numerical value"
-msgstr ""
+msgstr "tá an lasc `C' ag súil le luach uimhriúil"
 
 msgid ""
 "apply options are incompatible with rebase.rebaseMerges.  Consider adding --"
 "no-rebase-merges"
 msgstr ""
+"tá roghanna cur i bhfeidhm neamhoiriúnach le rebase.rebaseMerges. Smaoinigh "
+"ar --no-rebase-merges a chur leis"
 
 msgid ""
 "apply options are incompatible with rebase.updateRefs.  Consider adding --no-"
 "update-refs"
 msgstr ""
+"tá roghanna cur i bhfeidhm neamhoiriúnach le rebase.updateRefs. Smaoinigh ar "
+"--no-update-refs a chur leis"
 
 #, c-format
 msgid "Unknown rebase backend: %s"
-msgstr ""
+msgstr "Cúltaca athbhunaithe anaithnid: %s"
 
 msgid "--reschedule-failed-exec requires --exec or --interactive"
-msgstr ""
+msgstr "Éilíonn --reschedule-failed-exec --exec nó --interactive"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid upstream '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "neamhbhailí suas sruth '%s'"
 
-#, fuzzy
 msgid "Could not create new root commit"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "Ní fhéadfaí tiomantas fréimhe nua a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such branch/commit '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "gan aon bhrainse/tiomantas '%s' den sórt sin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "No such ref: %s"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "Níl aon tagairt den sórt sin: %s"
 
-#, fuzzy
 msgid "Could not resolve HEAD to a commit"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "Ní fhéadfaí HEAD a réiteach le tiomantas"
 
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
-msgstr ""
+msgstr "'%s': teastaíonn bonn cumaisc amháin díreach le brainse"
 
 #, c-format
 msgid "'%s': need exactly one merge base"
-msgstr ""
+msgstr "'%s': teastaíonn bonn cumaisc amháin díreach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Does not point to a valid commit '%s'"
-msgstr "Ní chuireann HEAD in iúl do bhrainse"
+msgstr "Ní thugann sé in iúl do thiomantas bailí '%s'"
 
-#, fuzzy
 msgid "HEAD is up to date."
-msgstr "Tá HEAD anois ag"
+msgstr "Tá HEAD cothrom le dáta."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Current branch %s is up to date.\n"
-msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
+msgstr "Tá an brainse reatha %s cothrom le dáta.\n"
 
 msgid "HEAD is up to date, rebase forced."
-msgstr ""
+msgstr "Tá HEAD cothrom le dáta, athbhunú éigeantach."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
-msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
+msgstr "Tá an brainse reatha %s cothrom le dáta, athbhunú éigeantach.\n"
 
 msgid "The pre-rebase hook refused to rebase."
-msgstr ""
+msgstr "Dhiúltaigh an crúca réamh-athbhunú a athbhunú."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Changes to %s:\n"
-msgstr "Ag brú chuig %s\n"
+msgstr "Athruithe ar %s:\n"
 
 #, c-format
 msgid "Changes from %s to %s:\n"
-msgstr ""
+msgstr "Athruithe ó %s go %s:\n"
 
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
+"Ar dtús, téann athfhillte chun do chuid oibre a athsheinm ar a bharr...\n"
 
-#, fuzzy
 msgid "Could not detach HEAD"
-msgstr "Níl CEANN bailí agat."
+msgstr "Ní fhéadfaí CEAD a dhícheangal"
 
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
-msgstr ""
+msgstr "Cuireadh %s ar aghaidh go tapa chuig %s.\n"
 
-#, fuzzy
 msgid "git receive-pack <git-dir>"
-msgstr "clár pacáiste a fháil"
+msgstr "git receive-pack <git-dir>"
 
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
@@ -10309,6 +10801,23 @@ msgid ""
 "To squelch this message and still keep the default behaviour, set\n"
 "'receive.denyCurrentBranch' configuration variable to 'refuse'."
 msgstr ""
+"De réir réamhshocraithe, nuashonrú an bhrainse reatha i stóras neamh-lom\n"
+"diúltaítear, toisc go ndéanfaidh sé an t-innéacs agus an crann oibre "
+"neamhréireach\n"
+"leis an méid a bhrúigh tú, agus beidh 'git reset --hard' ag teastáil uait "
+"chun a mheaitseáil\n"
+"an crann oibre go HEAD.\n"
+"\n"
+"Is féidir leat an t-athróg cumraíochta 'receive.denyCurrentBranch' a shocrú\n"
+"chun 'neamhaird' nó 'rabhadh' sa stór iargúlta chun ligean a bhrú isteach\n"
+"a bhrainse reatha; áfach, ní mholtar é seo mura bhfuil tú\n"
+"socraithe chun a chrann oibre a nuashonrú chun a mheaitseáil ar an méid a "
+"bhrú tú isteach\n"
+"bealach eile.\n"
+"\n"
+"Chun an teachtaireacht seo a bhrú agus an t-iompar réamhshocraithe a "
+"choinneáil fós, socraigh\n"
+"Athróg cumraíochta 'receive.denyCurrentBranch' go 'refuse'."
 
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
@@ -10320,20 +10829,28 @@ msgid ""
 "\n"
 "To squelch this message, you can set it to 'refuse'."
 msgstr ""
+"De réir réamhshocraithe, diúltaítear an bhrainse reatha a scriosadh, mar an "
+"chéad chéad\n"
+"Ní bheidh aon chomhad seiceáilte amach mar thoradh ar 'git clone', rud a "
+"chruthaíonn mearbhall.\n"
+"\n"
+"Is féidir leat athróg cumraíochta 'receive.denyDeleteCurrent' a shocrú go\n"
+"'rabhadh 'nó' neamhaird 'sa stór iargúlta chun cead a scriosadh an\n"
+"brainse reatha, le teachtaireacht rabhaidh nó gan é.\n"
+"\n"
+"Chun an teachtaireacht seo a ghearradh, is féidir leat é a shocrú go 'diúlt'."
 
 msgid "quiet"
-msgstr ""
+msgstr "ciúin"
 
-#, fuzzy
 msgid "you must specify a directory"
-msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
+msgstr "ní mór duit eolaire a shonrú"
 
-#, fuzzy
 msgid "git reflog [show] [<log-options>] [<ref>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "<ref>git reflog [taispeáin] [] [<log-options>]"
 
 msgid "git reflog list"
-msgstr ""
+msgstr "git reflog liosta"
 
 msgid ""
 "git reflog expire [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -10341,250 +10858,258 @@ msgid ""
 "                  [--dry-run | -n] [--verbose] [--all [--single-worktree] | "
 "<refs>...]"
 msgstr ""
+"<time><time>git reflog in éag [--expire=] [--expire-unreachable=]\n"
+" [--athscríobh] [--updateref] [--stale-fix]\n"
+" <refs>[--dry-run | -n] [--verbose] [--all [--one-worktree] |...]"
 
 msgid ""
 "git reflog delete [--rewrite] [--updateref]\n"
 "                  [--dry-run | -n] [--verbose] <ref>@{<specifier>}..."
 msgstr ""
+"git reflog scrios [--athscríobh] [--updateref]\n"
+" <ref><specifier>[--driy-run | -n] [--verbose] @ {}..."
 
 msgid "git reflog exists <ref>"
-msgstr ""
+msgstr "git reflog ann <ref>"
 
 msgid "git reflog drop [--all [--single-worktree] | <refs>...]"
-msgstr ""
+msgstr "<refs>git reflog titim [--all [--one-worktree] |...]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid timestamp '%s' given to '--%s'"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "stampa ama neamhbhailí '%s' a thugtar do '--%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s does not accept arguments: '%s'"
-msgstr "git checkout: --detach ní ghlacann argóint cosáin '%s'"
+msgstr "Ní ghlacann %s le hargóintí: '%s'"
 
 msgid "do not actually prune any entries"
-msgstr ""
+msgstr "ná déan aon iontrálacha a ghearradh"
 
 msgid ""
 "rewrite the old SHA1 with the new SHA1 of the entry that now precedes it"
 msgstr ""
+"athscríobh an sean-SHA1 leis an SHA1 nua den iontráil atá roimh ré anois"
 
 msgid "update the reference to the value of the top reflog entry"
-msgstr ""
+msgstr "an tagairt do luach an iontráil reflog barr a nuashonrú"
 
 msgid "print extra information on screen"
-msgstr ""
+msgstr "faisnéis bhreise a phriontáil ar an sc"
 
-#, fuzzy
 msgid "timestamp"
-msgstr "am"
+msgstr "stampa ama"
 
 msgid "prune entries older than the specified time"
-msgstr ""
+msgstr "iontrálacha brónta níos sine ná an t-am sonraithe"
 
 msgid ""
 "prune entries older than <time> that are not reachable from the current tip "
 "of the branch"
 msgstr ""
+"ní féidir iontrálacha br <time>ónta níos sine ná sin a bhaint amach ó bharr "
+"reatha na brainse"
 
 msgid "prune any reflog entries that point to broken commits"
 msgstr ""
+"aon iontrálacha reflog a ghearradh a chuireann in iúl do thiomantas briste"
 
 msgid "process the reflogs of all references"
-msgstr ""
+msgstr "athfhillteacha na dtagairtí go léir a phróiseáil"
 
 msgid "limits processing to reflogs from the current worktree only"
 msgstr ""
+"teorann sé leis an bpróiseáil do athfhillteacha ón gcrann oibre reatha amháin"
 
 #, c-format
 msgid "Marking reachable objects..."
-msgstr ""
+msgstr "Rudaí inrochtana a mharcáil..."
 
 #, c-format
 msgid "reflog could not be found: '%s'"
-msgstr ""
+msgstr "ní fhéadfaí reflog a fháil: '%s'"
 
 msgid "no reflog specified to delete"
-msgstr ""
+msgstr "níl aon reflog sonraithe le scriosadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid ref format: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "formáid tagartha neamhbhailí: %s"
 
 msgid "drop the reflogs of all references"
-msgstr ""
+msgstr "scaoil athbhreithniú na dtagairtí go léir"
 
 msgid "drop reflogs from the current worktree only"
-msgstr ""
+msgstr "scaoil reflogs ón gcrann oibre reatha amháin"
 
 msgid "references specified along with --all"
-msgstr ""
+msgstr "tagairtí sonraithe in éineacht le --all"
 
 msgid "git refs migrate --ref-format=<format> [--no-reflog] [--dry-run]"
-msgstr ""
+msgstr "git refs migrate --ref-format=<format> [--no-reflog] [--dry-run]"
 
 msgid "git refs verify [--strict] [--verbose]"
-msgstr ""
+msgstr "fíoraíonn git refs [--strong] [--verbose]"
 
-#, fuzzy
 msgid "specify the reference format to convert to"
-msgstr "sonraigh an fhormáid tagartha le húsáid"
+msgstr "sonraigh an fhormáid tagartha le tiontú"
 
 msgid "perform a non-destructive dry-run"
-msgstr ""
+msgstr "rith tirim neamh-millteach a dhéanamh"
 
 msgid "drop reflogs entirely during the migration"
-msgstr ""
+msgstr "titim athfhóga go hiomlán le linn na himirce"
 
 msgid "missing --ref-format=<format>"
-msgstr ""
+msgstr "ar iarraidh --ref-format=<format>"
 
 #, c-format
 msgid "repository already uses '%s' format"
-msgstr ""
+msgstr "úsáideann stór formáid '%s' cheana féin"
 
-#, fuzzy
 msgid "enable strict checking"
-msgstr "in ann crann oibre a sheiceáil"
+msgstr "cumasú seiceáil docht"
 
 msgid "'git refs verify' takes no arguments"
-msgstr ""
+msgstr "Ní ghlacann 'git refs verify' aon argóintí"
 
 msgid ""
 "git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--"
 "mirror=<fetch|push>] <name> <url>"
 msgstr ""
+"git remote add [-t <branch>] [-m <master>] [-f] [--tags | --no-tags] [--"
+"mirror=<fetch|push>] <name> <url>"
 
 msgid "git remote rename [--[no-]progress] <old> <new>"
-msgstr ""
+msgstr "git remote rename [--[no-]progress] <old> <new>"
 
 msgid "git remote remove <name>"
-msgstr ""
+msgstr "git remote remove <name>"
 
 msgid "git remote set-head <name> (-a | --auto | -d | --delete | <branch>)"
-msgstr ""
+msgstr "git remote set-head <name> (-a | --auto | -d | --delete | <branch>)"
 
 msgid "git remote [-v | --verbose] show [-n] <name>"
-msgstr ""
+msgstr "git remote [-v | --verbose] show [-n] <name>"
 
 msgid "git remote prune [-n | --dry-run] <name>"
-msgstr ""
+msgstr "git remote prune [-n | --dry-run] <name>"
 
 msgid ""
 "git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]"
 msgstr ""
+"git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]"
 
 msgid "git remote set-branches [--add] <name> <branch>..."
-msgstr ""
+msgstr "git remote set-branches [--add] <name> <branch>..."
 
 msgid "git remote get-url [--push] [--all] <name>"
-msgstr ""
+msgstr "git remote get-url [--push] [--all] <name>"
 
 msgid "git remote set-url [--push] <name> <newurl> [<oldurl>]"
-msgstr ""
+msgstr "git remote set-url [--push] <name> <newurl> [<oldurl>]"
 
 msgid "git remote set-url --add <name> <newurl>"
-msgstr ""
+msgstr "git iargúlta set-url --add <name><newurl>"
 
 msgid "git remote set-url --delete <name> <url>"
-msgstr ""
+msgstr "git iargúlta set-url --delete <name><url>"
 
-#, fuzzy
 msgid "git remote add [<options>] <name> <url>"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git remote add [<options>] <name> <url>"
 
 msgid "git remote set-branches <name> <branch>..."
-msgstr ""
+msgstr "git remote set-branches <name> <branch>..."
 
 msgid "git remote set-branches --add <name> <branch>..."
-msgstr ""
+msgstr "git remote set-branches --add <name> <branch>..."
 
-#, fuzzy
 msgid "git remote show [<options>] <name>"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git remote show [<options>] <name>"
 
-#, fuzzy
 msgid "git remote prune [<options>] <name>"
-msgstr "git checkout [<roghanna>] <brainse>"
+msgstr "git remote prune [<options>] <name>"
 
-#, fuzzy
 msgid "git remote update [<options>] [<group> | <remote>]..."
-msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+msgstr "git remote update [<options>] [<group> | <remote>]..."
 
 #, c-format
 msgid "Updating %s"
-msgstr ""
+msgstr "Nuashonrú %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not fetch %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "Níorbh fhéidir %s a fháil"
 
 msgid ""
 "--mirror is dangerous and deprecated; please\n"
 "\t use --mirror=fetch or --mirror=push instead"
 msgstr ""
+"--mirror tá scáthán contúirteach agus míchuir; le do thoil\n"
+" bain úsáid as --mirror=fetch nó --mirror=push ina ionad"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown --mirror argument: %s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "argóint --mirror anaithnid: %s"
 
 msgid "fetch the remote branches"
-msgstr ""
+msgstr "faigh na brainsí iargúlta"
 
 msgid ""
 "import all tags and associated objects when fetching\n"
 "or do not fetch any tag at all (--no-tags)"
 msgstr ""
+"iompórtáil gach clib agus rudaí gaolmhara agus tú ag tabhairt\n"
+"nó ná faigh aon chlib ar chor ar bith (--no-tags)"
 
 msgid "branch(es) to track"
-msgstr ""
+msgstr "brainse (í) chun rianú"
 
-#, fuzzy
 msgid "master branch"
-msgstr "brainse"
+msgstr "máistirbhrainse"
 
 msgid "set up remote as a mirror to push to or fetch from"
-msgstr ""
+msgstr "cuir iargúlta ar bun mar scáthán chun brú chuig nó a fháil uaidh"
 
 msgid "specifying a master branch makes no sense with --mirror"
-msgstr ""
+msgstr "níl aon chiall ar mháistirbhrainse a shonrú le --mirror"
 
 msgid "specifying branches to track makes sense only with fetch mirrors"
-msgstr ""
+msgstr "nííl ciall le brainsí a shonrú le rianú ach le scátháin faighte"
 
-#, fuzzy, c-format
+#, c-format
 msgid "remote %s already exists."
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "iargúlta %s ann cheana féin."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not setup master '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Ní raibh an máistir '%s' a shocrú"
 
 #, c-format
 msgid "more than one %s"
-msgstr ""
+msgstr "níos mó ná %s amháin"
 
 #, c-format
 msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
-msgstr ""
+msgstr "brainse gan láimhseáil. %s.rebase=%s; ag glacadh leis 'fíor'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not get fetch map for refspec %s"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "Níorbh fhéidir léarscáil a fháil do refspec %s"
 
 msgid "(matching)"
-msgstr ""
+msgstr "(meaitseáil)"
 
-#, fuzzy
 msgid "(delete)"
-msgstr "scriosta:"
+msgstr "(scrios)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not set '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a shocrú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not unset '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a dhíshocrú"
 
 #, c-format
 msgid ""
@@ -10592,14 +11117,17 @@ msgid ""
 "\t%s:%d\n"
 "now names the non-existent remote '%s'"
 msgstr ""
+"An cumraíocht %s remote.pushDefault i:\n"
+" %s: %d\n"
+"ainmníonn anois an iargúlta nach bhfuil ann '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "No such remote: '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "Níl aon iargúlta den sórt sin: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not rename config section '%s' to '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "Ní fhéadfaí an chuid cumraithe '%s' a athainmniú go '%s'"
 
 #, c-format
 msgid ""
@@ -10607,17 +11135,20 @@ msgid ""
 "\t%s\n"
 "\tPlease update the configuration manually if necessary."
 msgstr ""
+"Gan teacht refspec neamh-réamhshocraithe a nuashonrú\n"
+" %s\n"
+" Nuashonraigh an chumraíocht de láimh más gá."
 
 msgid "Renaming remote references"
-msgstr ""
+msgstr "Tagairtí cianda a athainmniú"
 
 #, c-format
 msgid "deleting '%s' failed"
-msgstr ""
+msgstr "theip ar '%s' a scriosadh"
 
 #, c-format
 msgid "creating '%s' failed"
-msgstr ""
+msgstr "theip ar chruthú '%s'"
 
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
@@ -10626,101 +11157,104 @@ msgid_plural ""
 "Note: Some branches outside the refs/remotes/ hierarchy were not removed;\n"
 "to delete them, use:"
 msgstr[0] ""
+"Nóta: Níor baineadh brainse lasmuigh den ordlathas refs/remotes/;\n"
+"chun é a scriosadh, bain úsáid as:"
 msgstr[1] ""
+"Nóta: Níor baineadh roinnt brainsí lasmuigh den ordlathas refs/remotes/;\n"
+"chun iad a scriosadh, bain úsáid as:"
 msgstr[2] ""
+"Nóta: Níor baineadh roinnt brainsí lasmuigh den ordlathas refs/remotes/;\n"
+"chun iad a scriosadh, bain úsáid as:"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not remove config section '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Ní raibh an chuid cumraithe '%s' in ann a bhaint"
 
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
-msgstr ""
+msgstr " nua (stóráilfidh an chéad fhaighteacht eile i iargúlta/%s)"
 
-#, fuzzy
 msgid " tracked"
-msgstr "Comhaid neamhrianaithe"
+msgstr " rianaithe"
 
 msgid " skipped"
-msgstr ""
+msgstr " scipeáilte"
 
 msgid " stale (use 'git remote prune' to remove)"
-msgstr ""
+msgstr " seasta (bain úsáid as 'git remote prune' chun a bhaint)"
 
 msgid " ???"
-msgstr ""
+msgstr " ???"
 
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
-msgstr ""
+msgstr "brainse neamhbhailí. %s.merge; ní féidir athbhunú ar> 1 bhrainse"
 
-#, fuzzy, c-format
+#, c-format
 msgid "rebases interactively onto remote %s"
-msgstr "iarraidh idirbheart adamach ar an taobh iargúl"
+msgstr "athbhunú go hidirghníomhach ar iargúlta %s"
 
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
-msgstr ""
+msgstr "athbhunú idirghníomhach (le cumaisc) ar iargúlta %s"
 
 #, c-format
 msgid "rebases onto remote %s"
-msgstr ""
+msgstr "athbhunú ar iargúlta %s"
 
 #, c-format
 msgid " merges with remote %s"
-msgstr ""
+msgstr " merges with remote %s"
 
 #, c-format
 msgid "merges with remote %s"
-msgstr ""
+msgstr "cumasc le iargúlta %s"
 
 #, c-format
 msgid "%-*s    and with remote %s\n"
-msgstr ""
+msgstr "%-*s    agus le iargúlta %s\n"
 
 msgid "create"
-msgstr ""
+msgstr "cruthú"
 
-#, fuzzy
 msgid "delete"
-msgstr "scriosta:"
+msgstr "scriosadh"
 
-#, fuzzy
 msgid "up to date"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "cothrom le dáta"
 
 msgid "fast-forwardable"
-msgstr ""
+msgstr "tapa a sheoladh"
 
 msgid "local out of date"
-msgstr ""
+msgstr "áitiúil as dáta"
 
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
-msgstr ""
+msgstr "    fórsaí %-*s go %-*s (%s)"
 
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
-msgstr ""
+msgstr "    %-*s ag brú go %-*s (%s)"
 
 #, c-format
 msgid "    %-*s forces to %s"
-msgstr ""
+msgstr "    feidhmíonn %-*s chuig %s"
 
 #, c-format
 msgid "    %-*s pushes to %s"
-msgstr ""
+msgstr "    %-*s ag brú chuig %s"
 
 msgid "do not query remotes"
-msgstr ""
+msgstr "ná fiosraigh iargúlta"
 
 #, c-format
 msgid "* remote %s"
-msgstr ""
+msgstr "* iargúlta %s"
 
 #, c-format
 msgid "  Fetch URL: %s"
-msgstr ""
+msgstr " Faigh URL: %s"
 
 #. TRANSLATORS: the colon ':' should align
 #. with the one in " Fetch URL: %s"
@@ -10728,370 +11262,378 @@ msgstr ""
 #.
 #, c-format
 msgid "  Push  URL: %s"
-msgstr ""
+msgstr "    Brúigh  URL: %s"
 
 msgid "(no URL)"
-msgstr ""
+msgstr "(gan URL)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "  HEAD branch: %s"
-msgstr "CEAD (gan aon bhrainse)"
+msgstr "  Brainse CEANN: %s"
 
 msgid "(not queried)"
-msgstr ""
+msgstr "(gan iarraidh)"
 
-#, fuzzy
 msgid "(unknown)"
-msgstr "anaithnid:"
+msgstr "(anaithnid)"
 
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr ""
+"  Brainse HEAD (tá CEAD iargúlta débhríoch, d'fhéadfadh a bheith ar cheann "
+"de na nithe seo a leanas)\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
-msgstr[0] "Athshocraigh brainse '%s'\n"
-msgstr[1] "Athshocraigh brainse '%s'\n"
-msgstr[2] "Athshocraigh brainse '%s'\n"
+msgstr[0] "  Brainse iargúlta: %s"
+msgstr[1] "  Brainsí iargúlta:%s"
+msgstr[2] "  Brainsí iargúlta:%s"
 
 msgid " (status not queried)"
-msgstr ""
+msgstr " (níor fiosraíodh an stádas)"
 
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "  Brainse áitiúil cumraithe le haghaidh 'git pull':"
+msgstr[1] "  Craobhacha áitiúla cumraithe le haghaidh 'git pull':"
+msgstr[2] "  Craobhacha áitiúla cumraithe le haghaidh 'git pull':"
 
 msgid "  Local refs will be mirrored by 'git push'"
-msgstr ""
+msgstr " Déanfar tagairtí áitiúla a léiriú le 'git push'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
-msgstr[0] "níl aon chumrú suas srutha le haghaidh brainse '%s'"
-msgstr[1] "níl aon chumrú suas srutha le haghaidh brainse '%s'"
-msgstr[2] "níl aon chumrú suas srutha le haghaidh brainse '%s'"
+msgstr[0] "  Tagairt áitiúil cumraithe le haghaidh 'git push'%s:"
+msgstr[1] "  Tagairtí áitiúla cumraithe le haghaidh 'git push'%s:"
+msgstr[2] "  Tagairtí áitiúla cumraithe le haghaidh 'git push'%s:"
 
 #, c-format
 msgid "'%s/HEAD' is unchanged and points to '%s'\n"
-msgstr ""
+msgstr "Níl '%s/head' gan athrú agus díríonn sé chuig '%s'\n"
 
 #, c-format
 msgid "'%s/HEAD' has changed from '%s' and now points to '%s'\n"
-msgstr ""
+msgstr "Tá '%s/head' athraithe ó '%s' agus léiríonn sé anois chuig '%s'\n"
 
 #, c-format
 msgid "'%s/HEAD' is now created and points to '%s'\n"
-msgstr ""
+msgstr "Cruthaítear '%s/head' anois agus léiríonn sé chuig '%s'\n"
 
 #, c-format
 msgid "'%s/HEAD' was detached at '%s' and now points to '%s'\n"
-msgstr ""
+msgstr "Bhí '%s/head' scoite ag '%s' agus díríonn sé anois chuig '%s'\n"
 
 #, c-format
 msgid ""
 "'%s/HEAD' used to point to '%s' (which is not a remote branch), but now "
 "points to '%s'\n"
 msgstr ""
+"Úsáidtear '%s/head' chun díriú chuig '%s' (nach brainse iargúlta é), ach "
+"léiríonn sé anois chuig '%s'\n"
 
 msgid "set refs/remotes/<name>/HEAD according to remote"
-msgstr ""
+msgstr "socraigh refs/remotes/<name>/HEAD de réir an chianrialtáin"
 
 msgid "delete refs/remotes/<name>/HEAD"
-msgstr ""
+msgstr "scrios refs/remotes/<name>/HEAD"
 
 msgid "Cannot determine remote HEAD"
-msgstr ""
+msgstr "Ní féidir CEAD cianda a chinneadh"
 
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr ""
+"Brainsí iomadúla HEAD iargúlta. Roghnaigh ceann go sainráite le do thoil:"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not delete %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "Ní fhéadfaí %s a scriosadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Not a valid ref: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "Ní tagairt bailí: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not set up %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "Níor féidir %s a chur ar bun"
 
 #, c-format
 msgid " %s will become dangling!"
-msgstr ""
+msgstr " Beidh %s ag crochadh!"
 
 #, c-format
 msgid " %s has become dangling!"
-msgstr ""
+msgstr " tá %s ag crochadh!"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Pruning %s"
-msgstr "Ag brú chuig %s\n"
+msgstr "Bearradh %s"
 
 #, c-format
 msgid "URL: %s"
-msgstr ""
+msgstr "URL: %s"
 
 #, c-format
 msgid " * [would prune] %s"
-msgstr ""
+msgstr " * [bhearna] %s"
 
 #, c-format
 msgid " * [pruned] %s"
-msgstr ""
+msgstr " * [gearrtha] %s"
 
 msgid "prune remotes after fetching"
-msgstr ""
+msgstr "iomadáin brónta tar éis a fháil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "No such remote '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "Níl aon iargúlta '%s' den sórt sin"
 
-#, fuzzy
 msgid "add branch"
-msgstr "brainse"
+msgstr "cuir brainse"
 
 msgid "no remote specified"
-msgstr ""
+msgstr "gan aon iargúlta sonraithe"
 
 msgid "query push URLs rather than fetch URLs"
-msgstr ""
+msgstr "cuir fiosrúcháin ar URLanna brú seachas URLanna aisghabhála"
 
 msgid "return all URLs"
-msgstr ""
+msgstr "gach URL a thabhairt ar ais"
 
 msgid "manipulate push URLs"
-msgstr ""
+msgstr "ionramháil URLanna bhrú"
 
 msgid "add URL"
-msgstr ""
+msgstr "cuir URL leis"
 
-#, fuzzy
 msgid "delete URLs"
-msgstr "scrios réimsí"
+msgstr "scrios URLanna"
 
-#, fuzzy
 msgid "--add --delete doesn't make sense"
-msgstr "--delete níl ciall leis gan aon réiteoirí"
+msgstr "Níl ciall ag --add --delete"
 
 #, c-format
 msgid "Invalid old URL pattern: %s"
-msgstr ""
+msgstr "Sean-phatrún URL neamhbhailí: %s"
 
 #, c-format
 msgid "No such URL found: %s"
-msgstr ""
+msgstr "Níor aimsíodh aon URL den sórt sin: %s"
 
 msgid "Will not delete all non-push URLs"
-msgstr ""
+msgstr "Ní scriosfaidh sé gach URL neamh-bhrú"
 
 msgid "be verbose; must be placed before a subcommand"
-msgstr ""
+msgstr "a bheith inearálta; caithfear é a chur os comhair fo-ordú"
 
 msgid ""
 "git repack [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b] [-m]\n"
 "[--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]\n"
 "[--write-midx] [--name-hash-version=<n>]"
 msgstr ""
+"git athphacáil [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b] [-m]\n"
+"<n><pack-name>[--fuinneog =] [-- <n>depth=] [--threads=] [--keep- <n>pack "
+"=]\n"
+"<n>[--write-midx] [--ainm-hash-leagan =]"
 
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writeBitmaps configuration."
 msgstr ""
+"Níl ath-phacáistí incréideacha comhoiriúnach le hinnéacsanna bitmap. Úsáid\n"
+"--no-write-bitmap-index nó díchumraíocht an pack.writeBitmaps a dhíchumasú."
 
-#, fuzzy
 msgid "could not start pack-objects to repack promisor objects"
-msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+msgstr "ní fhéadfaí rudaí pacáiste a thosú chun rudaí gealltanna a athphacáil"
 
-#, fuzzy
 msgid "failed to feed promisor objects to pack-objects"
-msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+msgstr "theip ar rudaí gealltanna a bheathú ar rudaí pacáiste"
 
-#, fuzzy
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
-"index-pack: Ag súil le línte aitheantais réada heicsidheachúlach iomlán ó "
-"pack-objects amháin."
+"athphacáil: Ag súil le línte aitheantais réad heicseach iomlána ach ó "
+"phacáistí."
 
-#, fuzzy
 msgid "could not finish pack-objects to repack promisor objects"
-msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+msgstr ""
+"ní fhéadfadh sé rudaí pacáiste a chríochnú chun rudaí geallta a athphacáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open index for %s"
-msgstr "Ní féidir comhad idx pacáiste atá ann cheana a oscailt do '%s'"
+msgstr "ní féidir innéacs a oscailt do %s"
 
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
-msgstr ""
+msgstr "pacáiste %s ró-mhór le breithniú i ddul chun cinn geo"
 
 #, c-format
 msgid "pack %s too large to roll up"
-msgstr ""
+msgstr "pacáiste %s ró-mhór le rolladh suas"
 
 #, c-format
 msgid "could not open tempfile %s for writing"
-msgstr ""
+msgstr "ní fhéadfaí teachtaireacht %s a oscailt le haghaidh scríobh"
 
 msgid "could not close refs snapshot tempfile"
-msgstr ""
+msgstr "ní raibh in ann tempfile snapshot refs a dhúnadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not remove stale bitmap: %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí bitmap seasta a bhaint: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "pack prefix %s does not begin with objdir %s"
-msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
+msgstr "ní thosaíonn réimír pacáiste %s le objdir %s"
 
 msgid "pack everything in a single pack"
-msgstr ""
+msgstr "pacáil gach rud i bpacáiste amháin"
 
 msgid "same as -a, and turn unreachable objects loose"
 msgstr ""
+"mar an gcéanna le -a, agus casadh rudaí nach féidir inrochtana scaoilte"
 
 msgid "same as -a, pack unreachable cruft objects separately"
-msgstr ""
+msgstr "mar an gcéanna le -a, pacáil rudaí cruft neamh-inrochtana ar leithligh"
 
 msgid "approxidate"
-msgstr ""
+msgstr "approxidate"
 
 msgid "with --cruft, expire objects older than this"
-msgstr ""
+msgstr "le --cruft, rachadh in éag rudaí níos sine ná seo"
 
 msgid "with --cruft, only repack cruft packs smaller than this"
-msgstr ""
+msgstr "le --cruft, ní athphacáil ach pacáistí cruft níos lú ná seo"
 
 msgid "remove redundant packs, and run git-prune-packed"
-msgstr ""
+msgstr "bain pacáistí iomarcacha, agus rith git-prune-packed"
 
 msgid "pass --no-reuse-delta to git-pack-objects"
-msgstr ""
+msgstr "pas --no-reuse-delta chuig git-pack-objects"
 
-#, fuzzy
 msgid "pass --no-reuse-object to git-pack-objects"
-msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+msgstr "pas --no-reuse-object chuig git-pack-objects"
 
 msgid ""
 "specify the name hash version to use for grouping similar objects by path"
 msgstr ""
+"sonraigh an leagan hash ainm atá le húsáid chun rudaí den chineál céanna a "
+"ghrúpáil"
 
 msgid "do not run git-update-server-info"
-msgstr ""
+msgstr "ná reáchtáil git-update-server-info"
 
-#, fuzzy
 msgid "pass --local to git-pack-objects"
-msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+msgstr "pas --local go git-pack-objects"
 
-#, fuzzy
 msgid "write bitmap index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "scríobh innéacs bitmap"
 
 msgid "pass --delta-islands to git-pack-objects"
-msgstr ""
+msgstr "pas --delta-islands chuig git-pack-objects"
 
 msgid "with -A, do not loosen objects older than this"
-msgstr ""
+msgstr "le -A, ná scaoil rudaí níos sine ná seo"
 
 msgid "with -a, repack unreachable objects"
-msgstr ""
+msgstr "le -a, athphacáil rudaí neamh-inrochtana"
 
 msgid "size of the window used for delta compression"
-msgstr ""
+msgstr "méid na fuinneoga a úsáidtear le haghaidh comhbhrú delta"
 
 msgid "bytes"
-msgstr ""
+msgstr "beart"
 
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
+"mar an gcéanna leis an méid thuas, ach teorainn le méid cuimhne in ionad "
+"iontrálacha"
 
 msgid "limits the maximum delta depth"
-msgstr ""
+msgstr "teorann sé leis an doimhneacht delta uasta"
 
 msgid "limits the maximum number of threads"
-msgstr ""
+msgstr "teorainn leis an líon uasta na snáitheanna"
 
 msgid "maximum size of each packfile"
-msgstr ""
+msgstr "uasmhéid gach pacáiste"
 
 msgid "repack objects in packs marked with .keep"
-msgstr ""
+msgstr "athphacáil rudaí i bpacáistí atá marcáilte le .keep"
 
 msgid "do not repack this pack"
-msgstr ""
+msgstr "ná déan an pacáiste seo a athphacáil"
 
 msgid "find a geometric progression with factor <N>"
-msgstr ""
+msgstr "faigh dul chun cinn geoiméadrach le fachtóir <N>"
 
 msgid "write a multi-pack index of the resulting packs"
-msgstr ""
+msgstr "scríobh innéacs il-phacáiste de na pacáistí mar thoradh air"
 
 msgid "pack prefix to store a pack containing filtered out objects"
-msgstr ""
+msgstr "réimír pacáiste chun pacáiste ina bhfuil rudaí scagtha amach a stóráil"
 
 msgid "cannot delete packs in a precious-objects repo"
-msgstr ""
+msgstr "ní féidir pacáistí a scriosadh i repo rudaí luachmhara"
 
-#, fuzzy, c-format
+#, c-format
 msgid "option '%s' can only be used along with '%s'"
-msgstr "Ní féidir '%s' a úsáid le '%s'"
+msgstr "ní féidir rogha '%s' a úsáid ach amháin in éineacht le '%s'"
 
 msgid "Nothing new to pack."
-msgstr ""
+msgstr "Níl aon rud nua le pacáil."
 
 #, c-format
 msgid "renaming pack to '%s' failed"
-msgstr ""
+msgstr "theip ar phacáiste a athainmniú go '%s'"
 
 #, c-format
 msgid "pack-objects did not write a '%s' file for pack %s-%s"
-msgstr ""
+msgstr "níor scríobh pack-objects comhad '%s' do phacáiste %s-%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not unlink: %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí dícheangal: %s"
 
 msgid "git replace [-f] <object> <replacement>"
-msgstr ""
+msgstr "git athsholáthair [-f] <object><replacement>"
 
 msgid "git replace [-f] --edit <object>"
-msgstr ""
+msgstr "git athsholáthair [-f] --edit <object>"
 
 msgid "git replace [-f] --graft <commit> [<parent>...]"
-msgstr ""
+msgstr "<commit><parent>git athsholáthair [-f] --graft [...]"
 
 msgid "git replace -d <object>..."
-msgstr ""
+msgstr "<object>git athsholáthair -d..."
 
 msgid "git replace [--format=<format>] [-l [<pattern>]]"
-msgstr ""
+msgstr "<pattern>git in ionad [--format =<format>] [-l []]"
 
 #, c-format
 msgid ""
 "invalid replace format '%s'\n"
 "valid formats are 'short', 'medium' and 'long'"
 msgstr ""
+"formáid athsholáthair neamhbhailí '%s'\n"
+"is iad formáidí bailí ná 'gearr', 'meánach' agus 'fada'"
 
 #, c-format
 msgid "replace ref '%s' not found"
-msgstr ""
+msgstr "athsholáthair nach bhfuarthas tagairt '%s'"
 
 #, c-format
 msgid "Deleted replace ref '%s'"
-msgstr ""
+msgstr "Scriosta in ionad tagairt '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid ref name"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní ainm tagartha bailí é '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "replace ref '%s' already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "athsholáthar tagairt '%s' atá ann cheana féin"
 
 #, c-format
 msgid ""
@@ -11099,222 +11641,230 @@ msgid ""
 "'%s' points to a replaced object of type '%s'\n"
 "while '%s' points to a replacement object of type '%s'."
 msgstr ""
+"Caithfidh rudaí a bheith den chineál céanna.\n"
+"Tugann '%s' in iúl do réad athsholáthair de chineál '%s'\n"
+"agus díríonn '%s' ar réad athsholáthair de chineál '%s'."
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open %s for writing"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir %s a oscailt le haghaidh scríobh"
 
 msgid "cat-file reported failure"
-msgstr ""
+msgstr "teip tuairiscithe ar chomhad cat"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open %s for reading"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir %s a oscailt le haghaidh léamh"
 
-#, fuzzy
 msgid "unable to spawn mktree"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "in ann mktree a shannadh"
 
-#, fuzzy
 msgid "unable to read from mktree"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "in ann léamh ó mktree"
 
 msgid "mktree reported failure"
-msgstr ""
+msgstr "thuairiscigh mktree teip"
 
-#, fuzzy
 msgid "mktree did not return an object name"
-msgstr "níor sheol iargúlta gach rud riachtanach"
+msgstr "níor thug mktree ainm réad ar ais"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to fstat %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní féidir le fstat %s"
 
-#, fuzzy
 msgid "unable to write object to database"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann réad a scríobh chuig bunachar sonraí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get object type for %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir cineál réad a fháil do %s"
 
 msgid "editing object file failed"
-msgstr ""
+msgstr "theip ar eagarthóireacht ar chomhad"
 
 #, c-format
 msgid "new object is the same as the old one: '%s'"
-msgstr ""
+msgstr "tá réad nua mar an gcéanna leis an sean-réad: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse %s as a commit"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí %s a pharsáil mar thiomantas"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad mergetag in commit '%s'"
-msgstr "droch-stóras '%s'"
+msgstr "cliciú neamhchuspóir i gcomhad '%s'"
 
 #, c-format
 msgid "malformed mergetag in commit '%s'"
-msgstr ""
+msgstr "comharthaí mífhoirmithe i dtiomantas '%s'"
 
 #, c-format
 msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
 "instead of --graft"
 msgstr ""
+"tá mergetag '%s' a dhíscaoiltear as '%s' bunaidh; bain úsáid as --edit in "
+"ionad --graft"
 
 #, c-format
 msgid "the original commit '%s' has a gpg signature"
-msgstr ""
+msgstr "tá síniú gpg ag an tiomantas bunaidh '%s'"
 
 msgid "the signature will be removed in the replacement commit!"
-msgstr ""
+msgstr "bainfear an síniú sa tiomantas athsholáthair!"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write replacement commit for: '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí gealltanas athsholáthair a scríobh do: '%s'"
 
 #, c-format
 msgid "graft for '%s' unnecessary"
-msgstr ""
+msgstr "graft le haghaidh '%s' gan ghá"
 
 #, c-format
 msgid "new commit is the same as the old one: '%s'"
-msgstr ""
+msgstr "tá tiomantas nua mar an gcéanna leis an seancheann: '%s'"
 
 #, c-format
 msgid ""
 "could not convert the following graft(s):\n"
 "%s"
 msgstr ""
+"ní raibh sé in ann an graft (í) seo a leanas a thiontú:\n"
+"%s"
 
 msgid "list replace refs"
-msgstr ""
+msgstr "liosta athsholáthair refs"
 
-#, fuzzy
 msgid "delete replace refs"
-msgstr "scrios réimsí"
+msgstr "scrios athsholáthair refs"
 
-#, fuzzy
 msgid "edit existing object"
-msgstr "Rudaí innéacsála"
+msgstr "réad atá ann cheana in eagar"
 
 msgid "change a commit's parents"
-msgstr ""
+msgstr "tuismitheoirí tiomanta a athrú"
 
 msgid "convert existing graft file"
-msgstr ""
+msgstr "tiontaigh an comhad graft atá ann cheana"
 
 msgid "replace the ref if it exists"
-msgstr ""
+msgstr "athsholáthar an tagartha má tá sé ann"
 
 msgid "do not pretty-print contents for --edit"
-msgstr ""
+msgstr "ná déan ábhar álainn a phriontáil le haghaidh --edit"
 
-#, fuzzy
 msgid "use this format"
-msgstr "bain úsáid as pacáiste tanaí"
+msgstr "bain úsáid as an bhformáid seo"
 
-#, fuzzy
 msgid "--format cannot be used when not listing"
-msgstr "ní féidir cosáin a úsáid le brainsí a athrú"
+msgstr "Ní féidir --format a úsáid nuair nach bhfuil sé liostaithe"
 
 msgid "-f only makes sense when writing a replacement"
-msgstr ""
+msgstr "Ní dhéanann -f ciall ach nuair a bhíonn athsholáthar á scríobh"
 
 msgid "--raw only makes sense with --edit"
-msgstr ""
+msgstr "Ní dhéanann --raw ciall ach le --edit"
 
 msgid "-d needs at least one argument"
-msgstr ""
+msgstr "-d teastaíonn argóint amháin ar a laghad"
 
 msgid "bad number of arguments"
-msgstr ""
+msgstr "droch-líon na n-argóintí"
 
 msgid "-e needs exactly one argument"
-msgstr ""
+msgstr "Teastaíonn argóint amháin díreach ó -e"
 
 msgid "-g needs at least one argument"
-msgstr ""
+msgstr "Teastaíonn argóint amháin ar a laghad ó -g"
 
 msgid "--convert-graft-file takes no argument"
-msgstr ""
+msgstr "Ní ghlacann --convert-graft-file aon argóint"
 
 msgid "only one pattern can be given with -l"
-msgstr ""
+msgstr "ní féidir ach patrún amháin a thabhairt le -l"
 
 msgid "need some commits to replay"
-msgstr ""
+msgstr "teastaíonn roinnt gealltanais chun athsheinm"
 
 msgid "all positive revisions given must be references"
-msgstr ""
+msgstr "caithfidh gach athbhreithniú dearfach a thugtar a bheith ina"
 
 msgid "argument to --advance must be a reference"
-msgstr ""
+msgstr "caithfidh argóint chuig --advance a bheith ina thagairt"
 
 msgid ""
 "cannot advance target with multiple sources because ordering would be ill-"
 "defined"
 msgstr ""
+"ní féidir leis an sprioc a chur chun cinn le foinsí iolracha toisc go mbeadh "
+"ordú"
 
 msgid ""
 "cannot implicitly determine whether this is an --advance or --onto operation"
 msgstr ""
+"ní féidir a chinneadh go hinneach an oibríocht --advance nó --onto é seo"
 
 msgid ""
 "cannot advance target with multiple source branches because ordering would "
 "be ill-defined"
 msgstr ""
+"ní féidir leis an sprioc a chur chun cinn le brainsí foinse iolracha mar go "
+"mbeadh ordú"
 
 msgid "cannot implicitly determine correct base for --onto"
-msgstr ""
+msgstr "ní féidir leis an mbonn ceart do --onto a chinneadh go hinneach"
 
 msgid ""
 "(EXPERIMENTAL!) git replay ([--contained] --onto <newbase> | --advance "
 "<branch>) <revision-range>..."
 msgstr ""
+"(TURGNAMHACH!) git replay ([--contained] --onto <newbase> | --advance "
+"<branch>) <revision-range>..."
 
 msgid "make replay advance given branch"
-msgstr ""
+msgstr "athsheoladh a dhéanamh roimh ré brainse ar leith"
 
 msgid "replay onto given commit"
-msgstr ""
+msgstr "athsheoladh ar thiomantas a thugtar"
 
 msgid "advance all branches contained in revision-range"
-msgstr ""
+msgstr "gach brainse atá sa raon athbhreithnithe a chur chun cinn"
 
 msgid "option --onto or --advance is mandatory"
-msgstr ""
+msgstr "tá rogha --onto nó --advance éigeantach"
 
 #, c-format
 msgid ""
 "some rev walking options will be overridden as '%s' bit in 'struct rev_info' "
 "will be forced"
 msgstr ""
+"cuirfear roinnt roghanna siúil rev a athshealbhú mar go gcuirfear giotán "
+"'%s' i 'struct rev_info' iallach"
 
-#, fuzzy
 msgid "error preparing revisions"
-msgstr "earráid inmheánach i dsiúlóid"
+msgstr "earráid ag ullmhú athbhreith"
 
 msgid "replaying down to root commit is not supported yet!"
-msgstr ""
+msgstr "ní thacaítear le athsheinm síos go dtí tiomantas fréimhe fós!"
 
 msgid "replaying merge commits is not supported yet!"
-msgstr ""
+msgstr "ní thacaítear le gealltanna cumaisc athsheinm fós!"
 
 msgid ""
 "git rerere [clear | forget <pathspec>... | diff | status | remaining | gc]"
 msgstr ""
+"git rerere [glan | déan dearmad<pathspec>... | diff | stádas | fágtha | gc]"
 
 msgid "register clean resolutions in index"
-msgstr ""
+msgstr "rúin glan a chlárú san innéacs"
 
 msgid "'git rerere forget' without paths is deprecated"
-msgstr ""
+msgstr "Tá 'git rerere dearmad' gan cosáin scothaithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to generate diff for '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "nach féidir éagsúlacht a ghiniúint do '%s'"
 
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
@@ -11427,49 +11977,47 @@ msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
 msgid "Could not write new index file."
 msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get disk usage of %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir úsáid diosca de %s a fháil"
 
 #, c-format
 msgid "invalid value for '%s': '%s', the only allowed format is '%s'"
-msgstr ""
+msgstr "luach neamhbhailí do '%s': '%s', is é '%s' an t-aon fhormáid ceadaithe"
 
 msgid "-z option used with unsupported option"
-msgstr ""
+msgstr "-z rogha a úsáidtear le rogha gan tacaíocht"
 
 msgid "rev-list does not support display of notes"
-msgstr ""
+msgstr "ní thacaíonn rev-list le taispeáint nótaí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "marked counting and '%s' cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr "comhaireamh marcáilte agus ní féidir '%s' a úsáid le chéile"
 
-#, fuzzy
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
-msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
+msgstr "git rev-parse --parseopt [<options>] -- [<args>...]"
 
 msgid "keep the `--` passed as an arg"
-msgstr ""
+msgstr "coinnigh an `--` a rith mar arg"
 
 msgid "stop parsing after the first non-option argument"
-msgstr ""
+msgstr "stop a pháirseáil tar éis an chéad argóint neamh-rogha"
 
 msgid "output in stuck long form"
-msgstr ""
+msgstr "aschur i bhfoirm fhada greamaithe"
 
-#, fuzzy
 msgid "premature end of input"
-msgstr "earráid léigh ar ionchur"
+msgstr "deireadh roimh ré an ionchuir"
 
 msgid "no usage string given before the `--' separator"
-msgstr ""
+msgstr "gan aon teaghrán úsáide a thugtar roimh an deighilteoir `--'"
 
 msgid "missing opt-spec before option flags"
-msgstr ""
+msgstr "sonraíocht rogha in easnamh roimh bhratacha roghanna"
 
 msgid "Needed a single revision"
-msgstr ""
+msgstr "Teastaíonn athbhreithniú amháin"
 
 msgid ""
 "git rev-parse --parseopt [<options>] -- [<args>...]\n"
@@ -11478,141 +12026,148 @@ msgid ""
 "\n"
 "Run \"git rev-parse --parseopt -h\" for more information on the first usage."
 msgstr ""
+"git rev-parse --parseopt [<options>] -- [<args>...]\n"
+"   or: git rev-parse --sq-quote [<arg>...]\n"
+"   or: git rev-parse [<options>] [<arg>...]\n"
+"\n"
+"Rith “git rev-parse --parseopt -h” le haghaidh tuilleadh faisnéise ar an "
+"gcéad úsáid."
 
 msgid "--resolve-git-dir requires an argument"
-msgstr ""
+msgstr "Teastaíonn argóint ag teastáil ó --resolve-git-dir"
 
 #, c-format
 msgid "not a gitdir '%s'"
-msgstr ""
+msgstr "ní ghearr '%s'"
 
 msgid "--git-path requires an argument"
-msgstr ""
+msgstr "Teastaíonn argóint ag teastáil ó --git-path"
 
-#, fuzzy
 msgid "-n requires an argument"
-msgstr "--stdin teastaíonn stórlann git"
+msgstr "Éilíonn -n argóint"
 
 msgid "--path-format requires an argument"
-msgstr ""
+msgstr "Éilíonn --path-format argóint"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown argument to --path-format: %s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "argóint anaithnid chuig --path-format: %s"
 
 msgid "--default requires an argument"
-msgstr ""
+msgstr "Teastaíonn argóint ar --default"
 
 msgid "--prefix requires an argument"
-msgstr ""
+msgstr "Teastaíonn argóint ar --prefix"
 
 msgid "no object format specified"
-msgstr ""
+msgstr "aon fhormáid réada a shonra"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unsupported object format: %s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "formáid réad gan tacaíocht: %s"
 
 #, c-format
 msgid "unknown mode for --abbrev-ref: %s"
-msgstr ""
+msgstr "modh anaithnid do --abbrev-ref: %s"
 
 msgid "this operation must be run in a work tree"
-msgstr ""
+msgstr "caithfear an oibríocht seo a reáchtáil i gcrann oibre"
 
-#, fuzzy
 msgid "Could not read the index"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "Ní fhéadfaí an t-innéacs a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown mode for --show-object-format: %s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "modh anaithnid do --show-object-format: %s"
 
 msgid ""
 "git revert [--[no-]edit] [-n] [-m <parent-number>] [-s] [-S[<keyid>]] "
 "<commit>..."
 msgstr ""
+"git revert [--[no-]edit] [-n] [-m <parent-number>] [-s] [-S[<keyid>]] "
+"<commit>..."
 
 msgid "git revert (--continue | --skip | --abort | --quit)"
-msgstr ""
+msgstr "git revert (--continue | --skip | --abort | --quit)"
 
 msgid ""
 "git cherry-pick [--edit] [-n] [-m <parent-number>] [-s] [-x] [--ff]\n"
 "                [-S[<keyid>]] <commit>..."
 msgstr ""
+"git cherry-pick [--edit] [-n] [-m <parent-number>] [-s] [-x] [--ff]\n"
+"                [-S[<keyid>]] <commit>..."
 
-#, fuzzy
 msgid "git cherry-pick (--continue | --skip | --abort | --quit)"
-msgstr " (reáchtáil “git cherry-pick --continue ” chun leanúint ar aghaidh)"
+msgstr "git cherry-pick (--continue | --skip | --abort | --quit)"
 
 #, c-format
 msgid "option `%s' expects a number greater than zero"
-msgstr ""
+msgstr "tá rogha `%s' ag súil go mbeidh uimhir níos mó ná nialas"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s: %s cannot be used with %s"
-msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
+msgstr "%s: Ní féidir %s a úsáid le %s"
 
 msgid "end revert or cherry-pick sequence"
-msgstr ""
+msgstr "aisiompú deiridh nó seicheamh piocadh silíní"
 
 msgid "resume revert or cherry-pick sequence"
-msgstr ""
+msgstr "athosú ar ais nó seicheamh a phiocadh silíní"
 
 msgid "cancel revert or cherry-pick sequence"
-msgstr ""
+msgstr "seicheamh aisiompthe nó silíní a roghnú a chealú"
 
 msgid "skip current commit and continue"
-msgstr ""
+msgstr "scipeáil tiomantas reatha agus lean ar aghaidh"
 
-#, fuzzy
 msgid "don't automatically commit"
-msgstr "Tiomantas tosaigh"
+msgstr "ná tiomantas go huathoibríoch"
 
 msgid "edit the commit message"
-msgstr ""
+msgstr "athraigh an teachtaireacht tiomanta"
 
 msgid "parent-number"
-msgstr ""
+msgstr "uimhir tuismitheora"
 
 msgid "select mainline parent"
-msgstr ""
+msgstr "roghnaigh tuismitheoir príomh"
 
 msgid "merge strategy"
-msgstr ""
+msgstr "straitéis cumaisc"
 
-#, fuzzy
 msgid "option for merge strategy"
-msgstr "rogha a tharchur"
+msgstr "rogha le haghaidh straitéis cumaisc"
 
 msgid "append commit name"
-msgstr ""
+msgstr "ainm tiomanta a chur leis"
 
 msgid "preserve initially empty commits"
-msgstr ""
+msgstr "gealltanais folamh a chaomhnú ar dt"
 
 msgid "allow commits with empty messages"
-msgstr ""
+msgstr "gealltanna a cheadú le teachtaireachtaí folamh"
 
 msgid "deprecated: use --empty=keep instead"
-msgstr ""
+msgstr "díscríofa: bain úsáid as --empty=keep ina ionad"
 
-#, fuzzy
 msgid "use the 'reference' format to refer to commits"
-msgstr "sonraigh an fhormáid tagartha le húsáid"
+msgstr ""
+"bain úsáid as an bhformáid 'tagartha' chun tagairt a dhéanamh do ghealltanais"
 
-#, fuzzy
 msgid "revert failed"
-msgstr "theip ar socrú siúlóid ath"
+msgstr "theip ar ais"
 
 msgid "cherry-pick failed"
-msgstr ""
+msgstr "theip ar an rogha silíní"
 
 msgid ""
 "git rm [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch]\n"
 "       [--quiet] [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "       [--] [<pathspec>...]"
 msgstr ""
+"git rm [-f | --force] [-n] [-r] [--cached] [--neamh-mheaitseáilte]\n"
+" <file>[--quiet] [--pathspec-ó-comhad = [--pathspec-comhad-nul]]\n"
+" [--] [<pathspec>...]"
 
 msgid ""
 "the following file has staged content different from both the\n"
@@ -11621,61 +12176,71 @@ msgid_plural ""
 "the following files have staged content different from both the\n"
 "file and the HEAD:"
 msgstr[0] ""
+"tá ábhar stáitse ag an gcomhad seo a leanas difriúil ón araon\n"
+"comhad agus an CEAD:"
 msgstr[1] ""
+"tá ábhar stáitseáilte difriúil idir an comhad agus\n"
+"an CEAD sna comhaid seo a leanas:"
 msgstr[2] ""
+"tá ábhar stáitseáilte difriúil idir an comhad agus \n"
+"an CEAD sna comhaid seo a leanas:"
 
 msgid ""
 "\n"
 "(use -f to force removal)"
 msgstr ""
+"\n"
+"(bain úsáid as -f chun a chur i bhfeidhm)"
 
 msgid "the following file has changes staged in the index:"
 msgid_plural "the following files have changes staged in the index:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "tá athruithe céime san innéacs ag an gcomhad seo a leanas:"
+msgstr[1] "tá athruithe céimnithe san innéacs sna comhaid seo a leanas:"
+msgstr[2] "tá athruithe céimnithe san innéacs sna comhaid seo a leanas:"
 
 msgid ""
 "\n"
 "(use --cached to keep the file, or -f to force removal)"
 msgstr ""
+"\n"
+"(bain úsáid as --cached chun an comhad a choinneáil, nó -f chun a bhaint a "
+"chur i bhfeidhm)"
 
-#, fuzzy
 msgid "the following file has local modifications:"
 msgid_plural "the following files have local modifications:"
-msgstr[0] "modhnuithe áitiúla a chaitheamh"
-msgstr[1] "modhnuithe áitiúla a chaitheamh"
-msgstr[2] "modhnuithe áitiúla a chaitheamh"
+msgstr[0] "tá modhnuithe áitiúla sa chomhad seo a leanas:"
+msgstr[1] "tá modhnuithe áitiúla ar na comhaid seo a leanas:"
+msgstr[2] "tá modhnuithe áitiúla ar na comhaid seo a leanas:"
 
 msgid "do not list removed files"
-msgstr ""
+msgstr "ná liostáil comhaid a bhaintear"
 
-#, fuzzy
 msgid "only remove from the index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "ach a bhaint as an innéacs"
 
 msgid "override the up-to-date check"
-msgstr ""
+msgstr "an seiceáil cothrom le dáta a chur ar"
 
 msgid "allow recursive removal"
-msgstr ""
+msgstr "cead a bhaint athfhillteach"
 
 msgid "exit with a zero status even if nothing matched"
-msgstr ""
+msgstr "imeacht le stádas nialasach fiú mura bhfuil aon rud comhoiriúnach"
 
 msgid "No pathspec was given. Which files should I remove?"
-msgstr ""
+msgstr "Níor tugadh aon bhealach. Cé na comhaid ba chóir dom a bhaint?"
 
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
+"cuir do chuid athruithe ar .gitmodules nó iad a stóráil chun dul ar aghaidh"
 
 #, c-format
 msgid "not removing '%s' recursively without -r"
-msgstr ""
+msgstr "gan '%s' a bhaint go athshlánach gan -r"
 
-#, fuzzy, c-format
+#, c-format
 msgid "git rm: unable to remove %s"
-msgstr "nach féidir %s a léamh"
+msgstr "git rm: ní féidir %s a bhaint"
 
 msgid ""
 "git send-pack [--mirror] [--dry-run] [--force]\n"
@@ -11684,69 +12249,70 @@ msgid ""
 "              [--[no-]signed | --signed=(true|false|if-asked)]\n"
 "              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [--[no-]signed | --signed=(true|false|if-asked)]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
 
-#, fuzzy
 msgid "remote name"
-msgstr "athainmnithe:"
+msgstr "ainm iargúlta"
 
-#, fuzzy
 msgid "push all refs"
-msgstr "brúigh gach brainse"
+msgstr "brúigh gach ceann"
 
 msgid "use stateless RPC protocol"
-msgstr ""
+msgstr "prótacal RPC gan stáit a úsáid"
 
 msgid "read refs from stdin"
-msgstr ""
+msgstr "léigh refs ó stdin"
 
 msgid "print status from remote helper"
-msgstr ""
+msgstr "stádas priontála ó chúntóir cianda"
 
-#, fuzzy
 msgid "git shortlog [<options>] [<revision-range>] [[--] <path>...]"
-msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
+msgstr "git shortlog [<options>] [<revision-range>] [[--]<path>...]"
 
 msgid "git log --pretty=short | git shortlog [<options>]"
-msgstr ""
+msgstr "git log --pretty=short | git shortlog [<options>]"
 
 msgid "using multiple --group options with stdin is not supported"
-msgstr ""
+msgstr "ní thacaítear le roghanna iolracha --group le stdin a úsáid"
 
 #, c-format
 msgid "using %s with stdin is not supported"
-msgstr ""
+msgstr "ní thacaítear le baint úsáide as %s le stdin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown group type: %s"
-msgstr "cineál réad anaithnid %d"
+msgstr "cineál grúpa anaithnid: %s"
 
 msgid "group by committer rather than author"
-msgstr ""
+msgstr "grúpa de réir coimiteora seachas údar"
 
 msgid "sort output according to the number of commits per author"
-msgstr ""
+msgstr "aschur a shórtáil de réir líon na ngealltanais in aghaidh an údair"
 
 msgid "suppress commit descriptions, only provides commit count"
-msgstr ""
+msgstr "tuairiscí tiomanta a chur faoi chois, ní sholáthraíonn"
 
 msgid "show the email address of each author"
-msgstr ""
+msgstr "taispeáin seoladh ríomhphoist gach údair"
 
 msgid "<w>[,<i1>[,<i2>]]"
-msgstr ""
+msgstr "<w>[, <i1>[,<i2>]]"
 
-#, fuzzy
 msgid "linewrap output"
-msgstr "aschur inléite meaisín"
+msgstr "aschur linewrap"
 
 msgid "field"
-msgstr ""
+msgstr "réimse"
 
 msgid "group by field"
-msgstr ""
+msgstr "grúpa de réir réimse"
 
 msgid "too many arguments given outside repository"
-msgstr ""
+msgstr "an iomarca argóintí a thugtar stóráil"
 
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
@@ -11755,328 +12321,349 @@ msgid ""
 "                [--no-name | --sha1-name] [--topics]\n"
 "                [(<rev> | <glob>)...]"
 msgstr ""
+"git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics]\n"
+"                [(<rev> | <glob>)...]"
 
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
-msgstr ""
+msgstr "<ref>git show-branch (-g | --reflog) [= [<n>,]] [--liosta] [<base>]"
 
 #, c-format
 msgid "ignoring %s; cannot handle more than %d ref"
 msgid_plural "ignoring %s; cannot handle more than %d refs"
 msgstr[0] ""
+"ag déanamh neamhaird de %s; ní féidir níos mó ná %d tagairt a láimhseáil"
 msgstr[1] ""
+"ag déanamh neamhaird de %s; ní féidir níos mó ná %d tagairtí a láimhseáil"
 msgstr[2] ""
+"ag déanamh neamhaird de %s; ní féidir níos mó ná %d tagairtí a láimhseáil"
 
 #, c-format
 msgid "no matching refs with %s"
-msgstr ""
+msgstr "gan aon fhreagraí a mheaitseáil le %s"
 
 msgid "show remote-tracking and local branches"
-msgstr ""
+msgstr "taispeáint cianrianú agus brainsí áitiúla"
 
-#, fuzzy
 msgid "show remote-tracking branches"
-msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
+msgstr "taispeáin brainsí cianrianaithe"
 
 msgid "color '*!+-' corresponding to the branch"
-msgstr ""
+msgstr "dath '*! +-' a fhreagraíonn don bhrainse"
 
 msgid "show <n> more commits after the common ancestor"
-msgstr ""
+msgstr "taispeáint <n>níos mó gealltanais tar éis an sinsear coiteann"
 
 msgid "synonym to more=-1"
-msgstr ""
+msgstr "comhchiallach le níos mó = -1"
 
-#, fuzzy
 msgid "suppress naming strings"
-msgstr "cur chun cinn tuairiscithe"
+msgstr "teaghráin ainmniúcháin"
 
-#, fuzzy
 msgid "include the current branch"
-msgstr "brainse nua gan breith"
+msgstr "san áireamh an bhrainse reatha"
 
 msgid "name commits with their object names"
-msgstr ""
+msgstr "geallann ainm lena n-ainmneacha réad"
 
 msgid "show possible merge bases"
-msgstr ""
+msgstr "taispeáin bonn cumaisc féidear"
 
 msgid "show refs unreachable from any other ref"
-msgstr ""
+msgstr "taispeántais neamh-inrochtana ó aon tagairt eile"
 
 msgid "show commits in topological order"
-msgstr ""
+msgstr "gealltanna seó in ord topolaíoch"
 
 msgid "show only commits not on the first branch"
-msgstr ""
+msgstr "seó ní geallann ach ar an gcéad bhrainse"
 
 msgid "show merges reachable from only one tip"
-msgstr ""
+msgstr "cumaisc seó inrochtana ó chomhairle amháin"
 
 msgid "topologically sort, maintaining date order where possible"
-msgstr ""
+msgstr "a shórtáil topaiceach, ag coinneáil ord dáta nuair is féidir"
 
 msgid "<n>[,<base>]"
-msgstr ""
+msgstr "<n>[,<base>]"
 
 msgid "show <n> most recent ref-log entries starting at base"
-msgstr ""
+msgstr "taispeáin ion <n>trálacha ref-log is déanaí ag tosú ag an mbonn"
 
 msgid "no branches given, and HEAD is not valid"
-msgstr ""
+msgstr "aon bhrainsí a thugtar, agus níl HEAD bailí"
 
-#, fuzzy
 msgid "--reflog option needs one branch name"
-msgstr "--track tá ainm brainse ag teastáil"
+msgstr "Teastaíonn ainm brainse amháin ag teastáil ó rogha --reflog"
 
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "ní féidir ach %d iontráil a thaispeáint ag an am céanna."
+msgstr[1] "ní féidir ach %d iontráil a thaispeáint ag an am céanna."
+msgstr[2] "ní féidir ach %d iontráil a thaispeáint ag an am céanna."
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such ref %s"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "aon tagairt den sórt sin %s"
 
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "ní féidir níos mó ná %d luasghéarú a láimhseáil."
+msgstr[1] "ní féidir níos mó ná %d luasghéarú a láimhseáil."
+msgstr[2] "ní féidir níos mó ná %d luasghéarú a láimhseáil."
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid ref."
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní tagairt bailí é '%s'."
 
 #, c-format
 msgid "cannot find commit %s (%s)"
-msgstr ""
+msgstr "ní féidir teacht ar thiomantas %s (%s)"
 
-#, fuzzy
 msgid "hash-algorithm"
-msgstr "algartam hais anaithnid '%s'"
+msgstr "hais-algartam"
 
-#, fuzzy
 msgid "Unknown hash algorithm"
-msgstr "algartam hais anaithnid '%s'"
+msgstr "Algartam hash anaithnid"
 
 msgid ""
 "git show-ref [--head] [-d | --dereference]\n"
 "             [-s | --hash[=<n>]] [--abbrev[=<n>]] [--branches] [--tags]\n"
 "             [--] [<pattern>...]"
 msgstr ""
+"git show-ref [--head] [-d | --dereference]\n"
+"             [-s | --hash[=<n>]] [--abbrev[=<n>]] [--branches] [--tags]\n"
+"             [--] [<pattern>...]"
 
 msgid ""
 "git show-ref --verify [-q | --quiet] [-d | --dereference]\n"
 "             [-s | --hash[=<n>]] [--abbrev[=<n>]]\n"
 "             [--] [<ref>...]"
 msgstr ""
+"git show-ref --verify [-q | --quiet] [-d | --dereference]\n"
+"             [-s | --hash[=<n>]] [--abbrev[=<n>]]\n"
+"             [--] [<ref>...]"
 
 msgid "git show-ref --exclude-existing[=<pattern>]"
-msgstr ""
+msgstr "git show-ref --exclude-existing[=<pattern>]"
 
 msgid "git show-ref --exists <ref>"
-msgstr ""
+msgstr "git show-ref --exists <ref>"
 
-#, fuzzy
 msgid "reference does not exist"
-msgstr "ní crann é tagairt: %s"
+msgstr "níl tagairt ann"
 
 msgid "failed to look up reference"
-msgstr ""
+msgstr "theip ort tagairt a lorg suas"
 
-#, fuzzy
 msgid "only show tags (can be combined with --branches)"
 msgstr ""
-"clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
+"taispeáin clibeanna amháin (is féidir iad a chomhcheangal le --branches)"
 
 msgid "only show branches (can be combined with --tags)"
-msgstr ""
+msgstr "ní thaispeáin ach brainsí (is féidir iad a chomhcheangal le --tags)"
 
 msgid "check for reference existence without resolving"
-msgstr ""
+msgstr "seiceáil chun tagartha a bheith ann gan réiteach"
 
 msgid "stricter reference checking, requires exact ref path"
-msgstr ""
+msgstr "seiceáil tagartha níos doichte, teastaíonn cosán tagartha"
 
 msgid "show the HEAD reference, even if it would be filtered out"
-msgstr ""
+msgstr "taispeáin tagairt HEAD, fiú dá ndéanfaí é a scagadh amach"
 
-#, fuzzy
 msgid "dereference tags into object IDs"
-msgstr "ní crann é tagairt: %s"
+msgstr "clibeanna a dhíthreorú isteach in IDanna réad"
 
 msgid "only show SHA1 hash using <n> digits"
-msgstr ""
+msgstr "ní thaispeáin ach hais SHA1 ag úsáid <n> dhigit"
 
 msgid "do not print results to stdout (useful with --verify)"
-msgstr ""
+msgstr "ná priontáil torthaí chuig stdout (úsáideach le --verify)"
 
-#, fuzzy
 msgid "show refs from stdin that aren't in local repository"
-msgstr "a chlónú ó stór áitiúil"
+msgstr "taispeáin airgeanna ó stdin nach bhfuil i stóras áitiúil"
 
 msgid ""
 "git sparse-checkout (init | list | set | add | reapply | disable | check-"
 "rules) [<options>]"
 msgstr ""
+"git sparse-checkout (init | list | set | add | reapply | disable | check-"
+"rules) [<options>]"
 
 msgid "this worktree is not sparse"
-msgstr ""
+msgstr "níl an crann oibre seo neamhchoitianta"
 
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
+"níl an crann oibre seo neamhchoitianta (b'fhéidir nach bhfuil comhad "
+"seiceála neamhchoitianta ann)"
 
 #, c-format
 msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
 "cone"
 msgstr ""
+"tá comhaid neamhrianaithe ag eolaire '%s', ach níl sé sa chón seiceála "
+"neamhchoitianta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to remove directory '%s'"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar eolaire '%s' a bhaint"
 
-#, fuzzy
 msgid "failed to create directory for sparse-checkout file"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar eolaire a chruthú do chomhad seiceála neamhchoitianta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to fdopen %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir %s a fdophríomhachtú"
 
-#, fuzzy
 msgid "failed to initialize worktree config"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "theip orthu cumraíocht crann oibre a thionscnamh"
 
-#, fuzzy
 msgid "failed to modify sparse-index config"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "theip orthu cumraíocht innéacs neamhchoitianta a mhodhnú"
 
-#, fuzzy
 msgid "initialize the sparse-checkout in cone mode"
-msgstr ""
-"comhad seiceála neamhchoitianta a thosú chun comhaid amháin a áireamh ag "
-"fréamh"
+msgstr "an tseiceáil neamhchoitianta a thosú i mód cón"
 
 msgid "toggle the use of a sparse index"
-msgstr ""
+msgstr "athsholáthar úsáid innéacs neamhchoitianta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create leading directories of %s"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "nach féidir eolairí tosaigh de %s a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to open '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar '%s' a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not normalize path %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí cosán %s a normalú"
 
 #, c-format
 msgid "unable to unquote C-style string '%s'"
-msgstr ""
+msgstr "nach féidir teaghrán '%s' i stíl C a dhíluachan"
 
-#, fuzzy
 msgid "unable to load existing sparse-checkout patterns"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "in ann patrúin seiceála neamhchoitianta atá ann a luchtú"
 
 msgid "existing sparse-checkout patterns do not use cone mode"
-msgstr ""
+msgstr "ní úsáideann patrúin seiceála neamhchoitianta atá ann cheana modh cón"
 
 msgid "please run from the toplevel directory in non-cone mode"
-msgstr ""
+msgstr "rith ón eolaire topevel le do thoil i mód neamh-chón"
 
 msgid "specify directories rather than patterns (no leading slash)"
-msgstr ""
+msgstr "eolairí a shonrú seachas patrúin (gan aon slash tosaigh)"
 
 msgid ""
 "specify directories rather than patterns.  If your directory starts with a "
 "'!', pass --skip-checks"
 msgstr ""
+"eolairí a shonrú seachas patrúin. Má thosaíonn d'eolaire le '!', pas --skip-"
+"checks"
 
 msgid ""
 "specify directories rather than patterns.  If your directory really has any "
 "of '*?[]\\' in it, pass --skip-checks"
 msgstr ""
+"eolairí a shonrú seachas patrúin. Má tá aon cheann de '* ag d'eolaire i "
+"ndáiríre? []\\ 'ann, pas --skip-checks"
 
 #, c-format
 msgid ""
 "'%s' is not a directory; to treat it as a directory anyway, rerun with --"
 "skip-checks"
 msgstr ""
+"Ní eolaire é '%s'; chun é a chóireáil mar eolaire ar aon nós, athrith le --"
+"skip-checks"
 
 #, c-format
 msgid ""
 "pass a leading slash before paths such as '%s' if you want a single file "
 "(see NON-CONE PROBLEMS in the git-sparse-checkout manual)."
 msgstr ""
+"téigh slasc tosaigh roimh chosáin mar '%s' más mian leat comhad amháin "
+"(féach FADHBANNA NEAMH-CONE sa lámhleabhar seiceála git-sparse-checkout)."
 
 msgid "git sparse-checkout add [--skip-checks] (--stdin | <patterns>)"
-msgstr ""
+msgstr "git sparse-checkout add [--skip-checks] (--stdin | <patterns>)"
 
 msgid ""
 "skip some sanity checks on the given paths that might give false positives"
 msgstr ""
+"scipeáil roinnt seiceálacha sláinte ar na cosáin a thugtar a d'fhéadfadh "
+"dearfacha bréagacha a"
 
 msgid "read patterns from standard in"
-msgstr ""
+msgstr "léigh patrúin ó chaighdeán i"
 
 msgid "no sparse-checkout to add to"
-msgstr ""
+msgstr "gan aon seiceáil neamhchoitianta le cur leis"
 
 msgid ""
 "git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] [--skip-checks] "
 "(--stdin | <patterns>)"
 msgstr ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] [--skip-checks] "
+"(--stdin | <patterns>)"
 
 msgid "must be in a sparse-checkout to reapply sparsity patterns"
 msgstr ""
+"caithfidh sé a bheith i seiceáil neamhchoitianta chun patrúin éagsúla a "
+"athchur i bhfeidh"
 
-#, fuzzy
 msgid "error while refreshing working directory"
-msgstr "earráid agus comhad pacáiste á dúnadh"
+msgstr "earráid agus tú ag athnuachan eolaire"
 
 msgid ""
 "git sparse-checkout check-rules [-z] [--skip-checks][--[no-]cone] [--rules-"
 "file <file>]"
 msgstr ""
+"git sparse-checkout check-rules [-z] [--skip-checks][--[no-]cone] [--rules-"
+"file <file>]"
 
 msgid "terminate input and output files by a NUL character"
-msgstr ""
+msgstr "comhaid ionchuir agus aschuir a fhoirceannadh le carachtar NUL"
 
 msgid "when used with --rules-file interpret patterns as cone mode patterns"
 msgstr ""
+"nuair a úsáidtear é le --rules-file patrúin a léirmhíniú mar phatrúin mód"
 
 msgid "use patterns in <file> instead of the current ones."
-msgstr ""
+msgstr "úsáid patrúin in <file>ionad na cinn reatha."
 
-#, fuzzy
 msgid "git stash list [<log-options>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "<log-options>liosta git stash []"
 
 msgid ""
 "git stash show [-u | --include-untracked | --only-untracked] [<diff-"
 "options>] [<stash>]"
 msgstr ""
+"git stash show [-u | --include-untracked | --only-untracked] [<diff-"
+"options>] [<stash>]"
 
 msgid "git stash drop [-q | --quiet] [<stash>]"
-msgstr ""
+msgstr "git stash drop [-q | --quiet] [<stash>]"
 
 msgid "git stash pop [--index] [-q | --quiet] [<stash>]"
-msgstr ""
+msgstr "git stash pop [--index] [-q | --quiet] [<stash>]"
 
 msgid "git stash apply [--index] [-q | --quiet] [<stash>]"
-msgstr ""
+msgstr "git stash apply [--index] [-q | --quiet] [<stash>]"
 
 msgid "git stash branch <branchname> [<stash>]"
-msgstr ""
+msgstr "git stash branch <branchname> [<stash>]"
 
 msgid "git stash store [(-m | --message) <message>] [-q | --quiet] <commit>"
 msgstr ""
+"git stash store [(-m | --teachtaireacht)<message>] [-q | --ciúin] <commit>"
 
 msgid ""
 "git stash [push [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q "
@@ -12086,33 +12673,41 @@ msgid ""
 "          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
+"git stash [bhrú [-p | --patch] [-S | --stage] [-k | -- [no-] coinneáil "
+"innéacs] [-q | --ciúin]\n"
+" <message>[-u | --include-untracked] [-a | --all] [(-m | --teachtaireacht)]\n"
+" <file>[--pathspec-ó-comhad = [--pathspec-comhad-nul]]\n"
+" [--] [<pathspec>...]]"
 
 msgid ""
 "git stash save [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q | "
 "--quiet]\n"
 "          [-u | --include-untracked] [-a | --all] [<message>]"
 msgstr ""
+"git stash save [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q | "
+"--quiet]\n"
+"          [-u | --include-untracked] [-a | --all] [<message>]"
 
 msgid "git stash create [<message>]"
-msgstr ""
+msgstr "<message>git stash cruthaigh []"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a stash-like commit"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní gealltanas cosúil le stash é '%s'"
 
 #, c-format
 msgid "Too many revisions specified:%s"
-msgstr ""
+msgstr "Sonraítear an iomarca athbhreithnithe: %s"
 
 msgid "No stash entries found."
-msgstr ""
+msgstr "Níor aimsíodh aon iontrálacha stash."
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s is not a valid reference"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní tagairt bailí é %s"
 
 msgid "git stash clear with arguments is unimplemented"
-msgstr ""
+msgstr "níl git stash clear le hargóintí neamh-chur i bhfeidhm"
 
 #, c-format
 msgid ""
@@ -12120,193 +12715,182 @@ msgid ""
 "            %s -> %s\n"
 "         to make room.\n"
 msgstr ""
+"RABHADH: Comhad neamhrianaithe ar bhealach comhad rianaithe!  Athainmniú\n"
+"            %s -> %s\n"
+"         chun seomra a dhéanamh.\n"
 
-#, fuzzy
 msgid "cannot apply a stash in the middle of a merge"
-msgstr "Ní féidir athshocrú %s a dhéanamh i lár cumaisc."
+msgstr "ní féidir stash a chur i bhfeidhm i lár cumaisc"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not generate diff %s^!."
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí diff %s^ a ghiniúint!."
 
 msgid "conflicts in index. Try without --index."
-msgstr ""
+msgstr "coinbhleachtaí in innéacs. Bain triail as gan --index."
 
-#, fuzzy
 msgid "could not save index tree"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní fhéadfadh crann innéacs a shábháil"
 
 #, c-format
 msgid "Merging %s with %s"
-msgstr ""
+msgstr "Cumasc %s le %s"
 
 msgid "Index was not unstashed."
-msgstr ""
+msgstr "Ní raibh an t-innéacs gan stashed."
 
-#, fuzzy
 msgid "could not restore untracked files from stash"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní raibh in ann comhaid neamhrianaithe a chur ar ais ó stash"
 
-#, fuzzy
 msgid "attempt to recreate the index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "iarracht an t-innéacs a athchruthú"
 
 #, c-format
 msgid "Dropped %s (%s)"
-msgstr ""
+msgstr "Scaoil %s (%s)"
 
 #, c-format
 msgid "%s: Could not drop stash entry"
-msgstr ""
+msgstr "%s: Ní fhéadfaí iontráil stash a scaoileadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a stash reference"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní tagairt stash é '%s'"
 
 msgid "The stash entry is kept in case you need it again."
-msgstr ""
+msgstr "Coinnítear an iontráil stash ar eagla go dteastaíonn sé uait arís."
 
 msgid "No branch name specified"
-msgstr ""
+msgstr "Níl aon ainm brainse sonraithe"
 
-#, fuzzy
 msgid "failed to parse tree"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "theip ar chrann a pháirseáil"
 
-#, fuzzy
 msgid "failed to unpack trees"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar chrainn a dhíphacáil"
 
-#, fuzzy
 msgid "include untracked files in the stash"
-msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+msgstr "comhaid neamhrianaithe san áireamh sa stash"
 
-#, fuzzy
 msgid "only show untracked files in the stash"
-msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+msgstr "ní thaispeánann ach comhaid neamhrianaithe sa stash"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Cannot update %s with %s"
-msgstr "Ní féidir %s a athshocrú le cosáin."
+msgstr "Ní féidir %s a nuashonrú le %s"
 
 msgid "stash message"
-msgstr ""
+msgstr "teachtaireacht stash"
 
 msgid "\"git stash store\" requires one <commit> argument"
-msgstr ""
+msgstr "<commit>Éilíonn “git stash store” argóint amháin"
 
-#, fuzzy
 msgid "No staged changes"
-msgstr "Gan aon athruithe"
+msgstr "Gan aon athruithe céime"
 
-#, fuzzy
 msgid "No changes selected"
-msgstr "Gan aon athruithe"
+msgstr "Gan aon athruithe roghnaithe"
 
-#, fuzzy
 msgid "You do not have the initial commit yet"
-msgstr "Níl CEANN bailí agat."
+msgstr "Níl an tiomantas tosaigh agat fós"
 
-#, fuzzy
 msgid "Cannot save the current index state"
-msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
+msgstr "Ní féidir an staid innéacs reatha a shábháil"
 
-#, fuzzy
 msgid "Cannot save the untracked files"
-msgstr "ní féidir le pacáiste fstat"
+msgstr "Ní féidir na comhaid neamhrianaithe a shábháil"
 
 msgid "Cannot save the current worktree state"
-msgstr ""
+msgstr "Ní féidir an stát crainn oibre reatha a shábháil"
 
-#, fuzzy
 msgid "Cannot save the current staged state"
-msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+msgstr "Ní féidir an stát stáitse reatha a shábháil"
 
-#, fuzzy
 msgid "Cannot record working tree state"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr "Ní féidir stát crann oibre a thaifead"
 
-#, fuzzy
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
-"Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
+"Ní féidir --patch agus --include-untracked nó --all a úsáid ag an am céanna"
 
 msgid "Can't use --staged and --include-untracked or --all at the same time"
 msgstr ""
+"Ní féidir --staged agus --include-untracked nó --all a úsáid ag an am céanna"
 
 msgid "Did you forget to 'git add'?"
-msgstr ""
+msgstr "Ar ndearna tú dearmad 'git add'?"
 
 msgid "No local changes to save"
-msgstr ""
+msgstr "Níl aon athruithe áitiúla le sábháil"
 
-#, fuzzy
 msgid "Cannot initialize stash"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "Ní féidir stash a thionscnamh"
 
 msgid "Cannot save the current status"
-msgstr ""
+msgstr "Ní féidir an stádas reatha a shábháil"
 
 #, c-format
 msgid "Saved working directory and index state %s"
-msgstr ""
+msgstr "Eolaire oibre shábháilte agus staid innéacs %s"
 
 msgid "Cannot remove worktree changes"
-msgstr ""
+msgstr "Ní féidir athruithe crann oibre a bhaint"
 
 msgid "keep index"
-msgstr ""
+msgstr "coinnigh innéacs"
 
 msgid "stash staged changes only"
-msgstr ""
+msgstr "athruithe céimeádta stash amháin"
 
 msgid "stash in patch mode"
-msgstr ""
+msgstr "stash i mód paiste"
 
 msgid "quiet mode"
-msgstr ""
+msgstr "modh ciúin"
 
-#, fuzzy
 msgid "include untracked files in stash"
-msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
+msgstr "comhaid neamhrianaithe a chur san áireamh i stash"
 
-#, fuzzy
 msgid "include ignore files"
-msgstr "Comhaid neamhaird"
+msgstr "áireamh neamhaird a dhéanamh"
 
 msgid "skip and remove all lines starting with comment character"
-msgstr ""
+msgstr "scipeáil agus bain gach líne ag tosú le carachtar trácht"
 
 msgid "prepend comment character and space to each line"
-msgstr ""
+msgstr "carachtar tráchta agus spás a chur ar fáil chuig gach líne"
 
 #, c-format
 msgid "Expecting a full ref name, got %s"
-msgstr ""
+msgstr "Ag súil le hainm tagartha iomlán, fuair %s"
 
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
-msgstr ""
+msgstr "ní fhéadfaí láimhseáil stór a fháil do fho-mhodúl '%s'"
 
 #, c-format
 msgid ""
 "could not look up configuration '%s'. Assuming this repository is its own "
 "authoritative upstream."
 msgstr ""
+"ní fhéadfaí cumraíocht '%s' a fheiceáil suas. Ag glacadh leis gurb é an stór "
+"seo a údarásach suas sruth féin."
 
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
-msgstr ""
+msgstr "Níl aon url le haghaidh cosán fo-mhodúil '%s' i .gitmodules"
 
 #, c-format
 msgid "Entering '%s'\n"
-msgstr ""
+msgstr "Ag iontráil '%s'\n"
 
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
 "."
 msgstr ""
+"thug run_command stádas neamh-nialas ar ais do %s.\n"
+"."
 
 #, c-format
 msgid ""
@@ -12314,160 +12898,171 @@ msgid ""
 "submodules of %s\n"
 "."
 msgstr ""
+"d'fhill run_command stádas neamh-nialasach agus é ag athshlánú sna fo-"
+"mhodúil neadaithe de %s\n"
+"."
 
 msgid "suppress output of entering each submodule command"
-msgstr ""
+msgstr "cosc a chur ar aschur gach ordú fo-mhodúil a chur isteach"
 
-#, fuzzy
 msgid "recurse into nested submodules"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "athshlánú isteach i bhfo-mhodúil neadaithe"
 
 msgid "git submodule foreach [--quiet] [--recursive] [--] <command>"
-msgstr ""
+msgstr "git submodule foreach [--quiet] [--recursive] [--] <command>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to register url for submodule path '%s'"
-msgstr "theip ar an iterator a thosú thar '%s'"
+msgstr "Theip ar url a chlárú le haghaidh cosán fo-mhodúil '%s'"
 
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
-msgstr ""
+msgstr "Fo-mhodúl '%s' (%s) cláraithe le haghaidh cosán '%s'\n"
 
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
-msgstr ""
+msgstr "rabhadh: modh nuashonraithe ordaithe a mholtar don fho-mhodúl '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to register update mode for submodule path '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "Theip ar mhodh nuashonraithe a chlárú do chonair fo-mhodúil '%s'"
 
 msgid "suppress output for initializing a submodule"
-msgstr ""
+msgstr "aschur a chur faoi chois chun fo-mhodúl a thosú"
 
-#, fuzzy
 msgid "git submodule init [<options>] [<path>]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git submodule init [<options>] [<path>]"
 
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr ""
+"níl aon mhapáil fo-mhodúil le fáil i .gitmodules le haghaidh cosán '%s'"
 
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
-msgstr ""
+msgstr "ní fhéadfaí tagairt HEAD a réiteach taobh istigh den fho-mhodúl '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to recurse into submodule '%s'"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar athshlánú isteach i bhfo-mhodúl '%s'"
 
 msgid "suppress submodule status output"
-msgstr ""
+msgstr "aschur stádas fo-mhodúil a chur faoi cho"
 
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
+"bain úsáid as tiomantas atá stóráilte san innéacs in ionad an ceann atá "
+"stóráilte sa fho-mhodúl HEAD"
 
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
-msgstr ""
+msgstr "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
-msgstr ""
+msgstr "* %s %s (blob) -> %s (fo-mhodúl)"
 
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
-msgstr ""
+msgstr "* %s %s (fo-mhodúl) -> %s (blob)"
 
 #, c-format
 msgid "%s"
-msgstr ""
+msgstr "%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "couldn't hash object from '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí réad hash ó '%s'"
 
 #, c-format
 msgid "unexpected mode %o"
-msgstr ""
+msgstr "modh gan choinne %o"
 
-#, fuzzy
 msgid "use the commit stored in the index instead of the submodule HEAD"
-msgstr "seiceáil <brainse> in ionad CEAD an iargúlta"
+msgstr ""
+"bain úsáid as an gealltanas atá stóráilte san innéacs in ionad an fho-mhodúl "
+"HEAD"
 
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr ""
+"comparáid a dhéanamh idir an tiomantas san innéacs leis an bhfo-mhodúl HEAD"
 
 msgid "skip submodules with 'ignore_config' value set to 'all'"
-msgstr ""
+msgstr "scipeáil fo-mhodúil le luach 'ignore_config' socraithe go 'go léir'"
 
 msgid "limit the summary size"
-msgstr ""
+msgstr "teorainn a chur leis an méid achoimre"
 
 msgid "git submodule summary [<options>] [<commit>] [--] [<path>]"
-msgstr ""
+msgstr "git achoimre fo-mhodúil [<options>] [<commit>] [--] [<path>]"
 
 msgid "could not fetch a revision for HEAD"
-msgstr ""
+msgstr "ní fhéadfaí athbhreithniú a fháil do HEAD"
 
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
-msgstr ""
+msgstr "Url fo-mhodúil a shioncrónú do '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to register url for submodule path '%s'"
-msgstr "theip ar an iterator a thosú thar '%s'"
+msgstr "theip ar url a chlárú le haghaidh cosán fo-mhodúil '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to update remote for submodule '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar iargúlta a nuashonrú do fho-mhodúl '%s'"
 
 msgid "suppress output of synchronizing submodule url"
-msgstr ""
+msgstr "aschur url fo-mhodúil sioncrónaithe a chur faoi chois"
 
 msgid "git submodule sync [--quiet] [--recursive] [<path>]"
-msgstr ""
+msgstr "git sioncrónú fo-mhodúil [--quiet] [--recursive] [<path>]"
 
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory. This will be replaced "
 "with a .git file by using absorbgitdirs."
 msgstr ""
+"Tá eolair .git i gcrann oibre fo-mhodúil '%s'. Cuirfear comhad .git in ionad "
+"seo trí absorbgitdirs a úsáid."
 
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
 "them"
 msgstr ""
+"Tá modhnuithe áitiúla i gcrann oibre fo-mhodúil '%s'; bain úsáid as '-f' "
+"chun iad a dhiúscairt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Cleared directory '%s'\n"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "Glanadh an eolaire '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not remove submodule work tree '%s'\n"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "Níor féidir crann oibre fo-mhodúil '%s' a bhaint\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create empty submodule directory %s"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire fo-mhodúil folamh %s a chruthú"
 
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
-msgstr ""
+msgstr "Fo-mhodúl '%s' (%s) neamhchláraithe le haghaidh cosán '%s'\n"
 
 msgid "remove submodule working trees even if they contain local changes"
-msgstr ""
+msgstr "crainn oibre fo-mhodúil a bhaint fiú má tá athruithe áitiúla iontu"
 
 msgid "unregister all submodules"
-msgstr ""
+msgstr "gach fo-mhodúl a dhíchlárú"
 
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
+"git fo-mhodúil deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 
 msgid "Use '--all' if you really want to deinitialize all submodules"
-msgstr ""
+msgstr "Úsáid '--all' más mian leat gach fo-mhodúl a dhíthionsú i ndáiríre"
 
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
@@ -12475,209 +13070,220 @@ msgid ""
 "submodule.alternateErrorStrategy to 'info' or, equivalently, clone with\n"
 "'--reference-if-able' instead of '--reference'."
 msgstr ""
+"Tá malartach arna ríomh ó mhalartach sárthionscadail neamhbhailí.\n"
+"Chun ligean Git a chlónú gan malartach i gcás den sórt sin, socraigh\n"
+"submodule.alternateErrorStrategy chun 'faisnéis' nó, go coibhéiseach, clónú "
+"le\n"
+"'--reference-if-able' in ionad '--reference'."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not get a repository handle for gitdir '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí láimhseáil stór a fháil do gitdir '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "submodule '%s' cannot add alternate: %s"
-msgstr "eolas: Ní féidir malartach a chur le haghaidh '%s': %s\n"
+msgstr "ní féidir le fo-mhodúl '%s' malartach a chur leis: %s"
 
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
-msgstr ""
+msgstr "Luach '%s' le haghaidh submodule.alternateErrorStrategy ní aithnítear"
 
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
-msgstr ""
+msgstr "Luach '%s' le haghaidh submodule.alternateLocation ní aithnítear"
 
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
-msgstr ""
+msgstr "diúltú '%s' a chruthú/úsáid i git dir fo-mhodúil eile"
 
 #, c-format
 msgid "directory not empty: '%s'"
-msgstr ""
+msgstr "eolaire nach folamh: '%s'"
 
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
-msgstr ""
+msgstr "theip ar chlón '%s' isteach i gcosán fo-mhodúil '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not get submodule directory for '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire fo-mhodúil a fháil do '%s'"
 
 msgid "alternative anchor for relative paths"
-msgstr ""
+msgstr "ancaire malartach do chonair choibhneasta"
 
-#, fuzzy
 msgid "where the new submodule will be cloned to"
-msgstr "beidh aon fho-mhodúil clónaithe éadrom"
+msgstr "áit a gclónófar an fo-mhodúl nua"
 
 msgid "name of the new submodule"
-msgstr ""
+msgstr "ainm an fho-mhodúil nua"
 
 msgid "url where to clone the submodule from"
-msgstr ""
+msgstr "url cá háit ar féidir an fo-mhodúl a chlónáil"
 
 msgid "depth for shallow clones"
-msgstr ""
+msgstr "doimhneacht do chlóin éadomhain"
 
-#, fuzzy
 msgid "force cloning progress"
-msgstr "tuairisciú dul chun cinn"
+msgstr "dul chun cinn clónaithe fórsa"
 
 msgid "disallow cloning into non-empty directory"
-msgstr ""
+msgstr "clónú a dhícheadú isteach i eolaire neamh-folamh"
 
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] [--filter "
 "<filter-spec>] --url <url> --path <path>"
 msgstr ""
+"git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
+"<repository>] [--name <name>] [--depth <depth>] [--single-branch] [--filter "
+"<filter-spec>] --url <url> --path <path>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
-msgstr "níl aon chumrú suas srutha le haghaidh brainse '%s'"
+msgstr ""
+"Modh nuashonraithe neamhbhailí '%s' cumraithe le haghaidh cosán fo-mhodúil "
+"'%s'"
 
 #, c-format
 msgid "Submodule path '%s' not initialized"
-msgstr ""
+msgstr "Níor thosaigh cosán fo-mhodúil '%s'"
 
 msgid "Maybe you want to use 'update --init'?"
-msgstr ""
+msgstr "B'fhéidir gur mhaith leat 'update --init' a úsáid?"
 
 #, c-format
 msgid "Skipping unmerged submodule %s"
-msgstr ""
+msgstr "Fo-mhodúl neamh-mheánaithe %s a scipeáil"
 
 #, c-format
 msgid "Skipping submodule '%s'"
-msgstr ""
+msgstr "Fo-mhodúl '%s' a scipeáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot clone submodule '%s' without a URL"
-msgstr "beidh aon fho-mhodúil clónaithe éadrom"
+msgstr "ní féidir le fo-mhodúl '%s' a chlónú gan URL"
 
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
-msgstr ""
+msgstr "Theip ar chlónáil '%s'. Déan iarracht sceidealta"
 
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
-msgstr ""
+msgstr "Theip ar chlónáil '%s' an dara huair, ag cur isteach"
 
 #, c-format
 msgid "Unable to checkout '%s' in submodule path '%s'"
-msgstr ""
+msgstr "Ní féidir '%s' a sheiceáil i gcosán fo-mhodúil '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to rebase '%s' in submodule path '%s'"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "Ní féidir '%s' a athbhunú i gcosán fo-mhodúil '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
-msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+msgstr "Ní féidir '%s' a chumasc i gcosán fo-mhodúil '%s'"
 
 #, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
-msgstr ""
+msgstr "Theip ar fhorghníomhú '%s %s' i gcosán fo-mhodúil '%s'"
 
 #, c-format
 msgid "Submodule path '%s': checked out '%s'\n"
-msgstr ""
+msgstr "Conair fo-mhodúil '%s': seiceáil amach '%s'\n"
 
 #, c-format
 msgid "Submodule path '%s': rebased into '%s'\n"
-msgstr ""
+msgstr "Conair fo-mhodúil '%s': athbhunaithe go '%s'\n"
 
 #, c-format
 msgid "Submodule path '%s': merged in '%s'\n"
-msgstr ""
+msgstr "Conair fo-mhodúil '%s': cumasc i '%s'\n"
 
 #, c-format
 msgid "Submodule path '%s': '%s %s'\n"
-msgstr ""
+msgstr "Conair fo-mhodúil '%s': '%s %s'\n"
 
 #, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr ""
+"Ní féidir cosán fo-mhodúil '%s' a fháil; ag iarraidh %s a fháil go díreach:"
 
 #, c-format
 msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
 "of that commit failed."
 msgstr ""
+"Faightear i gcosán fo-mhodúil '%s', ach ní raibh %s ann. Theip ar an "
+"tiomantas sin a thógáil go díreach."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not initialize submodule at path '%s'"
-msgstr "fo-mhodúil a thionscnamh sa chlón"
+msgstr "ní fhéadfaí fo-mhodúl a thosú ag cosán '%s'"
 
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
 "the superproject is not on any branch"
 msgstr ""
+"Brainse fo-mhodúil (%s) atá cumraithe chun brainse a oidhreacht ó "
+"sárthionscadal, ach níl an sárthionscadal ar aon bhrainse"
 
 #, c-format
 msgid "Unable to find current revision in submodule path '%s'"
-msgstr ""
+msgstr "Ní féidir an t-athbhreithniú reatha a fháil i gcosán fo-mhodúil '%s'"
 
 #, c-format
 msgid "Unable to fetch in submodule path '%s'"
-msgstr ""
+msgstr "Ní féidir le cosán fo-mhodúil '%s' a fháil"
 
 #, c-format
 msgid "Unable to find %s revision in submodule path '%s'"
-msgstr ""
+msgstr "Ní féidir athbhreithniú %s a aimsiú i gcosán fo-mhodúil '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to recurse into submodule path '%s'"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "Theip ar athshlánú isteach i gcosán fo-mhodúil '%s'"
 
-#, fuzzy
 msgid "force checkout updates"
-msgstr "nuashonruithe fórsa"
+msgstr "nuashonruithe seiceála de"
 
-#, fuzzy
 msgid "initialize uninitialized submodules before update"
-msgstr "fo-mhodúil a thionscnamh sa chlón"
+msgstr "fo-mhodúil neamhthosaithe a thosú roimh an nuashonrú"
 
-#, fuzzy
 msgid "use SHA-1 of submodule's remote tracking branch"
-msgstr "úsáidfidh aon fho-mhodúil clónaithe a mbrainse cianrianaithe"
+msgstr "úsáid SHA-1 de bhrainse cianrianaithe an fho-mhodúil"
 
 msgid "traverse submodules recursively"
-msgstr ""
+msgstr "fo-mhodúil a thrasú go athshlánach"
 
 msgid "don't fetch new objects from the remote site"
-msgstr ""
+msgstr "ná faigh rudaí nua ón suíomh iargúlta"
 
 msgid "use the 'checkout' update strategy (default)"
-msgstr ""
+msgstr "úsáid an straitéis nuashonraithe 'tseiceáil' (réamhshocraithe)"
 
 msgid "use the 'merge' update strategy"
-msgstr ""
+msgstr "úsáid an straitéis nuashonraithe 'cumaisc'"
 
 msgid "use the 'rebase' update strategy"
-msgstr ""
+msgstr "bain úsáid as an straitéis nuashonraithe 'rebase'"
 
-#, fuzzy
 msgid "create a shallow clone truncated to the specified number of revisions"
-msgstr "clón éadrom a chruthú ó am ar leith"
+msgstr ""
+"clón éadomhain a chruthú a ghearrtar go dtí an líon sonraithe athbhreithnithe"
 
 msgid "parallel jobs"
-msgstr ""
+msgstr "poist chomhthreomhara"
 
 msgid "whether the initial clone should follow the shallow recommendation"
-msgstr ""
+msgstr "cibé an chóir don chlón tosaigh an moladh éadrom a leanú"
 
 msgid "don't print cloning progress"
-msgstr ""
+msgstr "ná déan dul chun cinn clónaithe a phriontáil"
 
 msgid "disallow cloning into non-empty directory, implies --init"
 msgstr ""
+"clónú a dhícheadú isteach i eolaire neamh-folamh, tugann le tuiscint --init"
 
 msgid ""
 "git submodule [--quiet] update [--init [--filter=<filter-spec>]] [--remote] "
@@ -12685,66 +13291,69 @@ msgid ""
 "shallow] [--reference <repository>] [--recursive] [--[no-]single-branch] "
 "[--] [<path>...]"
 msgstr ""
+"git submodule [--quiet] update [--init [--filter=<filter-spec>]] [--remote] "
+"[-N|--no-fetch] [-f|--force] [--checkout|--merge|--rebase] [--[no-]recommend-"
+"shallow] [--reference <repository>] [--recursive] [--[no-]single-branch] "
+"[--] [<path>...]"
 
-#, fuzzy
 msgid "Failed to resolve HEAD as a valid ref."
-msgstr "Theip ar '%s' a réiteach mar chrann bailí."
+msgstr "Theip ar HEAD a réiteach mar thagartha bailí."
 
-#, fuzzy
 msgid "git submodule absorbgitdirs [<options>] [<path>...]"
-msgstr "git switch [<roghanna>] [<brainse>]"
+msgstr "git submodule absorbgitdirs [<options>] [<path>...]"
 
 msgid "suppress output for setting url of a submodule"
-msgstr ""
+msgstr "aschur a chur faoi chois chun url fo-mhodúil a shocrú"
 
 msgid "git submodule set-url [--quiet] <path> <newurl>"
-msgstr ""
+msgstr "git submodule set-url [--quiet] <path> <newurl>"
 
 msgid "set the default tracking branch to master"
-msgstr ""
+msgstr "socraigh an mbrainse rianaithe réamhshocraithe chun"
 
-#, fuzzy
 msgid "set the default tracking branch"
-msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
+msgstr "socraigh an brainse rianaithe réamhshoc"
 
 msgid "git submodule set-branch [-q|--quiet] (-d|--default) <path>"
-msgstr ""
+msgstr "git submodule set-branch [-q|--quiet] (-d|--default) <path>"
 
 msgid "git submodule set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
-msgstr ""
+msgstr "git submodule set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 
 msgid "--branch or --default required"
-msgstr ""
+msgstr "--branch nó --default ag teastáil"
 
 msgid "print only error messages"
-msgstr ""
+msgstr "teachtaireachtaí earráide amháin a phrion"
 
 msgid "force creation"
-msgstr ""
+msgstr "cruthú fórsa"
 
 msgid "show whether the branch would be created"
-msgstr ""
+msgstr "taispeáint an cruthófaí an mbrainse"
 
 msgid ""
 "git submodule--helper create-branch [-f|--force] [--create-reflog] [-q|--"
 "quiet] [-t|--track] [-n|--dry-run] <name> <start-oid> <start-name>"
 msgstr ""
+"git submodule--helper create-branch [-f|--force] [--create-reflog] [-q|--"
+"quiet] [-t|--track] [-n|--dry-run] <name> <start-oid> <start-name>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "creating branch '%s'"
-msgstr "Athshocraigh brainse '%s'\n"
+msgstr "ag cruthú brainse '%s'"
 
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
-msgstr ""
+msgstr "Ag cur repo atá ann cheana ag '%s' leis an innéacs\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' already exists and is not a valid git repo"
-msgstr "Tá %s ann agus ní eolaire é"
+msgstr "Tá '%s' ann cheana féin agus ní repo git bailí é"
 
 #, c-format
 msgid "A git directory for '%s' is found locally with remote(s):\n"
-msgstr ""
+msgstr "Faightear eolaire git le haghaidh '%s' go háitiúil le cianda(í):\n"
 
 #, c-format
 msgid ""
@@ -12755,107 +13364,117 @@ msgid ""
 "or you are unsure what this means choose another name with the '--name' "
 "option."
 msgstr ""
+"Más mian leat an eolaire git áitiúil seo a athúsáid in ionad clónú arís ó\n"
+" %s\n"
+"bain úsáid as an rogha '--force'. Mura bhfuil an t-eolaire git áitiúil an "
+"repo ceart\n"
+"nó níl tú cinnte cad a chiallaíonn sé seo roghnaigh ainm eile leis an rogha "
+"'--name'."
 
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
-msgstr ""
+msgstr "Eolaire git áitiúil a athghníomhachtú do fho-mhodúl '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to checkout submodule '%s'"
-msgstr "in ann crann oibre a sheiceáil"
+msgstr "ní féidir le fo-mhodúl '%s' a sheiceáil"
 
 msgid "please make sure that the .gitmodules file is in the working tree"
-msgstr ""
+msgstr "déan cinnte go bhfuil an comhad .gitmodules sa chrann oibre"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to add submodule '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "Theip ar fho-mhodúl '%s' a chur leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to register submodule '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "Theip ar fho-mhodúl '%s' a chlárú"
 
 #, c-format
 msgid "'%s' already exists in the index"
-msgstr ""
+msgstr "Tá '%s' ann cheana féin san innéacs"
 
 #, c-format
 msgid "'%s' already exists in the index and is not a submodule"
-msgstr ""
+msgstr "Tá '%s' ann cheana féin san innéacs agus ní fo-mhodúl é"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' does not have a commit checked out"
-msgstr "Teastaíonn '%s' na cosáin chun seiceáil"
+msgstr "Níl tiomantas seiceáilte ag '%s'"
 
 msgid "branch of repository to add as submodule"
-msgstr ""
+msgstr "brainse an stór le cur mar fho-mhodúl"
 
 msgid "allow adding an otherwise ignored submodule path"
-msgstr ""
+msgstr "ligean cosán fo-mhodúil a neamhaird a chur leis"
 
 msgid "borrow the objects from reference repositories"
-msgstr ""
+msgstr "iasacht na rudaí ó stórais tagartha"
 
 msgid ""
 "sets the submodule's name to the given string instead of defaulting to its "
 "path"
 msgstr ""
+"socraíonn ainm an fho-mhodúil don teaghrán a thugtar in ionad réamhshocrú ar "
+"a chosán"
 
-#, fuzzy
 msgid "git submodule add [<options>] [--] <repository> [<path>]"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git submodule add [<options>] [--] <repository> [<path>]"
 
 msgid "Relative path can only be used from the toplevel of the working tree"
-msgstr ""
+msgstr "Ní féidir cosán coibhneasta a úsáid ach ó bharr an chrainn oibre"
 
 #, c-format
 msgid "repo URL: '%s' must be absolute or begin with ./|../"
-msgstr ""
+msgstr "repo URL: caithfidh '%s' a bheith iomlán nó tosú leis. /| .. /"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid submodule name"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní ainm bailí fo-mhodúil é '%s'"
 
 msgid "git submodule--helper <command>"
-msgstr ""
+msgstr "git submodule--helper <command>"
 
 msgid "git symbolic-ref [-m <reason>] <name> <ref>"
-msgstr ""
+msgstr "git symbolic-ref [-m <reason>] <name> <ref>"
 
 msgid "git symbolic-ref [-q] [--short] [--no-recurse] <name>"
-msgstr ""
+msgstr "git symbolic-ref [-q] [--short] [--no-recurse] <name>"
 
 msgid "git symbolic-ref --delete [-q] <name>"
-msgstr ""
+msgstr "git symbolic-ref --delete [-q] <name>"
 
 msgid "suppress error message for non-symbolic (detached) refs"
 msgstr ""
+"teachtaireacht earráide a chur faoi chois le haghaidh tuairimí neamh-"
+"shiombalacha"
 
-#, fuzzy
 msgid "delete symbolic ref"
-msgstr "scrios réimsí"
+msgstr "scrios tagairt siombalach"
 
 msgid "shorten ref output"
-msgstr ""
+msgstr "aschur tagairt a ghiorrú"
 
-#, fuzzy
 msgid "recursively dereference (default)"
-msgstr "úsáid modh forleagtha (réamhshocraithe)"
+msgstr "dereference athshlánach (réamhshocraithe)"
 
 msgid "reason"
-msgstr ""
+msgstr "cúis"
 
 msgid "reason of the update"
-msgstr ""
+msgstr "cúis an nuashonraithe"
 
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "        [(--trailer <token>[(=|:)<value>])...]\n"
 "        <tagname> [<commit> | <object>]"
 msgstr ""
+"git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>] [-e]\n"
+"        [(--trailer <token>[(=|:)<value>])...]\n"
+"        <tagname> [<commit> | <object>]"
 
 msgid "git tag -d <tagname>..."
-msgstr ""
+msgstr "git tag -d <tagname>..."
 
 msgid ""
 "git tag [-n[<num>]] -l [--contains <commit>] [--no-contains <commit>]\n"
@@ -12863,17 +13482,21 @@ msgid ""
 "        [--create-reflog] [--sort=<key>] [--format=<format>]\n"
 "        [--merged <commit>] [--no-merged <commit>] [<pattern>...]"
 msgstr ""
+"<commit>tag git [-n [<num>]] -l [--conté] [--no-conté<commit>]\n"
+" <options>[--points-ag<object>] [--column [=] | --no-column]\n"
+" <key><format>[--create-reflog] [--sort=] [--format =]\n"
+" <pattern>[--cumaisc<commit>] [--no-cumaisc] [...<commit>]"
 
 msgid "git tag -v [--format=<format>] <tagname>..."
-msgstr ""
+msgstr "<format><tagname>tag git -v [--format =]..."
 
 #, c-format
 msgid "tag '%s' not found."
-msgstr ""
+msgstr "níor aimsíodh tag '%s'."
 
 #, c-format
 msgid "Deleted tag '%s' (was %s)\n"
-msgstr ""
+msgstr "Clib scriosta '%s' (bhí %s)\n"
 
 #, c-format
 msgid ""
@@ -12882,6 +13505,10 @@ msgid ""
 "  %s\n"
 "Lines starting with '%s' will be ignored.\n"
 msgstr ""
+"\n"
+"Scríobh teachtaireacht don chlib:\n"
+"  %s\n"
+"Déanfar neamhaird ar línte a thosaíonn le '%s'.\n"
 
 #, c-format
 msgid ""
@@ -12891,10 +13518,14 @@ msgid ""
 "Lines starting with '%s' will be kept; you may remove them yourself if you "
 "want to.\n"
 msgstr ""
+"\n"
+"Scríobh teachtaireacht don chlib:\n"
+"  %s\n"
+"Coinneofar línte a thosaíonn le '%s'; féadfaidh tú iad a bhaint féin más "
+"mian leat.\n"
 
-#, fuzzy
 msgid "unable to sign the tag"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "in ann an chlib a shíniú"
 
 #, c-format
 msgid ""
@@ -12903,419 +13534,428 @@ msgid ""
 "\n"
 "\tgit tag -f %s %s^{}"
 msgstr ""
+"Tá clib neadaithe cruthaithe agat. Is é an réad dá dtagraíonn do chlib nua\n"
+"clib cheana féin. Má bhí sé i gceist agat an réad a thugann sé in iúl dó a "
+"chlibeáil, bain úsáid as:\n"
+"\n"
+" clib git -f %s %s^ {}"
 
-#, fuzzy
 msgid "bad object type."
-msgstr "cineál réad anaithnid %d"
+msgstr "droch-chineál réad."
 
 msgid "no tag message?"
-msgstr ""
+msgstr "gan aon teachtaireacht clib?"
 
 #, c-format
 msgid "The tag message has been left in %s\n"
-msgstr ""
+msgstr "Tá an teachtaireacht clib fágtha i %s\n"
 
 msgid "list tag names"
-msgstr ""
+msgstr "ainmneacha clibeanna liosta"
 
 msgid "print <n> lines of each tag message"
-msgstr ""
+msgstr "<n>línte priontála de gach teachtaireacht clib"
 
-#, fuzzy
 msgid "delete tags"
-msgstr "scrios réimsí"
+msgstr "clibeanna a scriosadh"
 
 msgid "verify tags"
-msgstr ""
+msgstr "clibeanna a fíorú"
 
 msgid "Tag creation options"
-msgstr ""
+msgstr "Roghanna cruthaithe clibeanna"
 
 msgid "annotated tag, needs a message"
-msgstr ""
+msgstr "clib anótáilte, teastaíonn teachtaireacht"
 
 msgid "tag message"
-msgstr ""
+msgstr "teachtaireacht tag"
 
 msgid "force edit of tag message"
-msgstr ""
+msgstr "eagarthóireacht fórsa ar theachtaireacht"
 
 msgid "annotated and GPG-signed tag"
-msgstr ""
+msgstr "clib anótáilte agus sínithe GPS"
 
 msgid "use another key to sign the tag"
-msgstr ""
+msgstr "bain úsáid as eochair eile chun an chlib a shíniú"
 
 msgid "replace the tag if exists"
-msgstr ""
+msgstr "athsholáthar an chlib má tá sé ann"
 
-#, fuzzy
 msgid "create a reflog"
-msgstr "stóras lom a chruthú"
+msgstr "cruthaigh reflog"
 
 msgid "Tag listing options"
-msgstr ""
+msgstr "Roghanna liostaithe clibeanna"
 
 msgid "show tag list in columns"
-msgstr ""
+msgstr "taispeáin liosta clibeanna i gcolúin"
 
 msgid "print only tags that contain the commit"
-msgstr ""
+msgstr "clibeanna a phriontáil ach ina bhfuil an tiomantas"
 
 msgid "print only tags that don't contain the commit"
-msgstr ""
+msgstr "clibeanna nach bhfuil an tiomantas a phriontáil ach amháin"
 
 msgid "print only tags that are merged"
-msgstr ""
+msgstr "clibeanna a chumasc amháin a phriontáil"
 
 msgid "print only tags that are not merged"
-msgstr ""
+msgstr "clibeanna nach ndéantar cumaisc a phriontáil ach amháin"
 
 msgid "print only tags of the object"
-msgstr ""
+msgstr "clibeanna den réad amháin a phriontáil"
 
 msgid "could not start 'git column'"
-msgstr ""
+msgstr "ní fhéadfaí 'git column' a thosú"
 
 #, c-format
 msgid "the '%s' option is only allowed in list mode"
-msgstr ""
+msgstr "ní cheadaítear an rogha '%s' ach i mód liosta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid tag name."
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní ainm bailí clibeanna é '%s'."
 
-#, fuzzy, c-format
+#, c-format
 msgid "tag '%s' already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "tá clib '%s' ann cheana féin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid cleanup mode %s"
-msgstr "réad blob neamhbhailí %s"
+msgstr "Modh glantacháin neamhbhailí %s"
 
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
-msgstr ""
+msgstr "Clib nuashonraithe '%s' (bhí %s)\n"
 
-#, fuzzy
 msgid "pack exceeds maximum allowed size"
-msgstr "sáraíonn an pacáiste an méid uasta ceadaithe (%s)"
+msgstr "sáraíonn an pacáiste an méid uasta a"
 
-#, fuzzy
 msgid "failed to write object in stream"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar réad a scríobh sa sruth"
 
-#, fuzzy, c-format
+#, c-format
 msgid "inflate returned (%d)"
-msgstr "infleáil ar ais %d"
+msgstr "inflate ar ais (%d)"
 
-#, fuzzy
 msgid "invalid blob object from stream"
-msgstr "réad blob neamhbhailí %s"
+msgstr "réad blob neamhbhailí ón sruth"
 
-#, fuzzy
 msgid "Unpacking objects"
-msgstr "Rud a sheiceáil"
+msgstr "Rudaí a dhíphacáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to create directory %s"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar eolaire %s a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to delete file %s"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar chomhad %s a scriosadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to delete directory %s"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar eolaire %s a scriosadh"
 
 #, c-format
 msgid "Testing mtime in '%s' "
-msgstr ""
+msgstr "Tástáil mtime i '%s' "
 
 msgid "directory stat info does not change after adding a new file"
-msgstr ""
+msgstr "ní athraíonn eolas stat eolaire tar éis comhad nua a chur leis"
 
 msgid "directory stat info does not change after adding a new directory"
-msgstr ""
+msgstr "ní athraíonn eolas stat eolaire tar éis eolaire nua a chur leis"
 
 msgid "directory stat info changes after updating a file"
-msgstr ""
+msgstr "athraíonn faisnéis eolaire stat tar éis comhad a nuashonrú"
 
 msgid "directory stat info changes after adding a file inside subdirectory"
 msgstr ""
+"athraíonn eolas stat eolaire tar éis comhad a chur taobh istigh den fho-"
+"eolaire"
 
 msgid "directory stat info does not change after deleting a file"
-msgstr ""
+msgstr "ní athraíonn eolas stat eolaire tar éis comhad a scriosadh"
 
 msgid "directory stat info does not change after deleting a directory"
-msgstr ""
+msgstr "ní athraíonn eolas stat eolaire tar éis eolaire a scriosadh"
 
 msgid " OK"
-msgstr ""
+msgstr " CEART GO LEOR"
 
-#, fuzzy
 msgid "git update-index [<options>] [--] [<file>...]"
-msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
+msgstr "<file>git update-index [<options>] [--] [...]"
 
 msgid "continue refresh even when index needs update"
-msgstr ""
+msgstr "leanúint ar aghaidh ar aghaidh ag athnuachan fiú nu"
 
-#, fuzzy
 msgid "refresh: ignore submodules"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "athnuachan: neamhaird a dhéanamh ar fho"
 
-#, fuzzy
 msgid "do not ignore new files"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ná déan neamhaird de chomhaid nua"
 
 msgid "let files replace directories and vice-versa"
-msgstr ""
+msgstr "lig do chomhaid eolairí in ionad agus a mhalairt"
 
 msgid "notice files missing from worktree"
-msgstr ""
+msgstr "fógra comhaid atá ar iarraidh ón gcrann oibre"
 
 msgid "refresh even if index contains unmerged entries"
-msgstr ""
+msgstr "athnuachan fiú má tá iontrálacha neamh-iontrálacha"
 
 msgid "refresh stat information"
-msgstr ""
+msgstr "faisnéis stáit a athnuachan"
 
 msgid "like --refresh, but ignore assume-unchanged setting"
-msgstr ""
+msgstr "cosúil le --refresh, ach déan neamhaird de shuíomh gan athrú"
 
 msgid "<mode>,<object>,<path>"
-msgstr ""
+msgstr "<mode>,<object>, <path>"
 
-#, fuzzy
 msgid "add the specified entry to the index"
-msgstr "Nuashonraíodh %d cosán ón innéacs"
+msgstr "cuir an iontráil sonraithe leis an innéacs"
 
 msgid "mark files as \"not changing\""
-msgstr ""
+msgstr "comhad a mharcáil mar “gan athrú”"
 
 msgid "clear assumed-unchanged bit"
-msgstr ""
+msgstr "giotán soiléir glactha gan athrú"
 
 msgid "mark files as \"index-only\""
-msgstr ""
+msgstr "comhad a mharcáil mar “innéacs amháin”"
 
 msgid "clear skip-worktree bit"
-msgstr ""
+msgstr "giotán crainn oibre scipeála soiléir"
 
 msgid "do not touch index-only entries"
-msgstr ""
+msgstr "ná déan teagmháil le iontrálacha innéacs amháin"
 
 msgid "add to index only; do not add content to object database"
-msgstr ""
+msgstr "cuir le hinnéacs amháin; ná cuir ábhar le bunachar sonraí réada"
 
 msgid "remove named paths even if present in worktree"
-msgstr ""
+msgstr "bain cosáin ainmnithe fiú má tá sé i gcrann oibre"
 
 msgid "with --stdin: input lines are terminated by null bytes"
-msgstr ""
+msgstr "le --stdin: cuirtear deireadh le línte ionchuir le bytes null"
 
 msgid "read list of paths to be updated from standard input"
-msgstr ""
+msgstr "léigh liosta na gcosáin atá le nuashonrú ó ionchur caighdeánach"
 
 msgid "add entries from standard input to the index"
-msgstr ""
+msgstr "cuir iontrálacha ón ionchur caighdeánach leis an innéacs"
 
 msgid "repopulate stages #2 and #3 for the listed paths"
-msgstr ""
+msgstr "céimeanna #2 agus #3 a athdhíonrú do na cosáin liostaithe"
 
 msgid "only update entries that differ from HEAD"
-msgstr ""
+msgstr "ach iontrálacha a nuashonrú atá difriúil ó HEAD"
 
 msgid "ignore files missing from worktree"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar chomhaid atá in easnamh"
 
 msgid "report actions to standard output"
-msgstr ""
+msgstr "gníomhartha a thuairisciú go dtí"
 
 msgid "(for porcelains) forget saved unresolved conflicts"
-msgstr ""
+msgstr "(le haghaidh poircealláin) déan dearmad ar choimhlintí gan réiteach"
 
 msgid "write index in this format"
-msgstr ""
+msgstr "scríobh innéacs san fhormáid seo"
 
 msgid "report on-disk index format version"
-msgstr ""
+msgstr "leagan formáid innéacs ar dhiosca tuairisc"
 
 msgid "enable or disable split index"
-msgstr ""
+msgstr "innéacs scoilte a chumasú nó a dh"
 
 msgid "enable/disable untracked cache"
-msgstr ""
+msgstr "taisce neamhrianaithe a chumasú/a dhíchumasú"
 
 msgid "test if the filesystem supports untracked cache"
-msgstr ""
+msgstr "tástáil an dtacaíonn an córas comhaid le taisce neamhrianaithe"
 
 msgid "enable untracked cache without testing the filesystem"
-msgstr ""
+msgstr "taisce neamhrianaithe a chumasú gan an córas comhaid a thástáil"
 
 msgid "write out the index even if is not flagged as changed"
 msgstr ""
+"scríobh amach an t-innéacs fiú mura bhfuil sé brataithe mar a athraítear"
 
 msgid "enable or disable file system monitor"
-msgstr ""
+msgstr "monatóireacht chórais chomhaid a chumasú"
 
 msgid "mark files as fsmonitor valid"
-msgstr ""
+msgstr "comhad a mharcáil mar fsmonitor bailí"
 
 msgid "clear fsmonitor valid bit"
-msgstr ""
+msgstr "giotán bailí fsmonitor soiléir"
 
 #, c-format
 msgid "%d\n"
-msgstr ""
+msgstr "%d\n"
 
 #, c-format
 msgid "index-version: was %d, set to %d"
-msgstr ""
+msgstr "leagan innéacs: bhí %d, socraithe go %d"
 
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
 msgstr ""
+"tá core.splitIndex socraithe go bréagach; bain nó athraigh é, más mian leat "
+"innéacs scoilte a chumasú i ndáiríre"
 
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
 msgstr ""
+"tá core.splitIndex socraithe go fíor; bain nó athraigh é, más mian leat "
+"innéacs scoilte a dhíchumasú"
 
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
 msgstr ""
+"tá core.untrackedCache  go fíor; bain nó athraigh é, más mian leat an taisce "
+"neamhrianaithe a dhíchumasú"
 
-#, fuzzy
 msgid "Untracked cache disabled"
-msgstr "Comhaid neamhrianaithe"
+msgstr "Taisce neamhrianaithe míchumasaithe"
 
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
 msgstr ""
+"tá core.untrackedCache socraithe go bréagach; bain nó athraigh é, más mian "
+"leat an taisce neamhrianaithe a chumasú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Untracked cache enabled for '%s'"
-msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
+msgstr "Cumasaíodh taisce neamhrianaithe do '%s'"
 
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
+"tá core.fsmonitor díshocraithe; socraigh é más mian leat fsmonitor a chumasú "
+"i ndáiríre"
 
 msgid "fsmonitor enabled"
-msgstr ""
+msgstr "fsmonitor cumasaithe"
 
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
+"tá core.fsmonitor socraithe; bain é más mian leat fsmonitor a dhíchumasú i "
+"ndáiríre"
 
 msgid "fsmonitor disabled"
-msgstr ""
+msgstr "fsmonitor míchumasaithe"
 
-#, fuzzy
 msgid "git update-ref [<options>] -d <refname> [<old-oid>]"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "<refname><old-oid>git update-ref [<options>] -d []"
 
-#, fuzzy
 msgid "git update-ref [<options>]    <refname> <new-oid> [<old-oid>]"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "<refname><new-oid><old-oid>git update-ref [<options>] []"
 
 msgid "git update-ref [<options>] --stdin [-z] [--batch-updates]"
-msgstr ""
+msgstr "git update-ref [<options>] --stdin [-z] [--batch-updates]"
 
-#, fuzzy
 msgid "delete the reference"
-msgstr "scrios réimsí"
+msgstr "scrios an tagairt"
 
 msgid "update <refname> not the one it points to"
-msgstr ""
+msgstr "nuashon <refname>raigh ní an ceann a thugann sé in iúl"
 
 msgid "stdin has NUL-terminated arguments"
-msgstr ""
+msgstr "tá argóintí ag foirceannadh NUL ag stdin"
 
 msgid "read updates from stdin"
-msgstr ""
+msgstr "léigh nuashonruithe ó stdin"
 
-#, fuzzy
 msgid "batch reference updates"
-msgstr "nuashonruithe fórsa"
+msgstr "nuashonruithe tagairt baisc"
 
-#, fuzzy
 msgid "update the info files from scratch"
-msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
+msgstr "nuashonraigh na comhaid faisnéise ón tús"
 
 msgid ""
 "git-upload-pack [--[no-]strict] [--timeout=<n>] [--stateless-rpc]\n"
 "                [--advertise-refs] <directory>"
 msgstr ""
+"git-upload-pack [--[no-]strict] [--timeout=<n>] [--stateless-rpc]\n"
+"                [--advertise-refs] <directory>"
 
 msgid "quit after a single request/response exchange"
-msgstr ""
+msgstr "scor tar éis iarrata/malartú freagartha amháin"
 
 msgid "serve up the info/refs for git-http-backend"
-msgstr ""
+msgstr "freastal suas ar na faisnéise/réimsí le haghaidh git-http-backend"
 
 msgid "do not try <directory>/.git/ if <directory> is no Git directory"
 msgstr ""
+"ná déan iarracht <directory>/.git/ mura bhfuil aon eolaire G <directory> it "
+"ann"
 
 msgid "interrupt transfer after <n> seconds of inactivity"
-msgstr ""
+msgstr "cur isteach ar aistriú tar éis so <n>icind neamhghníomhach"
 
 msgid "git verify-commit [-v | --verbose] [--raw] <commit>..."
-msgstr ""
+msgstr "git verify-commit [-v | --verbose] [--raw] <commit>..."
 
 msgid "print commit contents"
-msgstr ""
+msgstr "ábhair tiomanta priontála"
 
 msgid "print raw gpg status output"
-msgstr ""
+msgstr "aschur stádas amh-gpg a phriontáil"
 
 msgid "git verify-pack [-v | --verbose] [-s | --stat-only] [--] <pack>.idx..."
-msgstr ""
+msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] [--] <pack>.idx..."
 
 msgid "verbose"
-msgstr ""
+msgstr "eolach"
 
 msgid "show statistics only"
-msgstr ""
+msgstr "taispeáin staitisticí amháin"
 
 msgid "git verify-tag [-v | --verbose] [--format=<format>] [--raw] <tag>..."
-msgstr ""
+msgstr "<format><tag>git verify-tag [-v | --verbose] [--format =] [--raw]..."
 
 msgid "print tag contents"
-msgstr ""
+msgstr "ábhar clib priontáil"
 
 msgid ""
 "git worktree add [-f] [--detach] [--checkout] [--lock [--reason <string>]]\n"
 "                 [--orphan] [(-b | -B) <new-branch>] <path> [<commit-ish>]"
 msgstr ""
+"git worktree add [-f] [--detach] [--checkout] [--lock [--reason <string>]]\n"
+"                 [--orphan] [(-b | -B) <new-branch>] <path> [<commit-ish>]"
 
 msgid "git worktree list [-v | --porcelain [-z]]"
-msgstr ""
+msgstr "liosta crann oibre git [-v | --poirceallán [-z]]"
 
 msgid "git worktree lock [--reason <string>] <worktree>"
-msgstr ""
+msgstr "<string>glas crann oibre git [--reason] <worktree>"
 
 msgid "git worktree move <worktree> <new-path>"
-msgstr ""
+msgstr "gluaiseacht sraith oibre git <worktree><new-path>"
 
 msgid "git worktree prune [-n] [-v] [--expire <expire>]"
-msgstr ""
+msgstr "<expire>git worktree prun [-n] [-v] [--dul in éag]"
 
 msgid "git worktree remove [-f] <worktree>"
-msgstr ""
+msgstr "git worktree a bhaint [-f] <worktree>"
 
 msgid "git worktree repair [<path>...]"
-msgstr ""
+msgstr "deisiú crainn oibre git [<path>...]"
 
 msgid "git worktree unlock <worktree>"
-msgstr ""
+msgstr "díghlasáil git worktree <worktree>"
 
 msgid "No possible source branch, inferring '--orphan'"
-msgstr ""
+msgstr "Níl aon bhrainse foinse féideartha, ag tabhairt faoi deara '--orphan'"
 
 #, c-format
 msgid ""
@@ -13325,6 +13965,13 @@ msgid ""
 "\n"
 "    git worktree add --orphan -b %s %s\n"
 msgstr ""
+"Má bhí i gceist agat crann oibre a chruthú ina bhfuil brainse nua gan "
+"breith\n"
+"(brainse gan aon ghealltanais) don stór seo, is féidir leat é sin a "
+"dhéanamh\n"
+"ag baint úsáide as an bhratach --díllí:\n"
+"\n"
+"    git worktree add --orphan -b %s %s\n"
 
 #, c-format
 msgid ""
@@ -13334,80 +13981,94 @@ msgid ""
 "\n"
 "    git worktree add --orphan %s\n"
 msgstr ""
+"Má bhí i gceist agat crann oibre a chruthú ina bhfuil brainse nua gan "
+"breith\n"
+"(brainse gan aon ghealltanais) don stór seo, is féidir leat é sin a "
+"dhéanamh\n"
+"ag baint úsáide as an --orphan flag:\n"
+"\n"
+"    git worktree add --orphan %s\n"
 
 #, c-format
 msgid "Removing %s/%s: %s"
-msgstr ""
+msgstr "Ag baint %s/%s: %s"
 
-#, fuzzy
 msgid "report pruned working trees"
-msgstr "athshocraigh HEAD, innéacs agus crann oibre"
+msgstr "crainn oibre gearrtha a thuairisciú"
 
 msgid "expire working trees older than <time>"
-msgstr ""
+msgstr "dul in éag crainn oibre níos sine ná <time>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "Tá '%s' ann cheana féin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unusable worktree destination '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ceann scríbe crainn oibre neamhúsáidte '%s'"
 
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
 "use '%s -f -f' to override, or 'unlock' and 'prune' or 'remove' to clear"
 msgstr ""
+"Is crann oibre atá ar iarraidh ach faoi ghlas é '%s';\n"
+"bain úsáid as '%s -f 'chun athshealbhú, nó' díghlasáil 'agus' bearradh 'nó' "
+"bhaint 'chun a ghlanadh"
 
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
 "use '%s -f' to override, or 'prune' or 'remove' to clear"
 msgstr ""
+"Is crann oibre atá ar iarraidh ach cláraithe cheana féin é '%s';\n"
+"bain úsáid as '%s -f' chun athshlánú, nó 'bearradh' nó 'bhaint' chun a "
+"ghlanadh"
 
 #, c-format
 msgid "failed to copy '%s' to '%s'; sparse-checkout may not work correctly"
 msgstr ""
+"theip ar '%s' a chóipeáil go '%s'; b'fhéidir nach n-oibreoidh an tseiceáil "
+"neamhchoitianta i gceart"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to copy worktree config from '%s' to '%s'"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar chumraíocht crann oibre a chóipeáil ó '%s' go '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to unset '%s' in '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar '%s' a dhíshocrú i '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create directory of '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní raibh in ann eolaire de '%s' a chruthú"
 
 msgid "initializing"
-msgstr ""
+msgstr "a thionscnamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not find created worktree '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní raibh an crann oibre cruthaithe '%s' a aimsiú"
 
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
-msgstr ""
+msgstr "Crann oibre a ullmhú (brainse nua '%s')"
 
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
-msgstr ""
+msgstr "Ullmhú crann oibre (athshocrú brainse '%s'; bhí ag %s)"
 
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
-msgstr ""
+msgstr "Crann oibre a ullmhú (seiceáil '%s')"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unreachable: invalid reference: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "unrochtana: tagairt neamhbhailí: %s"
 
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
-msgstr ""
+msgstr "Crann oibre a ullmhú (CEAD scoite %s)"
 
 #, c-format
 msgid ""
@@ -13415,1198 +14076,1215 @@ msgid ""
 "HEAD path: '%s'\n"
 "HEAD contents: '%s'"
 msgstr ""
+"Tugann HEAD in iúl do thagairt neamhbhailí (nó dílleachta).\n"
+"Conair CEAD: '%s'\n"
+"Ábhar CEAD: '%s'"
 
 msgid ""
 "No local or remote refs exist despite at least one remote\n"
 "present, stopping; use 'add -f' to override or fetch a remote first"
 msgstr ""
+"Níl aon réimsí áitiúla ná iargúlta ann in ainneoin cianda amháin ar a "
+"laghad\n"
+"láthair, ag stopadh; bain úsáid as 'add -f' chun iargúlta a shárú nó a fháil "
+"ar dtús"
 
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
+"seiceáil <branch>fiú má tá sé seiceáilte cheana féin i gcrann oibre eile"
 
-#, fuzzy
 msgid "create a new branch"
-msgstr "cruthú reflog do bhrainse nua"
+msgstr "brainse nua a chruthú"
 
-#, fuzzy
 msgid "create or reset a branch"
-msgstr "cruthú reflog do bhrainse nua"
+msgstr "brainse a chruthú nó a athshocrú"
 
-#, fuzzy
 msgid "create unborn branch"
-msgstr "brainse nua gan breith"
+msgstr "cruthú brainse gan breith"
 
-#, fuzzy
 msgid "populate the new working tree"
-msgstr "in ann crann oibre a sheiceáil"
+msgstr "an crann oibre nua a dhaonrú"
 
-#, fuzzy
 msgid "keep the new working tree locked"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr "coinnigh an crann oibre nua faoi ghlas"
 
 msgid "reason for locking"
-msgstr ""
+msgstr "cúis le glasáil"
 
 msgid "set up tracking mode (see git-branch(1))"
-msgstr ""
+msgstr "modh rianaithe a bhunú (féach git-branch (1))"
 
-#, fuzzy
 msgid "try to match the new branch name with a remote-tracking branch"
-msgstr "brainse suas srutha '%s' nach stóráiltear mar bhrainse cianrianaithe"
+msgstr ""
+"déan iarracht ainm nua na brainse a mheaitseáil le brainse cianrianaithe"
 
-#, fuzzy
 msgid "use relative paths for worktrees"
-msgstr "git dir ar leithligh ó chrann oibre"
+msgstr "úsáid cosáin choibhneasta do chrainn oibre"
 
-#, fuzzy, c-format
+#, c-format
 msgid "options '%s', '%s', and '%s' cannot be used together"
-msgstr "ní féidir na roghanna '-%c', '-%c', agus '%s' a úsáid le chéile"
+msgstr "ní féidir roghanna '%s', '%s', agus '%s' a úsáid le chéile"
 
-#, fuzzy, c-format
+#, c-format
 msgid "option '%s' and commit-ish cannot be used together"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr "ní féidir rogha '%s' agus comm-ish a úsáid le chéile"
 
 msgid "added with --lock"
-msgstr ""
+msgstr "cuireadh leis le --lock"
 
 msgid "--[no-]track can only be used if a new branch is created"
-msgstr ""
+msgstr "Ní féidir --[no-]rian a úsáid ach amháin má chruthaítear brainse nua"
 
 msgid "show extended annotations and reasons, if available"
-msgstr ""
+msgstr "anótaí agus cúiseanna leathnaithe a thaispeáint, má tá sé ar fáil"
 
 msgid "add 'prunable' annotation to worktrees older than <time>"
-msgstr ""
+msgstr "cuir anótáil 'prunable' le crainn oibre níos sine ná <time>"
 
 msgid "terminate records with a NUL character"
-msgstr ""
+msgstr "deireadh a chur le taifid le carachtar NUL"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a working tree"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní crann oibre é '%s'"
 
 msgid "The main working tree cannot be locked or unlocked"
-msgstr ""
+msgstr "Ní féidir an príomhchrann oibre a ghlasáil nó a dhíghlasáil"
 
 #, c-format
 msgid "'%s' is already locked, reason: %s"
-msgstr ""
+msgstr "Tá '%s' faoi ghlas cheana féin, cúis: %s"
 
 #, c-format
 msgid "'%s' is already locked"
-msgstr ""
+msgstr "Tá '%s' faoi ghlas cheana féin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not locked"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Níl '%s' faoi ghlas"
 
 msgid "working trees containing submodules cannot be moved or removed"
-msgstr ""
+msgstr "ní féidir crainn oibre ina bhfuil fo-mhodúil a bhogadh ná a bhaint"
 
 msgid "force move even if worktree is dirty or locked"
-msgstr ""
+msgstr "bogadh fórsa fiú má tá crann oibre salach nó faoi ghlas"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is a main working tree"
-msgstr "git dir ar leithligh ó chrann oibre"
+msgstr "Is príomhchrann oibre é '%s'"
 
 #, c-format
 msgid "could not figure out destination name from '%s'"
-msgstr ""
+msgstr "ní fhéadfaí ainm ceann scríbe a fháil amach ó '%s'"
 
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
+"ní féidir crann oibre faoi ghlas a bhogadh, cúis ghlasála: %s\n"
+"bain úsáid as 'move -f -f' chun athshárú nó a dhíghlasáil ar dtús"
 
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
+"ní féidir le crann oibre faoi ghlas a bhogadh;\n"
+"bain úsáid as 'move -f -f' chun athshárú nó a dhíghlasáil ar dtús"
 
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
-msgstr ""
+msgstr "theip ar bhailíochtú, ní féidir crann oibre a bhogadh: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to move '%s' to '%s'"
-msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+msgstr "theip ar '%s' a bhogadh go '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to run 'git status' on '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar 'git status' a reáchtáil ar '%s'"
 
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
+"Tá comhaid modhnaithe nó neamhrianaithe i '%s', bain úsáid as --force chun é "
+"a scriosadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to run 'git status' on '%s', code %d"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar 'git status' a reáchtáil ar '%s', cód %d"
 
 msgid "force removal even if worktree is dirty or locked"
-msgstr ""
+msgstr "bhaint fórsa fiú má tá crann oibre salach nó faoi ghlas"
 
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
+"ní féidir crann oibre faoi ghlas a bhaint, cúis ghlasála: %s\n"
+"bain úsáid as 'remove -f -f' chun athshárú nó a dhíghlasáil ar dtús"
 
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
+"ní féidir crann oibre faoi ghlas a bhaint;\n"
+"bain úsáid as 'remove -f -f' chun athshárú nó a dhíghlasáil ar dtús"
 
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
-msgstr ""
+msgstr "theip ar bhailíochtú, ní féidir crann oibre a bhaint: %s"
 
 #, c-format
 msgid "repair: %s: %s"
-msgstr ""
+msgstr "deisiú: %s: %s"
 
 #, c-format
 msgid "error: %s: %s"
-msgstr ""
+msgstr "earráid: %s: %s"
 
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
-msgstr ""
+msgstr "git write-tree [--missing-ok] [--prefix=<prefix>/]"
 
 msgid "<prefix>/"
-msgstr ""
+msgstr "<prefix>/"
 
 msgid "write tree object for a subdirectory <prefix>"
-msgstr ""
+msgstr "scríobh réad crann le haghaidh fo-eolaire <prefix>"
 
 msgid "only useful for debugging"
-msgstr ""
+msgstr "ach úsáideach le haghaidh dífhabhtú"
 
 msgid "core.fsyncMethod = batch is unsupported on this platform"
-msgstr ""
+msgstr "core.fsyncMethod = ní thacaítear leis an bhaisc ar an ardán seo"
 
 #, c-format
 msgid "could not parse bundle list key %s with value '%s'"
-msgstr ""
+msgstr "ní fhéadfaí eochair liosta beartán %s a pháirseáil le luach '%s'"
 
 #, c-format
 msgid "bundle list at '%s' has no mode"
-msgstr ""
+msgstr "níl aon mhodh ag liosta beartán ag '%s'"
 
-#, fuzzy
 msgid "failed to create temporary file"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar chomhad sealadach a chruthú"
 
 msgid "insufficient capabilities"
-msgstr ""
+msgstr "cumais neamhleor"
 
 #, c-format
 msgid "file downloaded from '%s' is not a bundle"
-msgstr ""
+msgstr "ní beartán é an comhad a íoslódáladh ó '%s'"
 
-#, fuzzy
 msgid "failed to store maximum creation token"
-msgstr "theip ar an iterator a thosú thar '%s'"
+msgstr "theip ar an comhartha cruthaithe uasta a stórá"
 
 #, c-format
 msgid "unrecognized bundle mode from URI '%s'"
-msgstr ""
+msgstr "modh beartán neamhaithnithe ó URI '%s'"
 
 #, c-format
 msgid "exceeded bundle URI recursion limit (%d)"
-msgstr ""
+msgstr "sháraigh teorainn athshlánaithe URI beartán (%d)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to download bundle from URI '%s'"
-msgstr "theip ar rudaí a fháil ó URI '%s'"
+msgstr "theip ar an mbeartán a íoslódáil ó URI '%s'"
 
 #, c-format
 msgid "file at URI '%s' is not a bundle or bundle list"
-msgstr ""
+msgstr "comhad ag URI ní beacán nó liosta beartán é '%s'"
 
 #, c-format
 msgid "bundle-uri: unexpected argument: '%s'"
-msgstr ""
+msgstr "bundle-uri: argóint gan choinne: '%s'"
 
 msgid "bundle-uri: expected flush after arguments"
-msgstr ""
+msgstr "bundle-uri: súil le sruth tar éis argóintí"
 
 msgid "bundle-uri: got an empty line"
-msgstr ""
+msgstr "bundle-uri: got an líne folamh"
 
 msgid "bundle-uri: line is not of the form 'key=value'"
-msgstr ""
+msgstr "bundle-uri: níl an líne den fhoirm 'key=value'"
 
 msgid "bundle-uri: line has empty key or value"
-msgstr ""
+msgstr "bundle-uri: tá eochair nó luach folamh ag líne"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized bundle hash algorithm: %s"
-msgstr "algartam hais anaithnid '%s'"
+msgstr "algartam hash beartán gan aithint: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown capability '%s'"
-msgstr "stíl choimhlinte anaithnid '%s'"
+msgstr "cumas anaithnid '%s'"
 
 #, c-format
 msgid "'%s' does not look like a v2 or v3 bundle file"
-msgstr ""
+msgstr "Níl cuma '%s' cosúil le comhad beartán v2 nó v3"
 
 #, c-format
 msgid "unrecognized header: %s%s (%d)"
-msgstr ""
+msgstr "ceanntásc gan aithint: %s%s (%d)"
 
 msgid "Repository lacks these prerequisite commits:"
-msgstr ""
+msgstr "Níl na tiomantas réamhriachtanais seo ag an stór:"
 
 msgid ""
 "some prerequisite commits exist in the object store, but are not connected "
 "to the repository's history"
 msgstr ""
+"tá roinnt gealltanais réamhriachtanais ann sa stór réada, ach níl siad "
+"ceangailte le stair an stór"
 
 #, c-format
 msgid "The bundle contains this ref:"
 msgid_plural "The bundle contains these %<PRIuMAX> refs:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Tá an tagairt seo sa phacáiste:"
+msgstr[1] "Tá na tagairtí %<PRIuMAX> seo sa phacáiste:"
+msgstr[2] "Tá na tagairtí %<PRIuMAX> seo sa phacáiste:"
 
 msgid "The bundle records a complete history."
-msgstr ""
+msgstr "Taifeadann an beartán stair iomlán."
 
 #, c-format
 msgid "The bundle requires this ref:"
 msgid_plural "The bundle requires these %<PRIuMAX> refs:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Éilíonn an pacáiste seo an tagairt:"
+msgstr[1] "Éilíonn an pacáiste seo na tagairtí %<PRIuMAX> seo:"
+msgstr[2] "Éilíonn an pacáiste seo na tagairtí %<PRIuMAX> seo:"
 
-#, fuzzy, c-format
+#, c-format
 msgid "The bundle uses this hash algorithm: %s"
-msgstr "algartam hais anaithnid '%s'"
+msgstr "Úsáideann an beartán an algartam hash seo: %s"
 
 #, c-format
 msgid "The bundle uses this filter: %s"
-msgstr ""
+msgstr "Úsáideann an beartán an scagaire seo: %s"
 
-#, fuzzy
 msgid "unable to dup bundle descriptor"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir tuairiscí a chur ar bhearnadh"
 
-#, fuzzy
 msgid "Could not spawn pack-objects"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Ní fhéadfaí rudaí pacáiste a shannadh"
 
 msgid "pack-objects died"
-msgstr ""
+msgstr "rudaí pacáiste fuair bás"
 
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
-msgstr ""
+msgstr "tá ref '%s' eisiata ag na roghanna rev-list"
 
 #, c-format
 msgid "unsupported bundle version %d"
-msgstr ""
+msgstr "leagan beartán gan tacaíocht %d"
 
 #, c-format
 msgid "cannot write bundle version %d with algorithm %s"
-msgstr ""
+msgstr "ní féidir leagan beartán %d a scríobh le algartam %s"
 
 msgid "Refusing to create empty bundle."
-msgstr ""
+msgstr "Diúltú beartán folamh a chruthú."
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot create '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir '%s' a chruthú"
 
 msgid "index-pack died"
-msgstr ""
+msgstr "fuair an pacáiste innéacs"
 
 #, c-format
 msgid "directory '%s' is present in index, but not sparse"
-msgstr ""
+msgstr "tá eolaire '%s' i láthair in innéacs, ach níl sé neamhchoitianta"
 
 msgid "corrupted cache-tree has entries not present in index"
 msgstr ""
+"tá iontrálacha nach bhfuil i láthair san innéacs ag crann cache-crainn "
+"truaillte"
 
 #, c-format
 msgid "%s with flags 0x%x should not be in cache-tree"
-msgstr ""
+msgstr "Níor chóir go mbeadh %s le bratacha 0x%x i gcrann cache-tree"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad subtree '%.*s'"
-msgstr "droch-stóras '%s'"
+msgstr "droch-fho-chrann '%.*s'"
 
 #, c-format
 msgid "cache-tree for path %.*s does not match. Expected %s got %s"
 msgstr ""
+"ní hionann crann-taisce don chonair %.*s. Bhíothas ag súil le %s, ach fuair "
+"%s"
 
 msgid "terminating chunk id appears earlier than expected"
-msgstr ""
+msgstr "is cosúil le feiceáil id cúince a fhoirceannadh níos luaithe"
 
 #, c-format
 msgid "chunk id %<PRIx32> not %d-byte aligned"
-msgstr ""
+msgstr "id chosc% <PRIx32>nach bhfuil %d-byte ailínithe"
 
 #, c-format
 msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
-msgstr ""
+msgstr "fritháireamh píosa míchuí (í)% <PRIx64>agus% <PRIx64>"
 
 #, c-format
 msgid "duplicate chunk ID %<PRIx32> found"
-msgstr ""
+msgstr "aimsíodh ID smután dúblach %<PRIx32>"
 
 #, c-format
 msgid "final chunk has non-zero id %<PRIx32>"
-msgstr ""
+msgstr "tá id neamh-nialasach ag an gcuid deiridh% <PRIx32>"
 
-#, fuzzy
 msgid "invalid hash version"
-msgstr "sonraíocht cosáin nebhail"
+msgstr "leagan hash neamhbhailí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid color value: %.*s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "luach dath neamhbhailí: %.*s"
 
 msgid "Add file contents to the index"
-msgstr ""
+msgstr "Cuir ábhar an chomhaid leis an innéacs"
 
 msgid "Apply a series of patches from a mailbox"
-msgstr ""
+msgstr "Cuir sraith paistí i bhfeidhm ó bhosca poist"
 
 msgid "Annotate file lines with commit information"
-msgstr ""
+msgstr "Línte comhaid a anótáil le faisnéis tiomanta"
 
 msgid "Apply a patch to files and/or to the index"
-msgstr ""
+msgstr "Cuir paiste i bhfeidhm ar chomhaid agus/nó ar an innéacs"
 
 msgid "Import a GNU Arch repository into Git"
-msgstr ""
+msgstr "Iompórtáil stór GNU Arch isteach i Git"
 
 msgid "Create an archive of files from a named tree"
-msgstr ""
+msgstr "Cruthaigh cartlann comhaid ó chrann ainmnithe"
 
 msgid "Download missing objects in a partial clone"
-msgstr ""
+msgstr "Íoslódáil rudaí atá in easnamh i gclón pá"
 
 msgid "Use binary search to find the commit that introduced a bug"
 msgstr ""
+"Úsáid cuardach dénártha chun an gealltanas a thug isteach fabht a fháil"
 
 msgid "Show what revision and author last modified each line of a file"
 msgstr ""
+"Taispeáin an t-athbhreithniú agus an t-údar a mhodhnaigh gach líne de chomhad"
 
-#, fuzzy
 msgid "List, create, or delete branches"
-msgstr "Ní féidir %s a réiteach chuig an mbrainse"
+msgstr "Brainsí a liostáil, a chruthú nó a scriosadh"
 
 msgid "Collect information for user to file a bug report"
-msgstr ""
+msgstr "Bailigh faisnéis don úsáideoir chun tuarascáil fabht a chomhdú"
 
 msgid "Move objects and refs by archive"
-msgstr ""
+msgstr "Bogadh rudaí agus scríbhinní de réir cartlann"
 
 msgid "Provide contents or details of repository objects"
-msgstr ""
+msgstr "Ábhar nó sonraí rudaí stórais a sholáthar"
 
 msgid "Display gitattributes information"
-msgstr ""
+msgstr "Taispeáin faisnéis gitattributs"
 
 msgid "Debug gitignore / exclude files"
-msgstr ""
+msgstr "Dífhabhtú gitignore/eisiamh comhaid"
 
 msgid "Show canonical names and email addresses of contacts"
-msgstr ""
+msgstr "Taispeáin ainmneacha canónach agus seoltaí ríomhphoist teagmhál"
 
 msgid "Ensures that a reference name is well formed"
-msgstr ""
+msgstr "Cinntíonn sé go bhfuil ainm tagartha foirmithe go maith"
 
-#, fuzzy
 msgid "Switch branches or restore working tree files"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr "Athraigh brainsí nó cuir comhaid crainn oibre ar ais"
 
 msgid "Copy files from the index to the working tree"
-msgstr ""
+msgstr "Cóipeáil comhaid ón innéacs go dtí an crann oibre"
 
 msgid "Find commits yet to be applied to upstream"
-msgstr ""
+msgstr "Faigh gealltanais nach ndéanfar cur i bhfeidhm fós ar an sruth"
 
 msgid "Apply the changes introduced by some existing commits"
 msgstr ""
+"Cuir isteach na hathruithe a thug isteach ag roinnt gealltanais atá ann"
 
 msgid "Graphical alternative to git-commit"
-msgstr ""
+msgstr "Rogha eile grafach seachas git-commit"
 
-#, fuzzy
 msgid "Remove untracked files from the working tree"
-msgstr "git dir ar leithligh ó chrann oibre"
+msgstr "Bain comhaid neamhrianaithe ón gcrann oibre"
 
 msgid "Clone a repository into a new directory"
-msgstr ""
+msgstr "Clóin stór isteach i eolaire nua"
 
 msgid "Display data in columns"
-msgstr ""
+msgstr "Taispeáin sonraí i gcolúin"
 
-#, fuzzy
 msgid "Record changes to the repository"
-msgstr "stóras lom a chruthú"
+msgstr "Taifeadadh athruithe ar an stór"
 
 msgid "Write and verify Git commit-graph files"
-msgstr ""
+msgstr "Scríobh agus fíoraigh comhaid choimisi-graf Git"
 
 msgid "Create a new commit object"
-msgstr ""
+msgstr "Cruthaigh réad tiomanta nua"
 
 msgid "Get and set repository or global options"
-msgstr ""
+msgstr "Faigh agus socraigh stór nó roghanna domhanda"
 
 msgid "Count unpacked number of objects and their disk consumption"
-msgstr ""
+msgstr "Líon rudaí neamhphacáilte a chomhaireamh agus a dtomhaltas"
 
 msgid "Retrieve and store user credentials"
-msgstr ""
+msgstr "Dintiúir úsáideora a aisghabháil agus"
 
 msgid "Helper to temporarily store passwords in memory"
-msgstr ""
+msgstr "Cúntóir chun pasfhocail a stóráil i gcuimhne"
 
 msgid "Helper to store credentials on disk"
-msgstr ""
+msgstr "Cúntóir chun dintiúir a stóráil ar dhios"
 
 msgid "Export a single commit to a CVS checkout"
-msgstr ""
+msgstr "Easpórtáil tiomantas amháin chuig seiceáil CVS"
 
 msgid "Salvage your data out of another SCM people love to hate"
 msgstr ""
+"Sábháil do chuid sonraí as SCM eile is breá le daoine fuath a thabhairt"
 
 msgid "A CVS server emulator for Git"
-msgstr ""
+msgstr "Aithritheoir freastalaí CVS do Git"
 
 msgid "A really simple server for Git repositories"
-msgstr ""
+msgstr "Freastalaí an-simplí do stórais Git"
 
 msgid "Give an object a human readable name based on an available ref"
-msgstr ""
+msgstr "Tabhair ainm inléite daonna do réad bunaithe ar thagartha atá ar fáil"
 
 msgid "Generate a zip archive of diagnostic information"
-msgstr ""
+msgstr "Cruthaigh cartlann zip faisnéise diagnóiseach"
 
-#, fuzzy
 msgid "Show changes between commits, commit and working tree, etc"
-msgstr "aon rud le tiomantas, crann oibre glan\n"
+msgstr "Taispeáin athruithe idir gealltanais, tiomantas agus crann oibre, srl"
 
 msgid "Compares files in the working tree and the index"
-msgstr ""
+msgstr "Déanann comparáid idir comhaid sa chrann oibre agus san innéacs"
 
-#, fuzzy
 msgid "Compare a tree to the working tree or index"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr "Déan comparáid idir crann leis an gcrann oibre nó leis an innéacs"
 
 msgid "Compare the content and mode of provided blob pairs"
-msgstr ""
+msgstr "Déan comparáid idir ábhar agus modh na bpéirí blob atá curtha ar fáil"
 
 msgid "Compares the content and mode of blobs found via two tree objects"
 msgstr ""
+"Déanann comparáid idir ábhar agus modh blobs a fhaightear trí dhá rud crann"
 
 msgid "Show changes using common diff tools"
-msgstr ""
+msgstr "Taispeáin athruithe ag úsáid uirlisí coitianta diff"
 
 msgid "Git data exporter"
-msgstr ""
+msgstr "Easpórtóir sonraí Git"
 
 msgid "Backend for fast Git data importers"
-msgstr ""
+msgstr "Backend d'allmhaireoirí sonraí tapa Git"
 
 msgid "Download objects and refs from another repository"
-msgstr ""
+msgstr "Íoslódáil rudaí agus réimsí ó stór eile"
 
 msgid "Receive missing objects from another repository"
-msgstr ""
+msgstr "Faigh rudaí atá in easnamh ó stór eile"
 
-#, fuzzy
 msgid "Rewrite branches"
-msgstr "Athshocraigh brainse '%s'\n"
+msgstr "Brainsí a athscríobh"
 
 msgid "Produce a merge commit message"
-msgstr ""
+msgstr "Teachtaireacht tiomanta cumaisc a chur"
 
 msgid "Output information on each ref"
-msgstr ""
+msgstr "Eolas aschuir ar gach tagairt"
 
 msgid "Run a Git command on a list of repositories"
-msgstr ""
+msgstr "Rith ordú Git ar liosta stórais"
 
 msgid "Prepare patches for e-mail submission"
-msgstr ""
+msgstr "Ullmhaigh paistí le haghaidh aighneachta"
 
 msgid "Verifies the connectivity and validity of the objects in the database"
-msgstr ""
+msgstr "Fíoraíonn sé nascacht agus bailíocht na rudaí sa bhunachar sonraí"
 
 msgid "Cleanup unnecessary files and optimize the local repository"
-msgstr ""
+msgstr "Glan comhaid gan ghá agus an stór áitiúil a bharrfheabhsú"
 
 msgid "Extract commit ID from an archive created using git-archive"
 msgstr ""
+"Bain ID tiomanta as cartlann a cruthaíodh ag baint úsáide as git-archive"
 
 msgid "Print lines matching a pattern"
-msgstr ""
+msgstr "Línte priontála a mheaitseálann"
 
 msgid "A portable graphical interface to Git"
-msgstr ""
+msgstr "Comhéadan grafach iniompartha chuig Git"
 
 msgid "Compute object ID and optionally create an object from a file"
-msgstr ""
+msgstr "Ríomh ID réad agus cruthaigh réad ó chomhad go roghnach"
 
 msgid "Display help information about Git"
-msgstr ""
+msgstr "Taispeáin faisnéis chabhrach faoi Git"
 
 msgid "Run git hooks"
-msgstr ""
+msgstr "Rith crúcaí git"
 
 msgid "Server side implementation of Git over HTTP"
-msgstr ""
+msgstr "Cur i bhfeidhm taobh freastalaí Git thar HTTP"
 
 msgid "Download from a remote Git repository via HTTP"
-msgstr ""
+msgstr "Íoslódáil ó stór iargúlta Git trí HTTP"
 
 msgid "Push objects over HTTP/DAV to another repository"
-msgstr ""
+msgstr "Brúigh rudaí thar HTTP/DAV chuig stór eile"
 
 msgid "Send a collection of patches from stdin to an IMAP folder"
-msgstr ""
+msgstr "Seol bailiúchán paistí ó stdin chuig fillteán IMAP"
 
 msgid "Build pack index file for an existing packed archive"
-msgstr ""
+msgstr "Tóg comhad innéacs pacáiste do chartlann pacáilte atá ann"
 
 msgid "Create an empty Git repository or reinitialize an existing one"
-msgstr ""
+msgstr "Cruthaigh stór Git folamh nó déan ceann atá ann cheana a athionsú"
 
 msgid "Instantly browse your working repository in gitweb"
-msgstr ""
+msgstr "Brabhsáil láithreach do stór oibre i gitweb"
 
 msgid "Add or parse structured information in commit messages"
-msgstr ""
+msgstr "Cuir nó déan faisnéis struchtúrtha i dteachtaireachtaí tiomanta"
 
-#, fuzzy
 msgid "Show commit logs"
-msgstr "tiomantais nua, "
+msgstr "Taispeáin logaí tiomanta"
 
 msgid "Show information about files in the index and the working tree"
-msgstr ""
+msgstr "Taispeáin faisnéis faoi chomhaid san innéacs agus sa chrann oibre"
 
-#, fuzzy
 msgid "List references in a remote repository"
-msgstr "stór tagartha"
+msgstr "Liostaigh tagairtí i stór iargúlta"
 
 msgid "List the contents of a tree object"
-msgstr ""
+msgstr "Liostaigh ábhar réad crann"
 
 msgid "Extracts patch and authorship from a single e-mail message"
-msgstr ""
+msgstr "Baineann paiste agus údaracht as teachtaireacht ríomhphoist amháin"
 
 msgid "Simple UNIX mbox splitter program"
-msgstr ""
+msgstr "Clár scoilteora mbox UNIX simplí"
 
 msgid "Run tasks to optimize Git repository data"
-msgstr ""
+msgstr "Rith tascanna chun sonraí stór Git a bharrfheabhsú"
 
 msgid "Join two or more development histories together"
-msgstr ""
+msgstr "Bí le dhá stair forbartha nó níos mó le chéile"
 
 msgid "Find as good common ancestors as possible for a merge"
-msgstr ""
+msgstr "Faigh sinsear choiteann chomh maith agus is féidir le cumasc"
 
 msgid "Run a three-way file merge"
-msgstr ""
+msgstr "Rith cumasc comhad trí bhealach"
 
 msgid "Run a merge for files needing merging"
-msgstr ""
+msgstr "Reáchtáil cumaisc le haghaidh comhaid a bhfuil gá le cumasc orthu"
 
 msgid "The standard helper program to use with git-merge-index"
-msgstr ""
+msgstr "An clár cúntóra caighdeánach le húsáid le git-merge-index"
 
 msgid "Perform merge without touching index or working tree"
-msgstr ""
+msgstr "Déan cumasc gan teagmháil a dhéanamh le hInnéacs nó crann"
 
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
-msgstr ""
+msgstr "Rith uirlisí réitigh coinbhleachtaí cumaisc chun coinbhleachtaí"
 
 msgid "Creates a tag object with extra validation"
-msgstr ""
+msgstr "Cruthaíonn sé réad clibeanna le bailíochtú breise"
 
 msgid "Build a tree-object from ls-tree formatted text"
-msgstr ""
+msgstr "Tóg réad crann ó théacs formáidithe ls-tree"
 
 msgid "Write and verify multi-pack-indexes"
-msgstr ""
+msgstr "Innéacsanna il-phacáiste a scríobh agus a fhíorú"
 
 msgid "Move or rename a file, a directory, or a symlink"
-msgstr ""
+msgstr "Bogadh nó athainmnigh comhad, eolaire, nó nasc comhsheasmhach"
 
 msgid "Find symbolic names for given revs"
-msgstr ""
+msgstr "Faigh ainmneacha siombalacha do thiomhartha tugtha"
 
-#, fuzzy
 msgid "Add or inspect object notes"
-msgstr "nár bhfuair sé réad ag súil leis %s"
+msgstr "Cuir nó iniúchadh nótaí réad"
 
 msgid "Import from and submit to Perforce repositories"
-msgstr ""
+msgstr "Iompórtáil ó stórais Perforce agus cuir isteach chuig"
 
 msgid "Create a packed archive of objects"
-msgstr ""
+msgstr "Cruthaigh cartlann pacáilte rudaí"
 
-#, fuzzy
 msgid "Find redundant pack files"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "Faigh comhaid pacáiste iomarcacha"
 
 msgid "Pack heads and tags for efficient repository access"
-msgstr ""
+msgstr "Ceannanna agus clibeanna pacála le haghaidh rochtain éifeachtach"
 
 msgid "Compute unique ID for a patch"
-msgstr ""
+msgstr "Ríomh ID uathúil le haghaidh paiste"
 
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
+"Déan gach rud nach féidir inrochtana a ghearradh ón mbunachar sonraí réad"
 
 msgid "Remove extra objects that are already in pack files"
-msgstr ""
+msgstr "Bain rudaí breise atá i gcomhaid pacáiste cheana féin"
 
 msgid "Fetch from and integrate with another repository or a local branch"
-msgstr ""
+msgstr "Faigh ó stór eile nó brainse áitiúil agus comhtháthú leis"
 
 msgid "Update remote refs along with associated objects"
-msgstr ""
+msgstr "Nuashonraigh iargúlta mar aon le rudaí gaolmhara"
 
 msgid "Applies a quilt patchset onto the current branch"
-msgstr ""
+msgstr "Cuireann paistset cuilte i bhfeidhm ar an mbrainse reatha"
 
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
-msgstr ""
+msgstr "Déan comparáid idir dhá raon tiomanta (e.g. dhá leagan de bhrainse)"
 
 msgid "Reads tree information into the index"
-msgstr ""
+msgstr "Léann faisnéis crainn isteach san innéacs"
 
 msgid "Reapply commits on top of another base tip"
-msgstr ""
+msgstr "Déan gealltanna a athchur i bhfeidhm ar bharr leid bonn eile"
 
 msgid "Receive what is pushed into the repository"
-msgstr ""
+msgstr "Faigh an méid a bhrúitear isteach sa stór"
 
 msgid "Manage reflog information"
-msgstr ""
+msgstr "Bainistigh faisnéis reflog"
 
 msgid "Low-level access to refs"
-msgstr ""
+msgstr "Rochtain ar leibhéal íseal ar réimsí"
 
-#, fuzzy
 msgid "Manage set of tracked repositories"
-msgstr "socrú mar stór roinnte"
+msgstr "Bainistigh sraith stórais rianaithe"
 
 msgid "Pack unpacked objects in a repository"
-msgstr ""
+msgstr "Pacáil rudaí neamhphacáilte i stóras"
 
 msgid "Create, list, delete refs to replace objects"
-msgstr ""
+msgstr "Cruthaigh, liostáil, scrios scríobh chun rudaí a athsholáthar"
 
 msgid "EXPERIMENTAL: Replay commits on a new base, works with bare repos too"
 msgstr ""
+"TURGNAMHACH: Tiomann athsheoladh ar bhonn nua, oibríonn sé le repos lom "
+"freisin"
 
 msgid "Generates a summary of pending changes"
-msgstr ""
+msgstr "Gineann achoimre ar athruithe ar feitheamh"
 
 msgid "Reuse recorded resolution of conflicted merges"
-msgstr ""
+msgstr "Réiteach taifeadta ar chumaisc coinbhleachta a athúsáid"
 
 msgid "Reset current HEAD to the specified state"
-msgstr ""
+msgstr "Athshocraigh HEAD reatha go dtí an stát sonraithe"
 
-#, fuzzy
 msgid "Restore working tree files"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr "Athchóirigh comhaid crann oibre"
 
 msgid "Lists commit objects in reverse chronological order"
-msgstr ""
+msgstr "Tiomann liostaí rudaí in ord croineolaíoch droim"
 
 msgid "Pick out and massage parameters"
-msgstr ""
+msgstr "Paraiméadair a roghnú agus massage"
 
 msgid "Revert some existing commits"
-msgstr ""
+msgstr "Cuir roinnt gealltanais atá ann cheana ar ais"
 
 msgid "Remove files from the working tree and from the index"
-msgstr ""
+msgstr "Bain comhaid ón gcrann oibre agus ón innéacs"
 
 msgid "Send a collection of patches as emails"
-msgstr ""
+msgstr "Seol bailiúchán paistí mar ríomhphoist"
 
 msgid "Push objects over Git protocol to another repository"
-msgstr ""
+msgstr "Brúigh rudaí thar phrótacal Git chuig stór eile"
 
 msgid "Git's i18n setup code for shell scripts"
-msgstr ""
+msgstr "Cód socraithe i18n Git le haghaidh scripteanna blaosc"
 
 msgid "Common Git shell script setup code"
-msgstr ""
+msgstr "Cód socraithe script bhlaosc Git coitianta"
 
 msgid "Restricted login shell for Git-only SSH access"
-msgstr ""
+msgstr "Blaosc logála isteach srianta le haghaidh rochtain SSH GIT amháin"
 
 msgid "Summarize 'git log' output"
-msgstr ""
+msgstr "Achoimre ar aschur 'git log'"
 
 msgid "Show various types of objects"
-msgstr ""
+msgstr "Taispeáin cineálacha éagsúla rudaí"
 
-#, fuzzy
 msgid "Show branches and their commits"
-msgstr "níl aon athruithe curtha le tiomantas\n"
+msgstr "Taispeáin brainsí agus a ngealltanais"
 
 msgid "Show packed archive index"
-msgstr ""
+msgstr "Taispeáin an t-innéacs cartlainne"
 
-#, fuzzy
 msgid "List references in a local repository"
-msgstr "stór tagartha"
+msgstr "Liostaigh tagairtí i stóras áitiúil"
 
-#, fuzzy
 msgid "Reduce your working tree to a subset of tracked files"
-msgstr " (bain úsáid as an rogha -u chun comhaid neamhrianaithe a thaispeáint)"
+msgstr "Laghdaigh do chrann oibre go fo-thacar de chomhaid rianaithe"
 
 msgid "Add file contents to the staging area"
-msgstr ""
+msgstr "Cuir ábhar an chomhaid leis an limistéar stáitse"
 
 msgid "Stash the changes in a dirty working directory away"
-msgstr ""
+msgstr "Stóráil na hathruithe in eolaire oibre salach ar shiúl"
 
-#, fuzzy
 msgid "Show the working tree status"
-msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
+msgstr "Taispeáin stádas an chrann oibre"
 
 msgid "Remove unnecessary whitespace"
-msgstr ""
+msgstr "Bain spás bán gan ghá"
 
 msgid "Initialize, update or inspect submodules"
-msgstr ""
+msgstr "Fo-mhodúil a thionscnamh, a nuashonrú nó a"
 
 msgid "Bidirectional operation between a Subversion repository and Git"
-msgstr ""
+msgstr "Oibriú déthreorach idir stór Subversion agus Git"
 
-#, fuzzy
 msgid "Switch branches"
-msgstr "Aistrithe go brainse '%s'\n"
+msgstr "Athraigh brainsí"
 
 msgid "Read, modify and delete symbolic refs"
-msgstr ""
+msgstr "Léigh, modhnaigh agus scriosadh taiscéalaí siombalacha"
 
 msgid "Create, list, delete or verify a tag object signed with GPG"
-msgstr ""
+msgstr "Cruthaigh, liostáil, scrios nó fíorú réad clibeanna sínithe le GPG"
 
 msgid "Creates a temporary file with a blob's contents"
-msgstr ""
+msgstr "Cruthaíonn sé comhad sealadach le hábhar blob"
 
 msgid "Unpack objects from a packed archive"
-msgstr ""
+msgstr "Díphacáil rudaí ó chartlann pacáilte"
 
 msgid "Register file contents in the working tree to the index"
-msgstr ""
+msgstr "Cláraigh ábhar an chomhaid sa chrann oibre chuig an innéacs"
 
 msgid "Update the object name stored in a ref safely"
-msgstr ""
+msgstr "Nuashonraigh ainm an réad atá stóráilte i dtagairt go sá"
 
 msgid "Update auxiliary info file to help dumb servers"
-msgstr ""
+msgstr "Nuashonraigh comhad faisnéise cúnta chun cabhrú le freastalaithe"
 
 msgid "Send archive back to git-archive"
-msgstr ""
+msgstr "Seol cartlann ar ais chuig git-archive"
 
 msgid "Send objects packed back to git-fetch-pack"
-msgstr ""
+msgstr "Seol rudaí pacáilte ar ais chuig git-fetch-pack"
 
 msgid "Show a Git logical variable"
-msgstr ""
+msgstr "Taispeáin athróg loighciúil Git"
 
 msgid "Check the GPG signature of commits"
-msgstr ""
+msgstr "Seiceáil síniú GPG na ngealltanais"
 
 msgid "Validate packed Git archive files"
-msgstr ""
+msgstr "Bailíochtú comhaid cartlainne Git pacáilte"
 
 msgid "Check the GPG signature of tags"
-msgstr ""
+msgstr "Seiceáil síniú GPG na gclibeanna"
 
 msgid "Display version information about Git"
-msgstr ""
+msgstr "Taispeáin faisnéis leagan faoi Git"
 
 msgid "Show logs with differences each commit introduces"
-msgstr ""
+msgstr "Taispeáin logaí le difríochtaí a thugann gach tiomantas"
 
-#, fuzzy
 msgid "Manage multiple working trees"
-msgstr "in ann crann oibre a sheiceáil"
+msgstr "Bainistigh iliomad crainn oibre"
 
 msgid "Create a tree object from the current index"
-msgstr ""
+msgstr "Cruthaigh réad crann ón innéacs reatha"
 
 msgid "Defining attributes per path"
-msgstr ""
+msgstr "Sainmhíniú tréithe in aghaidh an"
 
 msgid "Git command-line interface and conventions"
-msgstr ""
+msgstr "Comhéadan agus coinbhinsiúin líne ordaithe Git"
 
 msgid "A Git core tutorial for developers"
-msgstr ""
+msgstr "Teagaisc lárnach Git d'fhorbróirí"
 
 msgid "Providing usernames and passwords to Git"
-msgstr ""
+msgstr "Ainmneacha úsáideora agus pasfhocail a sholáthar do"
 
 msgid "Git for CVS users"
-msgstr ""
+msgstr "Git d'úsáideoirí CVS"
 
 msgid "Tweaking diff output"
-msgstr ""
+msgstr "Aschur difriúil a athrú"
 
 msgid "A useful minimum set of commands for Everyday Git"
-msgstr ""
+msgstr "Sraith íosta úsáideach orduithe do Everyday Git"
 
 msgid "Frequently asked questions about using Git"
-msgstr ""
+msgstr "Ceisteanna coitianta faoi úsáid Git"
 
-#, fuzzy
 msgid "The bundle file format"
-msgstr "comhad innéacs truaillithe"
+msgstr "An formáid comhaid beartán"
 
 msgid "Chunk-based file formats"
-msgstr ""
+msgstr "Formáidí comhaid bunaithe ar bhunús"
 
 msgid "Git commit-graph format"
-msgstr ""
+msgstr "Formáid comh-graph Git"
 
 msgid "Git index format"
-msgstr ""
+msgstr "Formáid innéacs Git"
 
 msgid "Git pack format"
-msgstr ""
+msgstr "Formáid pacáiste Git"
 
 msgid "Git cryptographic signature formats"
-msgstr ""
+msgstr "Formáidí sínithe cripteagrafach Git"
 
 msgid "A Git Glossary"
-msgstr ""
+msgstr "Gloclóir Git"
 
 msgid "Hooks used by Git"
-msgstr ""
+msgstr "Crúcaí a úsáideann Git"
 
 msgid "Specifies intentionally untracked files to ignore"
-msgstr ""
+msgstr "Sonraíonn sé comhaid neamhrianaithe de ghnó le neamhaird"
 
 msgid "The Git repository browser"
-msgstr ""
+msgstr "Brabhsálaí stór Git"
 
 msgid "Map author/committer names and/or E-Mail addresses"
-msgstr ""
+msgstr "Léarscáil ainmneacha údar/coistí agus/nó seoltaí rí"
 
 msgid "Defining submodule properties"
-msgstr ""
+msgstr "Airíonna fomhodúil a shainiú"
 
 msgid "Git namespaces"
-msgstr ""
+msgstr "Spásanna ainmneacha Git"
 
 msgid "Protocol v0 and v1 capabilities"
-msgstr ""
+msgstr "Cumais Prótacal v0 agus v1"
 
 msgid "Things common to various protocols"
-msgstr ""
+msgstr "Rudaí coitianta le prótacail éagsúla"
 
 msgid "Git HTTP-based protocols"
-msgstr ""
+msgstr "Prótacail Git HTTP bunaithe"
 
 msgid "How packs are transferred over-the-wire"
-msgstr ""
+msgstr "Conas a aistrítear pacáistí thar an sreang"
 
 msgid "Git Wire Protocol, Version 2"
-msgstr ""
+msgstr "Prótacal Wire Git, Leagan 2"
 
 msgid "Helper programs to interact with remote repositories"
-msgstr ""
+msgstr "Cláir chúntóirí chun idirghníomhú le stórálaí"
 
 msgid "Git Repository Layout"
-msgstr ""
+msgstr "Leagan Amach Stórála Git"
 
 msgid "Specifying revisions and ranges for Git"
-msgstr ""
+msgstr "Athbhreithnithe agus raonta a shonrú do Git"
 
 msgid "Mounting one repository inside another"
-msgstr ""
+msgstr "Stóra amháin a chur isteach taobh istigh de cheann"
 
 msgid "A tutorial introduction to Git"
-msgstr ""
+msgstr "Réamhrá teagaisc ar Git"
 
 msgid "A tutorial introduction to Git: part two"
-msgstr ""
+msgstr "Réamhrá teagaisc ar Git: cuid a dara"
 
 msgid "Git web interface (web frontend to Git repositories)"
-msgstr ""
+msgstr "Comhéadan gréasáin Git (tosaigh gréasáin chuig stórais Git)"
 
 msgid "An overview of recommended workflows with Git"
-msgstr ""
+msgstr "Forbhreathnú ar shreafaí oibre a mholtar le Git"
 
 msgid "A tool for managing large Git repositories"
-msgstr ""
+msgstr "Uirlis chun stórtha móra Git a bhainistiú"
 
 msgid "commit-graph file is too small"
-msgstr ""
+msgstr "tá comhad coimit-graph ró-bheag"
 
 msgid "commit-graph oid fanout chunk is wrong size"
-msgstr ""
+msgstr "tá an méid mícheart ar an smután fanout oid commit-graph"
 
 msgid "commit-graph fanout values out of order"
-msgstr ""
+msgstr "luachanna fanout choimisi-graph as ord"
 
 msgid "commit-graph OID lookup chunk is the wrong size"
-msgstr ""
+msgstr "tá an méid mícheart ar an smután cuardaigh OID commit-graph"
 
 msgid "commit-graph commit data chunk is wrong size"
-msgstr ""
+msgstr "tá méid mícheart ar an smután sonraí commit commit-graph"
 
 msgid "commit-graph generations chunk is wrong size"
-msgstr ""
+msgstr "is méid mícheart é an píosa glúine ghlúin chomhghraif"
 
 msgid "commit-graph changed-path index chunk is too small"
-msgstr ""
+msgstr "tá píosa innéacs cosáin athraithe coimisithe ró-bheag"
 
 #, c-format
 msgid ""
 "ignoring too-small changed-path chunk (%<PRIuMAX> < %<PRIuMAX>) in commit-"
 "graph file"
 msgstr ""
+"ag neamhaird a dhéanamh den smután róbheag den chonair athraithe (%<PRIuMAX> "
+"< %<PRIuMAX>) i gcomhad commit-graph"
 
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
-msgstr ""
+msgstr "ní mheaitseálann síniú gráf coimiteach %X síniú %X"
 
 #, c-format
 msgid "commit-graph version %X does not match version %X"
-msgstr ""
+msgstr "ní hionann leagan %X den commit-graph agus leagan %X"
 
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
-msgstr ""
+msgstr "ní hionann leagan %X den hais commit-graph agus leagan %X"
 
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
-msgstr ""
+msgstr "tá comhad comh-graph ró-bheag chun codanna %u a choinneáil"
 
 msgid "commit-graph required OID fanout chunk missing or corrupted"
-msgstr ""
+msgstr "teastaíonn gráf coimisiúnaithe OID ar iarraidh nó truaillithe"
 
 msgid "commit-graph required OID lookup chunk missing or corrupted"
-msgstr ""
+msgstr "teastaíonn píosa cuardaigh OID atá ar iarraidh nó truaillithe"
 
 msgid "commit-graph required commit data chunk missing or corrupted"
 msgstr ""
+"gráf choimisiúnaithe riachtanach a thabhairt do chuid sonraí atá ar iarraidh "
+"nó"
 
 #, c-format
 msgid ""
 "disabling Bloom filters for commit-graph layer '%s' due to incompatible "
 "settings"
 msgstr ""
+"scagairí Bloom a dhíchumasú le haghaidh ciseal coimit-graf '%s' mar gheall "
+"ar shuíomhanna neamh-chomho"
 
 msgid "commit-graph has no base graphs chunk"
-msgstr ""
+msgstr "níl aon phíosa graif bunghraif ag commit-graph"
 
 msgid "commit-graph base graphs chunk is too small"
-msgstr ""
+msgstr "tá an píosa graif bonn coimisi-graf ró-bheag"
 
 msgid "commit-graph chain does not match"
-msgstr ""
+msgstr "ní mheaitseálann slabhra graf coimisiúnaithe"
 
 #, c-format
 msgid "commit count in base graph too high: %<PRIuMAX>"
-msgstr ""
+msgstr "líon tiomanta i mbonngraf ró-ard:%<PRIuMAX>"
 
 msgid "commit-graph chain file too small"
-msgstr ""
+msgstr "comhad slabhra commit-graph ró-bheag"
 
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
-msgstr ""
+msgstr "slabhra coimit-graf neamhbhailí: ní hash é líne '%s'"
 
-#, fuzzy
 msgid "unable to find all commit-graph files"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir gach comhad gráf coimisiúnaithe a fháil"
 
 msgid "invalid commit position. commit-graph is likely corrupt"
-msgstr ""
+msgstr "post tiomanta neamhbhailí. Is dócha go bhfuil graf coimite truaillithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not find commit %s"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "ní raibh sé in ann teacht ar thiomantas %s"
 
 msgid "commit-graph requires overflow generation data but has none"
-msgstr ""
+msgstr "teastaíonn sonraí giniúna ró-shreabhadh ach níl aon cheann acu"
 
 msgid "commit-graph overflow generation data is too small"
-msgstr ""
+msgstr "tá sonraí giniúna ró-shreabha tiomnaithe-graif róbheag"
 
 msgid "commit-graph extra-edges pointer out of bounds"
-msgstr ""
+msgstr "léiríonn imill shrea-ghraif choimisiúin amach as teorainneacha"
 
 msgid "Loading known commits in commit graph"
-msgstr ""
+msgstr "Gealltanna aitheanta a luchtú i ngraf tiomanta"
 
 msgid "Expanding reachable commits in commit graph"
-msgstr ""
+msgstr "Gealltanais inrochtana a leathnú sa ghraf tiomanta"
 
 msgid "Clearing commit marks in commit graph"
-msgstr ""
+msgstr "Marcanna tiomanta a ghlanadh sa ghraf tiom"
 
 msgid "Computing commit graph topological levels"
-msgstr ""
+msgstr "Tiomann ríomhaireacht leibhéil topaic"
 
 msgid "Computing commit graph generation numbers"
-msgstr ""
+msgstr "Tiomann an ríomhaireacht uimhreacha"
 
 msgid "Computing commit changed paths Bloom filters"
-msgstr ""
+msgstr "Déanann ríomhaireacht cosáin athraithe a"
 
 msgid "Collecting referenced commits"
-msgstr ""
+msgstr "Gealltanna tagartha a bhailiú"
 
 #, c-format
 msgid "Finding commits for commit graph in %<PRIuMAX> pack"
 msgid_plural "Finding commits for commit graph in %<PRIuMAX> packs"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Ag aimsiú tiomantais don ghraf tiomantais sa phacáiste %<PRIuMAX>"
+msgstr[1] "Ag aimsiú tiomantais don ghraf tiomantais i bpacáistí %<PRIuMAX>"
+msgstr[2] "Ag aimsiú tiomantais don ghraf tiomantais i bpacáistí %<PRIuMAX>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "error adding pack %s"
-msgstr "fsck earráid i rudaí pacáiste"
+msgstr "earráid ag cur pacáiste %s"
 
 #, c-format
 msgid "error opening index for %s"
-msgstr ""
+msgstr "innéacs oscailte earráide do %s"
 
 msgid "Finding commits for commit graph among packed objects"
-msgstr ""
+msgstr "Tiomantas a aimsiú maidir le graf tiomanta i measc rudaí pacá"
 
 msgid "Finding extra edges in commit graph"
-msgstr ""
+msgstr "Imill bhreise a aimsiú i ngraf tiomanta"
 
 msgid "failed to write correct number of base graph ids"
-msgstr ""
+msgstr "theip orthu líon ceart na n-idí graif bonn a scríobh"
 
-#, fuzzy
 msgid "unable to create temporary graph layer"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "in ann ciseal graf sealadach a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to adjust shared permissions for '%s'"
-msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+msgstr "nach féidir ceadanna roinnte a choigeartú do '%s'"
 
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Ag scríobh amach graf tiomantais i %d pas"
+msgstr[1] "Ag scríobh amach graf tiomantais i %d pas"
+msgstr[2] "Ag scríobh amach graf tiomantais i %d pas"
 
-#, fuzzy
 msgid "unable to open commit-graph chain file"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir comhad slabhra coimis-graf a oscailt"
 
 msgid "failed to rename base commit-graph file"
-msgstr ""
+msgstr "theip ar an gcomhad gráf bunchoiste a athainmniú"
 
-#, fuzzy
 msgid "failed to rename temporary commit-graph file"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "theip ar chomhad gráf choiste sealadach a athainmniú"
 
 #, c-format
 msgid "cannot merge graphs with %<PRIuMAX>, %<PRIuMAX> commits"
-msgstr ""
+msgstr "ní féidir graif a chumasc le %<PRIuMAX>, %<PRIuMAX> tiomantais"
 
 #, c-format
 msgid "cannot merge graph %s, too many commits: %<PRIuMAX>"
-msgstr ""
+msgstr "ní féidir graf %s a chumasc, an iomarca tiomantais: %<PRIuMAX>"
 
 msgid "Scanning merged commits"
-msgstr ""
+msgstr "Tiomanta cumaisc ag scanadh"
 
 msgid "Merging commit-graph"
-msgstr ""
+msgstr "Graf coiste a chumasc"
 
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
+"ag iarraidh graf coimite a scríobh, ach tá 'core.commitGraph' díchumasaithe"
 
 #, c-format
 msgid ""
 "attempting to write a commit-graph, but 'commitGraph.changedPathsVersion' "
 "(%d) is not supported"
 msgstr ""
+"ag iarraidh commit-graph a scríobh, ach tá 'commitGraph.changedPathsVersion' "
+"(%d) ní thacaítear leis"
 
 msgid "too many commits to write graph"
-msgstr ""
+msgstr "an iomarca gealltanais graf a scríobh"
 
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
+"tá seicsum mícheart ag an gcomhad graf coimite agus is dócha go bhfuil sé "
+"truaillithe"
 
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
-msgstr ""
+msgstr "tá ordú OID mícheart ag commit-graph: %s ansin %s"
 
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
-msgstr ""
+msgstr "tá luach fanout mícheart ag commit-graph: fanout [%d] = %u! = %u"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to parse commit %s from commit-graph"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "theip ar thiomantas %s a pharsáil ó ghraif choimisiúnaithe"
 
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
+"theip ar thiomantas %s a pharsáil ó bhunachar sonraí réad le haghaidh graf "
+"coimite"
 
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
+"crann fréimhe Is é OID do thiomantas %s sa ghraf tiomantais ná %s != %s"
 
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
-msgstr ""
+msgstr "tá liosta tuismitheoirí comh-graph do thiomantas %s rófhada"
 
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
-msgstr ""
+msgstr "is é an tuismitheoir comh-graph do %s ná %s! = %s"
 
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
+"foirceannann liosta tuismitheora commit-graph le haghaidh commit %s go luath"
 
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
+"is é giniúint commit-graph le haghaidh commit %s %<PRIuMAX> < %<PRIuMAX>"
 
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
+"is é dáta tiomantais don tiomantas %s i commit-graph %<PRIuMAX> != %<PRIuMAX>"
 
 #, c-format
 msgid ""
 "commit-graph has both zero and non-zero generations (e.g., commits '%s' and "
 "'%s')"
 msgstr ""
+"tá glúine nialasach agus neamh-nialasach ag comh-graph (e.g., geallann sé "
+"'%s' agus '%s')"
 
 msgid "Verifying commits in commit graph"
-msgstr ""
+msgstr "Gealltanna a fhíorú i ngraf tiomanta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse commit %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "ní fhéadfaí a pharsáil a dhéanamh ar thiomantas %s"
 
 #, c-format
 msgid "%s %s is not a commit!"
-msgstr ""
+msgstr "Ní gealltanas é %s %s!"
 
 msgid ""
 "Support for <GIT_DIR>/info/grafts is deprecated\n"
@@ -14618,233 +15296,241 @@ msgid ""
 "Turn this message off by running\n"
 "\"git config set advice.graftFileDeprecated false\""
 msgstr ""
+"Tá tacaíocht d' <GIT_DIR>/info/grafts imithe\n"
+"agus bainfear é i leagan Git amach anseo.\n"
+"\n"
+"Úsáid le do thoil “git replace --convert-graft-file”\n"
+"chun na grafts a thiontú ina ionad refs.\n"
+"\n"
+"Cas an teachtaireacht seo as trí rith\n"
+"“git config socraigh advice.graftFileDeprecated bréagach”"
 
 #, c-format
 msgid "commit %s exists in commit-graph but not in the object database"
-msgstr ""
+msgstr "tá comhad %s ann sa choimit-graph ach níl sa bhunachar sonraí réad"
 
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
-msgstr ""
+msgstr "Tá síniú GPG neamhiontaofa ag Commit %s, a líomhnaítear ag %s."
 
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
-msgstr ""
+msgstr "Tá droch-shíniú GPG ag Commit %s a líomhnaítear ag %s."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Commit %s does not have a GPG signature."
-msgstr "níl ár leagan ag cosán '%s'"
+msgstr "Níl síniú GPG ag Teacht %s."
 
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
-msgstr ""
+msgstr "Tá síniú maith GPG ag Teacht %s le %s\n"
 
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
 "variable i18n.commitEncoding to the encoding your project uses.\n"
 msgstr ""
+"Rabhadh: níor chomhlíon teachtaireacht tiomanta le UTF-8.\n"
+"B'fhéidir gur mhaith leat é a leasú tar éis an teachtaireacht a shocrú, nó "
+"an cumraíocht a shocrú\n"
+"athróg i18N.CommitEncoding don ionchódú a úsáideann do thionscadal.\n"
 
 msgid "no compiler information available\n"
-msgstr ""
+msgstr "níl aon fhaisnéis tiomsaitheora ar fáil\n"
 
 msgid "no libc information available\n"
-msgstr ""
+msgstr "níl aon fhaisnéis libc ar fáil\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not determine free disk size for '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí méid diosca saor in aisce a chinneadh do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not get info for '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí faisnéis a fháil do '%s'"
 
 #, c-format
 msgid "[GLE %ld] health thread could not open '%ls'"
-msgstr ""
+msgstr "[GLE %ld] ní fhéadfadh snáithe sláinte '%ls' a oscailt"
 
 #, c-format
 msgid "[GLE %ld] health thread getting BHFI for '%ls'"
-msgstr ""
+msgstr "[GLE %ld] snáithe sláinte ag fáil BHFI do '%ls'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not convert to wide characters: '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní raibh sé in ann tiontú go carachtair leathan: '%s'"
 
 #, c-format
 msgid "BHFI changed '%ls'"
-msgstr ""
+msgstr "Athraigh BHFI '%ls'"
 
 #, c-format
 msgid "unhandled case in 'has_worktree_moved': %d"
-msgstr ""
+msgstr "cás neamh-láimhseáilte i 'has_worktree_moved': %d"
 
 #, c-format
 msgid "health thread wait failed [GLE %ld]"
-msgstr ""
+msgstr "theip ar fanacht snáithe sláinte [GLE %ld]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid path: %s"
-msgstr "%s neamhbhailí"
+msgstr "Conair neamhbhailí: %s"
 
-#, fuzzy
 msgid "Unable to create FSEventStream."
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "Ní féidir FSeventStream a chruthú."
 
-#, fuzzy
 msgid "Failed to start the FSEventStream"
-msgstr "theip ar an iterator a thosú thar '%s'"
+msgstr "Theip ar an FSevenStream a thosú"
 
 #, c-format
 msgid "[GLE %ld] could not convert path to UTF-8: '%.*ls'"
-msgstr ""
+msgstr "[GLE %ld] níorbh fhéidir an cosán a thiontú go UTF-8: '%.*ls'"
 
 #, c-format
 msgid "[GLE %ld] could not watch '%s'"
-msgstr ""
+msgstr "Ní raibh [GLE %ld] in ann féachaint ar '%s'"
 
 #, c-format
 msgid "[GLE %ld] could not get longname of '%s'"
-msgstr ""
+msgstr "Ní raibh [GLE %ld] in ann ainm fadainm '%s' a fháil"
 
 #, c-format
 msgid "ReadDirectoryChangedW failed on '%s' [GLE %ld]"
-msgstr ""
+msgstr "Theip ar ReadDirectoryChangedW ar '%s' [GLE %ld]"
 
 #, c-format
 msgid "GetOverlappedResult failed on '%s' [GLE %ld]"
-msgstr ""
+msgstr "Theip ar getOverlappedResult ar '%s' [GLE %ld]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read directory changes [GLE %ld]"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí athruithe eolaire a léamh [GLE %ld]"
 
 #, c-format
 msgid "opendir('%s') failed"
-msgstr ""
+msgstr "theip ar opendir ('%s')"
 
 #, c-format
 msgid "lstat('%s') failed"
-msgstr ""
+msgstr "theip ar lstat ('%s')"
 
 #, c-format
 msgid "strbuf_readlink('%s') failed"
-msgstr ""
+msgstr "theip ar strbuf_readlink ('%s')"
 
 #, c-format
 msgid "closedir('%s') failed"
-msgstr ""
+msgstr "theip ar closedir ('%s')"
 
-#, fuzzy, c-format
+#, c-format
 msgid "[GLE %ld] unable to open for read '%ls'"
-msgstr "nach féidir %s a léamh"
+msgstr "[GLE %ld] nach féidir é a oscailt le haghaidh léamh '%ls'"
 
 #, c-format
 msgid "[GLE %ld] unable to get protocol information for '%ls'"
-msgstr ""
+msgstr "[GLE %ld] in ann faisnéis phrótacail a fháil do '%ls'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to copy SID (%ld)"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar SID (%ld) a chóipeáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to get owner for '%s' (%ld)"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar úinéir a fháil do '%s' (%ld)"
 
 msgid "memory exhausted"
-msgstr ""
+msgstr "cuimhne ídithe"
 
 msgid "Success"
-msgstr ""
+msgstr "Rath"
 
 msgid "No match"
-msgstr ""
+msgstr "Gan aon mheaitseáil"
 
 msgid "Invalid regular expression"
-msgstr ""
+msgstr "Léiriú rialta nebhailí"
 
 msgid "Invalid collation character"
-msgstr ""
+msgstr "Carachtar comparáide neamhbhailí"
 
 msgid "Invalid character class name"
-msgstr ""
+msgstr "Ainm ranga carachtar neamhbhailí"
 
 msgid "Trailing backslash"
-msgstr ""
+msgstr "Cúlbhraith rianaithe"
 
-#, fuzzy
 msgid "Invalid back reference"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "Tagairt cúil neamhbhailí"
 
 msgid "Unmatched [ or [^"
-msgstr ""
+msgstr "Gan chomhoiriúnú [nó [^"
 
 msgid "Unmatched ( or \\("
-msgstr ""
+msgstr "Gan chomhoiriúnú (nó\\ ("
 
 msgid "Unmatched \\{"
-msgstr ""
+msgstr "Gan comhoiriúnú\\ {"
 
 msgid "Invalid content of \\{\\}"
-msgstr ""
+msgstr "Ábhar neamhbhailí de\\ {\\}"
 
 msgid "Invalid range end"
-msgstr ""
+msgstr "Deireadh raon neamhbhailí"
 
 msgid "Memory exhausted"
-msgstr ""
+msgstr "Cuimhne ídithe"
 
 msgid "Invalid preceding regular expression"
-msgstr ""
+msgstr "Léiriú rialta neamhbhailí"
 
 msgid "Premature end of regular expression"
-msgstr ""
+msgstr "Deireadh roimh am an léirithe rialta"
 
 msgid "Regular expression too big"
-msgstr ""
+msgstr "Léiriú rialta ró-mhór"
 
 msgid "Unmatched ) or \\)"
-msgstr ""
+msgstr "Gan chomhoiriúnú) nó\\)"
 
 msgid "No previous regular expression"
-msgstr ""
+msgstr "Gan aon léiriú rialta roimhe seo"
 
 msgid "could not send IPC command"
-msgstr ""
+msgstr "ní fhéadfaí ordú IPC a sheoladh"
 
-#, fuzzy
 msgid "could not read IPC response"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh sé in ann freagra IPC a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not start accept_thread '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí tosú accept_thread '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not start worker[0] for '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí oibrí [0] a thosú le haghaidh '%s'"
 
 #, c-format
 msgid "ConnectNamedPipe failed for '%s' (%lu)"
-msgstr ""
+msgstr "Theip ar ConnectNamedPipe le haghaidh '%s' (%lu)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create fd from pipe for '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí fd a chruthú ó phíopa do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not start thread[0] for '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí snáithe [0] a thosú le haghaidh '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "wait for hEvent failed for '%s'"
-msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
+msgstr "fanacht go dtí Theip ar feadh '%s'"
 
 msgid "cannot resume in the background, please use 'fg' to resume"
-msgstr ""
+msgstr "ní féidir atosú sa chúlra, bain úsáid as 'fg' le do thoil chun atosú"
 
 msgid "cannot restore terminal settings"
-msgstr ""
+msgstr "ní féidir le socruithe teirminéil"
 
 #, c-format
 msgid ""
@@ -14854,291 +15540,300 @@ msgid ""
 "\t%s\n"
 "This might be due to circular includes."
 msgstr ""
+"sháraigh an uasmhéid san áireamh doimhneacht (%d) agus\n"
+" %s\n"
+"ó\n"
+" %s\n"
+"D'fhéadfadh sé seo a bheith mar gheall ar áireamh ciorclach."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not expand include path '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí leathnú san áireamh cosán '%s'"
 
 msgid "relative config includes must come from files"
-msgstr ""
+msgstr "folaíonn cumraíocht choibhneasta caithfidh teacht ó chomh"
 
 msgid "relative config include conditionals must come from files"
-msgstr ""
+msgstr "ní mór coinníollacha a theacht ó chomhaid i gcumraíocht choibhneasta"
 
 msgid ""
 "remote URLs cannot be configured in file directly or indirectly included by "
 "includeIf.hasconfig:remote.*.url"
 msgstr ""
+"ní féidir URLanna iargúlta a chumrú i gcomhad san áireamh go díreach nó go "
+"hindíreach ag includeIf.hasconfig:remote.*.url"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid config format: %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "formáid cumraíochta neamhbhailí: %s"
 
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
-msgstr ""
+msgstr "ainm athróg comhshaoil atá in easnamh do chumraíocht '%.*s'"
 
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
-msgstr ""
+msgstr "athróg comhshaoil in easnamh '%s' le haghaidh cumraíocht '%.*s'"
 
 #, c-format
 msgid "key does not contain a section: %s"
-msgstr ""
+msgstr "níl rannán ag eochair: %s"
 
 #, c-format
 msgid "key does not contain variable name: %s"
-msgstr ""
+msgstr "níl ainm athraitheach sa eochair: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid key: %s"
-msgstr "%s neamhbhailí"
+msgstr "eochair neamhbhailí: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid key (newline): %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "eochair neamhbhailí (líne nua): %s"
 
 msgid "empty config key"
-msgstr ""
+msgstr "eochair cumraíochta folamh"
 
 #, c-format
 msgid "bogus config parameter: %s"
-msgstr ""
+msgstr "paraiméadar cumraíochta bréagach: %s"
 
 #, c-format
 msgid "bogus format in %s"
-msgstr ""
+msgstr "formáid bhréagach i %s"
 
 #, c-format
 msgid "bogus count in %s"
-msgstr ""
+msgstr "comhaireamh bréagach i %s"
 
 #, c-format
 msgid "too many entries in %s"
-msgstr ""
+msgstr "an iomarca iontrálacha i %s"
 
 #, c-format
 msgid "missing config key %s"
-msgstr ""
+msgstr "eochair chumraithe %s in easnamh"
 
 #, c-format
 msgid "missing config value %s"
-msgstr ""
+msgstr "luach cumraíochta %s ar iarraidh"
 
 #, c-format
 msgid "bad config line %d in blob %s"
-msgstr ""
+msgstr "droch-líne cumraíochta %d i mblob %s"
 
 #, c-format
 msgid "bad config line %d in file %s"
-msgstr ""
+msgstr "droch-líne cumraíochta %d i gcomhad %s"
 
 #, c-format
 msgid "bad config line %d in standard input"
-msgstr ""
+msgstr "droch-líne cumraíochta %d i ionchur caighdeánach"
 
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
-msgstr ""
+msgstr "droch-líne cumraíochta %d i bhfo-modul-blob %s"
 
 #, c-format
 msgid "bad config line %d in command line %s"
-msgstr ""
+msgstr "droch-líne cumraíochta %d i líne ordaithe %s"
 
 #, c-format
 msgid "bad config line %d in %s"
-msgstr ""
+msgstr "droch-líne cumraíochta %d i %s"
 
 msgid "out of range"
-msgstr ""
+msgstr "lasmuigh den raon"
 
-#, fuzzy
 msgid "invalid unit"
-msgstr "%s neamhbhailí"
+msgstr "aonad neamhbhailí"
 
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
-msgstr ""
+msgstr "droch-luach cumraíochta uimhriúil '%s' do '%s': %s"
 
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
-msgstr ""
+msgstr "droch-luach cumraíochta uimhriúil '%s' do '%s' i mblob %s: %s"
 
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
-msgstr ""
+msgstr "droch-luach cumraíochta uimhriúil '%s' do '%s' i gcomhad %s: %s"
 
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr ""
+"droch-luach cumraíochta uimhriúil '%s' do '%s' in ionchur caighdeánach: %s"
 
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
-msgstr ""
+msgstr "droch-luach cumraíochta uimhriúil '%s' do '%s' i bhfo-mhodúl %s: %s"
 
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
-msgstr ""
+msgstr "droch-luach cumraíochta uimhriúil '%s' do '%s' i líne ordaithe %s: %s"
 
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
-msgstr ""
+msgstr "droch-luach cumraíochta uimhriúil '%s' do '%s' i %s: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid value for variable %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "luach neamhbhailí don athróg %s"
 
 #, c-format
 msgid "ignoring unknown core.fsync component '%s'"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar chomhpháirt core.fsync anaithnid '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad boolean config value '%s' for '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "droch-luach cumraíochta boolean '%s' do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to expand user dir in: '%s'"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar dir an úsáideora a leathnú i: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní stampa ama bailí é '%s' do '%s'"
 
 #, c-format
 msgid "abbrev length out of range: %d"
-msgstr ""
+msgstr "fad a ghiorrú lasmuigh den raon: %d"
 
 #, c-format
 msgid "bad zlib compression level %d"
-msgstr ""
+msgstr "droch-leibhéal comhbhrúite zlib %d"
 
 #, c-format
 msgid "%s cannot contain newline"
-msgstr ""
+msgstr "Ní féidir le líne nua a bheith ag %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s must have at least one character"
-msgstr "ní chóir go mbeadh carachtair líne nua ag roghanna brú"
+msgstr "Ní mór carachtar amháin ar a laghad a bheith ag %s"
 
 #, c-format
 msgid "ignoring unknown core.fsyncMethod value '%s'"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar luach core.fsyncMethod anaithnid '%s'"
 
 msgid "core.fsyncObjectFiles is deprecated; use core.fsync instead"
 msgstr ""
+"tá core.fsyncObjectFiles díscothaithe; bain úsáid as core.fsync ina ionad"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid mode for object creation: %s"
-msgstr "réad blob neamhbhailí %s"
+msgstr "modh neamhbhailí chun réad a chruthú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed value for %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "luach mífhoirmithe do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed value for %s: %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "luach mífhoirmithe do %s: %s"
 
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
+"caithfidh sé a bheith ar cheann de rud ar bith, meaitseálach, simplí, suas "
+"srutha nó reatha"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to load config blob object '%s'"
-msgstr "réad blob neamhbhailí %s"
+msgstr "nach féidir réad blob cumraithe '%s' a luchtú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "reference '%s' does not point to a blob"
-msgstr "Ní chuireann HEAD in iúl do bhrainse"
+msgstr "ní thugann tagairt '%s' in iúl do bhlob"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to resolve config blob '%s'"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "in ann clob config '%s' a réiteach"
 
-#, fuzzy
 msgid "unable to parse command-line config"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir cumraíocht líne ordaithe a pháirseáil"
 
 msgid "unknown error occurred while reading the configuration files"
-msgstr ""
+msgstr "tharla earráid anaithnid agus na comhaid cumraíochta á léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid %s: '%s'"
-msgstr "%s neamhbhailí"
+msgstr "%s neamhbhailí: '%s'"
 
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
-msgstr ""
+msgstr "splitIndex.maxPercentChange value '%d' bheith idir 0 agus 100"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse '%s' from command-line config"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "ní féidir '%s' a pháirseáil ó chumraíocht líne ordaithe"
 
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
-msgstr ""
+msgstr "droch-athróg cumraithe '%s' sa chomhad '%s' ag líne %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid section name '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "ainm rannán neamhbhailí '%s'"
 
 #, c-format
 msgid "%s has multiple values"
-msgstr ""
+msgstr "Tá luachanna iolracha ag %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to write new configuration file %s"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "theip ar chomhad cumraíochta nua %s a scríobh"
 
 #, c-format
 msgid "no multi-line comment allowed: '%s'"
-msgstr ""
+msgstr "níl aon trácht illíne ceadaithe: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not lock config file %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí comhad cumraíochta %s a ghlasáil"
 
 #, c-format
 msgid "opening %s"
-msgstr ""
+msgstr "oscailt %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid config file %s"
-msgstr "réad blob neamhbhailí %s"
+msgstr "comhad cumraithe neamhbhailí %s"
 
 #, c-format
 msgid "fstat on %s failed"
-msgstr ""
+msgstr "theip ar fstat ar %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to mmap '%s'%s"
-msgstr "nach féidir %s a léamh"
+msgstr "ní féidir le '%s'%s a mmapáil"
 
 #, c-format
 msgid "chmod on %s failed"
-msgstr ""
+msgstr "theip ar chmod ar %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write config file %s"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní fhéadfaí comhad cumraithe %s a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not set '%s' to '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a shocrú go '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid section name: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "ainm rannán neamhbhailí: %s"
 
 #, c-format
 msgid "refusing to work with overly long line in '%s' on line %<PRIuMAX>"
-msgstr ""
+msgstr "diúltú oibriú le líne rófhada i '%s' ar líne%<PRIuMAX>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "missing value for '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "luach ar iarraidh do '%s'"
 
 msgid "the remote end hung up upon initial contact"
-msgstr ""
+msgstr "crochadh an deireadh iargúlta ar an teagmháil tosaigh"
 
 msgid ""
 "Could not read from remote repository.\n"
@@ -15146,75 +15841,78 @@ msgid ""
 "Please make sure you have the correct access rights\n"
 "and the repository exists."
 msgstr ""
+"Ní fhéadfaí léamh ó stór iargúlta.\n"
+"\n"
+"Déan cinnte go bhfuil na cearta rochtana cearta agat\n"
+"agus tá an stór ann."
 
 #, c-format
 msgid "server doesn't support '%s'"
-msgstr ""
+msgstr "ní thacaíonn freastalaí le '%s'"
 
 #, c-format
 msgid "server doesn't support feature '%s'"
-msgstr ""
+msgstr "ní thacaíonn freastalaí le gné '%s'"
 
 msgid "expected flush after capabilities"
-msgstr ""
+msgstr "súil le sruth tar éis cumais"
 
 #, c-format
 msgid "ignoring capabilities after first line '%s'"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar chumais tar éis an chéad líne '%s'"
 
 msgid "protocol error: unexpected capabilities^{}"
-msgstr ""
+msgstr "earráid prótacal: cumais gan choinne ^ {}"
 
 #, c-format
 msgid "protocol error: expected shallow sha-1, got '%s'"
-msgstr ""
+msgstr "earráid prótacal: táthar ag súil le sha-1 éadrom, fuair '%s'"
 
 msgid "repository on the other end cannot be shallow"
-msgstr ""
+msgstr "ní féidir stór ar an gceann eile a bheith éadrom"
 
-#, fuzzy
 msgid "invalid packet"
-msgstr "%s neamhbhailí"
+msgstr "pacáiste neamhbhail"
 
 #, c-format
 msgid "protocol error: unexpected '%s'"
-msgstr ""
+msgstr "earráid prótacal: '%s' gan choinne"
 
 #, c-format
 msgid "unknown object format '%s' specified by server"
-msgstr ""
+msgstr "formáid réad anaithnid '%s' arna shonrú ag freastalaí"
 
 #, c-format
 msgid "error on bundle-uri response line %d: %s"
-msgstr ""
+msgstr "earráid ar líne freagartha cumhachta %d: %s"
 
 msgid "expected flush after bundle-uri listing"
-msgstr ""
+msgstr "súil le sruth tar éis liostú bundle-uri"
 
 msgid "expected response end packet after ref listing"
-msgstr ""
+msgstr "pacáiste deiridh freagartha a bhfuiltear ag súil leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid ls-refs response: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "freagra neamhbhailí ls-refs: %s"
 
 msgid "expected flush after ref listing"
-msgstr ""
+msgstr "súil le sruth tar éis liostú tagartha"
 
-#, fuzzy, c-format
+#, c-format
 msgid "protocol '%s' is not supported"
-msgstr "níl an stóras '%s' ann"
+msgstr "ní thacaítear le prótacal '%s'"
 
 msgid "unable to set SO_KEEPALIVE on socket"
-msgstr ""
+msgstr "in ann SO_KEEPALIVE a shocrú ar an soicéad"
 
 #, c-format
 msgid "Looking up %s ... "
-msgstr ""
+msgstr "Ag féachaint suas %s... "
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to look up %s (port %s) (%s)"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir a lorg suas %s (port %s) (%s)"
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
 #, c-format
@@ -15222,890 +15920,938 @@ msgid ""
 "done.\n"
 "Connecting to %s (port %s) ... "
 msgstr ""
+"déanta.\n"
+"Ag nascadh le %s (port %s)... "
 
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "unable to connect to %s:\n"
 "%s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr ""
+"ní féidir a nascadh le %s:\n"
+"%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#, fuzzy
 msgid "done."
-msgstr "déanta.\n"
+msgstr "déanta."
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to look up %s (%s)"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir a lorg suas %s (%s)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown port %s"
-msgstr "algartam hais anaithnid '%s'"
+msgstr "port anaithnid %s"
 
 #, c-format
 msgid "strange hostname '%s' blocked"
-msgstr ""
+msgstr "ainm óstach aisteach '%s' blocáilte"
 
 #, c-format
 msgid "strange port '%s' blocked"
-msgstr ""
+msgstr "cosc ar chalafort aisteach '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot start proxy %s"
-msgstr "ní féidir le pacáiste fstat"
+msgstr "ní féidir le seachfhreastalaí %s"
 
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr ""
+"níl aon chosán sonraithe; féach 'git help pull' le haghaidh comhréireachta "
+"bailí url"
 
 msgid "newline is forbidden in git:// hosts and repo paths"
-msgstr ""
+msgstr "tá cosc ​​ar líne nua in óstaigh git:// agus cosáin stórais"
 
 msgid "ssh variant 'simple' does not support -4"
-msgstr ""
+msgstr "ní thacaíonn leagan ssh 'simplí' le -4"
 
 msgid "ssh variant 'simple' does not support -6"
-msgstr ""
+msgstr "ní thacaíonn leagan ssh 'simplí' le -6"
 
 msgid "ssh variant 'simple' does not support setting port"
-msgstr ""
+msgstr "ní thacaíonn leagan ssh 'simplí' le port socrú"
 
 #, c-format
 msgid "strange pathname '%s' blocked"
-msgstr ""
+msgstr "cosc ar ainm cosán aisteach '%s'"
 
-#, fuzzy
 msgid "unable to fork"
-msgstr "nach féidir %s a léamh"
+msgstr "in ann a fhorc"
 
-#, fuzzy
 msgid "Could not run 'git rev-list'"
-msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
+msgstr "Ní fhéadfaí 'git rev-list' a reáchtáil"
 
-#, fuzzy
 msgid "failed write to rev-list"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar scríobh chuig rev-list"
 
 msgid "failed to close rev-list's stdin"
-msgstr ""
+msgstr "theip orthu stdin rev-list a dhúnadh"
 
 #, c-format
 msgid "illegal crlf_action %d"
-msgstr ""
+msgstr "crlf_action mídhleathach %d"
 
 #, c-format
 msgid "CRLF would be replaced by LF in %s"
-msgstr ""
+msgstr "Bheadh LF in ionad CRLF i %s"
 
 #, c-format
 msgid ""
 "in the working copy of '%s', CRLF will be replaced by LF the next time Git "
 "touches it"
 msgstr ""
+"sa chóip oibre de '%s', cuirfear LF in ionad CRLF an chéad uair eile a "
+"théann Git leis"
 
 #, c-format
 msgid "LF would be replaced by CRLF in %s"
-msgstr ""
+msgstr "Bheadh CRLF in ionad LF i %s"
 
 #, c-format
 msgid ""
 "in the working copy of '%s', LF will be replaced by CRLF the next time Git "
 "touches it"
 msgstr ""
+"sa chóip oibre de '%s', cuirfear CRLF in ionad LF an chéad uair eile a "
+"théann Git leis"
 
 #, c-format
 msgid "BOM is prohibited in '%s' if encoded as %s"
-msgstr ""
+msgstr "Tá cosc ar BOM i '%s' má tá sé ionchódaithe mar %s"
 
 #, c-format
 msgid ""
 "The file '%s' contains a byte order mark (BOM). Please use UTF-%.*s as "
 "working-tree-encoding."
 msgstr ""
+"Tá marc ordaithe beart (BOM) sa chomhad '%s'. Bain úsáid as UTF-%.*s mar "
+"ionchódú crann oibre le do thoil."
 
 #, c-format
 msgid "BOM is required in '%s' if encoded as %s"
-msgstr ""
+msgstr "Tá BOM ag teastáil i '%s' má tá sé ionchódaithe mar %s"
 
 #, c-format
 msgid ""
 "The file '%s' is missing a byte order mark (BOM). Please use UTF-%sBE or UTF-"
 "%sLE (depending on the byte order) as working-tree-encoding."
 msgstr ""
+"Tá marc ordaithe beart (BOM) ar iarraidh sa chomhad '%s'. Bain úsáid as UTF-"
+"%sBE nó UTF-%sLE (ag brath ar ord na mbeart) mar ionchódú crann oibre."
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to encode '%s' from %s to %s"
-msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+msgstr "theip ar '%s' a ionchódú ó %s go %s"
 
 #, c-format
 msgid "encoding '%s' from %s to %s and back is not the same"
-msgstr ""
+msgstr "ionchódú '%s' ó %s go %s agus níl sé mar an gcéanna ar ais"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot fork to run external filter '%s'"
-msgstr "Ní féidir comhad pacáiste atá ann cheana '%s' a oscailt"
+msgstr "ní féidir forc chun scagaire seachtrach '%s' a reáchtáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot feed the input to external filter '%s'"
-msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
+msgstr "ní féidir leis an ionchur a bheathú chuig scagaire seachtrach '%s'"
 
 #, c-format
 msgid "external filter '%s' failed %d"
-msgstr ""
+msgstr "theip ar scagaire seachtrach '%s' %d"
 
 #, c-format
 msgid "read from external filter '%s' failed"
-msgstr ""
+msgstr "theip ar léamh ó scagaire seachtrach '%s'"
 
 #, c-format
 msgid "external filter '%s' failed"
-msgstr ""
+msgstr "theip ar scagaire seachtrach '%s'"
 
 msgid "unexpected filter type"
-msgstr ""
+msgstr "cineál scagaire gan choinne"
 
 msgid "path name too long for external filter"
-msgstr ""
+msgstr "ainm cosáin rófhada le haghaidh scagaire seachtrach"
 
 #, c-format
 msgid ""
 "external filter '%s' is not available anymore although not all paths have "
 "been filtered"
 msgstr ""
+"níl an scagaire seachtrach '%s' ar fáil a thuilleadh cé nach bhfuil na "
+"cosáin uile scagtha"
 
 msgid "true/false are no valid working-tree-encodings"
-msgstr ""
+msgstr "níl aon ionchódaithe bailí crainn oibre fíor-bhréagach"
 
 #, c-format
 msgid "%s: clean filter '%s' failed"
-msgstr ""
+msgstr "%s: theip ar scagaire glan '%s'"
 
 #, c-format
 msgid "%s: smudge filter %s failed"
-msgstr ""
+msgstr "%s: theip ar scagaire smudge %s"
 
 #, c-format
 msgid "skipping credential lookup for key: credential.%s"
-msgstr ""
+msgstr "cuardach creidiúnaithe a scipeáil le haghaidh eochair: creidiúnas. %s"
 
 msgid "refusing to work with credential missing host field"
-msgstr ""
+msgstr "diúltú oibriú le réimse óstach creidiúnaithe atá ar"
 
 msgid "refusing to work with credential missing protocol field"
-msgstr ""
+msgstr "diúltú oibriú le réimse prótacal ar iarraidh creidiú"
 
 #, c-format
 msgid "url contains a newline in its %s component: %s"
-msgstr ""
+msgstr "tá líne nua ina chomhpháirt %s ag url: %s"
 
 #, c-format
 msgid "url has no scheme: %s"
-msgstr ""
+msgstr "níl aon scéim ag url: %s"
 
 #, c-format
 msgid "credential url cannot be parsed: %s"
-msgstr ""
+msgstr "ní féidir url creidiúnaithe a pháirseáil: %s"
 
 #, c-format
 msgid "invalid timeout '%s', expecting a non-negative integer"
-msgstr ""
+msgstr "ama neamhbhailí '%s', ag súil le sláimhir neamh-dhiúltach"
 
 #, c-format
 msgid "invalid init-timeout '%s', expecting a non-negative integer"
-msgstr ""
+msgstr "ama init-time '%s' neamhbhailí, ag súil le sláimhir neamh-dhiúltach"
 
 #, c-format
 msgid "invalid max-connections '%s', expecting an integer"
-msgstr ""
+msgstr "naisc uasta neamhbhailí '%s', ag súil le sláimhir"
 
 msgid "in the future"
-msgstr ""
+msgstr "sa todhchaí"
 
 #, c-format
 msgid "%<PRIuMAX> second ago"
 msgid_plural "%<PRIuMAX> seconds ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> soicind ó shin"
+msgstr[1] "%<PRIuMAX> soicind ó shin"
+msgstr[2] "%<PRIuMAX> soicind ó shin"
 
 #, c-format
 msgid "%<PRIuMAX> minute ago"
 msgid_plural "%<PRIuMAX> minutes ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> nóiméad ó shin"
+msgstr[1] "%<PRIuMAX> nóiméad ó shin"
+msgstr[2] "%<PRIuMAX> nóiméad ó shin"
 
 #, c-format
 msgid "%<PRIuMAX> hour ago"
 msgid_plural "%<PRIuMAX> hours ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> uair an chloig ó shin"
+msgstr[1] "%<PRIuMAX> uair an chloig ó shin"
+msgstr[2] "%<PRIuMAX> uair an chloig ó shin"
 
 #, c-format
 msgid "%<PRIuMAX> day ago"
 msgid_plural "%<PRIuMAX> days ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> lá ó shin"
+msgstr[1] "%<PRIuMAX> lá ó shin"
+msgstr[2] "%<PRIuMAX> lá ó shin"
 
 #, c-format
 msgid "%<PRIuMAX> week ago"
 msgid_plural "%<PRIuMAX> weeks ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> seachtain ó shin"
+msgstr[1] "%<PRIuMAX> seachtain ó shin"
+msgstr[2] "%<PRIuMAX> seachtain ó shin"
 
 #, c-format
 msgid "%<PRIuMAX> month ago"
 msgid_plural "%<PRIuMAX> months ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> mí ó shin"
+msgstr[1] "%<PRIuMAX> mí ó shin"
+msgstr[2] "%<PRIuMAX> mí ó shin"
 
 #, c-format
 msgid "%<PRIuMAX> year"
 msgid_plural "%<PRIuMAX> years"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> bliain"
+msgstr[1] "%<PRIuMAX> bliain"
+msgstr[2] "%<PRIuMAX> bliain"
 
 #. TRANSLATORS: "%s" is "<n> years"
 #, c-format
 msgid "%s, %<PRIuMAX> month ago"
 msgid_plural "%s, %<PRIuMAX> months ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s, %<PRIuMAX> mí ó shin"
+msgstr[1] "%s, %<PRIuMAX> mí ó shin"
+msgstr[2] "%s, %<PRIuMAX> mí ó shin"
 
 #, c-format
 msgid "%<PRIuMAX> year ago"
 msgid_plural "%<PRIuMAX> years ago"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%<PRIuMAX> bliain ó shin"
+msgstr[1] "%<PRIuMAX> bliain ó shin"
+msgstr[2] "%<PRIuMAX> bliain ó shin"
 
 msgid "Propagating island marks"
-msgstr ""
+msgstr "Marcanna oileáin a iomadú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad tree object %s"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "réad droch-chrann %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to load island regex for '%s': %s"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar an oileán regex a luchtú do '%s': %s"
 
 #, c-format
 msgid "island regex from config has too many capture groups (max=%d)"
-msgstr ""
+msgstr "tá an iomarca grúpaí gabhála ag an oileán regex ó config (max = %d)"
 
 #, c-format
 msgid "Marked %d islands, done.\n"
-msgstr ""
+msgstr "Oileáin %d marcáilte, déanta.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid --%s value '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "neamhbhailí --%s luach '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not archive missing directory '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire '%s' in easnamh a chartlannú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not open directory '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní raibh in ann eolaire '%s' a oscailt"
 
 #, c-format
 msgid "skipping '%s', which is neither file nor directory"
-msgstr ""
+msgstr "ag scipeáil '%s', nach comhad ná eolaire"
 
-#, fuzzy
 msgid "could not duplicate stdout"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí stdout a dhúbailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not add directory '%s' to archiver"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire '%s' a chur leis an gcartlann"
 
-#, fuzzy
 msgid "failed to write archive"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "theip ar chartlann a scríobh"
 
 msgid "--merge-base does not work with ranges"
-msgstr ""
+msgstr "ní oibríonn --merge-base le raonta"
 
-#, fuzzy
 msgid "unable to get HEAD"
-msgstr "in ann HEAD a nuashonrú"
+msgstr "in ann HEAD a fháil"
 
 msgid "no merge base found"
-msgstr ""
+msgstr "níl aon bhonn cumaisc le fáil"
 
 msgid "multiple merge bases found"
-msgstr ""
+msgstr "fuarthas bonn cumaisc iolr"
 
 msgid "cannot compare stdin to a directory"
-msgstr ""
+msgstr "ní féidir stdin a chur i gcomparáid le eolaire"
 
 msgid "cannot compare a named pipe to a directory"
-msgstr ""
+msgstr "ní féidir píopa ainmnithe a chur i gcomparáid le eolaire"
 
-#, fuzzy
 msgid "git diff --no-index [<options>] <path> <path>"
-msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
+msgstr "git diff --no-index [<options>] <path> <path>"
 
 msgid ""
 "Not a git repository. Use --no-index to compare two paths outside a working "
 "tree"
 msgstr ""
+"Ní stór git. Úsáid --no-index chun dhá chosán a chur i gcomparáid lasmuigh "
+"de chrann oibre"
 
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
-msgstr ""
+msgstr "  Theip ar chéatadán scoir dirstat '%s' a pharsáil\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "  Paraiméadar dirstat anaithnid '%s'\n"
 
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
 msgstr ""
+"caithfidh socrú dath a bhogadh a bheith ar cheann de 'níl', "
+"'réamhshocraithe', 'bloic', 'zebra', 'dimmed-zebra', 'simplí'"
 
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
 "'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-change'"
 msgstr ""
+"modh dath-gluaisea-ws anaithnid '%s', is iad na luachanna féideartha "
+"'neamhaird-spas-athrú', 'neamhaird a dhéanamh ar spás-at-eol', 'neamhaird a "
+"dhéanamh ar uile-spás', 'ligead-indentation-change'"
 
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
 msgstr ""
+"dath-moved-ws: ní féidir athrú ligead-ionchur a chomhcheangal le modhanna "
+"spás bán eile"
 
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
-msgstr ""
+msgstr "Luach anaithnid d'athróg cumraithe 'diff.submodule': '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown value for config '%s': %s"
-msgstr "stíl choimhlinte anaithnid '%s'"
+msgstr "luach anaithnid do chumraíocht '%s': %s"
 
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
 "%s"
 msgstr ""
+"Earráidí aimsithe in athróg config 'diff.dirstat':\n"
+"%s"
 
 #, c-format
 msgid "external diff died, stopping at %s"
-msgstr ""
+msgstr "fuair diff seachtrach bás, ag stopadh ag %s"
 
 msgid "--follow requires exactly one pathspec"
-msgstr ""
+msgstr "Teastaíonn --follow go díreach cosán amháin"
 
 #, c-format
 msgid "pathspec magic not supported by --follow: %s"
-msgstr ""
+msgstr "draíocht pathspec nach dtacaíonn --follow: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "options '%s', '%s', '%s', and '%s' cannot be used together"
-msgstr "ní féidir na roghanna '-%c', '-%c', agus '%s' a úsáid le chéile"
+msgstr "ní féidir roghanna '%s', '%s', '%s', agus '%s' a úsáid le chéile"
 
-#, fuzzy, c-format
+#, c-format
 msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr ""
+"ní féidir roghanna '%s' agus '%s' a úsáid le chéile, bain úsáid as '%s' le "
+"'%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
-msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
+msgstr ""
+"ní féidir roghanna '%s' agus '%s' a úsáid le chéile, bain úsáid as '%s' le "
+"'%s' agus '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid --stat value: %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "luach --stat neamhbhailí: %s"
 
 #, c-format
 msgid "%s expects a numerical value"
-msgstr ""
+msgstr "Tá %s ag súil le luach uimhriúil"
 
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
 "%s"
 msgstr ""
+"Theip ar pharaiméadar rogha --dirstat/-X a pháirseáil:\n"
+"%s"
 
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
-msgstr ""
+msgstr "aicme athraithe anaithnid '%c' i --diff-filter=%s"
 
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
-msgstr ""
+msgstr "luach anaithnid tar éis ws-error-highlight =%.*s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to resolve '%s'"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir '%s' a réiteach"
 
 #, c-format
 msgid "%s expects <n>/<m> form"
-msgstr ""
+msgstr "Tá %s ag súil le<n>/fo <m>irm"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s expects a character, got '%s'"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "Tá %s ag súil le carachtar, fuair '%s'"
 
 #, c-format
 msgid "bad --color-moved argument: %s"
-msgstr ""
+msgstr "argóint lochtach --color-moved: %s"
 
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
-msgstr ""
+msgstr "modh neamhbhailí '%s' i --color-moved-ws"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid argument to %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "argóint neamhbhailí chuig %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid regex given to -I: '%s'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "regex neamhbhailí a thugtar do -I: '%s'"
 
 msgid "-G requires a non-empty argument"
-msgstr ""
+msgstr "Éilíonn -G argóint neamh-folamh"
 
 msgid "-S requires a non-empty argument"
-msgstr ""
+msgstr "Éilíonn -S argóint neamh-folamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
-msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+msgstr "theip ar pharaiméadar rogha --submodule a pháirseáil: '%s'"
 
 #, c-format
 msgid "bad --word-diff argument: %s"
-msgstr ""
+msgstr "argóint olc --word-diff: %s"
 
 msgid "Diff output format options"
-msgstr ""
+msgstr "Roghanna formáid aschuir diff"
 
-#, fuzzy
 msgid "generate patch"
-msgstr "Cosáin neamh-chumasaithe:"
+msgstr "paiste a ghiniúint"
 
 msgid "<n>"
-msgstr ""
+msgstr "<n>"
 
 msgid "generate diffs with <n> lines context"
-msgstr ""
+msgstr "difríochtaí a ghiniúint le comhthéacs <n>lín"
 
 msgid "generate the diff in raw format"
-msgstr ""
+msgstr "giniúint an diff i bhformáid amh"
 
 msgid "synonym for '-p --raw'"
-msgstr ""
+msgstr "comhchiallach do '-p --raw'"
 
 msgid "synonym for '-p --stat'"
-msgstr ""
+msgstr "comhchiallach do '-p --stat'"
 
-#, fuzzy
 msgid "machine friendly --stat"
-msgstr "aschur inléite meaisín"
+msgstr "cairdiúil le meaisín --stat"
 
 msgid "output only the last line of --stat"
-msgstr ""
+msgstr "aschur ach an líne dheireanach de --stat"
 
 msgid "<param1>,<param2>..."
-msgstr ""
+msgstr "<param1>,<param2>..."
 
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
-msgstr ""
+msgstr "aschur dáileadh méid coibhneasta na n-athruithe do gach fo-eolaire"
 
 msgid "synonym for --dirstat=cumulative"
-msgstr ""
+msgstr "comhchiallach do --dirstat=cumulative"
 
 msgid "synonym for --dirstat=files,<param1>,<param2>..."
-msgstr ""
+msgstr "comhchiallaigh le haghaidh --dirstat=files,<param1>,<param2>..."
 
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
+"rabhadh má thugann athruithe marcóirí coinbhleachta nó earráidí spás bán "
+"isteach"
 
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
+"achoimre chomhdhlúite mar chruthúcháin, athainmneacha agus athruithe mó"
 
 msgid "show only names of changed files"
-msgstr ""
+msgstr "taispeáint ach ainmneacha comhaid athraithe"
 
 msgid "show only names and status of changed files"
-msgstr ""
+msgstr "taispeáint ach ainmneacha agus stádas na gcomhaid athraithe"
 
 msgid "<width>[,<name-width>[,<count>]]"
-msgstr ""
+msgstr "<width>[, <name-width>[,<count>]]"
 
 msgid "generate diffstat"
-msgstr ""
+msgstr "diffstat a ghiniúint"
 
 msgid "<width>"
-msgstr ""
+msgstr "<width>"
 
 msgid "generate diffstat with a given width"
-msgstr ""
+msgstr "diffstat a ghiniúint le leithead ar leith"
 
 msgid "generate diffstat with a given name width"
-msgstr ""
+msgstr "diffstat a ghiniúint le leithead ainm ar leith"
 
 msgid "generate diffstat with a given graph width"
-msgstr ""
+msgstr "diffstat a ghiniúint le leithead graf ar leith"
 
 msgid "<count>"
-msgstr ""
+msgstr "<count>"
 
 msgid "generate diffstat with limited lines"
-msgstr ""
+msgstr "diffstat a ghiniúint le línte teoranta"
 
 msgid "generate compact summary in diffstat"
-msgstr ""
+msgstr "achoimre dlúth a ghiniúint i diffstat"
 
 msgid "output a binary diff that can be applied"
-msgstr ""
+msgstr "aschur diff dénártha is féidir a chur i bhfeidhm"
 
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
+"taispeáint ainmneacha réad réad réamh-íomhá iomlána ar na línte “innéacs”"
 
 msgid "show colored diff"
-msgstr ""
+msgstr "taispeáin éagsúlacht daite"
 
 msgid "<kind>"
-msgstr ""
+msgstr "<kind>"
 
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
 msgstr ""
+"aird a tharraingt ar earráidí spás bán sna línte 'comhthéacs', 'sean' nó "
+"'nua' sa diff"
 
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
 msgstr ""
+"ná cuir ainmneacha cosáin agus bain úsáid as NULanna mar chríochnóirí réimse "
+"aschuir i --raw nó --numstat"
 
 msgid "<prefix>"
-msgstr ""
+msgstr "<prefix>"
 
 msgid "show the given source prefix instead of \"a/\""
-msgstr ""
+msgstr "taispeáint an réimír foinse a thugtar in ionad “a/”"
 
 msgid "show the given destination prefix instead of \"b/\""
-msgstr ""
+msgstr "taispeáin an réimír ceann scríbe tugtha in ionad “b/”"
 
 msgid "prepend an additional prefix to every line of output"
-msgstr ""
+msgstr "réimír bhreise a chur ar fáil do gach líne aschuir"
 
 msgid "do not show any source or destination prefix"
-msgstr ""
+msgstr "ná taispeáin aon réimír foinse nó ceann scríbe"
 
 msgid "use default prefixes a/ and b/"
-msgstr ""
+msgstr "bain úsáid as réamhshocraithe a/ agus b/"
 
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
+"comhthéacs a thaispeáint idir diff hunks suas go dtí an líon sonraithe línte"
 
 msgid "<char>"
-msgstr ""
+msgstr "<char>"
 
 msgid "specify the character to indicate a new line instead of '+'"
-msgstr ""
+msgstr "sonraigh an carachtar chun líne nua a léiriú in ionad '+'"
 
 msgid "specify the character to indicate an old line instead of '-'"
-msgstr ""
+msgstr "sonraigh an carachtar chun sean-líne a chur in iúl in ionad '-'"
 
 msgid "specify the character to indicate a context instead of ' '"
-msgstr ""
+msgstr "sonraigh an carachtar chun comhthéacs in ionad '' a chur in iúl"
 
 msgid "Diff rename options"
-msgstr ""
+msgstr "Roghanna athainmnithe Diff"
 
 msgid "<n>[/<m>]"
-msgstr ""
+msgstr "<n>[/<m>]"
 
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
+"athruithe iomlána athscríobh a bhriseadh i bpéirí scrios agus cruthaigh"
 
 msgid "detect renames"
-msgstr ""
+msgstr "athainmneacha a bhrath"
 
 msgid "omit the preimage for deletes"
-msgstr ""
+msgstr "fág an réamhíomhá le haghaidh scriosadh"
 
 msgid "detect copies"
-msgstr ""
+msgstr "cóipí a bhrath"
 
 msgid "use unmodified files as source to find copies"
-msgstr ""
+msgstr "úsáid comhaid neamh-mhodhnaithe mar fhoinse chun cóipeanna a fháil"
 
 msgid "disable rename detection"
-msgstr ""
+msgstr "díchumasaigh braite athainmnithe"
 
 msgid "use empty blobs as rename source"
-msgstr ""
+msgstr "bain úsáid as blobs folamh mar fhoinse athainmnithe"
 
 msgid "continue listing the history of a file beyond renames"
-msgstr ""
+msgstr "leanúint ar aghaidh ag liostáil stair chomhaid thar athainmneacha"
 
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
 msgstr ""
+"cosc a chur ar athainmniú/braite cóipeála má sháraíonn líon na spriocanna "
+"athainmniúcháin/cóipeála"
 
 msgid "Diff algorithm options"
-msgstr ""
+msgstr "Roghanna algartam Diff"
 
 msgid "produce the smallest possible diff"
-msgstr ""
+msgstr "an difríocht is lú is féidir a tháirgeadh"
 
 msgid "ignore whitespace when comparing lines"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar spás bán agus tú ag comparáid"
 
 msgid "ignore changes in amount of whitespace"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar athruithe i méid an spás bán"
 
 msgid "ignore changes in whitespace at EOL"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar athruithe i spás bán ag EOL"
 
 msgid "ignore carrier-return at the end of line"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar thuairisceán iompróra ag deireadh na líne"
 
 msgid "ignore changes whose lines are all blank"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar athruithe atá a línte bán"
 
 msgid "<regex>"
-msgstr ""
+msgstr "<regex>"
 
 msgid "ignore changes whose all lines match <regex>"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar athruithe a mheaitseann <regex>"
 
 msgid "heuristic to shift diff hunk boundaries for easy reading"
-msgstr ""
+msgstr "heuristic chun teorainneacha éagsúla a aistriú le haghaidh léamh éasca"
 
 msgid "generate diff using the \"patience diff\" algorithm"
-msgstr ""
+msgstr "diff a ghiniúint ag baint úsáide as an algartam “diff foighne”"
 
 msgid "generate diff using the \"histogram diff\" algorithm"
-msgstr ""
+msgstr "diff a ghiniúint ag baint úsáide as an algartam “diff histogram”"
 
 msgid "<text>"
-msgstr ""
+msgstr "<text>"
 
 msgid "generate diff using the \"anchored diff\" algorithm"
-msgstr ""
+msgstr "diff a ghiniúint ag baint úsáide as an algartam “diff ancáraithe”"
 
 msgid "<mode>"
-msgstr ""
+msgstr "<mode>"
 
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
+"taispeáint diff focal, ag baint úsáide as focail <mode>athraithe a theorannú"
 
 msgid "use <regex> to decide what a word is"
-msgstr ""
+msgstr "bain úsáid <regex>as chun cinneadh a dhéanamh cad é focal"
 
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
-msgstr ""
+msgstr "coibhéiseach le --word-diff=color --word-diff-regex=<regex>"
 
 msgid "moved lines of code are colored differently"
-msgstr ""
+msgstr "tá línte cóid bogadh daite difriúil"
 
 msgid "how white spaces are ignored in --color-moved"
-msgstr ""
+msgstr "conas a dhéantar neamhaird de spásanna bána i --color-moved"
 
 msgid "Other diff options"
-msgstr ""
+msgstr "Roghanna diff eile"
 
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
+"nuair a bheidh á rith ó subdir, eisiamh athruithe lasmuigh agus taispeáin "
+"coibhneasta"
 
 msgid "treat all files as text"
-msgstr ""
+msgstr "déileáil le gach comhad mar théacs"
 
 msgid "swap two inputs, reverse the diff"
-msgstr ""
+msgstr "dhá ionchur a mhalartú, an diff a aisiompú"
 
 msgid "exit with 1 if there were differences, 0 otherwise"
-msgstr ""
+msgstr "imeacht le 1 má bhí difríochtaí ann, 0 ar shlí eile"
 
 msgid "disable all output of the program"
-msgstr ""
+msgstr "díchumasú gach aschur an chláir"
 
 msgid "allow an external diff helper to be executed"
-msgstr ""
+msgstr "ligean do chúntóir diff seachtrach a fhorghníomhú"
 
 msgid "run external text conversion filters when comparing binary files"
-msgstr ""
+msgstr "reáchtáil scagairí tiontaithe téacs seachtracha agus comhaid"
 
 msgid "<when>"
-msgstr ""
+msgstr "<when>"
 
 msgid "ignore changes to submodules in the diff generation"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar athruithe ar fho-mhodúil sa ghiniúint diff"
 
-#, fuzzy
 msgid "<format>"
-msgstr "formáid"
+msgstr "<format>"
 
 msgid "specify how differences in submodules are shown"
-msgstr ""
+msgstr "sonraigh conas a thaispeántar na difríochtaí i bhfo-"
 
-#, fuzzy
 msgid "hide 'git add -N' entries from the index"
-msgstr "Nuashonraíodh %d cosán ón innéacs"
+msgstr "folaigh iontrálacha 'git add -N' ón innéacs"
 
 msgid "treat 'git add -N' entries as real in the index"
-msgstr ""
+msgstr "déileáil le hiontrálacha 'git add -N' mar atá fíor san innéacs"
 
 msgid "<string>"
-msgstr ""
+msgstr "<string>"
 
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr ""
+"cuardaigh difríochtaí a athraíonn líon na n-imeachtaí sa sreang sonraithe"
 
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
 msgstr ""
+"cuardaigh difríochtaí a athraíonn líon na n-imeachtaí sa regex sonraithe"
 
 msgid "show all changes in the changeset with -S or -G"
-msgstr ""
+msgstr "taispeáint na hathruithe go léir sa tacar athraithe le -S nó -G"
 
 msgid "treat <string> in -S as extended POSIX regular expression"
-msgstr ""
+msgstr "caitheamh <string>le -S mar léiriú rialta POSIX leathnaithe"
 
 msgid "control the order in which files appear in the output"
-msgstr ""
+msgstr "rialú an t-ord ina bhfuil comhaid le feiceáil san aschur"
 
-#, fuzzy
 msgid "<path>"
-msgstr "cosán"
+msgstr "<path>"
 
 msgid "show the change in the specified path first"
-msgstr ""
+msgstr "taispeáin an t-athrú ar an gcosán sonraithe ar dtús"
 
 msgid "skip the output to the specified path"
-msgstr ""
+msgstr "scipeáil an t-aschur chuig an gcosán sonraithe"
 
 msgid "<object-id>"
-msgstr ""
+msgstr "<object-id>"
 
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
-msgstr ""
+msgstr "cuardaigh difríochtaí a athraíonn líon na n-earraí den réad sonraithe"
 
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
-msgstr ""
+msgstr "[(A|C|D|M|R|T|U|X|B)... [*]]"
 
 msgid "select files by diff type"
-msgstr ""
+msgstr "roghnaigh comhaid de réir cineál diff"
 
 msgid "<file>"
-msgstr ""
+msgstr "<file>"
 
 msgid "output to a specific file"
-msgstr ""
+msgstr "aschur chuig comhad ar leith"
 
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr ""
+"scipeánadh braite athainmnithe uileghabhálach mar gheall ar an iomarca "
+"comhaid."
 
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
+"ní bhfuarthas ach cóipeanna ó chosáin modhnaithe mar gheall ar an iomarca "
+"comhaid."
 
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
 msgstr ""
+"b'fhéidir gur mhaith leat d'athróg %s a shocrú go %d ar a laghad agus "
+"iarracht a dhéanamh arís ar an ordú."
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to read orderfile '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar chomhad ordaithe '%s' a léamh"
 
 msgid "Performing inexact rename detection"
-msgstr ""
+msgstr "Braite athainmnithe míchruinn a dhéanamh"
 
 #, c-format
 msgid "No such path '%s' in the diff"
-msgstr ""
+msgstr "Níl aon chosán den sórt sin '%s' sa diff"
 
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
-msgstr ""
+msgstr "níor mheaitseáil pathspec '%s' aon chomhad (í) ar eolas ag git"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized pattern: '%s'"
-msgstr "aistriú luacha transfer.credentialsInUrl: '%s'"
+msgstr "patrún gan aithint: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized negative pattern: '%s'"
-msgstr "aistriú luacha transfer.credentialsInUrl: '%s'"
+msgstr "patrún diúltach gan aithint: '%s'"
 
 #, c-format
 msgid "your sparse-checkout file may have issues: pattern '%s' is repeated"
 msgstr ""
+"d'fhéadfadh fadhbanna a bheith ag do chomhad seiceála neamhchoitianta: "
+"déantar patrún '%s' arís eile"
 
 msgid "disabling cone pattern matching"
-msgstr ""
+msgstr "meaitseáil patrún cón a dhíchumas"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot use %s as an exclude file"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "ní féidir %s a úsáid mar chomhad eisiata"
 
 msgid "failed to get kernel name and information"
-msgstr ""
+msgstr "theip ar ainm eithne agus faisnéis a fháil"
 
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
+"tá taisce neamhrianaithe díchumasaithe ar an gcóras nó ar an suíomh seo"
 
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
 msgstr ""
+"Ní fhéadfaí aon ainm eolaire a thuairim.\n"
+"Sonraigh eolaire ar an líne ordaithe le do thoil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "index file corrupt in repo %s"
-msgstr "comhad innéacs truaillithe"
+msgstr "comhad innéacs truaillithe i repo %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create directories for %s"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolairí a chruthú do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire git a aistriú ó '%s' go '%s'"
 
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
-msgstr ""
+msgstr "leid: Ag fanacht go ndúnfaidh d'eagarthóir an comhad... %c"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write to '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí scríobh chuig '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not edit '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a chur in eagar"
 
 msgid "Filtering content"
-msgstr ""
+msgstr "Ábhar scagadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not stat file '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí an comhad '%s' a statú"
 
 #, c-format
 msgid "bad git namespace path \"%s\""
-msgstr ""
+msgstr "cosán spás ainmneacha git go dona “%s”"
 
-#, fuzzy, c-format
+#, c-format
 msgid "too many args to run %s"
-msgstr "An iomarca argóintí."
+msgstr "an iomarca args chun %s a rith"
 
 #, c-format
 msgid ""
@@ -16115,165 +16861,168 @@ msgid ""
 "If you are attempting to repair this repo corruption by refetching the "
 "missing object, use 'git fetch --refetch' with the missing object."
 msgstr ""
+"Tá tú ag iarraidh %s a fháil, atá sa chomhad graf tiomanta ach nach bhfuil "
+"sa bhunachar sonraí réada.\n"
+"Is dócha go bhfuil sé seo mar gheall ar éilliú repo.\n"
+"Má tá tú ag iarraidh an éilliú repo seo a dheisiú tríd an réad atá in "
+"easnamh a athghabháil, bain úsáid as 'git fetch --refetch' leis an réad atá "
+"ar iarraidh."
 
 msgid "git fetch-pack: expected shallow list"
-msgstr ""
+msgstr "git fetch-pack: liosta éadomhain a bhfuiltear ag súil leis"
 
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr ""
+"git fetch-pack: bhíothas ag súil le paicéad sruthán tar éis liosta éadrom"
 
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
-msgstr ""
+msgstr "git fetch-pack: ag súil le ACK/NAK, fuair sé paicéad sruthán"
 
-#, fuzzy, c-format
+#, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "git fetch-pack: ag súil le ACK/NAK, fuair '%s'"
 
-#, fuzzy
 msgid "unable to write to remote"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "in ann scríobh chuig iargúlta"
 
 msgid "Server supports filter"
-msgstr ""
+msgstr "Tacaíonn freastalaí le sc"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid shallow line: %s"
-msgstr "réad blob neamhbhailí %s"
+msgstr "líne éadomhain neamhbhailí: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid unshallow line: %s"
-msgstr "réad blob neamhbhailí %s"
+msgstr "líne neamhéadrom neamhbhailí: %s"
 
 #, c-format
 msgid "object not found: %s"
-msgstr ""
+msgstr "níor aimsíodh réad: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "error in object: %s"
-msgstr "fsck earráid i rudaí pacáiste"
+msgstr "earráid i réad: %s"
 
 #, c-format
 msgid "no shallow found: %s"
-msgstr ""
+msgstr "níl aon éadrom aimsithe: %s"
 
 #, c-format
 msgid "expected shallow/unshallow, got %s"
-msgstr ""
+msgstr "bhíothas ag súil leis íol/neamhéadrom, fuair %s"
 
 #, c-format
 msgid "got %s %d %s"
-msgstr ""
+msgstr "fuair %s %d %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid commit %s"
-msgstr "%s neamhbhailí"
+msgstr "tiomantas neamhbhailí %s"
 
 msgid "giving up"
-msgstr ""
+msgstr "tabhairt suas"
 
-#, fuzzy
 msgid "done"
-msgstr "déanta.\n"
+msgstr "déanta"
 
 #, c-format
 msgid "got %s (%d) %s"
-msgstr ""
+msgstr "fuair %s (%d) %s"
 
 #, c-format
 msgid "Marking %s as complete"
-msgstr ""
+msgstr "Mharcáil %s mar iomlán"
 
 #, c-format
 msgid "already have %s (%s)"
-msgstr ""
+msgstr "tá %s ann cheana féin (%s)"
 
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
-msgstr ""
+msgstr "pacáiste tarchuir: ní féidir le démultiplexer banna taobh a fhorc"
 
 msgid "protocol error: bad pack header"
-msgstr ""
+msgstr "earráid prótacal: ceanntásc an phacá"
 
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
-msgstr ""
+msgstr "fetch-pack: ní féidir %s a fhorc"
 
 msgid "fetch-pack: invalid index-pack output"
-msgstr ""
+msgstr "fetch-pack: aschur pacáiste innéacs-neamhbhailí"
 
 #, c-format
 msgid "%s failed"
-msgstr ""
+msgstr "Theip ar %s"
 
 msgid "error in sideband demultiplexer"
-msgstr ""
+msgstr "earráid i demultiplexer taobhbanna"
 
 #, c-format
 msgid "Server version is %.*s"
-msgstr ""
+msgstr "Is é leagan freastalaí %.*s"
 
 #, c-format
 msgid "Server supports %s"
-msgstr ""
+msgstr "Tacaíonn freastalaí le %s"
 
 msgid "Server does not support shallow clients"
-msgstr ""
+msgstr "Ní thacaíonn freastalaí le cliaint éadrom"
 
 msgid "Server does not support --shallow-since"
-msgstr ""
+msgstr "Ní thacaíonn freastalaí le --shallow-since"
 
 msgid "Server does not support --shallow-exclude"
-msgstr ""
+msgstr "Ní thacaíonn freastalaí le --shallow-exclude"
 
 msgid "Server does not support --deepen"
-msgstr ""
+msgstr "Ní thacaíonn freastalaí le --deepen"
 
 msgid "Server does not support this repository's object format"
-msgstr ""
+msgstr "Ní thacaíonn freastalaí le formáid réad an stór seo"
 
-#, fuzzy
 msgid "no common commits"
-msgstr "aon rud le tiomantas\n"
+msgstr "gan aon gealltanais choiteann"
 
 msgid "git fetch-pack: fetch failed."
-msgstr ""
+msgstr "git fetch-pack: theip ar fáil."
 
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
-msgstr ""
+msgstr "halgartaim míchomhoiriúnach: cliant %s; freastalaí %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "the server does not support algorithm '%s'"
-msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
+msgstr "ní thacaíonn an freastalaí algartam '%s'"
 
 msgid "Server does not support shallow requests"
-msgstr ""
+msgstr "Ní thacaíonn an freastalaí le hiarratais"
 
-#, fuzzy
 msgid "unable to write request to remote"
-msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+msgstr "in ann iarratas a scríobh chuig iargúlta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "expected '%s', received '%s'"
-msgstr "tá %s ag teastáil don rogha '%s'"
+msgstr "bhíothas ag súil le '%s', fuarthas '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "expected '%s'"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "ag súil le '%s'"
 
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
-msgstr ""
+msgstr "líne admhaithe gan choinne: '%s'"
 
 #, c-format
 msgid "error processing acks: %d"
-msgstr ""
+msgstr "earráidí próiseála earráide: %d"
 
 #. TRANSLATORS: The parameter will be 'ready', a protocol
 #. keyword.
 #.
 #, c-format
 msgid "expected packfile to be sent after '%s'"
-msgstr ""
+msgstr "táthar ag súil go seolfar pacáid tar éis '%s'"
 
 #. TRANSLATORS: The parameter will be 'ready', a protocol
 #. keyword.
@@ -16281,76 +17030,79 @@ msgstr ""
 #, c-format
 msgid "expected no other sections to be sent after no '%s'"
 msgstr ""
+"bhíothas ag súil nach gcuirfear aon chuid eile a sheoladh tar éis gan '%s'"
 
 #, c-format
 msgid "error processing shallow info: %d"
-msgstr ""
+msgstr "earráid ag próiseáil faisnéis éadrom: %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "expected wanted-ref, got '%s'"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "bhíothas ag súil leis an tagairt a theastaigh, fuair '%s'"
 
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
-msgstr ""
+msgstr "gan choinne wanted-ref: '%s'"
 
 #, c-format
 msgid "error processing wanted refs: %d"
-msgstr ""
+msgstr "próiseáil earráidí a theastaíonn referens: %d"
 
 msgid "git fetch-pack: expected response end packet"
-msgstr ""
+msgstr "git fetch-pack: paicéad deiridh freagartha ag súil leis"
 
 msgid "no matching remote head"
-msgstr ""
+msgstr "gan ceann iargúlta meaitseála"
 
 msgid "unexpected 'ready' from remote"
-msgstr ""
+msgstr "gan choinne 'réidh' ó iargúlta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such remote ref %s"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "aon tagairt iargúlta den sórt sin %s"
 
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
-msgstr ""
+msgstr "Ní cheadaíonn freastalaí iarraidh ar réad neamhfhógraithe %s"
 
 #, c-format
 msgid "fsmonitor_ipc__send_query: invalid path '%s'"
-msgstr ""
+msgstr "fsmonitor_ipc__send_query: cosán neamhbhailí '%s'"
 
 #, c-format
 msgid "fsmonitor_ipc__send_query: unspecified error on '%s'"
-msgstr ""
+msgstr "fsmonitor_ipc__send_query: earráid neamhshonraithe ar '%s'"
 
 msgid "fsmonitor--daemon is not running"
-msgstr ""
+msgstr "níl fsmonitor--daemon ag rith"
 
 #, c-format
 msgid "could not send '%s' command to fsmonitor--daemon"
-msgstr ""
+msgstr "ní fhéadfaí ordú '%s' a sheoladh chuig fsmonitor--daemon"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bare repository '%s' is incompatible with fsmonitor"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl stór lom '%s' neamhoiriúnach le fsmonitor"
 
 #, c-format
 msgid "repository '%s' is incompatible with fsmonitor due to errors"
-msgstr ""
+msgstr "tá stór '%s' neamh-chomhoiriúnach le fsmonitor de bharr earráidí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "remote repository '%s' is incompatible with fsmonitor"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl stór iargúlta '%s' neamhoiriúnach le fsmonitor"
 
 #, c-format
 msgid "virtual repository '%s' is incompatible with fsmonitor"
-msgstr ""
+msgstr "níl stór fíorúil '%s' neamhoiriúnach le fsmonitor"
 
 #, c-format
 msgid ""
 "socket directory '%s' is incompatible with fsmonitor due to lack of Unix "
 "sockets support"
 msgstr ""
+"tá eolaire soicéad '%s' neamhoiriúnach le fsmonitor mar gheall ar easpa "
+"tacaíochta soicéid Unix"
 
 msgid ""
 "git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]\n"
@@ -16362,6 +17114,14 @@ msgid ""
 "env=<name>=<envvar>]\n"
 "           <command> [<args>]"
 msgstr ""
+"git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]\n"
+"           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n"
+"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--no-"
+"lazy-fetch]\n"
+"           [--no-optional-locks] [--no-advice] [--bare] [--git-dir=<path>]\n"
+"           [--work-tree=<path>] [--namespace=<name>] [--config-"
+"env=<name>=<envvar>]\n"
+"           <command> [<args>]"
 
 msgid ""
 "'git help -a' and 'git help -g' list available subcommands and some\n"
@@ -16369,270 +17129,298 @@ msgid ""
 "to read about a specific subcommand or concept.\n"
 "See 'git help git' for an overview of the system."
 msgstr ""
+"Liostaíonn 'git help -a' agus 'git help -g' fo-orduithe atá ar fáil agus "
+"roinnt\n"
+"treoracha coincheap. <concept>Féach 'git cabhr <command>'nó 'git cabhr'\n"
+"léamh faoi fho-ordú nó coincheap ar leith.\n"
+"Féach 'git help git' le haghaidh forbhreathnú ar an gcóras."
 
 #, c-format
 msgid "unsupported command listing type '%s'"
-msgstr ""
+msgstr "cineál liostaithe ordaithe gan tacaíocht '%s'"
 
 #, c-format
 msgid "no directory given for '%s' option\n"
-msgstr ""
+msgstr "níl aon eolaire tugtha do rogha '%s'\n"
 
 #, c-format
 msgid "no namespace given for --namespace\n"
-msgstr ""
+msgstr "aon spás ainmneacha a thugtar do --namespace\n"
 
 #, c-format
 msgid "-c expects a configuration string\n"
-msgstr ""
+msgstr "-c ag súil le teaghrán cumraíochta\n"
 
 #, c-format
 msgid "no config key given for --config-env\n"
-msgstr ""
+msgstr "níl aon eochair chumraithe tugtha do --config-env\n"
 
 #, c-format
 msgid "no attribute source given for --attr-source\n"
-msgstr ""
+msgstr "níor tugadh foinse tréith do --attr-source\n"
 
 #, c-format
 msgid "unknown option: %s\n"
-msgstr ""
+msgstr "rogha anaithnid: %s\n"
 
 #, c-format
 msgid "while expanding alias '%s': '%s'"
-msgstr ""
+msgstr "agus ainm '%s' á leathnú: '%s'"
 
 #, c-format
 msgid ""
 "alias '%s' changes environment variables.\n"
 "You can use '!git' in the alias to do this"
 msgstr ""
+"athraíonn alias '%s' athróga comhshaoil.\n"
+"Is féidir leat úsáid a bhaint as '!git' san alias chun é seo a dhéanamh"
 
 #, c-format
 msgid "empty alias for %s"
-msgstr ""
+msgstr "alias folamh do %s"
 
 #, c-format
 msgid "recursive alias: %s"
-msgstr ""
+msgstr "ainm athfhillteach: %s"
 
 msgid "write failure on standard output"
-msgstr ""
+msgstr "teip scríobh ar aschur caighdeánach"
 
 msgid "unknown write failure on standard output"
-msgstr ""
+msgstr "teip scríbhneoireachta anaithnid ar aschur"
 
 msgid "close failed on standard output"
-msgstr ""
+msgstr "theip ar dhún ar aschur caighdeánach"
 
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
-msgstr ""
+msgstr "aimsíodh lúb alias: ní chuirtear deireadh le leathnú '%s': %s"
 
 #, c-format
 msgid "cannot handle %s as a builtin"
-msgstr ""
+msgstr "ní féidir %s a láimhseáil mar thógáil"
 
 #, c-format
 msgid ""
 "usage: %s\n"
 "\n"
 msgstr ""
+"úsáid: %s\n"
+"\n"
 
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
-msgstr ""
+msgstr "theip ar leathnú an leasainm '%s'; ní ordú git é '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to run command '%s': %s\n"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ort an t-ordú '%s' a reáchtáil: %s\n"
 
-#, fuzzy
 msgid "could not create temporary file"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí comhad sealadach a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed writing detached signature to '%s'"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar shíniú scoite a scríobh chuig '%s'"
 
 msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
 msgstr ""
+"ní mór gpg.ssh.allowedSignersFile a chumrú agus a bheith ann le haghaidh "
+"fíorú sínithe ssh"
 
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
 msgstr ""
+"tá gá le ssh-keygen -Y aimsithe/fíorú le haghaidh fíorú sínithe ssh (ar fáil "
+"i leagan openssh 8.2p1 +)"
 
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
-msgstr ""
+msgstr "comhad cúlghairm sínithe ssh cumraithe ach níor aimsíodh: %s"
 
 #, c-format
 msgid "bad/incompatible signature '%s'"
-msgstr ""
+msgstr "síniú droch-/neamhchomhoiriúnach '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
-msgstr "theip ar an iterator a thosú thar '%s'"
+msgstr "theip ar mhéarloirg ssh a fháil don eochair '%s'"
 
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
-msgstr ""
+msgstr "is gá user.signingkey nó gpg.ssh.defaultKeyCommand a chumrú"
 
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
 msgstr ""
+"d’éirigh le gpg.ssh.defaultKeyCommand ach níor tugadh aon eochracha ar ais: "
+"%s %s"
 
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
-msgstr ""
+msgstr "theip ar gpg.ssh.defaultKeyCommand: %s %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "gpg failed to sign the data:\n"
 "%s"
-msgstr "theip ar '%s' a stáil"
+msgstr ""
+"theip ar gpg na sonraí a shíniú:\n"
+"%s"
 
 msgid "user.signingKey needs to be set for ssh signing"
-msgstr ""
+msgstr "ní mór user.signingKey a shocrú le haghaidh síniú ssh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed writing ssh signing key to '%s'"
-msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+msgstr "theip ar an eochair sínithe ssh a scríobh chuig '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
-msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+msgstr "theip ar scríobh ssh a shíniú maolán eochair chuig '%s'"
 
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
 msgstr ""
+"ssh-keygen -Y comhartha ag teastáil le haghaidh síniú ssh (ar fáil i leagan "
+"openssh 8.2p1+)"
 
 #, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
-msgstr ""
+msgstr "theip ar mhaolán sonraí sínithe ssh a léamh ó '%s'"
 
 #, c-format
 msgid "ignored invalid color '%.*s' in log.graphColors"
-msgstr ""
+msgstr "neamhaird ar dhath neamhbhailí '%.*s' i log.graphColors"
 
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
 msgstr ""
+"tá byte NULL (trí -f<file>) i bpatrún tugtha. Ní thacaítear leis seo ach le "
+"-P faoi PCRE v2"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s': unable to read %s"
-msgstr "nach féidir %s a léamh"
+msgstr "'%s': ní féidir %s a léamh"
 
 #, c-format
 msgid "'%s': short read"
-msgstr ""
+msgstr "'%s': léamh gearr"
 
 msgid "start a working area (see also: git help tutorial)"
-msgstr ""
+msgstr "tús a chur le limistéar oibre (féach freisin: teagaisc cabhrach git)"
 
 msgid "work on the current change (see also: git help everyday)"
-msgstr ""
+msgstr "obair ar an athrú reatha (féach freisin: git help gach lá)"
 
 msgid "examine the history and state (see also: git help revisions)"
 msgstr ""
+"scrúdú a dhéanamh ar an stair agus an stát (féach freisin: athbhreithnithe "
+"cabhrach git)"
 
 msgid "grow, mark and tweak your common history"
-msgstr ""
+msgstr "do stair choiteann a fhás, a mharcáil agus a athrú"
 
 msgid "collaborate (see also: git help workflows)"
-msgstr ""
+msgstr "comhoibriú (féach freisin: sreafaí oibre cabhrach git)"
 
 msgid "Main Porcelain Commands"
-msgstr ""
+msgstr "Príomh-Orduithe Poirce"
 
 msgid "Ancillary Commands / Manipulators"
-msgstr ""
+msgstr "Orduithe Coimhdeachta/Ionramhálaí"
 
 msgid "Ancillary Commands / Interrogators"
-msgstr ""
+msgstr "Orduithe Coimhdeacha/Ceisteoirí"
 
 msgid "Interacting with Others"
-msgstr ""
+msgstr "Idirghníomhú le daoine eile"
 
 msgid "Low-level Commands / Manipulators"
-msgstr ""
+msgstr "Orduithe Ísealleibhéil/Ionramhálaithe"
 
 msgid "Low-level Commands / Interrogators"
-msgstr ""
+msgstr "Orduithe ísealleibhéil/ceisteoirí"
 
 msgid "Low-level Commands / Syncing Repositories"
-msgstr ""
+msgstr "Orduithe Leibhéal Íseal/Stóráin Sioncrónaithe"
 
 msgid "Low-level Commands / Internal Helpers"
-msgstr ""
+msgstr "Orduithe Leibhéal Íseal/Cúntóirí Inmheánacha"
 
 msgid "User-facing repository, command and file interfaces"
-msgstr ""
+msgstr "Comhéadain stór, ordaithe agus comhad atá os comhair úsáideora"
 
 msgid "Developer-facing file formats, protocols and other interfaces"
 msgstr ""
+"Formáidí comhaid, prótacail agus comhéadain eile atá os comhair an fhorbróra"
 
-#, fuzzy, c-format
+#, c-format
 msgid "available git commands in '%s'"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "orduithe git atá ar fáil i '%s'"
 
 msgid "git commands available from elsewhere on your $PATH"
-msgstr ""
+msgstr "orduithe git ar fáil ó áiteanna eile ar do $PATH"
 
 msgid "These are common Git commands used in various situations:"
-msgstr ""
+msgstr "Seo orduithe coitianta Git a úsáidtear i gcásanna éagsúla:"
 
 msgid "The Git concept guides are:"
-msgstr ""
+msgstr "Is iad na treoracha coincheap Git:"
 
 msgid "User-facing repository, command and file interfaces:"
-msgstr ""
+msgstr "Stóráil, ordaithe agus comhéadain comhad atá os comhair úsáideora:"
 
 msgid "File formats, protocols and other developer interfaces:"
-msgstr ""
+msgstr "Formáidí comhaid, prótacail agus comhéadain forbróra eile:"
 
 msgid "External commands"
-msgstr ""
+msgstr "Orduithe seachtracha"
 
 msgid "Command aliases"
-msgstr ""
+msgstr "Ainmneacha ordaithe"
 
 msgid "See 'git help <command>' to read about a specific subcommand"
-msgstr ""
+msgstr "Féach 'git help <command>'chun léamh faoi fho-ordú ar leith"
 
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
 "able to execute it. Maybe git-%s is broken?"
 msgstr ""
+"Is cosúil gur ordú git é '%s', ach ní raibh muid\n"
+"in ann é a fhorghníomhú. B'fhéidir go bhfuil git-%s briste?"
 
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
-msgstr ""
+msgstr "git: Ní ordú git é '%s'. Féach 'git --help'."
 
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr ""
+"Ó, a Dhia. Ní thuairiscíonn do chóras aon orduithe Git ar chor ar bith."
 
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
-msgstr ""
+msgstr "RABHADH: Ghlaoigh tú ordú Git darb ainm '%s', nach bhfuil ann."
 
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
-msgstr ""
+msgstr "Ag leanúint faoin toimhde gur chiallaigh tú '%s'."
 
 #, c-format
 msgid "Run '%s' instead [y/N]? "
-msgstr ""
+msgstr "Rith '%s' ina ionad sin [y/N]? "
 
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr ""
+"Ag leanúint ar aghaidh i %0.1f soicind, ag glacadh leis gur chiallaigh tú "
+"'%s'."
 
 msgid ""
 "\n"
@@ -16641,15 +17429,21 @@ msgid_plural ""
 "\n"
 "The most similar commands are"
 msgstr[0] ""
+"\n"
+"Is é an t-ordú is cosúla ná"
 msgstr[1] ""
+"\n"
+"Is iad na horduithe is cosúla ná"
 msgstr[2] ""
+"\n"
+"Is iad na horduithe is cosúla ná"
 
 msgid "git version [--build-options]"
-msgstr ""
+msgstr "leagan git [--build-options]"
 
 #, c-format
 msgid "%s: %s - %s"
-msgstr ""
+msgstr "%s: %s - %s"
 
 msgid ""
 "\n"
@@ -16658,54 +17452,65 @@ msgid_plural ""
 "\n"
 "Did you mean one of these?"
 msgstr[0] ""
+"\n"
+"An raibh sé seo i gceist agat?"
 msgstr[1] ""
+"\n"
+"An raibh ceann acu seo i gceist agat?"
 msgstr[2] ""
+"\n"
+"An raibh ceann acu seo i gceist agat?"
 
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
 "You can disable this warning with `git config set advice.ignoredHook false`."
 msgstr ""
+"Rinneadh neamhaird ar an gcroca '%s' toisc nach bhfuil sé socraithe mar "
+"infheidhmithe.\n"
+"Is féidir leat an rabhadh seo a dhíchumasú le `git config set "
+"advice.ignoredHook false `."
 
-#, fuzzy
 msgid "not a git repository"
-msgstr "stóras lom a chruthú"
+msgstr "ní stór git"
 
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr ""
+"caithfidh argóint chuig --packfile a bheith ina hash bailí (fuair '%s')"
 
 #, c-format
 msgid "negative value for http.postBuffer; defaulting to %d"
-msgstr ""
+msgstr "luach diúltach do http.postBuffer; réamhshocraithe go %d"
 
 msgid "Delegation control is not supported with cURL < 7.22.0"
-msgstr ""
+msgstr "Ní thacaítear le cURL <7.22.0 le rialú tarscaireachta"
 
 msgid "Unknown value for http.proactiveauth"
-msgstr ""
+msgstr "Luach anaithnid do http.proactiveauth"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to parse %s"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar %s a pharsáil"
 
 #, c-format
 msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
-msgstr ""
+msgstr "'%s' cúltaca SSL gan tacaíocht. Cúltaca SSL tacaithe:"
 
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
-msgstr ""
+msgstr "Níor féidir cúltaca SSL a shocrú go '%s': Tógadh cURL gan cúltaca SSL"
 
 #, c-format
 msgid "Could not set SSL backend to '%s': already set"
-msgstr ""
+msgstr "Níorbh fhéidir cúltaca SSL a shocrú go '%s': socraithe cheana féin"
 
 msgid "refusing to read cookies from http.cookiefile '-'"
-msgstr ""
+msgstr "diúltú fianáin a léamh ó http.cookiefile '-'"
 
 msgid "ignoring http.savecookies for empty http.cookiefile"
 msgstr ""
+"neamhaird a dhéanamh ar http.savecookies le haghaidh http.cookiefile folamh"
 
 #, c-format
 msgid ""
@@ -16713,12 +17518,15 @@ msgid ""
 "  asked for: %s\n"
 "   redirect: %s"
 msgstr ""
+"in ann bonn url a nuashonrú ó atreorú:\n"
+" iarrtha ar: %s\n"
+" atreorú: %s"
 
 msgid "Author identity unknown\n"
-msgstr ""
+msgstr "Céannacht an údair anaithnid\n"
 
 msgid "Committer identity unknown\n"
-msgstr ""
+msgstr "Céannacht an chomórtais anaithnid\n"
 
 msgid ""
 "\n"
@@ -16733,81 +17541,91 @@ msgid ""
 "Omit --global to set the identity only in this repository.\n"
 "\n"
 msgstr ""
+"\n"
+"*** Inis dom cé tú féin, le do thoil.\n"
+"\n"
+"Rith\n"
+"\n"
+"  git config --global user.email \"you@example.com”\n"
+"  git config --global user.name “Do Ainm”\n"
+"\n"
+"chun féiniúlacht réamhshocraithe do chuntais a shocrú.\n"
+"Fág --global chun an aitheantas a shocrú sa stór seo amháin.\n"
 
 msgid "no email was given and auto-detection is disabled"
-msgstr ""
+msgstr "níor tugadh aon ríomhphost agus tá brath uathoibríoch faoi"
 
 #, c-format
 msgid "unable to auto-detect email address (got '%s')"
-msgstr ""
+msgstr "in ann seoladh ríomhphoist a bhrath go huathoibríoch (fuair '%s')"
 
 msgid "no name was given and auto-detection is disabled"
-msgstr ""
+msgstr "ní tugadh aon ainm agus tá brath uathoibríoch faoi dhíchum"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to auto-detect name (got '%s')"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "ní féidir ainm a bhrath go huathoibríoch (fuair '%s')"
 
 #, c-format
 msgid "empty ident name (for <%s>) not allowed"
-msgstr ""
+msgstr "ainm ident folamh (le haghaidh <%s>) nach gceadaítear"
 
 #, c-format
 msgid "name consists only of disallowed characters: %s"
-msgstr ""
+msgstr "ní chuimsíonn ainm ach carachtair neamh-cheadaithe: %s"
 
 msgid "expected 'tree:<depth>'"
-msgstr ""
+msgstr "<depth>'crann ag súil leis: '"
 
 msgid "sparse:path filters support has been dropped"
-msgstr ""
+msgstr "neamhchoitianta: tá tacaíocht scagairí cosáin titim"
 
 #, c-format
 msgid "'%s' for 'object:type=<type>' is not a valid object type"
-msgstr ""
+msgstr "<type>Ní cineál réad bailí é '%s' le haghaidh 'object:type='"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid filter-spec '%s'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "scagaire neamhbhailí '%s'"
 
 #, c-format
 msgid "must escape char in sub-filter-spec: '%c'"
-msgstr ""
+msgstr "ní mór don char a éalú i sub-filter-spec: '%c'"
 
 msgid "expected something after combine:"
-msgstr ""
+msgstr "ag súil le rud éigin tar éis an chomhcheangail:"
 
 msgid "multiple filter-specs cannot be combined"
-msgstr ""
+msgstr "ní féidir ilshonraíochtaí scagaire a chomhcheangal"
 
 msgid "unable to upgrade repository format to support partial clone"
-msgstr ""
+msgstr "in ann formáid stórais a uasghrádú chun tacú le clón páirteach"
 
 msgid "args"
-msgstr ""
+msgstr "args"
 
 msgid "object filtering"
-msgstr ""
+msgstr "scagadh réad"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to access sparse blob in '%s'"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "ní féidir rochtain a fháil ar bhlob neamhchoitianta i '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse sparse filter data in %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir sonraí scagaire neamhchoitianta a pháirseáil i %s"
 
 #, c-format
 msgid "entry '%s' in tree %s has tree mode, but is not a tree"
-msgstr ""
+msgstr "tá modh crann ag iontráil '%s' i gcrann %s, ach ní crann í"
 
 #, c-format
 msgid "entry '%s' in tree %s has blob mode, but is not a blob"
-msgstr ""
+msgstr "tá modh blob ag iontráil '%s' i gcrann %s, ach ní blob í"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to load root tree for commit %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir crann fréimhe a luchtú le haghaidh tiomanta %s"
 
 #, c-format
 msgid ""
@@ -16819,107 +17637,122 @@ msgid ""
 "may have crashed in this repository earlier:\n"
 "remove the file manually to continue."
 msgstr ""
+"Ní féidir '%s.lock' a chruthú: %s.\n"
+"\n"
+"Is cosúil go bhfuil próiseas git eile ag rith sa stór seo, e.g.\n"
+"eagarthóir a osclaíodh ag 'git commit'. Déan cinnte le do thoil gach "
+"próiseas\n"
+"foirceanntar ansin déan iarracht arís. Má theipeann air fós, próiseas git\n"
+"d'fhéadfadh go mbeadh sé titim sa stór seo níos luaithe:\n"
+"bain an comhad de láimh chun leanúint ar aghaidh."
 
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to create '%s.lock': %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "Ní féidir '%s.lock' a chruthú: %s"
 
-#, fuzzy
 msgid "unable to create temporary object directory"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "in ann eolaire réad sealadach a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write loose object index %s"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí innéacs réad scaoilte %s a scrí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to write loose object index %s"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar innéacs réad scaoilte %s a scríobh"
 
 #, c-format
 msgid "unexpected line: '%s'"
-msgstr ""
+msgstr "líne gan choinne: '%s'"
 
 msgid "expected flush after ls-refs arguments"
-msgstr ""
+msgstr "súil le sruth tar éis argóintí ls-refs"
 
 msgid "quoted CRLF detected"
-msgstr ""
+msgstr "braithíodh CRLF a luaitear"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to format message: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir teachtaireacht a fhormáidiú: %s"
 
 #, c-format
 msgid "invalid marker-size '%s', expecting an integer"
-msgstr ""
+msgstr "méid marcóra neamhbhailí '%s', ag súil le sláimhir"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not parse object '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Ní fhéadfaí réad '%s' a pháirseáil"
 
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
-msgstr ""
+msgstr "Theip ar fho-mhodúl %s a chumasc (níor seiceáiltear amach)"
 
 #, c-format
 msgid "Failed to merge submodule %s (no merge base)"
-msgstr ""
+msgstr "Theip ar fho-mhodúl %s a chumasc (gan aon bhonn cumaisc)"
 
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
-msgstr ""
+msgstr "Theip ar fho-mhodúl %s a chumasc (níl gealltanas ann)"
 
 #, c-format
 msgid "error: failed to merge submodule %s (repository corrupt)"
-msgstr ""
+msgstr "earráid: theip ar fho-mhodúl %s a chumasc (stór truaillithe)"
 
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
-msgstr ""
+msgstr "Theip ar fho-mhodúl %s a chumasc (ní leanann gealltanna cumaisc bonn)"
 
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
-msgstr ""
+msgstr "Nóta: Fo-mhodúl %s a chur ar aghaidh go tapa chuig %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to merge submodule %s"
-msgstr "theip ar athrá thar '%s'"
+msgstr "Theip ar fho-mhodúl %s a chumasc"
 
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists: %s"
 msgstr ""
+"Theip ar fho-mhodúl %s a chumasc, ach tá réiteach cumaisc féideartha ann: %s"
 
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
+"Theip ar fho-mhodúl %s a chumasc, ach tá go leor cumaisc féideartha ann:\n"
+"%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "error: failed to execute internal merge for %s"
-msgstr "theip ar athrá thar '%s'"
+msgstr "earráid: theip ar chumasc inmheánach a chur i gcrích le haghaidh %s"
 
 #, c-format
 msgid "error: unable to add %s to database"
-msgstr ""
+msgstr "earráid: ní féidir %s a chur leis an mbunachar sonraí"
 
 #, c-format
 msgid "Auto-merging %s"
-msgstr ""
+msgstr "Cumaisc uathoibríoch %s"
 
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
 "implicit directory rename(s) putting the following path(s) there: %s."
 msgstr ""
+"COIMHLINT (athainmniú intuigthe dir): Comhad/dir atá ann cheana ag %s i "
+"mbealach athainmniú eolaire intuigthe ag cur na cosáin seo a leanas ann: %s."
 
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
 "implicit directory renames tried to put these paths there: %s"
 msgstr ""
+"CONFLICT (athainmniú intuigthe): Ní féidir níos mó ná cosán amháin a mhapáil "
+"chuig %s; rinne athainmneacha eolaire intuigthe iarracht na cosáin seo a "
+"chur ann: %s"
 
 #, c-format
 msgid ""
@@ -16927,40 +17760,57 @@ msgid ""
 "renamed to multiple other directories, with no destination getting a "
 "majority of the files."
 msgstr ""
+"CONFLICT (scoilt athainmniú eolaire): Níl soiléir cá háit le %s a "
+"athainmniú; athainmníodh é go eolairí éagsúla eile, gan aon cheann scríbe a "
+"fháil tromlach na gcomhaid."
 
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
 "renamed."
 msgstr ""
+"RABHADH: Seachaint %s a chur i bhfeidhm -> %s a athainmniú go %s, toisc gur "
+"athainmníodh %s féin."
 
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
 "moving it to %s."
 msgstr ""
+"Conair nuashonraithe: Cuireadh %s isteach i %s taobh istigh de eolaire a "
+"athainmníodh i %s; ag bogadh é go %s."
 
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
 "%s; moving it to %s."
 msgstr ""
+"Conair nuashonraithe: Athainmníodh %s go %s i %s, taobh istigh de eolaire a "
+"athainmníodh i %s; é ag bogadh go %s."
 
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
 "in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
+"COIMHLINT (suíomh comhaid): Cuireadh %s isteach i %s taobh istigh de eolaire "
+"a athainmníodh i %s, rud a thugann le tuiscint gur cheart é a aistriú go %s "
+"b'fhéidir."
 
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
 "was renamed in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
+"COIMHLINT (suíomh comhaid): Athainmníodh %s go %s i %s, taobh istigh de "
+"eolaire a athainmníodh i %s, ag moladh gur cheart é a aistriú go %s "
+"b'fhéidir."
 
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
+"COIMHLINT (athainmniú/athainmniú): Athainmníodh %s go %s i %s agus go %s i "
+"%s."
 
 #, c-format
 msgid ""
@@ -16968,55 +17818,70 @@ msgid ""
 "conflicts AND collides with another path; this may result in nested conflict "
 "markers."
 msgstr ""
+"COIMHLINT (athainmniú a bhaineann le imbhualadh): athainmnigh %s -> tá "
+"coinbhleachtaí ábhair ag %s AGUS imbhuaileann sé le cosán eile; d'fhéadfadh "
+"marcóirí coinbhleachta neadaithe a bheith mar thoradh air seo."
 
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
+"COIMHLINT (athainmniú/scrios): Athainmníodh %s go %s i %s, ach scriosadh é i "
+"%s."
 
-#, fuzzy, c-format
+#, c-format
 msgid "error: cannot read object %s"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "earráid: ní féidir réad %s a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "error: object %s is not a blob"
-msgstr "tá réad áitiúil %s truaillithe"
+msgstr "earráid: ní blob é réad %s"
 
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
 msgstr ""
+"CONFLICT (comhad/eolaire): eolaire ar bhealach %s ó %s; é a bhogadh go %s "
+"ina ionad."
 
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
 "of them so each can be recorded somewhere."
 msgstr ""
+"COIMHLINT (cineálacha ar leith): Bhí cineálacha difriúla ag %s ar gach "
+"taobh; athainmníodh an dá cheann ionas gur féidir gach ceann a thaifeadadh "
+"áit éigin."
 
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
 "of them so each can be recorded somewhere."
 msgstr ""
+"COIMHLINT (cineálacha ar leith): Bhí cineálacha difriúla ag %s ar gach "
+"taobh; athainmníodh ceann acu ionas gur féidir gach ceann a thaifeadadh áit "
+"éigin."
 
 msgid "content"
-msgstr ""
+msgstr "ábhar"
 
 msgid "add/add"
-msgstr ""
+msgstr "cuirte/cuir leis"
 
 msgid "submodule"
-msgstr ""
+msgstr "fo-mhodúl"
 
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
-msgstr ""
+msgstr "COIMHLINT (%s): Cumaisc coinbhleacht i %s"
 
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
 "of %s left in tree."
 msgstr ""
+"CONFLICT (modhnó/scriosadh): Scriosta %s i %s agus modhnaithe i %s. Tá "
+"leagan %s de %s fágtha sa chrann."
 
 #. TRANSLATORS: This is a line of advice to resolve a merge
 #. conflict in a submodule. The first argument is the submodule
@@ -17029,6 +17894,9 @@ msgid ""
 " - go to submodule (%s), and either merge commit %s\n"
 "   or update to an existing commit which has merged those changes\n"
 msgstr ""
+" - téigh go dtí an fo-mhodúl (%s), agus cumasc an tiomantas %s\n"
+"   nó nuashonraigh chuig tiomantas atá ann cheana féin a bhfuil na "
+"hathruithe sin cumasctha aige.\n"
 
 #, c-format
 msgid ""
@@ -17043,270 +17911,278 @@ msgid ""
 " - resolve any other conflicts in the superproject\n"
 " - commit the resulting index in the superproject\n"
 msgstr ""
+"Faoi láthair ní thacaíonn cumasc athfhillteach le fo-mhodúil ach le cásanna "
+"míbhá\n"
+"Láimhseáil le cumasc gach fo-mhodúl coimhlinte de láimh le do thoil.\n"
+"Is féidir é seo a chur i gcrích leis na céimeanna seo a leanas:\n"
+"%s - teacht ar ais chuig superproject agus rith:\n"
+"\n"
+"      git add %s\n"
+"\n"
+" chun an cumasc thuas nó nuashonrú a thaifead\n"
+" - aon choimhlintí eile sa superproject a réiteach\n"
+" - an t-innéacs mar thoradh air a thiomnú sa sárthionscadal\n"
 
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
-msgstr ""
+msgstr "theip ar fhaisnéis chumaisc a bhailiú do chrainn %s, %s, %s"
 
-#, fuzzy
 msgid "failed to read the cache"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar an taisce a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to add packfile '%s'"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar chomhad pacáiste '%s' a chur leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to open pack-index '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar innéacs pacáiste '%s' a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to locate object %d in packfile"
-msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
+msgstr "theip ar réad %d a aimsiú i packfile"
 
-#, fuzzy
 msgid "cannot store reverse index file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "ní féidir comhad innéacs droim a stóráil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse line: %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí líne a pháirseáil: %s"
 
 #, c-format
 msgid "malformed line: %s"
-msgstr ""
+msgstr "líne mhífhoirmithe: %s"
 
-#, fuzzy
 msgid "could not load pack"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí pacáiste a luchtú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not open index for %s"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní raibh in ann innéacs a oscailt do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to link '%s' to '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "ní féidir '%s' a nascadh le '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to clear multi-pack-index at %s"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar innéacs il-phacáiste a ghlanadh ag %s"
 
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr ""
+"neamhaird a dhéanamh ar innéacs il-phacáiste atá ann cheana; mímheaitseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not load reverse index for MIDX %s"
-msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
+msgstr "ní fhéadfaí innéacs droim a luchtú do MIDX %s"
 
 msgid "Adding packfiles to multi-pack-index"
-msgstr ""
+msgstr "Comhaid pacáiste a chur le hinnéacs il-phacáiste"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown preferred pack: '%s'"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "pacáiste roghnaithe anaithnid: '%s'"
 
 #, c-format
 msgid "cannot select preferred pack %s with no objects"
-msgstr ""
+msgstr "ní féidir pacáiste roghnaithe %s a roghnú gan aon rudaí"
 
 #, c-format
 msgid "did not see pack-file %s to drop"
-msgstr ""
+msgstr "níor chonaic sé pacáist-chomhad %s le scaoileadh"
 
 #, c-format
 msgid "preferred pack '%s' is expired"
-msgstr ""
+msgstr "tá an pacáiste roghnaithe '%s' in éag"
 
 msgid "no pack files to index."
-msgstr ""
+msgstr "gan aon phacáiste comhaid le hinnéacs."
 
 msgid "refusing to write multi-pack .bitmap without any objects"
-msgstr ""
+msgstr "diúltú a scríobh il-pacáiste.bitmap gan aon rudaí"
 
-#, fuzzy
 msgid "unable to create temporary MIDX layer"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "in ann ciseal MIDX sealadach a chruthú"
 
 msgid "could not write multi-pack bitmap"
-msgstr ""
+msgstr "ní fhéadfaí bitmap il-phacáiste a scríobh"
 
-#, fuzzy
 msgid "unable to open multi-pack-index chain file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann comhad slabhra in-innéacs il-phacáiste a oscailt"
 
-#, fuzzy
 msgid "unable to rename new multi-pack-index layer"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann ciseal innéacs ilphacáiste nua a athainmniú"
 
-#, fuzzy
 msgid "could not write multi-pack-index"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní fhéadfaí innéacs il-phacáiste a scríobh"
 
 msgid "cannot expire packs from an incremental multi-pack-index"
 msgstr ""
+"ní féidir le pacáistí a chur in éag ó innéacs ilphacáiste incriminteach"
 
-#, fuzzy
 msgid "Counting referenced objects"
-msgstr "níl ach tagairt amháin ag súil leis"
+msgstr "Rud tagartha a chomhaireamh"
 
 msgid "Finding and deleting unreferenced packfiles"
-msgstr ""
+msgstr "Comhaid pacáiste gan tagairt a aimsiú agus a scriosadh"
 
-#, fuzzy
 msgid "cannot repack an incremental multi-pack-index"
-msgstr "ní féidir athphacáil chun glanadh"
+msgstr "ní féidir le hinnéacs ilphacáiste incriminteach a athphacáil"
 
-#, fuzzy
 msgid "could not start pack-objects"
-msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
+msgstr "ní fhéadfaí pacáiste-rudaí a thosú"
 
-#, fuzzy
 msgid "could not finish pack-objects"
-msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+msgstr "ní raibh sé in ann pacáistí a chríochnú"
 
 msgid "multi-pack-index OID fanout is of the wrong size"
-msgstr ""
+msgstr "tá fanout OID ilphacáiste den mhéid mícheart"
 
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
-msgstr ""
+msgstr "fanout oid as ord: fanout [%d] =% <PRIx32>>% <PRIx32>= fanout [%d]"
 
 msgid "multi-pack-index OID lookup chunk is the wrong size"
-msgstr ""
+msgstr "tá an méid mícheart ar an smután cuardaigh OID innéacs ilphacáiste"
 
 msgid "multi-pack-index object offset chunk is the wrong size"
 msgstr ""
+"tá an méid mícheart ar an smután fritháireamh réada innéacs ilphacáiste"
 
 #, c-format
 msgid "multi-pack-index file %s is too small"
-msgstr ""
+msgstr "tá comhad in-innéacs ilphacáiste %s ró-bheag"
 
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
-msgstr ""
+msgstr "ní mheaitseálann síniú innéacs il-phacáiste 0x%08x síniú 0x%08x"
 
 #, c-format
 msgid "multi-pack-index version %d not recognized"
-msgstr ""
+msgstr "ní aithnítear leagan innéacs il-phacáiste %d"
 
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
-msgstr ""
+msgstr "ní hionann leagan %u den hais innéacs ilphacáiste agus leagan %u"
 
 msgid "multi-pack-index required pack-name chunk missing or corrupted"
 msgstr ""
+"innéacs il-phacáiste teastaíonn píosa ainm pacáiste ar iarraidh nó "
+"truaillithe"
 
 msgid "multi-pack-index required OID fanout chunk missing or corrupted"
 msgstr ""
+"teastaíonn innéacs il-phacáiste le píosa fanout OID atá ar iarraidh nó "
+"truaillithe"
 
 msgid "multi-pack-index required OID lookup chunk missing or corrupted"
 msgstr ""
+"teastaíonn innéacs ilphacáiste cuardaigh OID atá ar iarraidh nó truaillithe"
 
 msgid "multi-pack-index required object offsets chunk missing or corrupted"
 msgstr ""
+"smután fritháireamh réada riachtanach innéacs ilphacáiste ar iarraidh nó "
+"truaillithe"
 
 msgid "multi-pack-index pack-name chunk is too short"
-msgstr ""
+msgstr "tá píosa ainm pacáiste innéacs il-phacáiste ró-ghearr"
 
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
-msgstr ""
+msgstr "ainmneacha pacáiste in-innéacs il-phacáiste as ord: '%s' roimh '%s'"
 
 msgid "multi-pack-index chain file too small"
-msgstr ""
+msgstr "comhad slabhra in-innéacs il-phacáiste ró-bheag"
 
 #, c-format
 msgid "pack count in base MIDX too high: %<PRIuMAX>"
-msgstr ""
+msgstr "líon pacáiste i mbonn MIDX ró-ard:%<PRIuMAX>"
 
 #, c-format
 msgid "object count in base MIDX too high: %<PRIuMAX>"
-msgstr ""
+msgstr "líon rudaí i mbonn MIDX ró-ard:%<PRIuMAX>"
 
 #, c-format
 msgid "invalid multi-pack-index chain: line '%s' not a hash"
-msgstr ""
+msgstr "slabhra innéacs il-phacáiste neamhbhailí: ní hash é líne '%s'"
 
-#, fuzzy
 msgid "unable to find all multi-pack index files"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann gach comhad innéacs il-phacáiste a fháil"
 
 msgid "invalid MIDX object position, MIDX is likely corrupt"
-msgstr ""
+msgstr "suíomh réad MIDX neamhbhailí, is dócha go bhfuil MIDX truaillithe"
 
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
-msgstr ""
+msgstr "bad pack-int-id: %u (pacáistí iomlána %u)"
 
 msgid "MIDX does not contain the BTMP chunk"
-msgstr ""
+msgstr "Níl an píosa BTMP i MIDX"
 
 #, c-format
 msgid "could not load bitmapped pack %<PRIu32>"
-msgstr ""
+msgstr "ní fhéadfaí pacáiste bitmapped a luchtú% <PRIu32>"
 
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
+"stórálann innéacs il-phacáiste fritháireamh 64-giotán, ach tá off_t ró-bheag"
 
-#, fuzzy
 msgid "multi-pack-index large offset out of bounds"
-msgstr "tá fhritháireamh bonn delta as ceangailte"
+msgstr "innéacs il-phacáiste fhritháireamh mór as teorainneacha"
 
 msgid "multi-pack-index file exists, but failed to parse"
-msgstr ""
+msgstr "tá comhad in-innéacs il-phacáiste ann, ach theip air a pháirseáil"
 
 msgid "incorrect checksum"
-msgstr ""
+msgstr "seiceáil mícheart"
 
-#, fuzzy
 msgid "Looking for referenced packfiles"
-msgstr "níl ach tagairt amháin ag súil leis"
+msgstr "Ag lorg comhaid pacáiste tagartha"
 
 msgid "the midx contains no oid"
-msgstr ""
+msgstr "níl aon oid sa midx"
 
 msgid "Verifying OID order in multi-pack-index"
-msgstr ""
+msgstr "Ordú OID a fhíorú in innéacs il-phacáiste"
 
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
-msgstr ""
+msgstr "cuardach oid as ord: oid [%d] = %s >= %s = oid [%d]"
 
 msgid "Sorting objects by packfile"
-msgstr ""
+msgstr "Rudaí a shórtáil de réir pacáiste"
 
-#, fuzzy
 msgid "Verifying object offsets"
-msgstr "Rudaí a fháil"
+msgstr "Athshraith réada a fhíorú"
 
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
-msgstr ""
+msgstr "theip ar iontráil pacáiste a luchtú do oid [%d] = %s"
 
 #, c-format
 msgid "failed to load pack-index for packfile %s"
-msgstr ""
+msgstr "theip ar innéacs pacáiste a luchtú do phacáiste %s"
 
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr ""
+"fritháireamh réada mícheart le haghaidh oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create lazy_dir thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir snáithe lazy_dir a chruthú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create lazy_name thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir snáithe lazy_name a chruthú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to join lazy_name thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "ní féidir teacht le snáithe lazy_name: %s"
 
 #, c-format
 msgid ""
@@ -17314,200 +18190,199 @@ msgid ""
 "Please, use 'git notes merge --commit' or 'git notes merge --abort' to "
 "commit/abort the previous merge before you start a new notes merge."
 msgstr ""
+"Níor chríochnaigh tú do chuid nótaí roimhe seo a chumasc (%s ann).\n"
+"Le do thoil, bain úsáid as 'git notes merge --commit 'nó 'git notes merge --"
+"abort' chun an cumasc roimhe seo a cheangail/deireadh a chur leis sula "
+"dtosaíonn tú le cumasc nótaí nua."
 
 #, c-format
 msgid "You have not concluded your notes merge (%s exists)."
-msgstr ""
+msgstr "Níor chríochnaigh tú do chuid nótaí a chumasc (%s ann)."
 
 msgid "Cannot commit uninitialized/unreferenced notes tree"
-msgstr ""
+msgstr "Ní féidir crann nótaí neamhthionsaithe/gan tagairt a dhéanamh"
 
 #, c-format
 msgid "Bad notes.rewriteMode value: '%s'"
-msgstr ""
+msgstr "Luach lochtach notes.rewriteMode: '%s'"
 
 #, c-format
 msgid "Refusing to rewrite notes in %s (outside of refs/notes/)"
-msgstr ""
+msgstr "Diúltú nótaí a athscríobh i %s (lasmuigh de refs/notes/)"
 
 #. TRANSLATORS: The first %s is the name of
 #. the environment variable, the second %s is
 #. its value.
 #.
-#, fuzzy, c-format
+#, c-format
 msgid "Bad %s value: '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "Droch-luach %s: '%s'"
 
-#, fuzzy
 msgid "failed to decode tree entry"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar iontráil crann a dhíchódú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to map tree entry for %s"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar iontráil crann a mhapáil do %s"
 
 #, c-format
 msgid "bad %s in commit"
-msgstr ""
+msgstr "droch %s i dtiomantas"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to map %s %s in commit object"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir %s %s a mhapáil i réad tiomanta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to convert object from %s to %s"
-msgstr "theip ar rudaí a fháil ó URI '%s'"
+msgstr "Theip ar réad a thiontú ó %s go %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object file %s is empty"
-msgstr "tá réad áitiúil %s truaillithe"
+msgstr "tá comhad réad %s folamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "corrupt loose object '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "réad scaoilte truaillithe '%s'"
 
 #, c-format
 msgid "garbage at end of loose object '%s'"
-msgstr ""
+msgstr "truflais ag deireadh réad scaoilte '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open loose object %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir réad scaoilte %s a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse %s header"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir ceannteideal %s a pháirseáil"
 
-#, fuzzy
 msgid "invalid object type"
-msgstr "réad blob neamhbhailí %s"
+msgstr "cineál réad neamhbhailí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to unpack %s header"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní féidir ceannteideal %s a dhíphacáil"
 
 #, c-format
 msgid "header for %s too long, exceeds %d bytes"
-msgstr ""
+msgstr "ceannteideal do %s rófhada, níos mó ná %d bytes"
 
-#, fuzzy, c-format
+#, c-format
 msgid "loose object %s (stored in %s) is corrupt"
-msgstr "tá réad áitiúil %s truaillithe"
+msgstr "tá réad scaoilte %s (stóráilte i %s) truaillithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní féidir %s a oscailt"
 
 #, c-format
 msgid "files '%s' and '%s' differ in contents"
-msgstr ""
+msgstr "tá difríocht idir comhaid '%s' agus '%s' in ábhar"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to write file %s"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "nach féidir comhad %s a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to write repeatedly vanishing file %s"
-msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+msgstr "in ann comhad %s atá ag imeacht arís agus arís eile a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to set permission to '%s'"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir cead a shocrú do '%s'"
 
-#, fuzzy
 msgid "error when closing loose object file"
-msgstr "earráid agus comhad pacáiste á dúnadh"
+msgstr "earráid agus comhad réad scaoilte á ndú"
 
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
-msgstr ""
+msgstr "cead neamhleor chun réad a chur le bunachar sonraí stórais %s"
 
-#, fuzzy
 msgid "unable to create temporary file"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "in ann comhad sealadach a chruthú"
 
-#, fuzzy
 msgid "unable to write loose object file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann comhad réad scaoilte a scríobh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to deflate new object %s (%d)"
-msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+msgstr "nach féidir réad nua %s a dhíoslagadh (%d)"
 
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
-msgstr ""
+msgstr "theip ar deflateEnd ar réad %s (%d)"
 
 #, c-format
 msgid "confused by unstable object source data for %s"
-msgstr ""
+msgstr "mearbhall de bharr sonraí foinse réada éagobhsaí do %s"
 
 #, c-format
 msgid "write stream object %ld != %<PRIuMAX>"
-msgstr ""
+msgstr "scríobh réad srutha %ld! =%<PRIuMAX>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to stream deflate new object (%d)"
-msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+msgstr "nach féidir réad nua a dhíscaoileadh a shruthlú (%d)"
 
 #, c-format
 msgid "deflateEnd on stream object failed (%d)"
-msgstr ""
+msgstr "theip ar réad srutha DeflateEnd (%d)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create directory %s"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "nach féidir eolaire %s a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read object for %s"
-msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+msgstr "ní féidir réad a léamh do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot map object %s to %s"
-msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+msgstr "ní féidir réad %s a mhapáil go %s"
 
 #, c-format
 msgid "object fails fsck: %s"
-msgstr ""
+msgstr "teipeann ar réad fsck: %s"
 
 msgid "refusing to create malformed object"
-msgstr ""
+msgstr "diúltú réad mífhoirmithe a chruthú"
 
 #, c-format
 msgid "read error while indexing %s"
-msgstr ""
+msgstr "earráid léite agus %s á innéacsú"
 
 #, c-format
 msgid "short read while indexing %s"
-msgstr ""
+msgstr "léamh gearr agus %s á innéacsú"
 
 #, c-format
 msgid "%s: failed to insert into database"
-msgstr ""
+msgstr "%s: theip ort a chur isteach sa bhunachar sonraí"
 
 #, c-format
 msgid "%s: unsupported file type"
-msgstr ""
+msgstr "%s: cineál comhaid gan tacaíocht"
 
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
-msgstr ""
+msgstr "neamhoiriúnú hash do %s (súil leis %s)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to mmap %s"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir %s a mmapáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to unpack header of %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir ceanntásc %s a dhíphacáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse header of %s"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir ceannteideal %s a pháirseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to unpack contents of %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir ábhar %s a dhíphacáil"
 
 #. TRANSLATORS: This is a line of ambiguous object
 #. output shown when we cannot look up or parse the
@@ -17515,16 +18390,16 @@ msgstr "nach féidir %s a nuashonrú"
 #.
 #, c-format
 msgid "%s [bad object]"
-msgstr ""
+msgstr "%s [droch-réad]"
 
 #. TRANSLATORS: This is a line of ambiguous commit
 #. object output. E.g.:
 #. *
 #.    "deadbeef commit 2021-01-01 - Some Commit Message"
 #.
-#, fuzzy, c-format
+#, c-format
 msgid "%s commit %s - %s"
-msgstr "Rianann %s %s agus %s araon"
+msgstr "Déanann %s tiomanta %s - %s"
 
 #. TRANSLATORS: This is a line of ambiguous
 #. tag object output. E.g.:
@@ -17537,9 +18412,9 @@ msgstr "Rianann %s %s agus %s araon"
 #. The third argument is the "tag" string
 #. from object.c.
 #.
-#, fuzzy, c-format
+#, c-format
 msgid "%s tag %s - %s"
-msgstr "Rianann %s %s agus %s araon"
+msgstr "Clib %s %s - %s"
 
 #. TRANSLATORS: This is a line of ambiguous
 #. tag object output where we couldn't parse
@@ -17549,25 +18424,25 @@ msgstr "Rianann %s %s agus %s araon"
 #.
 #, c-format
 msgid "%s [bad tag, could not parse it]"
-msgstr ""
+msgstr "%s [droch-chlib, ní fhéadfaí é a pháirseáil]"
 
 #. TRANSLATORS: This is a line of ambiguous <type>
 #. object output. E.g. "deadbeef tree".
 #.
 #, c-format
 msgid "%s tree"
-msgstr ""
+msgstr "%s crann"
 
 #. TRANSLATORS: This is a line of ambiguous <type>
 #. object output. E.g. "deadbeef blob".
 #.
 #, c-format
 msgid "%s blob"
-msgstr ""
+msgstr "%s blob"
 
 #, c-format
 msgid "short object ID %s is ambiguous"
-msgstr ""
+msgstr "tá ID réad gairid %s débhríoch"
 
 #. TRANSLATORS: The argument is the list of ambiguous
 #. objects composed in show_ambiguous_object(). See
@@ -17578,6 +18453,8 @@ msgid ""
 "The candidates are:\n"
 "%s"
 msgstr ""
+"Is iad na hiarrthóirí:\n"
+"%s"
 
 msgid ""
 "Git normally never creates a ref that ends with 40 hex characters\n"
@@ -17590,441 +18467,467 @@ msgid ""
 "examine these refs and maybe delete them. Turn this message off by\n"
 "running \"git config set advice.objectNameWarning false\""
 msgstr ""
+"De ghnáth ní chruthaíonn Git tagartha riamh a chríochnaíonn le 40 carachtar\n"
+"toisc go ndéanfar neamhaird air nuair a shonraíonn tú ach 40-hex. Na "
+"hiarratais seo\n"
+"d'fhéadfaí a chruthú trí dhearmad. Mar shampla,\n"
+"\n"
+"  git switch -c $br $(git rev-parse ...)\n"
+"\n"
+"áit a bhfuil “$br” folamh ar bhealach éigin agus cruthaítear tagairt 40-hex. "
+"Le do thoil\n"
+"scrúdú a dhéanamh ar na haifeanna seo agus b'fhéidir iad a scriosadh. Cas an "
+"teachtaireacht seo as\n"
+"ag rith \"git config set advice.objectNameWarning false\""
 
 #, c-format
 msgid "log for '%.*s' only goes back to %s"
-msgstr ""
+msgstr "ní théann logáil le haghaidh '%.*s' ach ar ais go %s"
 
 #, c-format
 msgid "log for '%.*s' only has %d entries"
-msgstr ""
+msgstr "níl ach iontráil i logáil le haghaidh '%.*s' ach %d ceann"
 
 #, c-format
 msgid "path '%s' exists on disk, but not in '%.*s'"
-msgstr ""
+msgstr "tá cosán '%s' ann ar an diosca, ach ní i '%.*s'"
 
 #, c-format
 msgid ""
 "path '%s' exists, but not '%s'\n"
 "hint: Did you mean '%.*s:%s' aka '%.*s:./%s'?"
 msgstr ""
+"tá an cosán '%s' ann, ach níl '%s' ann\n"
+"leid: An raibh tú i gceist agat '%.*s:%s' aka '%.*s:./%s'?"
 
-#, fuzzy, c-format
+#, c-format
 msgid "path '%s' does not exist in '%.*s'"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl cosán '%s' ann i '%.*s'"
 
 #, c-format
 msgid ""
 "path '%s' is in the index, but not at stage %d\n"
 "hint: Did you mean ':%d:%s'?"
 msgstr ""
+"tá cosán '%s' san innéacs, ach ní ag céim %d\n"
+"leid: An raibh i gceist agat ': %d: %s'?"
 
 #, c-format
 msgid ""
 "path '%s' is in the index, but not '%s'\n"
 "hint: Did you mean ':%d:%s' aka ':%d:./%s'?"
 msgstr ""
+"tá an conair '%s' san innéacs, ach ní '%s'\n"
+"leideanna: an é ':%d:%s' a bhí i gceist agat, nó ':%d:./%s'?"
 
 #, c-format
 msgid "path '%s' exists on disk, but not in the index"
-msgstr ""
+msgstr "tá cosán '%s' ann ar an diosca, ach ní san innéacs"
 
-#, fuzzy, c-format
+#, c-format
 msgid "path '%s' does not exist (neither on disk nor in the index)"
-msgstr "níl a leagan ag cosán '%s'"
+msgstr "níl cosán '%s' ann (ní ar an diosca ná san innéacs)"
 
 msgid "relative path syntax can't be used outside working tree"
 msgstr ""
+"ní féidir comhréir cosáin choibhneasta a úsáid lasmuigh de chrann oibre"
 
 #, c-format
 msgid "<object>:<path> required, only <object> '%s' given"
-msgstr ""
+msgstr "<object>: ri <path>achtanach, ní <object>thugtar ach '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid object name '%.*s'."
-msgstr "réad blob neamhbhailí %s"
+msgstr "ainm réada neamhbhailí '%.*s'."
 
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
-msgstr ""
+msgstr "níl an eolaire réada %s ann; seiceáil .git/objects/info/alternates"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to normalize alternate object path: %s"
-msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+msgstr "nach féidir cosán réad malartach a normalú: %s"
 
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
-msgstr ""
+msgstr "%s: neamhaird a dhéanamh ar stórais rudaí malartacha, neadú ró-"
 
-#, fuzzy
 msgid "unable to fdopen alternates lockfile"
-msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
+msgstr "in ann comhad glasála malartacha a fdopen"
 
-#, fuzzy
 msgid "unable to read alternates file"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "in ann comhad malartach a léamh"
 
-#, fuzzy
 msgid "unable to move new alternates file into place"
-msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
+msgstr "in ann comhad malartacha nua a bhogadh isteach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "path '%s' does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl cosán '%s' ann"
 
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
-msgstr ""
+msgstr "ní thacaítear le stór tagartha '%s' mar sheiceáil nasctha go fóill."
 
-#, fuzzy, c-format
+#, c-format
 msgid "reference repository '%s' is not a local repository."
-msgstr "níl an stóras '%s' ann"
+msgstr "ní stór áitiúil é stór tagartha '%s'."
 
-#, fuzzy, c-format
+#, c-format
 msgid "reference repository '%s' is shallow"
-msgstr "stór tagartha"
+msgstr "tá stóras tagartha '%s' éadomhain"
 
-#, fuzzy, c-format
+#, c-format
 msgid "reference repository '%s' is grafted"
-msgstr "stór tagartha"
+msgstr "tá stór tagartha '%s' grapháilte"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not find object directory matching %s"
-msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
+msgstr "ní fhéadfaí eolaire réada a fháil a mheaitseáil %s"
 
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
-msgstr ""
+msgstr "líne neamhbhailí agus tú ag paráil iarmhairtí malartacha: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "replacement %s not found for %s"
-msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+msgstr "nach bhfuarthas %s a athsholáthar do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "packed object %s (stored in %s) is corrupt"
-msgstr "tá réad áitiúil %s truaillithe"
+msgstr "tá réad pacáilte %s (stóráilte i %s) truaillithe"
 
 #, c-format
 msgid "missing mapping of %s to %s"
-msgstr ""
+msgstr "mapáil atá in easnamh de %s go %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s is not a valid '%s' object"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní réad bailí '%s' é %s '"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid object type \"%s\""
-msgstr "réad blob neamhbhailí %s"
+msgstr "cineál réad neamhbhailí “%s”"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object %s is a %s, not a %s"
-msgstr "mímheaitseáil cineál réad ag %s"
+msgstr "is %s é réad %s, ní %s"
 
 #, c-format
 msgid "object %s has unknown type id %d"
-msgstr ""
+msgstr "réad %s tá cineál ID anaithnid %d aige"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse object: %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir réad a pháirseáil: %s"
 
 #, c-format
 msgid "hash mismatch %s"
-msgstr ""
+msgstr "neamhoiriúnú hash %s"
 
 #, c-format
 msgid "duplicate entry when writing bitmap index: %s"
-msgstr ""
+msgstr "iontráil dúblach agus innéacs bitmap á scríobh: %s"
 
 #, c-format
 msgid "attempted to store non-selected commit: '%s'"
-msgstr ""
+msgstr "rinne iarracht tiomantas neamh-roghnaithe a stóráil: '%s'"
 
 msgid "too many pseudo-merges"
-msgstr ""
+msgstr "an iomarca bréag-chumaisc"
 
 msgid "trying to write commit not in index"
-msgstr ""
+msgstr "ag iarraidh tiomantas a scríobh ní in innéacs"
 
 msgid "failed to load bitmap index (corrupted?)"
-msgstr ""
+msgstr "theip ar innéacs bitmap a luchtú (truaillithe?)"
 
 msgid "corrupted bitmap index (too small)"
-msgstr ""
+msgstr "innéacs bitmap truaillithe (ró-bheag)"
 
 msgid "corrupted bitmap index file (wrong header)"
-msgstr ""
+msgstr "comhad innéacs bitmap truaillithe (ceanntásc mícheart)"
 
 #, c-format
 msgid "unsupported version '%d' for bitmap index file"
-msgstr ""
+msgstr "leagan gan tacaíocht '%d' do chomhad innéacs bitmap"
 
 msgid "corrupted bitmap index file (too short to fit hash cache)"
 msgstr ""
+"comhad innéacs bitmap truaillithe (róghearr chun taisce hash a fheistiú)"
 
 msgid "corrupted bitmap index file (too short to fit lookup table)"
 msgstr ""
+"comhad innéacs bitmap truaillithe (róghearr chun tábla cuardaigh a fheistiú)"
 
 msgid ""
 "corrupted bitmap index file (too short to fit pseudo-merge table header)"
 msgstr ""
+"comhad innéacs bitmap truaillithe (ró-ghearr chun ceannteideal tábla bréag-"
+"chumasc a fheistiú)"
 
 msgid "corrupted bitmap index file (too short to fit pseudo-merge table)"
 msgstr ""
+"comhad innéacs bitmap truaillithe (ró-ghearr chun tábla bréag-chumasc a "
+"fheistiú)"
 
 msgid "corrupted bitmap index file, pseudo-merge table too short"
-msgstr ""
+msgstr "comhad innéacs bitmap truaillithe, tábla bréag-chumasc ró-ghearr"
 
 #, c-format
 msgid "duplicate entry in bitmap index: '%s'"
-msgstr ""
+msgstr "iontráil dúblach in innéacs bitmap: '%s'"
 
 #, c-format
 msgid "corrupt ewah bitmap: truncated header for entry %d"
-msgstr ""
+msgstr "bitmap ewah truaillithe: ceannteideal gearrtha le haghaidh iontráil %d"
 
 #, c-format
 msgid "corrupt ewah bitmap: commit index %u out of range"
-msgstr ""
+msgstr "bitmap ewah truaillithe: innéacs tiomanta %u lasmuigh den raon"
 
 msgid "corrupted bitmap pack index"
-msgstr ""
+msgstr "innéacs pacáiste bitmap truaillte"
 
 msgid "invalid XOR offset in bitmap pack index"
-msgstr ""
+msgstr "fritháireamh XOR neamhbhailí in innéacs pacáiste bitmap"
 
-#, fuzzy
 msgid "cannot fstat bitmap file"
-msgstr "ní féidir le pacáiste fstat"
+msgstr "ní féidir comhad bitmap fstat"
 
 msgid "checksum doesn't match in MIDX and bitmap"
-msgstr ""
+msgstr "ní mheaitseálann seicsum i MIDX agus bitmap"
 
 msgid "multi-pack bitmap is missing required reverse index"
-msgstr ""
+msgstr "tá an t-innéacs droim riachtanach in easnamh ilphacáiste"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not open pack %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí pacáiste %s a oscailt"
 
 msgid "corrupt bitmap lookup table: triplet position out of index"
-msgstr ""
+msgstr "tábla cuardaigh bitmap truaillithe: suíomh triplet as innéacs"
 
 msgid "corrupt bitmap lookup table: xor chain exceeds entry count"
-msgstr ""
+msgstr "tábla cuardaigh bitmap truaillithe: sáraíonn slabhra xor líon iontrála"
 
 #, c-format
 msgid "corrupt bitmap lookup table: commit index %u out of range"
 msgstr ""
+"tábla cuardaigh bitmap truaillithe: innéacs tiomanta %u lasmuigh den raon"
 
 #, c-format
 msgid "corrupt ewah bitmap: truncated header for bitmap of commit \"%s\""
 msgstr ""
+"bitmap ewah truaillithe: ceannteideal gearrtha le haghaidh bitmap de "
+"thiomantas “%s”"
 
 #, c-format
 msgid "unable to load pack: '%s', disabling pack-reuse"
-msgstr ""
+msgstr "in ann pacáiste a luchtú: '%s', athúsáid pacáiste a dhíchumasú"
 
 msgid "unable to compute preferred pack, disabling pack-reuse"
-msgstr ""
+msgstr "in ann pacáiste roghnaithe a ríomh, athúsáid pacáiste a dhíchumasú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object '%s' not found in type bitmaps"
-msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+msgstr "níor aimsíodh réad '%s' i gcineál bitmaps"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object '%s' does not have a unique type"
-msgstr "níl ár leagan ag cosán '%s'"
+msgstr "níl cineál uathúil ag réad '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "object '%s': real type '%s', expected: '%s'"
-msgstr "réad %s: súil leis an gcineál %s, aimsíodh %s"
+msgstr "réad '%s': fíor-chineál '%s', ag súil leis: '%s'"
 
 #, c-format
 msgid "object not in bitmap: '%s'"
-msgstr ""
+msgstr "réad nach bhfuil i mbitmap: '%s'"
 
-#, fuzzy
 msgid "failed to load bitmap indexes"
-msgstr "theip ar delta a chur i bhfeidhm"
+msgstr "theip ar innéacsanna bitmap a luchtú"
 
-#, fuzzy
 msgid "you must specify exactly one commit to test"
-msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
+msgstr "ní mór duit tiomantas amháin a shonrú go díreach chun tástáil"
 
 #, c-format
 msgid "commit '%s' doesn't have an indexed bitmap"
-msgstr ""
+msgstr "cumann nach bhfuil bitmap innéacsaithe ag '%s'"
 
 msgid "mismatch in bitmap results"
-msgstr ""
+msgstr "mímheaitseáil i dtorthaí bitmap"
 
 #, c-format
 msgid "pseudo-merge index out of range (%<PRIu32> >= %<PRIuMAX>)"
-msgstr ""
+msgstr "innéacs bréag-chumaisc lasmuigh den raon (%<PRIu32> >= %<PRIuMAX>)"
 
 #, c-format
 msgid "could not find '%s' in pack '%s' at offset %<PRIuMAX>"
 msgstr ""
+"ní raibh '%s' in ann teacht i bpacáiste '%s' ag fhritháireamh%<PRIuMAX>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get disk usage of '%s'"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní féidir úsáid diosca a fháil de '%s'"
 
 #, c-format
 msgid "bitmap file '%s' has invalid checksum"
-msgstr ""
+msgstr "tá seicsum neamhbhailí ag comhad bitmap '%s'"
 
 #, c-format
 msgid "mtimes file %s is too small"
-msgstr ""
+msgstr "tá comhad mtimes %s ró-bheag"
 
 #, c-format
 msgid "mtimes file %s has unknown signature"
-msgstr ""
+msgstr "tá síniú anaithnid ag comhad mtimes %s"
 
 #, c-format
 msgid "mtimes file %s has unsupported version %<PRIu32>"
-msgstr ""
+msgstr "tá leagan neamh-tacaithe ag comhad mtimes %s% <PRIu32>"
 
 #, c-format
 msgid "mtimes file %s has unsupported hash id %<PRIu32>"
-msgstr ""
+msgstr "tá id hash neamh-tacaithe ag comhad %s mtimes% <PRIu32>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "mtimes file %s is corrupt"
-msgstr "comhad innéacs truaillithe"
+msgstr "tá comhad mtimes %s truaillithe"
 
 #, c-format
 msgid "reverse-index file %s is too small"
-msgstr ""
+msgstr "tá comhad innéacs droim %s róbheag"
 
-#, fuzzy, c-format
+#, c-format
 msgid "reverse-index file %s is corrupt"
-msgstr "comhad innéacs truaillithe"
+msgstr "tá comhad innéacs droim %s truaillithe"
 
 #, c-format
 msgid "reverse-index file %s has unknown signature"
-msgstr ""
+msgstr "tá síniú anaithnid ag comhad innéacs droim %s"
 
 #, c-format
 msgid "reverse-index file %s has unsupported version %<PRIu32>"
-msgstr ""
+msgstr "tá leagan neamh-tacaithe ag comhad innéacs droim %s% <PRIu32>"
 
 #, c-format
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
-msgstr ""
+msgstr "tá id hash neamh-tacaithe ag comhad innéacs droim %s% <PRIu32>"
 
-#, fuzzy
 msgid "invalid checksum"
-msgstr "%s neamhbhailí"
+msgstr "seiceáil neamhbhailí"
 
 #, c-format
 msgid "invalid rev-index position at %<PRIu64>: %<PRIu32> != %<PRIu32>"
 msgstr ""
+"suíomh innéacs-athraithe neamhbhailí ag %<PRIu64>: %<PRIu32> != %<PRIu32>"
 
 msgid "multi-pack-index reverse-index chunk is the wrong size"
-msgstr ""
+msgstr "tá smután droim ar ais-innéacs il-phacáiste ar an méid mícheart"
 
 msgid "could not determine preferred pack"
-msgstr ""
+msgstr "ní fhéadfaí pacáiste is fearr a chinneadh"
 
 msgid "cannot both write and verify reverse index"
-msgstr ""
+msgstr "ní féidir innéacs droim a scríobh agus a fhíorú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not stat: %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí stat: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to make %s readable"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar %s a dhéanamh inléite"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write '%s' promisor file"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní fhéadfaí comhad gealltanais '%s' a scríobh"
 
 msgid "offset before end of packfile (broken .idx?)"
-msgstr ""
+msgstr "fhritháireamh roimh dheireadh an phackfile (.idx briste?)"
 
 #, c-format
 msgid "packfile %s cannot be mapped%s"
-msgstr ""
+msgstr "ní féidir comhaid pacáiste %s a mhapáil %s"
 
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
+"fhritháireamh roimh thús an innéacs pacáiste do %s (innéacs truaillithe?)"
 
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
+"fhritháireamh thar dheireadh an innéacs pacáiste do %s (innéacs gearrtha?)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed expiration date '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "dáta éaga mífhoirmithe '%s'"
 
 #, c-format
 msgid "option `%s' expects \"always\", \"auto\", or \"never\""
-msgstr ""
+msgstr "tá rogha `%s' ag súil le “i gcónaí”, “uathoibríoch”, nó “riamh”"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed object name '%s'"
-msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+msgstr "ainm réad mífhoirmithe '%s'"
 
 #, c-format
 msgid "option `%s' expects \"%s\" or \"%s\""
-msgstr ""
+msgstr "tá rogha `%s' ag súil le “%s” nó “%s”"
 
 #, c-format
 msgid "%s requires a value"
-msgstr ""
+msgstr "Teastaíonn luach ó %s"
 
 #, c-format
 msgid "%s takes no value"
-msgstr ""
+msgstr "Ní ghlacann %s aon luach"
 
 #, c-format
 msgid "%s isn't available"
-msgstr ""
+msgstr "Níl %s ar fáil"
 
 #, c-format
 msgid "value %s for %s not in range [%<PRIdMAX>,%<PRIdMAX>]"
-msgstr ""
+msgstr "luach %s do %s nach bhfuil sa raon [%<PRIdMAX>,%<PRIdMAX>]"
 
 #, c-format
 msgid "%s expects an integer value with an optional k/m/g suffix"
-msgstr ""
+msgstr "Tá %s ag súil le luach sláireach le iarmhír roghnach k/m/g"
 
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr ""
+"Tá %s ag súil le luach sláimhir neamh-dhiúltach le iarmhír roghnach k/m/g"
 
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
-msgstr ""
+msgstr "rogha débhríoch: %s (d'fhéadfadh a bheith --%s%s nó --%s%s)"
 
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
-msgstr ""
+msgstr "an raibh i gceist agat `--%s` (le dhá shraith)?"
 
 #, c-format
 msgid "alias of --%s"
-msgstr ""
+msgstr "alias de --%s"
 
 msgid "need a subcommand"
-msgstr ""
+msgstr "fo-ordú ag teastáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown option `%s'"
-msgstr "stíl choimhlinte anaithnid '%s'"
+msgstr "rogha anaithnid `%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown switch `%c'"
-msgstr "algartam hais anaithnid '%s'"
+msgstr "lasc anaithnid `%c'"
 
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
-msgstr ""
+msgstr "rogha neamh-ascii anaithnid i sreang: `%s'"
 
 #. TRANSLATORS: The "<%s>" part of this string
 #. stands for an optional value given to a command
@@ -18040,7 +18943,7 @@ msgstr ""
 #.
 #, c-format
 msgid "[=<%s>]"
-msgstr ""
+msgstr "[=<%s>]"
 
 #. TRANSLATORS: The "<%s>" part of this string
 #. stands for an optional value given to a command
@@ -18056,7 +18959,7 @@ msgstr ""
 #.
 #, c-format
 msgid "[<%s>]"
-msgstr ""
+msgstr "[<%s>]"
 
 #. TRANSLATORS: The "<%s>" part of this string stands for a
 #. value given to a command line option, and "<>" is there
@@ -18070,21 +18973,21 @@ msgstr ""
 #.
 #, c-format
 msgid " <%s>"
-msgstr ""
+msgstr " <%s>"
 
 msgid "..."
-msgstr ""
+msgstr "..."
 
 #, c-format
 msgid "usage: %s"
-msgstr ""
+msgstr "úsáid: %s"
 
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
 #, c-format
 msgid "   or: %s"
-msgstr ""
+msgstr "   nó: %s"
 
 #. TRANSLATORS: You should only need to translate this format
 #. string if your language is a RTL language (e.g. Arabic,
@@ -18107,490 +19010,504 @@ msgstr ""
 #.
 #, c-format
 msgid "%*s%s"
-msgstr ""
+msgstr "%*s%s"
 
 #, c-format
 msgid "    %s"
-msgstr ""
+msgstr "    %s"
 
 msgid "-NUM"
-msgstr ""
+msgstr "-NUMBER"
 
 #, c-format
 msgid "opposite of --no-%s"
-msgstr ""
+msgstr "os coinne de --no-%s"
 
 msgid "expiry-date"
-msgstr ""
+msgstr "dáta éaga"
 
 msgid "no-op (backward compatibility)"
-msgstr ""
+msgstr "no-op (comhoiriúnacht ar chúl)"
 
 msgid "be more verbose"
-msgstr ""
+msgstr "a bheith níos inbhreithnithe"
 
 msgid "be more quiet"
-msgstr ""
+msgstr "a bheith níos ciúine"
 
 msgid "use <n> digits to display object names"
-msgstr ""
+msgstr "úsáid dhigit <n>í chun ainmneacha réada a thaispe"
 
-#, fuzzy
 msgid "prefixed path to initial superproject"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "cosán réamhshocraithe chuig an superproject tosaigh"
 
 msgid "how to strip spaces and #comments from message"
-msgstr ""
+msgstr "conas spásanna agus #comments a scriosadh ó theachtaireacht"
 
 msgid "read pathspec from file"
-msgstr ""
+msgstr "léigh pathspec ón gcomhad"
 
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
+"le --pathspec-from-file, déantar eilimintí pathspec scartha le carachtar NUL"
 
 #, c-format
 msgid "bad boolean environment value '%s' for '%s'"
-msgstr ""
+msgstr "droch-luach timpeallachta boolean '%s' do '%s'"
 
 #, c-format
 msgid "failed to walk children of tree %s: not found"
-msgstr ""
+msgstr "theip ar pháistí crann %s a shiúl: níor aimsíodh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to find object %s"
-msgstr "Theip ar chrann %s a aimsiú."
+msgstr "theip ar réad %s a aimsiú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to find tag %s"
-msgstr "Theip ar chrann %s a aimsiú."
+msgstr "theip ar chlib %s a aimsiú"
 
-#, fuzzy
 msgid "failed to setup revision walk"
-msgstr "earráid inmheánach i dsiúlóid"
+msgstr "theip orthu siúlóid athbhreithnithe"
 
 #, c-format
 msgid "Could not make %s writable by group"
-msgstr ""
+msgstr "Ní fhéadfaí %s a dhéanamh inscríofa de réir grúpa"
 
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr ""
+"Ní cheadaítear carachtar éalaithe '\\' mar charachtar deireanach i luach attr"
 
 msgid "Only one 'attr:' specification is allowed."
-msgstr ""
+msgstr "Ní cheadaítear ach sonraíocht 'attr: 'amháin."
 
 msgid "attr spec must not be empty"
-msgstr ""
+msgstr "ní chóir go mbeadh sonraíocht attr folamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid attribute name %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "ainm tréithe neamhbhailí %s"
 
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
-msgstr ""
+msgstr "níl socruithe pathspec domhanda 'glob' agus 'noglob' neamhoiriúnach"
 
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
 msgstr ""
+"níl suíomh cosáin domhanda 'litriúil' gan luí le gach socruithe beatháin "
+"domhanda eile"
 
 msgid "invalid parameter for pathspec magic 'prefix'"
-msgstr ""
+msgstr "paraiméadar neamhbhailí do 'réimír' draíochta pathspec"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
-msgstr "sonraíocht cosáin nebhail"
+msgstr "Draíocht pathspec neamhbhailí '%.*s' i '%s'"
 
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
-msgstr ""
+msgstr "Ar iarraidh ')' ag deireadh draíochta pathspec i '%s'"
 
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
-msgstr ""
+msgstr "Draíocht pathspec neamh-chur i bhfeidhm '%c' i '%s'"
 
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
-msgstr ""
+msgstr "%s: Níl 'literal' agus 'glob' neamhoiriúnach"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is outside the directory tree"
-msgstr "Tá %s ann agus ní eolaire é"
+msgstr "Tá '%s' lasmuigh den chrann eolaire"
 
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
-msgstr ""
+msgstr "%s: Tá '%s' an stór lasmuigh ag '%s'"
 
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
-msgstr ""
+msgstr "'%s' (mnemonic: '%c')"
 
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
-msgstr ""
+msgstr "%s: nach dtacaíonn an t-ordú seo le draíocht pathspec: %s"
 
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
-msgstr ""
+msgstr "tá pathspec '%s' thar nasc siombalach"
 
 #, c-format
 msgid "line is badly quoted: %s"
-msgstr ""
+msgstr "tá an líne luaite go dona: %s"
 
-#, fuzzy
 msgid "unable to write flush packet"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann pacáiste srutháin a scríobh"
 
-#, fuzzy
 msgid "unable to write delim packet"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann pacáiste delim a scríobh"
 
-#, fuzzy
 msgid "unable to write response end packet"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann pacáiste deiridh freagartha a scríobh"
 
 msgid "flush packet write failed"
-msgstr ""
+msgstr "theip ar scríobh paicéad sru"
 
 msgid "protocol error: impossibly long line"
-msgstr ""
+msgstr "earráid prótacal: líne fhada dodhéanta"
 
 msgid "packet write with format failed"
-msgstr ""
+msgstr "theip ar scríobh pacáiste le formáid"
 
 msgid "packet write failed - data exceeds max packet size"
-msgstr ""
+msgstr "theip ar scríobh paicéad - sáraíonn sonraí méid uasta an"
 
-#, fuzzy, c-format
+#, c-format
 msgid "packet write failed: %s"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "theip ar scríobh pacáiste: %s"
 
-#, fuzzy
 msgid "read error"
-msgstr "earráid léigh ar ionchur"
+msgstr "earráid léigh"
 
 msgid "the remote end hung up unexpectedly"
-msgstr ""
+msgstr "crochadh an deireadh iargúlta suas gan choinne"
 
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
-msgstr ""
+msgstr "earráid prótacal: carachtar fad droch-líne: %.4s"
 
 #, c-format
 msgid "protocol error: bad line length %d"
-msgstr ""
+msgstr "earráid prótacal: fad droch-líne %d"
 
 #, c-format
 msgid "remote error: %s"
-msgstr ""
+msgstr "earráid iargúlta: %s"
 
-#, fuzzy
 msgid "Refreshing index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "Innéacs athnuachana"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create threaded lstat: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir lstat snáithithe a chruthú: %s"
 
-#, fuzzy
 msgid "unable to parse --pretty format"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "in ann formáid --pretty a pháirseáil"
 
 msgid "lazy fetching disabled; some objects may not be available"
 msgstr ""
+"tarraingt leisciúil míchumasaithe; b'fhéidir nach mbeidh roinnt rudaí ar fáil"
 
 msgid "promisor-remote: unable to fork off fetch subprocess"
-msgstr ""
+msgstr "gealltó-iargúlta: ní féidir leis an bhfophróiseas faighte a fhorc"
 
 msgid "promisor-remote: could not write to fetch subprocess"
-msgstr ""
+msgstr "gealltó-iargúlta: ní fhéadfaí scríobh chun fophróiseas a fháil"
 
 msgid "promisor-remote: could not close stdin to fetch subprocess"
-msgstr ""
+msgstr "gealltó-iargúlta: ní fhéadfaí stdin a dhúnadh chun fophróiseas a fháil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "promisor remote name cannot begin with '/': %s"
-msgstr "ní féidir le '/' tosú le gearrthánach iargúlta config: %s"
+msgstr "ní féidir ainm iargúlta gealltanaí tosú le '/': %s"
 
 #, c-format
 msgid "could not fetch %s from promisor remote"
-msgstr ""
+msgstr "ní fhéadfaí %s a fháil ó iargúlta gealltanach"
 
 #, c-format
 msgid "no or empty URL advertised for remote '%s'"
-msgstr ""
+msgstr "níl aon URL nó folamh fógraithe le haghaidh iargúlta '%s'"
 
 #, c-format
 msgid "known remote named '%s' but with URL '%s' instead of '%s'"
-msgstr ""
+msgstr "iargúlta ar a dtugtar '%s' ach le URL '%s' in ionad '%s'"
 
 #, c-format
 msgid "unknown '%s' value for '%s' config option"
-msgstr ""
+msgstr "luach '%s' anaithnid do rogha cumraithe '%s'"
 
 #, c-format
 msgid "unknown element '%s' from remote info"
-msgstr ""
+msgstr "eilimint anaithnid '%s' ó fhaisnéis iargúlta"
 
 #, c-format
 msgid "accepted promisor remote '%s' not found"
-msgstr ""
+msgstr "nár aimsíodh gealltanas iargúlta '%s'"
 
 msgid "object-info: expected flush after arguments"
-msgstr ""
+msgstr "ear-eolas: súil le sruth tar éis argóintí"
 
-#, fuzzy
 msgid "Removing duplicate objects"
-msgstr "Rudaí a fháil"
+msgstr "Rudaí dúblacha a bhaint"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to load pseudo-merge regex for %s: '%s'"
-msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+msgstr "theip ar régex bréag-cumaisc a luchtú do %s: '%s'"
 
 #, c-format
 msgid "%s must be non-negative, using default"
-msgstr ""
+msgstr "Ní mór %s a bheith neamh-dhiúltach, ag baint úsáide as"
 
 #, c-format
 msgid "%s must be between 0 and 1, using default"
-msgstr ""
+msgstr "Caithfidh %s a bheith idir 0 agus 1, ag baint úsáide as réamhshocrú"
 
 #, c-format
 msgid "%s must be positive, using default"
-msgstr ""
+msgstr "Caithfidh %s a bheith dearfach, ag úsáid réamhshocraithe"
 
 #, c-format
 msgid "pseudo-merge group '%s' missing required pattern"
-msgstr ""
+msgstr "grúpa bréagchumaisc '%s' ar iarraidh patrún riachtanach"
 
 #, c-format
 msgid "pseudo-merge group '%s' has unstable threshold before stable one"
-msgstr ""
+msgstr "tá tairseach éagobhsaí ag an ngrúpa bréagchumaisc '%s' roimh cheann"
 
 #, c-format
 msgid ""
 "pseudo-merge regex from config has too many capture groups (max=%<PRIuMAX>)"
 msgstr ""
+"tá an iomarca grúpaí gabhála sa regex pseudo-merge ón chumraíocht "
+"(uasmhéid=%<PRIuMAX>)"
 
 #, c-format
 msgid "extended pseudo-merge read out-of-bounds (%<PRIuMAX> >= %<PRIuMAX>)"
 msgstr ""
+"léamh sínte cumaisc bhréige lasmuigh de theorainneacha (%<PRIuMAX> >= "
+"%<PRIuMAX>)"
 
 #, c-format
 msgid "extended pseudo-merge entry is too short (%<PRIuMAX> >= %<PRIuMAX>)"
-msgstr ""
+msgstr "tá an iontráil shínte chumaisc ró-ghearr (%<PRIuMAX> >= %<PRIuMAX>)"
 
 #, c-format
 msgid "could not find pseudo-merge for commit %s at offset %<PRIuMAX>"
 msgstr ""
+"ní fhéadfaí a aimsiú bréag-chumasc do thiomantas %s ag "
+"fhritháireamh%<PRIuMAX>"
 
 #, c-format
 msgid "extended pseudo-merge lookup out-of-bounds (%<PRIu32> >= %<PRIu32>)"
 msgstr ""
+"cuardach sínte cumaisc bhréige lasmuigh de theorainneacha (%<PRIu32> >= "
+"%<PRIu32>)"
 
 #, c-format
 msgid "out-of-bounds read: (%<PRIuMAX> >= %<PRIuMAX>)"
-msgstr ""
+msgstr "léamh lasmuigh de theorainneacha: (%<PRIuMAX> >= %<PRIuMAX>)"
 
 #, c-format
 msgid "could not read extended pseudo-merge table for commit %s"
 msgstr ""
+"ní fhéadfaí tábla bréag-chumaisc leathnaithe a léamh le haghaidh tiomanta %s"
 
 msgid "could not start `log`"
-msgstr ""
+msgstr "ní fhéadfaí 'log' a thosú"
 
 msgid "could not read `log` output"
-msgstr ""
+msgstr "ní raibh in ann aschur `log` a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse commit '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí gealladh '%s' a pháirseáil"
 
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
 "'%s'"
 msgstr ""
+"ní raibh sé in ann an chéad líne d'aschur `log` a pháirseáil: níor thosaigh "
+"sé le 'commit': '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse git header '%.*s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "níorbh fhéidir ceanntásc git a pharsáil '%.*s'"
 
-#, fuzzy
 msgid "failed to generate diff"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar éagsúlacht a ghiniúint"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse log for '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní raibh in ann logáil a pháirseáil le haghaidh '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid extra cruft tip: '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "tip cruft bhreise neamhbhailí: '%s'"
 
-#, fuzzy
 msgid "unable to enumerate additional recent objects"
-msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
+msgstr "in ann rudaí breise le déanaí a áireamh"
 
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr ""
+"ní chuirfidh sé alias comhad '%s' leis (tá '%s' ann cheana féin san innéacs)"
 
-#, fuzzy
 msgid "cannot create an empty blob in the object database"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "ní féidir le blob folamh a chruthú sa bhunachar sonraí réad"
 
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
+"%s: ní féidir ach comhaid rialta, naisc siombalacha nó eolairí git-eolairí a "
+"chur leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to index file '%s'"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "ní féidir an comhad '%s' a innéacsú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to add '%s' to index"
-msgstr "nach féidir %s a léamh"
+msgstr "ní féidir '%s' a chur leis an innéacs"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' appears as both a file and as a directory"
-msgstr "Tá %s ann agus ní eolaire é"
+msgstr "Tá '%s' le feiceáil mar chomhad agus mar eolaire"
 
-#, fuzzy
 msgid "Refresh index"
-msgstr "an t-innéacs a chur ar ais"
+msgstr "Innéacs athnuachan"
 
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
+"index.version socraithe, ach tá an luach neamhbhailí.\n"
+"Ag baint úsáide as leagan %i"
 
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
+"socraigh GIT_INDEX_VERSION, ach tá an luach neamhbhailí.\n"
+"Ag baint úsáide as leagan %i"
 
 #, c-format
 msgid "bad signature 0x%08x"
-msgstr ""
+msgstr "droch-shíniú 0x%08x"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad index version %d"
-msgstr "droch-pack.indexVersion=%<PRIu32>"
+msgstr "leagan innéacs droch%d"
 
 msgid "bad index file sha1 signature"
-msgstr ""
+msgstr "comhad innéacs droch-sha1 síniú"
 
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
-msgstr ""
+msgstr "úsáideann innéacs síneadh %.4s, nach dtuigimid"
 
 #, c-format
 msgid "ignoring %.4s extension"
-msgstr ""
+msgstr "neamhaird a dhéanamh le síneadh %.4s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown index entry format 0x%08x"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "formáid iontrála innéacs anaithnid 0x%08x"
 
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
-msgstr ""
+msgstr "réimse ainm mhífhoirmithe san innéacs, in aice le cosán '%s'"
 
 msgid "unordered stage entries in index"
-msgstr ""
+msgstr "iontrálacha céime neamh-ordaithe san innéacs"
 
-#, fuzzy, c-format
+#, c-format
 msgid "multiple stage entries for merged file '%s'"
-msgstr "seiceáil a leagan le haghaidh comhaid neamh-chumasaithe"
+msgstr "iontrálacha ilchéime do chomhad cumaisc '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unordered stage entries for '%s'"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "iontrálacha stáitse neamh-ordaithe do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create load_cache_entries thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "ní féidir an snáithe load_cache_entries a chruthú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to join load_cache_entries thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "ní féidir teacht le snáithe load_cache_entries thread: %s"
 
 #, c-format
 msgid "%s: index file open failed"
-msgstr ""
+msgstr "%s: theip ar oscailt comhad innéacs"
 
 #, c-format
 msgid "%s: cannot stat the open index"
-msgstr ""
+msgstr "%s: ní féidir an t-innéacs oscailte a stáit"
 
 #, c-format
 msgid "%s: index file smaller than expected"
-msgstr ""
+msgstr "%s: comhad innéacs níos lú ná mar a bhí súil leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s: unable to map index file%s"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "%s: ní féidir comhad innéacs %s a mhapáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create load_index_extensions thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir snáithe load_index_extensions a chruthú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to join load_index_extensions thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "ní féidir teacht le snáithe load_index_extensions: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not freshen shared index '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní raibh in ann innéacs roinnte '%s' a athnuachan"
 
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
-msgstr ""
+msgstr "innéacs briste, súil le %s i %s, fuair %s"
 
 msgid "cannot write split index for a sparse index"
-msgstr ""
+msgstr "ní féidir innéacs scoilte a scríobh le haghaidh innéacs neall"
 
-#, fuzzy
 msgid "failed to convert to a sparse-index"
-msgstr "theip ar sheiceáil éagsúil a thosú"
+msgstr "theip ar thiontú go innéacs neamhchoitianta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open git dir: %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "in ann git dir a oscailt: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to unlink: %s"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "nach féidir dínasc a dhéanamh: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot fix permission bits on '%s'"
-msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+msgstr "ní féidir giotáin ceada a shocrú ar '%s'"
 
 #, c-format
 msgid "%s: cannot drop to stage #0"
-msgstr ""
+msgstr "%s: ní féidir titim go dtí céim #0"
 
 #, c-format
 msgid "unexpected diff status %c"
-msgstr ""
+msgstr "stádas diff gan choinne %c"
 
-#, fuzzy, c-format
+#, c-format
 msgid "remove '%s'\n"
-msgstr "Ar '%s' cheana féin\n"
+msgstr "bain '%s'\n"
 
 msgid ""
 "You can fix this with 'git rebase --edit-todo' and then run 'git rebase --"
 "continue'.\n"
 "Or you can abort the rebase with 'git rebase --abort'.\n"
 msgstr ""
+"Is féidir leat é seo a shocrú le 'git rebase --edit-todo' agus ansin 'git "
+"rebase --continue' a rith.\n"
+"Nó is féidir leat an rebase a chur le 'git rebase --abort'.\n"
 
 #, c-format
 msgid ""
 "unrecognized setting %s for option rebase.missingCommitsCheck. Ignoring."
 msgstr ""
+"socrú neamhaithnithe %s le haghaidh rogha rebase.missingCommitsCheck. "
+"Neamhaird a dhéanamh."
 
 msgid ""
 "\n"
@@ -18618,23 +19535,62 @@ msgid ""
 "\n"
 "These lines can be re-ordered; they are executed from top to bottom.\n"
 msgstr ""
+"\n"
+"Orduithe:\n"
+"p, pioc <commit>= úsáid tiomantas\n"
+"r, athfhocal <commit>= bain úsáid as tiomantas, ach cuir an teachtaireacht "
+"tiomanta in eagar\n"
+"e, eagarthóire <commit>acht = tiomantas a úsáid, ach stop le haghaidh leasú\n"
+"s, squash <commit>= gealltanas a úsáid, ach cuir isteach i dtiomantas roimhe "
+"seo\n"
+"f, fixup [-C | -c] <commit>= cosúil le “squash” ach ní choinnigh ach an "
+"ceann roimhe seo\n"
+"                   teachtaireacht logála commit, mura n-úsáidtear -C, sa "
+"chás sin\n"
+"                   coinnigh ach teachtaireacht an tiomanta seo; tá -c mar an "
+"gcéanna le -C ach\n"
+"                   osclaíonn an t-eagarthóir\n"
+"x, exec <command>= ordú reáchtáil (an chuid eile den líne) ag baint úsáide "
+"as bhlaosc\n"
+"b, briseadh = stad anseo (lean ar aghaidh ar rebase níos déanaí le 'git "
+"rebase --continue')\n"
+"d, titim <commit>= bain tiomantas\n"
+"l, lipéad <label>= lipéad CEAD reatha le hainm\n"
+"t, athshocraigh <label>= athshocraigh HEAD go lipéad\n"
+"<oneline>m, cumaisc [-C <commit>| -c<commit>] <label>[#]\n"
+"        tiomantas cumaisc a chruthú ag baint úsáide as an tiomantas cumaisc\n"
+"        teachtaireacht (nó an t-aonlíne, mura raibh aon chomhcheangal "
+"cumaisc bunaidh\n"
+"        sonraithe); bain úsáid as -c chun an teachtai <commit>reacht "
+"tiomanta a athfhocal\n"
+"<ref>u, update-ref <ref>= rianú sealbhóir áite chun an a nuashonrú\n"
+"                   chuig an bpost seo sna gealltanais nua. Is <ref>é\n"
+"                   nuashonraithe ag deireadh an athbhunaithe\n"
+"\n"
+"Is féidir na línte seo a athordú; déantar iad a fhorghníomhú ó bharr go "
+"bun.\n"
 
 #, c-format
 msgid "Rebase %s onto %s (%d command)"
 msgid_plural "Rebase %s onto %s (%d commands)"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Athbhunú %s ar %s (ordú %d)"
+msgstr[1] "Athbhunú %s ar %s (%d orduithe)"
+msgstr[2] "Athbhunú %s ar %s (%d orduithe)"
 
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
 msgstr ""
+"\n"
+"Ná bain aon líne. Bain úsáid as 'drop' go sainráite chun tiomantas a "
+"bhaint.\n"
 
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
 msgstr ""
+"\n"
+"Má bhaineann tú líne anseo CAILLFIDH AN TIOMANTAS.\n"
 
 msgid ""
 "\n"
@@ -18643,22 +19599,32 @@ msgid ""
 "    git rebase --continue\n"
 "\n"
 msgstr ""
+"\n"
+"Tá tú ag eagarthóireacht ar chomhad todo de athbhunú idirghníomhach "
+"leanúnach.\n"
+"Chun leanúint ar aghaidh ag athbhunú tar éis eagarthóireachta,\n"
+"    git rebase --continue\n"
+"\n"
 
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
 "\n"
 msgstr ""
+"\n"
+"Mar sin féin, má bhaineann tú gach rud, cuirfear deireadh leis an athbhunú.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write '%s'."
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a scríobh."
 
 #, c-format
 msgid ""
 "Warning: some commits may have been dropped accidentally.\n"
 "Dropped commits (newer to older):\n"
 msgstr ""
+"Rabhadh: b'fhéidir gur titim roinnt gealltanna de thaisme.\n"
+"Gealltanna titim (níos nuaí go níos sine):\n"
 
 #, c-format
 msgid ""
@@ -18669,235 +19635,241 @@ msgid ""
 "The possible behaviours are: ignore, warn, error.\n"
 "\n"
 msgstr ""
+"Chun an teachtaireacht seo a sheachaint, bain úsáid as “titim” chun "
+"tiomantas a bhaint go sainráite.\n"
+"\n"
+"Úsáid 'git config rebase.missingCommitsCheck' chun leibhéal na rabhaidh a "
+"athrú.\n"
+"Is iad na hiompraíochtaí féideartha: neamhaird a dhéanamh, rabhadh, "
+"earráid.\n"
 
 #, c-format
 msgid "%s: 'preserve' superseded by 'merges'"
-msgstr ""
+msgstr "%s: cuireadh 'caomhnú' in ionad 'le' cumaisc '"
 
 msgid "gone"
 msgstr "imithe"
 
-#, fuzzy, c-format
+#, c-format
 msgid "ahead %d"
-msgstr "chun tosaigh "
+msgstr "ar aghaidh %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "behind %d"
-msgstr "taobh thiar "
+msgstr "taobh thiar de %d"
 
 #, c-format
 msgid "ahead %d, behind %d"
-msgstr ""
+msgstr "tosaigh %d, taobh thiar de %d"
 
 #, c-format
 msgid "%%(%.*s) does not take arguments"
-msgstr ""
+msgstr "%%(%.*s) ní ghlacann argóintí"
 
 #, c-format
 msgid "unrecognized %%(%.*s) argument: %s"
-msgstr ""
+msgstr "neamhaithnithe %%(%.*s) argóint: %s"
 
 #, c-format
 msgid "expected format: %%(color:<color>)"
-msgstr ""
+msgstr "formáid ionchais: %%(color:<dath>)"
 
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
-msgstr ""
+msgstr "dath gan aithint: %%(color:%s)"
 
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
-msgstr ""
+msgstr "Luach sláimhir a bhfuiltear ag súil leis refname:lstrip=%s"
 
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
-msgstr ""
+msgstr "Luach sláimhir a bhfuiltear ag súil leis refname:rstrip=%s"
 
 #, c-format
 msgid "expected %%(trailers:key=<value>)"
-msgstr ""
+msgstr "ionchasach %%(trailers:key=<value>)"
 
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
-msgstr ""
+msgstr "argóint %%(trailers) anaithnid: %s"
 
 #, c-format
 msgid "positive value expected contents:lines=%s"
-msgstr ""
+msgstr "ábhar ag súil le luach dearfach:lines=%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "argument expected for %s"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "argóint ag súil le haghaidh %s"
 
 #, c-format
 msgid "positive value expected %s=%s"
-msgstr ""
+msgstr "luach dearfach a bhfuiltear ag súil leis %s=%s"
 
 #, c-format
 msgid "cannot fully parse %s=%s"
-msgstr ""
+msgstr "ní féidir %s=%s a pháirseáil go hiomlán"
 
 #, c-format
 msgid "value expected %s="
-msgstr ""
+msgstr "luach ag súil leis %s="
 
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
-msgstr ""
+msgstr "luach dearfach a bhíothas ag súil le '%s' i %%(%s)"
 
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
-msgstr ""
+msgstr "ionchasach formáid: %%(align:<width>,<position>)"
 
 #, c-format
 msgid "unrecognized position:%s"
-msgstr ""
+msgstr "suíomh gan aithint:%s"
 
 #, c-format
 msgid "unrecognized width:%s"
-msgstr ""
+msgstr "leithead gan aithint:%s"
 
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
-msgstr ""
+msgstr "argóint %%(%s) gan aitheantas: %s"
 
 #, c-format
 msgid "positive width expected with the %%(align) atom"
-msgstr ""
+msgstr "leithead dearfach a bhíothas ag súil leis leis an adamh %%(align)"
 
 #, c-format
 msgid "expected format: %%(ahead-behind:<committish>)"
-msgstr ""
+msgstr "formáid ionchais:  %%(ahead-behind:<committish>)"
 
 #, c-format
 msgid "expected format: %%(is-base:<committish>)"
-msgstr ""
+msgstr "formáid ionchais: %%(is-base:<committish>)"
 
 #, c-format
 msgid "malformed field name: %.*s"
-msgstr ""
+msgstr "ainm réimse mífhoirmithe: %.*s"
 
 #, c-format
 msgid "unknown field name: %.*s"
-msgstr ""
+msgstr "ainm réimse anaithnid: %.*s"
 
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
+"ní stórlann git é, ach éilíonn an réimse '%.*s' rochtain ar shonraí réada"
 
 #, c-format
 msgid "format: %%(%s) atom used without a %%(%s) atom"
-msgstr ""
+msgstr "formáid: %%(%s) adaim a úsáidtear gan adaim %%(%s)"
 
 #, c-format
 msgid "format: %%(then) atom used more than once"
-msgstr ""
+msgstr "formáid: %%(then) adaim a úsáidtear níos mó ná uair amháin"
 
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
-msgstr ""
+msgstr "formáid: %%(then) adaim a úsáidtear tar éis %%(else)"
 
 #, c-format
 msgid "format: %%(else) atom used more than once"
-msgstr ""
+msgstr "formáid: %%(else) adaim a úsáidtear níos mó ná uair amháin"
 
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
-msgstr ""
+msgstr "formáid: %%(end) adaim a úsáidtear gan adaim chomhfhreagrach"
 
 #, c-format
 msgid "malformed format string %s"
-msgstr ""
+msgstr "teaghrán formáid mhífhoirmithe %s"
 
 #, c-format
 msgid "this command reject atom %%(%.*s)"
-msgstr ""
+msgstr "diúltú an t-ordú seo adamh %%(%.*s)"
 
 #, c-format
 msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
-msgstr ""
+msgstr "--format=%.*s ní féidir é a úsáid le --python, --shell, --tcl"
 
-#, fuzzy
 msgid "failed to run 'describe'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar 'cur síos' a rith"
 
 #, c-format
 msgid "(no branch, rebasing %s)"
-msgstr ""
+msgstr "(gan aon bhrainse, athbhunú %s)"
 
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
-msgstr ""
+msgstr "(gan aon bhrainse, athbhunú CEAD scoite %s)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "(no branch, bisect started on %s)"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "(gan aon bhrainse, thosaigh bisect ar %s)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "(HEAD detached at %s)"
-msgstr "HEAD scoite ag "
+msgstr "(HEAD scoite ag %s)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "(HEAD detached from %s)"
-msgstr "CEANN scartha ó "
+msgstr "(CEAD scoite ó %s)"
 
-#, fuzzy
 msgid "(no branch)"
-msgstr "CEAD (gan aon bhrainse)"
+msgstr "(gan aon bhrainse)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "missing object %s for %s"
-msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
+msgstr "réad atá ar iarraidh %s do %s"
 
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
-msgstr ""
+msgstr "theip ar parse_object_buffer ar %s do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed object at '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "réad mífhoirmithe ag '%s'"
 
 #, c-format
 msgid "ignoring ref with broken name %s"
-msgstr ""
+msgstr "neamhaird a dhéanamh ar tagairt le ainm briste %s"
 
 #, c-format
 msgid "ignoring broken ref %s"
-msgstr ""
+msgstr "ag déanamh neamhaird ar thagairt briste %s"
 
 #, c-format
 msgid "format: %%(end) atom missing"
-msgstr ""
+msgstr "formáid :%%(end) ataim ar iarraidh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed object name %s"
-msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
+msgstr "ainm réad mífhoirmithe %s"
 
 #, c-format
 msgid "option `%s' must point to a commit"
-msgstr ""
+msgstr "caithfidh rogha `%s' a chur in iúl do thiomantas"
 
 msgid "key"
-msgstr ""
+msgstr "eochair"
 
 msgid "field name to sort on"
-msgstr ""
+msgstr "ainm réimse le sórtáil"
 
 msgid "exclude refs which match pattern"
-msgstr ""
+msgstr "a eisiamh iarmhairtí a mheaitseálann patrún"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a reflog: %s"
-msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+msgstr "ní athbhreithniú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no reflog for '%s'"
-msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+msgstr "gan aon athbhreithniú do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s does not point to a valid object!"
-msgstr "Ní chuireann HEAD in iúl do bhrainse"
+msgstr "Ní thugann %s in iúl go réad bailí!"
 
 #, c-format
 msgid ""
@@ -18912,305 +19884,331 @@ msgid ""
 "\n"
 "\tgit branch -m <name>\n"
 msgstr ""
+"Ag baint úsáide as '%s' mar ainm don bhrainse tosaigh. An ainm brainse "
+"réamhshocraithe\n"
+"tá sé faoi réir athraithe. Chun an t-ainm brainse tosaigh a chumrú le húsáid "
+"i ngach\n"
+"de do stór nua, a chuirfidh an rabhadh seo a chur faoi chois, glaoigh ar:\n"
+"\n"
+"\tgit config --global init.defaultBranch <name>\n"
+"\n"
+"Is iad na hainmneacha a roghnaítear go coitianta in ionad 'máistir' príomh "
+"',' stoc 'agus\n"
+"'forbair'. Is féidir an brainse atá díreach cruthaithe a athainmniú tríd an "
+"ordú seo:\n"
+"\n"
+"\tgit branch -m <name>\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not retrieve `%s`"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí `%s` a aisghabháil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid branch name: %s = %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "ainm brainse neamhbhailí: %s = %s"
 
 #, c-format
 msgid "ignoring dangling symref %s"
-msgstr ""
+msgstr "ag déanamh neamhaird ar shiomtref crochta %s"
 
 #, c-format
 msgid "log for ref %s has gap after %s"
-msgstr ""
+msgstr "tá bearna ag logáil le haghaidh tagairt %s tar éis %s"
 
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
-msgstr ""
+msgstr "chríochnaigh logáil le haghaidh tagairt %s gan choinne ar %s"
 
 #, c-format
 msgid "log for %s is empty"
-msgstr ""
+msgstr "tá logáil le haghaidh %s folamh"
 
 #, c-format
 msgid "refusing to update reflog for pseudoref '%s'"
-msgstr ""
+msgstr "diúltú reflog a nuashonrú do pseudoref '%s'"
 
 #, c-format
 msgid "refusing to update pseudoref '%s'"
-msgstr ""
+msgstr "diúltú pseudoref '%s' a nuashonrú"
 
 #, c-format
 msgid "refusing to update reflog with bad name '%s'"
-msgstr ""
+msgstr "diúltú reflog a nuashonrú le droch-ainm '%s'"
 
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
-msgstr ""
+msgstr "diúltú tagairt a nuashonrú le droch-ainm '%s'"
 
 msgid "refusing to force and skip creation of reflog"
-msgstr ""
+msgstr "diúltú cruthú reflog a chur i bhfeidhm agus a scipeáil"
 
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
-msgstr ""
+msgstr "theip ar update_ref le haghaidh tagairt '%s': %s"
 
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
-msgstr ""
+msgstr "ní cheadaítear nuashonruithe iolracha le haghaidh tagairt '%s'"
 
 msgid "ref updates forbidden inside quarantine environment"
-msgstr ""
+msgstr "nuashonruithe ref toirmiscthe laistigh de"
 
 msgid "ref updates aborted by hook"
-msgstr ""
+msgstr "nuashonruithe tagartha a chuirtear deireadh leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' exists; cannot create '%s'"
-msgstr "Ní féidir '%s' a úsáid le '%s'"
+msgstr "Tá '%s' ann; ní féidir '%s' a chruthú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot process '%s' and '%s' at the same time"
-msgstr ""
-"Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
+msgstr "ní féidir '%s' agus '%s' a phróiseáil ag an am céanna"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not delete reference %s: %s"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí tagairt %s a scriosadh: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not delete references: %s"
-msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
+msgstr "ní fhéadfaí tagairtí a scriosadh: %s"
 
 #, c-format
 msgid "Finished dry-run migration of refs, the result can be found at '%s'\n"
 msgstr ""
+"Imirce tirim críochnaithe na n-iarmhairc, is féidir an toradh a fháil ag "
+"'%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not remove temporary migration directory '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire imirce sealadach '%s' a bhaint"
 
 #, c-format
 msgid "migrated refs can be found at '%s'"
-msgstr ""
+msgstr "is féidir airgeanna imirceacha a fháil ag '%s'"
 
 #, c-format
 msgid ""
 "cannot lock ref '%s': expected symref with target '%s': but is a regular ref"
 msgstr ""
+"ní féidir tagairt '%s' a ghlasáil: ag súil le symref le sprioc '%s': ach is "
+"tagairt rialta é"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read ref file '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir comhad tagartha '%s' a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open directory %s"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "ní féidir eolaire %s a oscailt"
 
 msgid "Checking references consistency"
-msgstr ""
+msgstr "Comhsheasmhacht tagairtí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open '%s'"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní féidir '%s' a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read '%s'"
-msgstr "nach féidir %s a léamh"
+msgstr "ní féidir '%s' a léamh"
 
 #, c-format
 msgid "refname is dangerous: %s"
-msgstr ""
+msgstr "tá refname contúirteach: %s"
 
 #, c-format
 msgid "trying to write ref '%s' with nonexistent object %s"
-msgstr ""
+msgstr "ag iarraidh tagairt '%s' a scríobh le réad nach bhfuil %s ann"
 
 #, c-format
 msgid "trying to write non-commit object %s to branch '%s'"
-msgstr ""
+msgstr "ag iarraidh réad neamh-thiomanta %s a scríobh chuig brainse '%s'"
 
 #, c-format
 msgid ""
 "multiple updates for 'HEAD' (including one via its referent '%s') are not "
 "allowed"
 msgstr ""
+"ní cheadaítear nuashonruithe iolracha do 'HEAD' (lena n-áirítear ceann tríd "
+"an tagairt '%s')"
 
 #, c-format
 msgid "cannot lock ref '%s': unable to resolve reference '%s'"
-msgstr ""
+msgstr "ní féidir tagairt '%s' a ghlasáil: ní féidir tagairt '%s' a réiteach"
 
 #, c-format
 msgid "cannot lock ref '%s': error reading reference"
-msgstr ""
+msgstr "ní féidir tagairt '%s' a ghlasáil: earráid ag léamh tagairt"
 
 #, c-format
 msgid ""
 "multiple updates for '%s' (including one via symref '%s') are not allowed"
 msgstr ""
+"ní cheadaítear nuashonruithe iolracha do '%s' (lena n-áirítear ceann trí "
+"symref '%s')"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot lock ref '%s': reference already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "ní féidir tagairt '%s' a ghlasáil: tá tagairt ann cheana féin"
 
 #, c-format
 msgid "cannot lock ref '%s': reference is missing but expected %s"
 msgstr ""
+"ní féidir tagairt '%s' a ghlasáil: tá tagairt ar iarraidh ach táthar ag súil "
+"leis %s"
 
 #, c-format
 msgid "cannot lock ref '%s': is at %s but expected %s"
 msgstr ""
+"ní féidir tagairt '%s' a ghlasáil: tá sé ag %s ach táthar ag súil leis %s"
 
 #, c-format
 msgid "reftable: transaction prepare: %s"
-msgstr ""
+msgstr "athfhabhtaithe: ullmhú idirbheart: %s"
 
 #, c-format
 msgid "reftable: transaction failure: %s"
-msgstr ""
+msgstr "athfhabhtaithe: teip ar idirbheart: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to compact stack: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "nach féidir cruach a dhlúthú: %s"
 
 #, c-format
 msgid "refname %s not found"
-msgstr ""
+msgstr "ní aimsíodh refname %s"
 
 #, c-format
 msgid "refname %s is a symbolic ref, copying it is not supported"
-msgstr ""
+msgstr "rs tagairt siombalach é refname %s, ní thacaítear leis a chóipeáil"
 
 #, c-format
 msgid "pattern '%s' has no '*'"
-msgstr ""
+msgstr "níl aon '*' ag patrún '%s'"
 
 #, c-format
 msgid "replacement '%s' has no '*'"
-msgstr ""
+msgstr "níl aon '*' ag athsholáthar '%s'"
 
 #, c-format
 msgid "invalid quoting in push-option value: '%s'"
-msgstr ""
+msgstr "luachan neamhbhailí i luach brú rogha: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown value for object-format: %s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "luach anaithnid d'fhormáid réad: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
-msgstr "Ní cheadaítear athshocrú %s i stóras lom"
+msgstr "Níl %sinfo/refs bailí: an stór git é seo?"
 
 msgid "invalid server response; expected service, got flush packet"
-msgstr ""
+msgstr "freagra freastalaí neamhbhailí; seirbhís a bhíothas ag súil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid server response; got '%s'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "freagra freastalaí neamhbhailí; fuair '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "repository '%s' not found"
-msgstr "níl an stóras '%s' ann"
+msgstr "níor aimsíodh stór '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Authentication failed for '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "Theip ar fhíordheimhniú do '%s'"
 
 #, c-format
 msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
-msgstr ""
+msgstr "ní féidir rochtain a fháil ar '%s' le cumraíocht http.pinnedPubkey: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to access '%s': %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní féidir teacht ar '%s': %s"
 
 #, c-format
 msgid "redirecting to %s"
-msgstr ""
+msgstr "atreorú chuig %s"
 
 msgid "shouldn't have EOF when not gentle on EOF"
-msgstr ""
+msgstr "níor chóir go mbeadh EOF ann nuair nach bhfuil sé miline ar EOF"
 
 msgid "remote server sent unexpected response end packet"
-msgstr ""
+msgstr "sheol freastalaí iargúlta paicéad deiridh"
 
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
+"nach féidir sonraí post rpc a athfhillt - déan iarracht http.postBuffer a "
+"mhéadú"
 
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
-msgstr ""
+msgstr "iargúlta: carachtar fad droch-líne: %.4s"
 
 msgid "remote-curl: unexpected response end packet"
-msgstr ""
+msgstr "iargúlta: paicéad deiridh freagartha gan choinne"
 
 #, c-format
 msgid "RPC failed; %s"
-msgstr ""
+msgstr "Theip ar RPC; %s"
 
 msgid "cannot handle pushes this big"
-msgstr ""
+msgstr "ní féidir brú mór seo a láimhseáil"
 
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
-msgstr ""
+msgstr "ní féidir iarratas a dhíscaoileadh; earráid dífhabhtaithe zlib %d"
 
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
-msgstr ""
+msgstr "ní féidir iarratas a dhíscaoileadh; earráid deiridh zlib %d"
 
 #, c-format
 msgid "%d bytes of length header were received"
-msgstr ""
+msgstr "Fuarthas %d bytes de cheanntásc fad"
 
 #, c-format
 msgid "%d bytes of body are still expected"
-msgstr ""
+msgstr "Táthar ag súil fós ag súil le %d bytes den chorp"
 
 msgid "dumb http transport does not support shallow capabilities"
-msgstr ""
+msgstr "ní thacaíonn iompar HTTP dumb le cumais éadomhain"
 
 msgid "fetch failed."
-msgstr ""
+msgstr "theip ar fáil."
 
 msgid "cannot fetch by sha1 over smart http"
-msgstr ""
+msgstr "ní féidir le sha1 a fháil thar http cliste"
 
-#, fuzzy, c-format
+#, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
-msgstr "táthar ag súil le brainse, fuair '%s'"
+msgstr "earráid prótacal: súil le sha/ref, fuair '%s'"
 
 #, c-format
 msgid "http transport does not support %s"
-msgstr ""
+msgstr "ní thacaíonn iompar http le %s"
 
 msgid "protocol error: expected '<url> <path>', missing space"
-msgstr ""
+msgstr "earráid prótacal: súil leis '<url><path>', spás in easnamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to download file at URL '%s'"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "theip ar an comhad a íoslódáil ag URL '%s'"
 
 msgid "git-http-push failed"
-msgstr ""
+msgstr "theip ar git-http-push"
 
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
-msgstr ""
+msgstr "<remote><url>remote-curl: úsáid: git remote-curl []"
 
 msgid "remote-curl: error reading command stream from git"
-msgstr ""
+msgstr "remote-curl: earráid ag léamh sruth ordaithe ó git"
 
 msgid "remote-curl: fetch attempted without a local repo"
-msgstr ""
+msgstr "remote-curl: iarracht a fháil gan repo áitiúil"
 
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
-msgstr ""
+msgstr "remote-curl: ordú anaithnid '%s' ó git"
 
 #, c-format
 msgid ""
@@ -19482,397 +20480,403 @@ msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
 msgid "cannot strip one component off url '%s'"
 msgstr "ní féidir comhpháirt amháin a bhaint as url '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "bad replace ref name: %s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "droch-ainm tagartha athsholáthair: %s"
 
 #, c-format
 msgid "duplicate replace ref: %s"
-msgstr ""
+msgstr "athsholáthar dúblach tagairt: %s"
 
 #, c-format
 msgid "replace depth too high for object %s"
-msgstr ""
+msgstr "doimhneacht ró-ard a chur in ionad do réad %s"
 
 msgid "corrupt MERGE_RR"
-msgstr ""
+msgstr "truaillithe MERGE_RR"
 
-#, fuzzy
 msgid "unable to write rerere record"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "in ann taifead a scríobh arís"
 
 #, c-format
 msgid "there were errors while writing '%s' (%s)"
-msgstr ""
+msgstr "bhí earráidí ann agus tú ag scríobh '%s' (%s)"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse conflict hunks in '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí coimhlint a pharsáil i '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed utime() on '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar utime () ar '%s'"
 
 #, c-format
 msgid "writing '%s' failed"
-msgstr ""
+msgstr "theip ar scríobh '%s'"
 
 #, c-format
 msgid "Staged '%s' using previous resolution."
-msgstr ""
+msgstr "'%s 'céim ag baint úsáide as réiteach roimhe seo."
 
 #, c-format
 msgid "Recorded resolution for '%s'."
-msgstr ""
+msgstr "Réiteach taifeadta le haghaidh '%s'."
 
 #, c-format
 msgid "Resolved '%s' using previous resolution."
-msgstr ""
+msgstr "Réitigh '%s' ag úsáid réiteach roimhe seo."
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot unlink stray '%s'"
-msgstr "ní féidir le comhad malartacha sealadacha a dhínascadh"
+msgstr "ní féidir le '%s' a dhínascadh"
 
 #, c-format
 msgid "Recorded preimage for '%s'"
-msgstr ""
+msgstr "Réamhíomhá taifeadta do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to update conflicted state in '%s'"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "theip ar an stát coinbhleachta a nuashonrú i '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no remembered resolution for '%s'"
-msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+msgstr "níl aon réiteach cuimhne ar '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Updated preimage for '%s'"
-msgstr "Nuashonraíodh %d cosán ó %s"
+msgstr "Réamhíomhá nuashonraithe do '%s'"
 
 #, c-format
 msgid "Forgot resolution for '%s'\n"
-msgstr ""
+msgstr "Déan dearmad dearmad ar réiteach '%s'\n"
 
-#, fuzzy
 msgid "unable to open rr-cache directory"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "in ann eolaire rr-cache a oscailt"
 
 msgid "update the index with reused conflict resolution if possible"
-msgstr ""
+msgstr "an t-innéacs a nuashonrú le réiteach coinbhleachta a athúsáidtear"
 
-#, fuzzy
 msgid "could not determine HEAD revision"
-msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
+msgstr "ní raibh sé in ann athbhreithniú HEAD"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to find tree of %s"
-msgstr "Theip ar chrann %s a aimsiú."
+msgstr "theip ar chrann %s a aimsiú"
 
 #, c-format
 msgid "unsupported section for hidden refs: %s"
-msgstr ""
+msgstr "rannán gan tacaíocht do thaifeanna i bhfolach: %s"
 
 msgid "--exclude-hidden= passed more than once"
-msgstr ""
+msgstr "--exclude-hidden= rith níos mó ná uair amháin"
 
 #, c-format
 msgid "resolve-undo records `%s` which is missing"
-msgstr ""
+msgstr "taifid réitigh a chealú `%s` atá ar iarraidh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s exists but is a symbolic ref"
-msgstr "Tá %s ann agus ní eolaire é"
+msgstr "Tá %s ann ach is tagairt siombalach é"
 
 msgid ""
 "--merge requires one of the pseudorefs MERGE_HEAD, CHERRY_PICK_HEAD, "
 "REVERT_HEAD or REBASE_HEAD"
 msgstr ""
+"Teastaíonn --merge ceann de na pseudorefs MERGE_HEAD, CHERRY_PICK_HEAD, "
+"REVERT_HEAD nó REBASE_HEAD"
 
 #, c-format
 msgid "could not get commit for --ancestry-path argument %s"
-msgstr ""
+msgstr "ní fhéadfaí tiomantas a fháil le haghaidh argóint --ancestry-path %s"
 
 msgid "--unpacked=<packfile> no longer supported"
-msgstr ""
+msgstr "--unpacked=<packfile> ní thacaítear leis a thuilleadh"
 
 #, c-format
 msgid "invalid option '%s' in --stdin mode"
-msgstr ""
+msgstr "rogha neamhbhailí '%s' i mód --stdin"
 
-#, fuzzy
 msgid "your current branch appears to be broken"
-msgstr "Tá tú ar bhrainse nach rugadh fós"
+msgstr "is cosúil go bhfuil do bhrainse reatha briste"
 
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
-msgstr ""
+msgstr "níl aon gealltanais fós ag do bhrainse reatha '%s'"
 
 msgid "object filtering requires --objects"
-msgstr ""
+msgstr "teastaíonn scagadh réad --objects"
 
 msgid "-L does not yet support diff formats besides -p and -s"
-msgstr ""
+msgstr "Ní thacaíonn -L le formáidí diff fós seachas -p agus -s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot create async thread: %s"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "ní féidir snáithe async a chruthú: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "Níl '%s' ann"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not switch to '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí aistriú go '%s'"
 
 msgid "need a working directory"
-msgstr ""
+msgstr "teastaíonn eolaire oibre"
 
 msgid "Scalar enlistments require a worktree"
-msgstr ""
+msgstr "Teastaíonn crann oibre ó liostú scalar"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not configure %s=%s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí %s=%s a chumrú"
 
 msgid "could not configure log.excludeDecoration"
-msgstr ""
+msgstr "ní fhéadfaí log.excludeDecoration a chumrú"
 
 msgid "could not add enlistment"
-msgstr ""
+msgstr "ní fhéadfaí liostú a chur leis"
 
 msgid "could not set recommended config"
-msgstr ""
+msgstr "ní fhéadfaí cumraíocht mholta a shocrú"
 
 msgid "could not turn on maintenance"
-msgstr ""
+msgstr "ní fhéadfadh cothabháil a chasadh air"
 
 msgid "could not start the FSMonitor daemon"
-msgstr ""
+msgstr "ní fhéadfaí an daemon FSMonitor a thosú"
 
 msgid "could not turn off maintenance"
-msgstr ""
+msgstr "ní fhéadfadh cothabháil a mhúchadh"
 
-#, fuzzy
 msgid "could not remove enlistment"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí liostú a bhaint"
 
 #, c-format
 msgid "remote HEAD is not a branch: '%.*s'"
-msgstr ""
+msgstr "ní brainse é iargúlta HEAD: '%.*s"
 
 msgid "failed to get default branch name from remote; using local default"
 msgstr ""
+"theip ar ainm brainse réamhshocraithe a fháil ó iargúlta; ag baint úsáide as"
 
 msgid "failed to get default branch name"
-msgstr ""
+msgstr "theip ort ainm brainse réamhshocraithe a fháil"
 
-#, fuzzy
 msgid "failed to unregister repository"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar stór a dhíchlárú"
 
 msgid "failed to stop the FSMonitor daemon"
-msgstr ""
+msgstr "theip ar an daemon FSMonitor a stopadh"
 
-#, fuzzy
 msgid "failed to delete enlistment directory"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "theip ar eolaire liostála a scriosadh"
 
 msgid "branch to checkout after clone"
-msgstr ""
+msgstr "brainse chun an tseiceáil tar éis clóin"
 
 msgid "when cloning, create full working directory"
-msgstr ""
+msgstr "agus tú ag clónú, cruthaigh eolaire oibre iomlán"
 
 msgid "only download metadata for the branch that will be checked out"
-msgstr ""
+msgstr "meiteashonraí a íoslódáil ach don bhrainse a sheiceálfar"
 
 msgid "create repository within 'src' directory"
-msgstr ""
+msgstr "cruthaigh stór laistigh de eolaire 'src'"
 
 msgid "specify if tags should be fetched during clone"
-msgstr ""
+msgstr "sonraigh an gcaithfear clibeanna a fháil le linn clóin"
 
 msgid ""
 "scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]\n"
 "\t[--[no-]src] [--[no-]tags] <url> [<enlistment>]"
 msgstr ""
+"scalar clone [--single-branch] [--branch <main-branch>] [--full-clone]\n"
+"\t[--[no-]src] [--[no-]tags] <url> [<enlistment>]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot deduce worktree name from '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní féidir ainm crann oibre a bhaint as '%s'"
 
 #, c-format
 msgid "directory '%s' exists already"
-msgstr ""
+msgstr "tá eolaire '%s' ann cheana féin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to get default branch for '%s'"
-msgstr "theip ar athrá thar '%s'"
+msgstr "theip ar bhrainse réamhshocraithe a fháil do '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not configure remote in '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí iargúlta a chumrú i '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not disable tags in '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "ní fhéadfaí clibeanna a dhíchumasú i '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not configure '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a chumrú"
 
 msgid "partial clone failed; attempting full clone"
-msgstr ""
+msgstr "theip ar chlón páirteach; iarracht clón iomlán"
 
 msgid "could not configure for full clone"
-msgstr ""
+msgstr "ní fhéadfaí a chumrú le haghaidh clón iomlán"
 
 msgid "scalar diagnose [<enlistment>]"
-msgstr ""
+msgstr "<enlistment>diagnóis scalar []"
 
 msgid "`scalar list` does not take arguments"
-msgstr ""
+msgstr "Ní ghlacann `liosta scalar` argóintí"
 
 msgid "scalar register [<enlistment>]"
-msgstr ""
+msgstr "<enlistment>clár scalar []"
 
 msgid "reconfigure all registered enlistments"
-msgstr ""
+msgstr "gach liostáil cláraithe a athchumrú"
 
 msgid "scalar reconfigure [--all | <enlistment>]"
-msgstr ""
+msgstr "athchumrú scálach [--all | <enlistment>]"
 
 msgid "--all or <enlistment>, but not both"
-msgstr ""
+msgstr "--all nó <enlistment>, ach ní an dá cheann"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not remove stale scalar.repo '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí scalar.repo '%s' a bhaint as scalar.repo"
 
 #, c-format
 msgid "removed stale scalar.repo '%s'"
-msgstr ""
+msgstr "bainte scale scalar.repo '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "repository at '%s' has different owner"
-msgstr "níl an stóras '%s' ann"
+msgstr "tá úinéir difriúil ag an stórlann ag '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "repository at '%s' has a format issue"
-msgstr "níl an stóras '%s' ann"
+msgstr "tá ceist formáide ag stór ag '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "repository not found in '%s'"
-msgstr "droch-stóras '%s'"
+msgstr "ní bhfuarthas stór i '%s'"
 
 #, c-format
 msgid ""
 "to unregister this repository from Scalar, run\n"
 "\tgit config --global --unset --fixed-value scalar.repo \"%s\""
 msgstr ""
+"chun an stór seo a dhíchlárú ó Scalar, reáchtáil\n"
+" git config --global --unset --fixed-value scalar.repo “%s”"
 
 msgid ""
 "scalar run <task> [<enlistment>]\n"
 "Tasks:\n"
 msgstr ""
+"rith scalar <tasc> [<liostáil>]\n"
+"Tascanna:\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "no such task: '%s'"
-msgstr "aon bhrainse den sórt sin: '%s'"
+msgstr "gan aon tasc den sórt sin: '%s'"
 
 msgid "scalar unregister [<enlistment>]"
-msgstr ""
+msgstr "<enlistment>scálar díchlárú []"
 
 msgid "scalar delete <enlistment>"
-msgstr ""
+msgstr "scriosadh scalar <enlistment>"
 
 msgid "refusing to delete current working directory"
-msgstr ""
+msgstr "diúltú eolaire oibre reatha a scriosadh"
 
 msgid "include Git version"
-msgstr ""
+msgstr "leagan Git san áireamh"
 
 msgid "include Git's build options"
-msgstr ""
+msgstr "áireamh roghanna tógála Git"
 
 msgid "scalar verbose [-v | --verbose] [--build-options]"
-msgstr ""
+msgstr "scalar verbose [-v | --verbose] [--build-options]"
 
-#, fuzzy
 msgid "-C requires a <directory>"
-msgstr "--stdin teastaíonn stórlann git"
+msgstr "Éilíonn -C a <directory>"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not change to '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí athrú go '%s'"
 
 msgid "-c requires a <key>=<value> argument"
-msgstr ""
+msgstr "<value>Éilíonn -c a <key>= argóint"
 
 msgid ""
 "scalar [-C <directory>] [-c <key>=<value>] <command> [<options>]\n"
 "\n"
 "Commands:\n"
 msgstr ""
+"scalar [-C <eolaire>] [-c <eochair>=<luach>] <ordú> [<roghanna>]\n"
+"\n"
+"Orduithe:\n"
 
 msgid "unexpected flush packet while reading remote unpack status"
-msgstr ""
+msgstr "paicéad srutháin gan choinne agus stádas díphacála iargúlta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse remote unpack status: %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir stádas iargúlta díphacáil a pháirseáil: %s"
 
 #, c-format
 msgid "remote unpack failed: %s"
-msgstr ""
+msgstr "theip ar dhíphacáil iargúlta: %s"
 
 msgid "failed to sign the push certificate"
-msgstr ""
+msgstr "theip ar an deimhniú brú a shíniú"
 
 msgid "send-pack: unable to fork off fetch subprocess"
-msgstr ""
+msgstr "pacáiste seolta: ní féidir leis an bhfophróiseas faighte a fhorc"
 
 msgid "push negotiation failed; proceeding anyway with push"
-msgstr ""
+msgstr "theip ar chaibidlíocht brú; dul ar aghaidh ar aon nós"
 
 msgid "the receiving end does not support this repository's hash algorithm"
-msgstr ""
+msgstr "ní thacaíonn an deireadh glacadh le halgartam hash an stór seo"
 
 msgid "the receiving end does not support --signed push"
-msgstr ""
+msgstr "ní thacaíonn an deireadh glacadh le brú --signed"
 
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
 msgstr ""
+"níl teastas brú á sheoladh ós rud é nach dtacaíonn an taobh glactha le --"
+"signed brúigh"
 
 msgid "the receiving end does not support --atomic push"
-msgstr ""
+msgstr "ní thacaíonn an deireadh glacadh le brú --atomic"
 
 msgid "the receiving end does not support push options"
-msgstr ""
+msgstr "ní thacaíonn an deireadh glacadh le roghanna brú"
 
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
-msgstr ""
+msgstr "modh glantacháin teachtaireachta tiomanta neamhbhailí '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not delete '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a scriosadh"
 
 msgid "revert"
-msgstr ""
+msgstr "filleadh"
 
 msgid "cherry-pick"
-msgstr ""
+msgstr "pioc silíní"
 
 msgid "rebase"
-msgstr ""
+msgstr "athbhunú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown action: %d"
-msgstr "cineál réad anaithnid %d"
+msgstr "gníomh anaithnid: %d"
 
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
@@ -19881,11 +20885,19 @@ msgid ""
 "To abort and get back to the state before \"git rebase\", run \"git rebase --"
 "abort\"."
 msgstr ""
+"Réiteach na coinbhleachtaí go léir de láimh, marcáil iad mar réiteach\n"
+"“git add/rm <conflicted_files>“, ansin rith “git rebase --continue”.\n"
+"Ina áit sin is féidir leat an tiomantas seo a scipeáil: rith “git rebase --"
+"skip”.\n"
+"Chun abordú agus dul ar ais go dtí an stát roimh “git rebase”, reáchtáil "
+"“git rebase --abort”."
 
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
 msgstr ""
+"tar éis na coinbhleachtaí a réiteach, marcáil na cosáin cearta\n"
+"<paths>le 'git add <paths>'nó 'git rm'"
 
 msgid ""
 "After resolving the conflicts, mark them with\n"
@@ -19895,6 +20907,13 @@ msgid ""
 "To abort and get back to the state before \"git cherry-pick\",\n"
 "run \"git cherry-pick --abort\"."
 msgstr ""
+"Tar éis na coinbhleachtaí a réiteach, marcáil iad le\n"
+"“git add/rm <pathspec>“, ansin rith\n"
+"\"git cherry-pick --continue\".\n"
+"Is féidir leat an tiomantas seo a scipeáil ina ionad sin le \"git cherry-"
+"pick --skip\n"
+"Chun abordú agus dul ar ais go dtí an stát roimh “git cherry-pick”,\n"
+"reáchtáil “git cherry-pick --abort”."
 
 msgid ""
 "After resolving the conflicts, mark them with\n"
@@ -19904,70 +20923,76 @@ msgid ""
 "To abort and get back to the state before \"git revert\",\n"
 "run \"git revert --abort\"."
 msgstr ""
+"Tar éis na coinbhleachtaí a réiteach, marcáil iad le\n"
+"“git add/rm <pathspec>“, ansin rith\n"
+"“git ar ais --continue ar aghaidh”.\n"
+"Ina áit sin is féidir leat an tiomantas seo a scipeáil le “git revert --"
+"skip”.\n"
+"Chun deireadh a chur leis agus dul ar ais go dtí an stát roimh “git "
+"revert”,\n"
+"reáchtáil “git revert --abort”."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not lock '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a ghlasáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write eol to '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí eol a scríobh chuig '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to finalize '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "theip ar '%s' a chur i gcrích"
 
 #, c-format
 msgid "your local changes would be overwritten by %s."
-msgstr ""
+msgstr "d'athruithe áitiúla a fhorscríobhadh ag %s."
 
 msgid "commit your changes or stash them to proceed."
-msgstr ""
+msgstr "do chuid athruithe a dhéanamh nó iad a stóráil chun dul ar aghaidh."
 
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#, fuzzy, c-format
+#, c-format
 msgid "%s: Unable to write new index file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "%s: Ní féidir comhad innéacs nua a scríobh"
 
-#, fuzzy
 msgid "unable to update cache tree"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "in ann crann taisce a nuashonrú"
 
-#, fuzzy
 msgid "could not resolve HEAD commit"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí tiomantas HEAD a réiteach"
 
 #, c-format
 msgid "no key present in '%.*s'"
-msgstr ""
+msgstr "níl aon eochair i láthair i '%.*s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to dequote value of '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "nach féidir luach '%s' a dhíchur"
 
 msgid "'GIT_AUTHOR_NAME' already given"
-msgstr ""
+msgstr "'GIT_AUTHOR_NAME' tugtha cheana féin"
 
 msgid "'GIT_AUTHOR_EMAIL' already given"
-msgstr ""
+msgstr "'GIT_AUTHOR_EMAIL' tugtha cheana féin"
 
 msgid "'GIT_AUTHOR_DATE' already given"
-msgstr ""
+msgstr "'GIT_AUTHOR_DATE' tugtha cheana féin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown variable '%s'"
-msgstr "stíl choimhlinte anaithnid '%s'"
+msgstr "athróg anaithnid '%s'"
 
 msgid "missing 'GIT_AUTHOR_NAME'"
-msgstr ""
+msgstr "ar iarraidh 'GIT_AUTHOR_NAME'"
 
 msgid "missing 'GIT_AUTHOR_EMAIL'"
-msgstr ""
+msgstr "ar iarraidh 'GIT_AUTHOR_EMAIL'"
 
 msgid "missing 'GIT_AUTHOR_DATE'"
-msgstr ""
+msgstr "ar iarraidh 'GIT_AUTHOR_DATE'"
 
 #, c-format
 msgid ""
@@ -19984,9 +21009,22 @@ msgid ""
 "\n"
 "  git rebase --continue\n"
 msgstr ""
+"tá athruithe céime agat i do chrann oibre\n"
+"Má tá na hathruithe seo i gceist a chur isteach sa tiomantas roimhe seo, "
+"reáchtáil:\n"
+"\n"
+"  git commit --amend %s\n"
+"\n"
+"Má tá siad i gceist dul i dtiomantas nua, reáchtáil:\n"
+"\n"
+"  git commit %s\n"
+"\n"
+"Sa dá chás, nuair a bheidh tú déanta, lean ar aghaidh leis:\n"
+"\n"
+"  git rebase --continue\n"
 
 msgid "'prepare-commit-msg' hook failed"
-msgstr ""
+msgstr "Theip ar chroí 'prepar-chommit-msg'"
 
 msgid ""
 "Your name and email address were configured automatically based\n"
@@ -20001,6 +21039,21 @@ msgid ""
 "\n"
 "    git commit --amend --reset-author\n"
 msgstr ""
+"Cumraíodh d'ainm agus do sheoladh ríomhphoist bunaithe go huath\n"
+"ar d'ainm úsáideora agus d'ainm óstach. Seiceáil le do thoil go bhfuil siad "
+"cruinn.\n"
+"Is féidir leat an teachtaireacht seo a chosc trí iad a shocrú go sainráite. "
+"Rith an\n"
+"ag leanúint an t-ordú agus lean na treoracha i d'eagarthóir chun a chur in "
+"eagar\n"
+"do chomhad cumraíochta:\n"
+"\n"
+"    git config --global --edit\n"
+"\n"
+"Tar éis duit é seo a dhéanamh, féadfaidh tú an aitheantas a úsáidtear don "
+"tiomantas seo a shocrú le:\n"
+"\n"
+"    git commit --amend --reset-author\n"
 
 msgid ""
 "Your name and email address were configured automatically based\n"
@@ -20014,154 +21067,161 @@ msgid ""
 "\n"
 "    git commit --amend --reset-author\n"
 msgstr ""
+"Cumraíodh d'ainm agus do sheoladh ríomhphoist bunaithe go huath\n"
+"ar d'ainm úsáideora agus d'ainm óstach. Seiceáil le do thoil go bhfuil siad "
+"cruinn.\n"
+"Is féidir leat an teachtaireacht seo a chosc trí iad a shocrú go sainráite:\n"
+"\n"
+"    git config --global user.name \"Your Name\"\n"
+"    git config --global user.email you@example.com\n"
+"\n"
+"Tar éis duit é seo a dhéanamh, féadfaidh tú an aitheantas a úsáidtear don "
+"tiomantas seo a shocrú le:\n"
+"\n"
+"    git commit --amend --reset-author\n"
 
 msgid "couldn't look up newly created commit"
-msgstr ""
+msgstr "ní fhéadfadh sé gealltanas nua-chruthaithe a fheiceáil"
 
 msgid "could not parse newly created commit"
-msgstr ""
+msgstr "ní fhéadfadh sé gealltanas nua-chruthaithe a pháirsí"
 
 msgid "unable to resolve HEAD after creating commit"
-msgstr ""
+msgstr "in ann HEAD a réiteach tar éis tiomantas a chruthú"
 
-#, fuzzy
 msgid "detached HEAD"
-msgstr "HEAD scoite ag "
+msgstr "scoite CEANN"
 
 msgid " (root-commit)"
-msgstr ""
+msgstr " (fréamh-thiomantas)"
 
-#, fuzzy
 msgid "could not parse HEAD"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí HEAD a pháirseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "HEAD %s is not a commit!"
-msgstr "Tá HEAD anois ag"
+msgstr "Ní gealltanas é HEAD %s!"
 
-#, fuzzy
 msgid "unable to parse commit author"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "ní féidir leis an údar tiomanta a pharsáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read commit message from '%s'"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir teachtaireacht tiomanta ó '%s' a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid author identity '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "aitheantas údair neamhbhailí '%s'"
 
 msgid "corrupt author: missing date information"
-msgstr ""
+msgstr "údar truaillithe: faisnéis dáta in easnamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not update %s"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní fhéadfaí %s a nuashonrú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse parent commit %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "ní fhéadfaí tuismitheoir tiomantas %s a pharsáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown command: %d"
-msgstr "Níl aon orduithe déanta."
+msgstr "ordú anaithnid: %d"
 
 msgid "This is the 1st commit message:"
-msgstr ""
+msgstr "Seo an chéad teachtaireacht tiomanta:"
 
 #, c-format
 msgid "This is the commit message #%d:"
-msgstr ""
+msgstr "Seo an teachtaireacht tiomanta #%d:"
 
 msgid "The 1st commit message will be skipped:"
-msgstr ""
+msgstr "Scaipfear an chéad teachtaireacht tiomanta:"
 
 #, c-format
 msgid "The commit message #%d will be skipped:"
-msgstr ""
+msgstr "Scaipfear an teachtaireacht tiomanta #%d:"
 
 #, c-format
 msgid "This is a combination of %d commits."
-msgstr ""
+msgstr "Is meascán de ghealltanais %d é seo."
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot write '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir '%s' a scríobh"
 
 msgid "need a HEAD to fixup"
-msgstr ""
+msgstr "teastaíonn CEAD ag teastáil chun socrú"
 
-#, fuzzy
 msgid "could not read HEAD"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann HEAD a léamh"
 
 msgid "could not read HEAD's commit message"
-msgstr ""
+msgstr "ní raibh sé in ann teachtaireacht tiomanta HEAD a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read commit message of %s"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní raibh sé in ann teachtaireacht tiomanta %s a léamh"
 
 msgid "your index file is unmerged."
-msgstr ""
+msgstr "tá do chomhad innéacs neamh-chumasaithe."
 
-#, fuzzy
 msgid "cannot fixup root commit"
-msgstr "aon rud le tiomantas\n"
+msgstr "ní féidir le déanamh fréimhe a shocrú"
 
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
-msgstr ""
+msgstr "cumasc é tiomnú %s ach níor tugadh rogha -m."
 
-#, fuzzy, c-format
+#, c-format
 msgid "commit %s does not have parent %d"
-msgstr "níl ár leagan ag cosán '%s'"
+msgstr "commiteáil %s níl tuismitheoir %d aige"
 
 #, c-format
 msgid "cannot get commit message for %s"
-msgstr ""
+msgstr "ní féidir teachtaireacht tiomanta a fháil do %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#, fuzzy, c-format
+#, c-format
 msgid "%s: cannot parse parent commit %s"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "%s: ní féidir le tuismitheoir tiomantas %s a pharsáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not revert %s... %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh ann %s a chur ar ais... %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not apply %s... %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí %s a chur i bhfeidhm... %s"
 
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
-msgstr ""
+msgstr "scaoileadh %s %s -- ábhar paiste suas an sruth cheana féin\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "git %s: failed to read the index"
-msgstr "theip ar nasc '%s' a chruthú"
+msgstr "git %s: theip ar an t-innéacs a léamh"
 
 #, c-format
 msgid "git %s: failed to refresh the index"
-msgstr ""
+msgstr "git %s: theip ar an t-innéacs a athnuachan"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid label"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní lipéad bailí é '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid refname"
-msgstr "Ní ainm iargúlta bailí é '%s'"
+msgstr "Ní athainm bailí é '%s'"
 
 #, c-format
 msgid "update-ref requires a fully qualified refname e.g. refs/heads/%s"
-msgstr ""
+msgstr "teastaíonn athainm iomlán cáilithe uasghabháilte e.g. refs/heads/%s"
 
 #, c-format
 msgid "'%s' does not accept merge commits"
-msgstr ""
+msgstr "Ní ghlacann '%s' le gealltanais cumaisc"
 
 #. TRANSLATORS: 'pick' and 'merge -C' should not be
 #. translated.
@@ -20170,6 +21230,8 @@ msgid ""
 "'pick' does not take a merge commit. If you wanted to\n"
 "replay the merge, use 'merge -C' on the commit."
 msgstr ""
+"Ní ghlacann 'pick' tiomantas cumaisc. Dá mbeadh tú ag iarraidh\n"
+"athsheinn an cumaisc, bain úsáid as 'cumaisc -C' ar an tiomantas."
 
 #. TRANSLATORS: 'reword' and 'merge -c' should not be
 #. translated.
@@ -20179,6 +21241,10 @@ msgid ""
 "replay the merge and reword the commit message, use\n"
 "'merge -c' on the commit"
 msgstr ""
+"Ní ghlacann 'athfhoil' tiomantas cumaisc. Dá mbeadh tú ag iarraidh\n"
+"athsheinn an teachtaireacht thiomanta a chumasc agus athfhocal, bain úsáid "
+"as\n"
+"'cumaisc -c' ar an tiomantas"
 
 #. TRANSLATORS: 'edit', 'merge -C' and 'break' should
 #. not be translated.
@@ -20189,138 +21255,134 @@ msgid ""
 "'break' to give the control back to you so that you can\n"
 "do 'git commit --amend && git rebase --continue'."
 msgstr ""
+"Ní ghlacann 'eagarthó' tiomantas cumaisc. Dá mbeadh tú ag iarraidh\n"
+"athsheinn an cumaisc, bain úsáid as 'cumaisc -C' ar an tiomantas, agus "
+"ansin\n"
+"'brise' chun an rialú a thabhairt ar ais duit ionas gur féidir leat\n"
+"déan 'git commit --amend && git rebase --continue'."
 
 msgid "cannot squash merge commit into another commit"
-msgstr ""
+msgstr "ní féidir le squash tiomantas a chumasc i dtiomantas eile"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid command '%.*s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "ordú neamhbhailí '%.*s"
 
 #, c-format
 msgid "missing arguments for %s"
-msgstr ""
+msgstr "argóintí atá in easnamh do %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a pháirseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid line %d: %.*s"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "líne neamhbhailí %d: %.*s"
 
 #, c-format
 msgid "cannot '%s' without a previous commit"
-msgstr ""
+msgstr "ní féidir '%s' gan gealltanas roimhe seo"
 
-#, fuzzy
 msgid "cancelling a cherry picking in progress"
-msgstr "Cherry-pick atá ar siúl faoi láthair."
+msgstr "piocadh silíní atá ar siúl a chur ar ceal"
 
 msgid "cancelling a revert in progress"
-msgstr ""
+msgstr "filleadh atá ar siúl a chealú"
 
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
+"déan é seo a shocrú le do thoil ag baint úsáide as 'git rebase --edit-todo'."
 
 #, c-format
 msgid "unusable instruction sheet: '%s'"
-msgstr ""
+msgstr "bileog treoracha neamhúsáidte: '%s'"
 
-#, fuzzy
 msgid "no commits parsed."
-msgstr "Níl aon gealltanais fós"
+msgstr "níl aon gealltanais paráilsithe."
 
 msgid "cannot cherry-pick during a revert."
-msgstr ""
+msgstr "ní féidir le silíní a phiocadh le linn filleadh."
 
 msgid "cannot revert during a cherry-pick."
-msgstr ""
+msgstr "ní féidir filleadh ar ais le linn pioc silíní."
 
 msgid "unusable squash-onto"
-msgstr ""
+msgstr "squash-on neamhúsáidte"
 
-#, fuzzy, c-format
+#, c-format
 msgid "malformed options sheet: '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "bileog roghanna mífhoirmithe: '%s'"
 
 msgid "empty commit set passed"
-msgstr ""
+msgstr "rith tacar tiomanta folamh"
 
-#, fuzzy
 msgid "revert is already in progress"
-msgstr "Ar ais atá ar siúl faoi láthair."
+msgstr "tá filleadh ar siúl cheana féin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
-msgstr " (reáchtáil “git revert --continue” chun leanúint ar aghaidh)"
+msgstr "bain triail as “git revert (--continue | %s--abort | --quit)”"
 
-#, fuzzy
 msgid "cherry-pick is already in progress"
-msgstr "Cherry-pick atá ar siúl faoi láthair."
+msgstr "tá pioc silíní ar siúl cheana féin"
 
-#, fuzzy, c-format
+#, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
-msgstr " (reáchtáil “git cherry-pick --continue ” chun leanúint ar aghaidh)"
+msgstr "bain triail as “git cherry-pick (--continue | %s--abort | --quit)”"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not create sequencer directory '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí eolaire seicheamhach '%s' a chruthú"
 
-#, fuzzy
 msgid "no cherry-pick or revert in progress"
-msgstr "Cherry-pick atá ar siúl faoi láthair."
+msgstr "níl aon phiocadh silíní nó filleadh ar siúl ar siúl"
 
-#, fuzzy
 msgid "cannot resolve HEAD"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní féidir le HEAD a réiteach"
 
-#, fuzzy
 msgid "cannot abort from a branch yet to be born"
-msgstr "Tá tú ar bhrainse nach rugadh fós"
+msgstr "ní féidir éirí as brainse nach rugadh fós"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read '%s': %s"
-msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+msgstr "ní féidir '%s' a léamh: %s"
 
 msgid "unexpected end of file"
-msgstr ""
+msgstr "deireadh gan choinne an chomhaid"
 
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
-msgstr ""
+msgstr "tá comhad HEAD réamh-phiocadh silíní stóráilte '%s' truaillithe"
 
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
-msgstr ""
+msgstr "Is cosúil gur bhogadh tú CEANN. Gan athfhillte, seiceáil do CHEANN!"
 
-#, fuzzy
 msgid "no revert in progress"
-msgstr "Ar ais atá ar siúl faoi láthair."
+msgstr "níl aon fhilleadh ar siúl"
 
-#, fuzzy
 msgid "no cherry-pick in progress"
-msgstr "Cherry-pick atá ar siúl faoi láthair."
+msgstr "níl aon phiocadh silíní ar siúl"
 
-#, fuzzy
 msgid "failed to skip the commit"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "theip ar an gealltanas a scipeáil"
 
 msgid "there is nothing to skip"
-msgstr ""
+msgstr "níl aon rud le scipeáil"
 
 #, c-format
 msgid ""
 "have you committed already?\n"
 "try \"git %s --continue\""
 msgstr ""
+"an ndearna tú tiomanta cheana féin?\n"
+"bain triail as “git %s --continue”"
 
-#, fuzzy
 msgid "cannot read HEAD"
-msgstr "ní féidir comhad pacáiste a roghnú"
+msgstr "ní féidir le HEAD a léamh"
 
-#, fuzzy
 msgid "could not write commit message file"
-msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
+msgstr "ní raibh sé in ann comhad teachtaireachta tiomanta a"
 
 #, c-format
 msgid ""
@@ -20332,20 +21394,27 @@ msgid ""
 "\n"
 "  git rebase --continue\n"
 msgstr ""
+"Féadfaidh tú an gealltanas a leasú anois, le\n"
+"\n"
+"  git commit --amend %s\n"
+"\n"
+"Nuair a bheidh tú sásta le d'athruithe, rith\n"
+"\n"
+"  git rebase --continue\n"
 
 #, c-format
 msgid "Could not apply %s... %.*s"
-msgstr ""
+msgstr "Níorbh fhéidir iarratas a dhéanamh %s... %.*s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not merge %.*s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "Níorbh fhéidir cumasc %.*s"
 
 #, c-format
 msgid "Executing: %s\n"
-msgstr ""
+msgstr "Forghníomhú: %s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "execution failed: %s\n"
 "%sYou can fix the problem, and then run\n"
@@ -20353,11 +21422,13 @@ msgid ""
 "  git rebase --continue\n"
 "\n"
 msgstr ""
-" (déan coinbhleachtaí a shocrú agus ansin rith “git rebase --continue”)"
+"theip ar fhorghníomhú: %s\n"
+"%sIs féidir leat an fhadhb a shocrú, agus ansin rith\n"
+"\n"
+"  git rebase --continue\n"
 
-#, fuzzy
 msgid "and made changes to the index and/or the working tree.\n"
-msgstr "athshocraigh HEAD, innéacs agus crann oibre"
+msgstr "agus rinne siad athruithe ar an innéacs agus/nó ar an gcrann oibre.\n"
 
 #, c-format
 msgid ""
@@ -20368,91 +21439,100 @@ msgid ""
 "  git rebase --continue\n"
 "\n"
 msgstr ""
+"d'éirigh leis an bhforghníomhú: %s\n"
+"ach d'fhág sé athruithe ar an innéacs agus/nó ar an gcrann oibre.\n"
+"Déan do chuid athruithe a dhéanamh nó a stóráil, agus ansin rith\n"
+"\n"
+"  git rebase --continue\n"
+"\n"
 
 #, c-format
 msgid "illegal label name: '%.*s'"
-msgstr ""
+msgstr "ainm lipéid neamhdhleathach: '%.*s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not resolve '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a réiteach"
 
-#, fuzzy
 msgid "writing fake root commit"
-msgstr "aon rud le tiomantas\n"
+msgstr "tiomantas fréamh bréige a scríobh"
 
 msgid "writing squash-onto"
-msgstr ""
+msgstr "scríobh squash-on"
 
 msgid "cannot merge without a current revision"
-msgstr ""
+msgstr "ní féidir a chumasc gan athbhreithniú reatha"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse '%.*s'"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir le parsáil a dhéanamh '%.*s"
 
 #, c-format
 msgid "nothing to merge: '%.*s'"
-msgstr ""
+msgstr "níl aon rud le cumasc: '%.*s'"
 
 msgid "octopus merge cannot be executed on top of a [new root]"
-msgstr ""
+msgstr "ní féidir cumaisc ochtair a fhorghníomhú ar bharr [fréamh nua]"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not get commit message of '%s'"
-msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
+msgstr "ní fhéadfaí teachtaireacht tiomanta de '%s' a fháil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not even attempt to merge '%.*s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "níorbh fhéidir fiú iarracht a dhéanamh '%.*s' a chumasc"
 
-#, fuzzy
 msgid "merge: Unable to write new index file"
-msgstr "in ann comhad innéacs nua a scríobh"
+msgstr "cumaisc: Ní féidir comhad innéacs nua a scríobh"
 
 #, c-format
 msgid ""
 "another 'rebase' process appears to be running; '%s.lock' already exists"
 msgstr ""
+"is cosúil go bhfuil próiseas 'rebase' eile ag rith; tá '%s.lock' ann cheana "
+"féin"
 
 #, c-format
 msgid ""
 "Updated the following refs with %s:\n"
 "%s"
 msgstr ""
+"Nuashonraíodh na hifríochtaí seo a leanas le %s:\n"
+"%s"
 
 #, c-format
 msgid ""
 "Failed to update the following refs with %s:\n"
 "%s"
 msgstr ""
+"Theip ar na hiarratais seo a leanas a nuashonrú le %s:\n"
+"%s"
 
 msgid "Cannot autostash"
-msgstr ""
+msgstr "Ní féidir uathoibriú"
 
 #, c-format
 msgid "Unexpected stash response: '%s'"
-msgstr ""
+msgstr "Freagra stash gan choinne: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not create directory for '%s'"
-msgstr "theip ar eolaire '%s' a chruthú"
+msgstr "Ní fhéadfaí eolaire a chruthú do '%s'"
 
 #, c-format
 msgid "Created autostash: %s\n"
-msgstr ""
+msgstr "Autostash cruthaithe: %s\n"
 
-#, fuzzy
 msgid "could not reset --hard"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí athshocrú --hard"
 
 #, c-format
 msgid "Applied autostash.\n"
-msgstr ""
+msgstr "Autostash feidhmithe.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot store %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní féidir %s a stóráil"
 
 #, c-format
 msgid ""
@@ -20460,27 +21540,30 @@ msgid ""
 "Your changes are safe in the stash.\n"
 "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
 msgstr ""
+"%s\n"
+"Tá do chuid athruithe sábháilte sa stóras.\n"
+"Is féidir leat \"git stash pop\" nó \"git stash drop\" a rith ag am ar "
+"bith.\n"
 
 msgid "Applying autostash resulted in conflicts."
-msgstr ""
+msgstr "Bhí coinbhleachtaí mar thoradh ar autostash i bhfeidhm."
 
 msgid "Autostash exists; creating a new stash entry."
-msgstr ""
+msgstr "Tá Autostash ann; ag cruthú iontráil nua stash."
 
 msgid "autostash reference is a symref"
-msgstr ""
+msgstr "is é tagairt autostash ina symref"
 
-#, fuzzy
 msgid "could not detach HEAD"
-msgstr "Níl CEANN bailí agat."
+msgstr "ní fhéadfadh CEAD a dhícheangal"
 
 #, c-format
 msgid "Stopped at HEAD\n"
-msgstr ""
+msgstr "Stopadh ag HEAD\n"
 
 #, c-format
 msgid "Stopped at %s\n"
-msgstr ""
+msgstr "Stop ag %s\n"
 
 #, c-format
 msgid ""
@@ -20493,116 +21576,126 @@ msgid ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 msgstr ""
+"Ní fhéadfaí an t-ordú todo a fhorghníomhú\n"
+"\n"
+"    %.*s\n"
+"Tá sé athsceidealaithe; Chun an t-ordú a chur in eagar sula leanann tú ar "
+"aghaidh, le do thoil\n"
+"cuir an liosta todo in eagar ar dtús:\n"
+"\n"
+"    git rebase --edit-todo\n"
+"    git rebase --continue\n"
 
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
-msgstr ""
+msgstr "Stopadh ag %s...  %.*s\n"
 
 #, c-format
 msgid "Rebasing (%d/%d)%s"
-msgstr ""
+msgstr "Ag athbhunú (%d/%d) %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown command %d"
-msgstr "Níl aon orduithe déanta."
+msgstr "ordú anaithnid %d"
 
-#, fuzzy
 msgid "could not read orig-head"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh sé in ann ceann orig-head a léamh"
 
-#, fuzzy
 msgid "could not read 'onto'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí 'ar' léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not update HEAD to %s"
-msgstr "in ann HEAD a nuashonrú"
+msgstr "ní fhéadfaí HEAD a nuashonrú go %s"
 
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
-msgstr ""
+msgstr "Athbhunaithe agus nuashonraithe %s go rathúil.\n"
 
-#, fuzzy
 msgid "cannot rebase: You have unstaged changes."
-msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+msgstr "ní féidir athbhunú: Tá athruithe gan stáitse agat."
 
-#, fuzzy
 msgid "cannot amend non-existing commit"
-msgstr "ní féidir réad %s atá ann cheana a léamh"
+msgstr "ní féidir gealltanas nach bhfuil ann a leasú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid file: '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "comhad neamhbhailí: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid contents: '%s'"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "ábhar neamhbhailí: '%s'"
 
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
 "first and then run 'git rebase --continue' again."
 msgstr ""
+"\n"
+"Tá athruithe neamhthiomanta agat i do chrann oibre. Le do thoil, tiomnaigh "
+"iad\n"
+"ar dtús agus ansin rith 'git rebase --continue' arís."
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not write file: '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní fhéadfaí comhad a scríobh: '%s'"
 
-#, fuzzy
 msgid "could not remove CHERRY_PICK_HEAD"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí CHERRY_PICK_HEAD a bhaint"
 
-#, fuzzy
 msgid "could not commit staged changes."
-msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+msgstr "ní fhéadfadh athruithe stáitse a dhéanamh."
 
 #, c-format
 msgid "%s: can't cherry-pick a %s"
-msgstr ""
+msgstr "%s: ní féidir %s a roghnú silíní"
 
 #, c-format
 msgid "%s: bad revision"
-msgstr ""
+msgstr "%s: droch-athbhreithniú"
 
 msgid "can't revert as initial commit"
-msgstr ""
+msgstr "ní féidir teacht ar ais mar thiomantas tosaigh"
 
 #, c-format
 msgid "skipped previously applied commit %s"
-msgstr ""
+msgstr "scipeáil tiomantas %s a cuireadh i bhfeidhm"
 
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr ""
+"bain úsáid as --reapply-cherry-picks chun gealltanais scipeáilte a áireamh"
 
 msgid "make_script: unhandled options"
-msgstr ""
+msgstr "make_script: roghanna neamh-láimhseáilte"
 
 msgid "make_script: error preparing revisions"
-msgstr ""
+msgstr "make_script: earráid ag ullmhú athbhreithnithe"
 
-#, fuzzy
 msgid "nothing to do"
-msgstr "aon rud le tiomantas\n"
+msgstr "aon rud le déanamh"
 
 msgid "could not skip unnecessary pick commands"
-msgstr ""
+msgstr "ní fhéadfadh orduithe pioc gan ghá a scipeáil"
 
 msgid "the script was already rearranged."
-msgstr ""
+msgstr "athshocraíodh an script cheana féin."
 
 #, c-format
 msgid "update-refs file at '%s' is invalid"
-msgstr ""
+msgstr "tá comhad update-refs ag '%s' neamhbhailí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is outside repository at '%s'"
-msgstr "droch-stóras '%s'"
+msgstr "Tá '%s' an stór lasmuigh ag '%s'"
 
 #, c-format
 msgid ""
 "%s: no such path in the working tree.\n"
 "Use 'git <command> -- <path>...' to specify paths that do not exist locally."
 msgstr ""
+"%s: níl aon chosán den sórt sin sa chrann oibre.\n"
+"Úsáid 'git <command>--<path>... 'chun cosáin nach bhfuil ann go háitiúil a "
+"shonrú."
 
 #, c-format
 msgid ""
@@ -20610,10 +21703,14 @@ msgid ""
 "Use '--' to separate paths from revisions, like this:\n"
 "'git <command> [<revision>...] -- [<file>...]'"
 msgstr ""
+"argóint débhríoch '%s': athbhreithniú anaithnid nó cosán nach bhfuil sa "
+"chrann oibre.\n"
+"Úsáid '--' chun cosáin a scaradh ó athbhreithnithe, mar seo:\n"
+"'git <command>[<revision>...] -- [<file>...] '"
 
 #, c-format
 msgid "option '%s' must come before non-option arguments"
-msgstr ""
+msgstr "caithfidh rogha '%s' teacht roimh argóintí neamh-rogha"
 
 #, c-format
 msgid ""
@@ -20621,77 +21718,80 @@ msgid ""
 "Use '--' to separate paths from revisions, like this:\n"
 "'git <command> [<revision>...] -- [<file>...]'"
 msgstr ""
+"argóint débhríoch '%s': athbhreithniú agus ainm comhaid araon\n"
+"Úsáid '--' chun cosáin a scaradh ó athbhreithnithe, mar seo:\n"
+"'git <command>[<revision>...] -- [<file>...] '"
 
 msgid "unable to set up work tree using invalid config"
 msgstr ""
+"in ann crann oibre a chur ar bun ag baint úsáide as cumraíocht nebhailí"
 
 #, c-format
 msgid "'%s' already specified as '%s'"
-msgstr ""
+msgstr "'%s' sonraithe cheana féin mar '%s'"
 
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
-msgstr ""
+msgstr "Leagan repo git ag súil leis <= %d, aimsíodh %d"
 
 msgid "unknown repository extension found:"
 msgid_plural "unknown repository extensions found:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "síneadh stórais anaithnid aimsithe:"
+msgstr[1] "síntí stórais anaithnide aimsithe:"
+msgstr[2] "síntí stórais anaithnide aimsithe:"
 
 msgid "repo version is 0, but v1-only extension found:"
 msgid_plural "repo version is 0, but v1-only extensions found:"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "is é leagan repo 0, ach fuarthas síneadh v1 amháin:"
+msgstr[1] "is é 0 an leagan den stór, ach fuarthas síntí v1 amháin:"
+msgstr[2] "is é 0 an leagan den stór, ach fuarthas síntí v1 amháin:"
 
 #, c-format
 msgid "error opening '%s'"
-msgstr ""
+msgstr "earráid ag oscailt '%s'"
 
 #, c-format
 msgid "too large to be a .git file: '%s'"
-msgstr ""
+msgstr "ró-mhór le bheith ina chomhad .git: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "error reading %s"
-msgstr "nach féidir %s a léamh"
+msgstr "earráid ag léamh %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid gitfile format: %s"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "formáid gitfile neamhbhailí: %s"
 
 #, c-format
 msgid "no path in gitfile: %s"
-msgstr ""
+msgstr "gan aon chosán i gitfile: %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a git repository: %s"
-msgstr "droch-stóras '%s'"
+msgstr "ní stór git: %s"
 
 #, c-format
 msgid "'$%s' too big"
-msgstr ""
+msgstr "'$%s' ró-mhór"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not a git repository: '%s'"
-msgstr "droch-stóras '%s'"
+msgstr "ní stór git: '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot chdir to '%s'"
-msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
+msgstr "ní féidir teacht ar '%s'"
 
-#, fuzzy
 msgid "cannot come back to cwd"
-msgstr "Ní féidir teacht ar ais chuig cwd"
+msgstr "ní féidir teacht ar ais chuig cwd"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to stat '%*s%s%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar '%*s%s%s' a thaispeáint"
 
 #, c-format
 msgid "safe.directory '%s' not absolute"
-msgstr ""
+msgstr "níl safe.directory '%s' iomlán"
 
 #, c-format
 msgid ""
@@ -20700,339 +21800,362 @@ msgid ""
 "\n"
 "\tgit config --global --add safe.directory %s"
 msgstr ""
+"braitheadh ​​úinéireacht amhrasach sa stórlann ag '%s'\n"
+"%sChun eisceacht a chur leis an eolaire seo, glaoigh ar:\n"
+"\n"
+"git config --global --add safe.directory %s"
 
-#, fuzzy
 msgid "Unable to read current working directory"
-msgstr "in ann crann oibre a sheiceáil"
+msgstr "Ní féidir eolaire oibre reatha a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot change to '%s'"
-msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
+msgstr "ní féidir athrú go '%s'"
 
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
-msgstr ""
+msgstr "ní stór git (nó aon cheann de na tuismitheoireolairí): %s"
 
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
 "Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)."
 msgstr ""
+"ní stór git (nó aon thuismitheoir suas go dtí an pointe gléasta %s)\n"
+"Stopadh ag teorainn an chórais chomhaid (níl GIT_DISCOVERY_ACROSS_FILESYSTEM "
+"socraithe)."
 
 #, c-format
 msgid "cannot use bare repository '%s' (safe.bareRepository is '%s')"
-msgstr ""
+msgstr "ní féidir stór lom '%s' a úsáid (safe.bareRepository is '%s')"
 
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
 "The owner of files must always have read and write permissions."
 msgstr ""
+"fadhb le luach mód comhaid core.sharedRepository (0%.3o).\n"
+"Ní mór ceadanna léite agus scríbhneoireachta a bheith ag úinéir na gcomhad i "
+"gcónaí."
 
 msgid "fork failed"
-msgstr ""
+msgstr "theip ar fhorc"
 
 msgid "setsid failed"
-msgstr ""
+msgstr "theip ar setsid"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot stat template '%s'"
-msgstr "ní féidir le pacáiste fstat"
+msgstr "ní féidir teacht ar theimpléad '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot opendir '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir '%s' a oscailt"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot readlink '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir nasc '%s' a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot symlink '%s' '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir '%s' '' %s 'a nascadh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "cannot copy '%s' to '%s'"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir '%s' a chóipeáil chuig '%s'"
 
 #, c-format
 msgid "ignoring template %s"
-msgstr ""
+msgstr "ag neamhaird den teimpléad %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "templates not found in %s"
-msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
+msgstr "teimpléid gan aimsiú i %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "not copying templates from '%s': %s"
-msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
+msgstr "gan teimpléid a chóipeáil ó '%s': %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "invalid initial branch name: '%s'"
-msgstr "luach neamhbhailí do '%s'"
+msgstr "ainm brainse tosaigh neamhbhailí: '%s'"
 
 #, c-format
 msgid "re-init: ignored --initial-branch=%s"
-msgstr ""
+msgstr "ath-init: neamhaird a dhéanamh ar --initial-branch=%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to handle file type %d"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "in ann cineál comhad %d a láimhseáil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to move %s to %s"
-msgstr "nach féidir %s a léamh"
+msgstr "nach féidir %s a bhogadh go %s"
 
 msgid "attempt to reinitialize repository with different hash"
-msgstr ""
+msgstr "iarracht a dhéanamh stór a aththionsú le hash difriúil"
 
 msgid ""
 "attempt to reinitialize repository with different reference storage format"
 msgstr ""
+"iarracht a dhéanamh stór a aththionsú le formáid stórála tagartha difriúil"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s already exists"
-msgstr "tá crann oibre '%s' ann cheana féin."
+msgstr "Tá %s ann cheana féin"
 
 #, c-format
 msgid "Reinitialized existing shared Git repository in %s%s\n"
-msgstr ""
+msgstr "Stórlann Git roinnte atá ann cheana a athsheoladh i %s%s\n"
 
 #, c-format
 msgid "Reinitialized existing Git repository in %s%s\n"
-msgstr ""
+msgstr "Aththionscnaíodh stór Git atá ann cheana i %s%s\n"
 
 #, c-format
 msgid "Initialized empty shared Git repository in %s%s\n"
-msgstr ""
+msgstr "Stórlann Git roinnte folamh tosaithe i %s%s\n"
 
 #, c-format
 msgid "Initialized empty Git repository in %s%s\n"
-msgstr ""
+msgstr "Stórlann Git folamh tosaithe i %s%s\n"
 
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
-msgstr ""
+msgstr "is eolaire é iontráil innéacs, ach ní neamhchoitianta (%08x)"
 
 msgid "cannot use split index with a sparse index"
-msgstr ""
+msgstr "ní féidir innéacs scoilte a úsáid le hinnéacs neamhchoitianta"
 
 #. TRANSLATORS: The first %s is a command like "ls-tree".
-#, fuzzy, c-format
+#, c-format
 msgid "bad %s format: element '%s' does not start with '('"
-msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
+msgstr "fhormáid olc %s: ní thosaíonn eilimint '%s' le '('"
 
 #. TRANSLATORS: The first %s is a command like "ls-tree".
-#, fuzzy, c-format
+#, c-format
 msgid "bad %s format: element '%s' does not end in ')'"
-msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
+msgstr "droch-fhormáid %s: ní chríochnaíonn eilimint '%s' i ')'"
 
 #. TRANSLATORS: %s is a command like "ls-tree".
 #, c-format
 msgid "bad %s format: %%%.*s"
-msgstr ""
+msgstr "fhormáid %s olc: %%%.*s"
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
 #, c-format
 msgid "%u.%2.2u GiB"
-msgstr ""
+msgstr "%u.%2.2u GiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte/second
 #, c-format
 msgid "%u.%2.2u GiB/s"
-msgstr ""
+msgstr "%u.%2.2u GiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte
 #, c-format
 msgid "%u.%2.2u MiB"
-msgstr ""
+msgstr "%u.%2.2u MiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte/second
 #, c-format
 msgid "%u.%2.2u MiB/s"
-msgstr ""
+msgstr "%u.%2.2u MiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte
 #, c-format
 msgid "%u.%2.2u KiB"
-msgstr ""
+msgstr "%u.%2.2u KiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte/second
 #, c-format
 msgid "%u.%2.2u KiB/s"
-msgstr ""
+msgstr "%u.%2.2u KiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 byte
 #, c-format
 msgid "%u byte"
 msgid_plural "%u bytes"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%u beart"
+msgstr[1] "%u beart"
+msgstr[2] "%u beart"
 
 #. TRANSLATORS: IEC 80000-13:2008 byte/second
 #, c-format
 msgid "%u byte/s"
 msgid_plural "%u bytes/s"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%u beart/s"
+msgstr[1] "%u beart/s"
+msgstr[2] "%u beart/s"
 
 #, c-format
 msgid "ignoring suspicious submodule name: %s"
-msgstr ""
+msgstr "ag déanamh neamhaird d'ainm fo-mhodúil amhrasach: %s"
 
 msgid "negative values not allowed for submodule.fetchJobs"
-msgstr ""
+msgstr "luachanna diúltacha nach gceadaítear le haghaidh submodule.fetchJobs"
 
 #, c-format
 msgid "ignoring '%s' which may be interpreted as a command-line option: %s"
 msgstr ""
+"neamhaird a dhéanamh ar '%s' ar féidir a léirmhíniú mar rogha líne ordaithe: "
+"%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not update .gitmodules entry %s"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Ní fhéadfaí iontráil.gitmodules %s a nuashonrú"
 
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
 msgstr ""
+"Ní féidir .gitmodules neamh-chumhdaithe a athrú, coinbhleachtaí cumaisc a "
+"réiteach"
 
 #, c-format
 msgid "Could not find section in .gitmodules where path=%s"
 msgstr ""
+"Níorbh fhéidir an rannóg a aimsiú i .gitmodules áit a bhfuil an cosán = %s"
 
 #, c-format
 msgid "Could not remove .gitmodules entry for %s"
-msgstr ""
+msgstr "Ní fhéadfaí iontráil.gitmodules a bhaint do %s"
 
 msgid "staging updated .gitmodules failed"
-msgstr ""
+msgstr "theip ar stáisiú nuashonraithe .gitmodules"
 
 #, c-format
 msgid "in unpopulated submodule '%s'"
-msgstr ""
+msgstr "i bhfo-mhodúl neamhdhaonra '%s'"
 
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
-msgstr ""
+msgstr "Tá pathspec '%s' i bhfo-mhodúl '%.*s"
 
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
-msgstr ""
+msgstr "argóint olc --ignore-submodules: %s"
 
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
 "same. Skipping it."
 msgstr ""
+"Fo-mhodúl i dtiomantas %s ag an gcosán: imbhuaileann '%s' le fo-mhodúl darb "
+"ainm mar an gcéanna. Ag scipeáil é."
 
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
-msgstr ""
+msgstr "is %s é iontráil an fhomhodúil '%s' (%s), ní tiomnú"
 
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
 "submodule %s"
 msgstr ""
+"Ní raibh an t-ordú 'git rev-list <commits>--not --remotes -n 1' a reáchtáil "
+"i bhfo-mhodúl %s"
 
 #, c-format
 msgid "process for submodule '%s' failed"
-msgstr ""
+msgstr "theip ar phróiseas le haghaidh fo-mhodúl '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Pushing submodule '%s'\n"
-msgstr "Ag brú chuig %s\n"
+msgstr "Ag brú an fho-mhodúil '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to push submodule '%s'\n"
-msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
+msgstr "Ní féidir an fho-mhodúl '%s' a bhrú\n"
 
 #, c-format
 msgid "Fetching submodule %s%s\n"
-msgstr ""
+msgstr "Ag fáil fo-mhodúl %s%s\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not access submodule '%s'\n"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "Níorbh fhéidir rochtain a fháil ar fho-mhodúl '%s'\n"
 
 #, c-format
 msgid "Could not access submodule '%s' at commit %s\n"
-msgstr ""
+msgstr "Níorbh fhéidir rochtain a fháil ar fho-mhodúl '%s' ag tiomantas %s\n"
 
 #, c-format
 msgid "Fetching submodule %s%s at commit %s\n"
-msgstr ""
+msgstr "Ag fáil fo-mhodúl %s%s ag an tiomnú %s\n"
 
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
 "%s"
 msgstr ""
+"Earráidí le linn teacht fo-mhodúil:\n"
+"%s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' not recognized as a git repository"
-msgstr "--stdin teastaíonn stórlann git"
+msgstr "Ní aithnítear '%s' mar stór git"
 
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
-msgstr ""
+msgstr "Ní féidir 'git status --porcelain=2' a reáchtáil i bhfo-mhodúl %s"
 
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
-msgstr ""
+msgstr "Theip ar 'git status --porcelain=2' i bhfo-mhodúl %s"
 
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
-msgstr ""
+msgstr "ní fhéadfaí 'git status' a thosú i bhfo-mhodúl '%s'"
 
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
-msgstr ""
+msgstr "ní fhéadfaí 'git status' a reáchtáil i bhfo-mhodúl '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
-msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
+msgstr "Ní fhéadfaí socrú core.worktree a dhíshocrú i bhfo-mhodúl '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not recurse into submodule '%s'"
-msgstr "brú athfhillteach ar fho-mhodúil a rialú"
+msgstr "ní fhéadfaí athshlánú isteach i bhfo-mhodúl '%s'"
 
-#, fuzzy
 msgid "could not reset submodule index"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfadh innéacs fo-mhodúil a athshocrú"
 
 #, c-format
 msgid "submodule '%s' has dirty index"
-msgstr ""
+msgstr "tá innéacs salach ag fo-mhodúl '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "Submodule '%s' could not be updated."
-msgstr "Fo-mhodúil athraithe ach gan nuashonrú:"
+msgstr "Ní fhéadfaí fo-mhodúl '%s' a nuashonrú."
 
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
-msgstr ""
+msgstr "tá fo-mhodúl git dir '%s' taobh istigh de git dir '%.*s"
 
 #, c-format
 msgid "expected '%.*s' in submodule path '%s' not to be a symbolic link"
 msgstr ""
+"ag súil leis '%.*s' i gcosán fo-mhodúil '%s' gan a bheith ina nasc siombalach"
 
 #, c-format
 msgid "expected submodule path '%s' not to be a symbolic link"
-msgstr ""
+msgstr "ag súil nach mbeidh cosán fo-mhodúil '%s' ina nasc siombalach"
 
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
 msgstr ""
+"relocate_gitdir le haghaidh fo-mhodúil '%s' le níos mó ná crann oibre amháin "
+"nach dtacaítear leis"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not lookup name for submodule '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "ní fhéadfaí ainm a lorg don fho-mhodúl '%s'"
 
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
-msgstr ""
+msgstr "diúltú '%s' a bhogadh isteach i git dir atá ann cheana"
 
 #, c-format
 msgid ""
@@ -21040,348 +22163,357 @@ msgid ""
 "'%s' to\n"
 "'%s'\n"
 msgstr ""
+"Ag aistriú eolaire git de '%s%s' ó\n"
+"'%s' go\n"
+"'%s'\n"
 
-#, fuzzy
 msgid "could not start ls-files in .."
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí ls-files a thosú i.."
 
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
-msgstr ""
+msgstr "d’fhill an crann ls cód fillte gan choinne %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "failed to lstat '%s'"
-msgstr "theip ar '%s' a stáil"
+msgstr "theip ar lstat '%s'"
 
 msgid "no remote configured to get bundle URIs from"
-msgstr ""
+msgstr "gan aon iargúlta cumraithe chun URIs beartán a fháil ó"
 
 msgid "could not get the bundle-uri list"
-msgstr ""
+msgstr "ní raibh in ann an liosta bundle-uri a fháil"
 
 msgid "test-tool cache-tree <options> (control|prime|update)"
-msgstr ""
+msgstr "test-tool cache-tree <options> (control|prime|update)"
 
 msgid "clear the cache tree before each iteration"
-msgstr ""
+msgstr "glan an crann taisce roimh gach athrú"
 
 msgid "number of entries in the cache tree to invalidate (default 0)"
 msgstr ""
+"líon na n-iontrálacha sa chrann taisce le neamhbhailí (réamhshocraithe 0)"
 
 msgid "the number of objects to write"
-msgstr ""
+msgstr "líon na rudaí le scríobh"
 
 msgid "test-tool path-walk <options> -- <revision-options>"
-msgstr ""
+msgstr "test-tool path-walk <options> -- <revision-options>"
 
-#, fuzzy
 msgid "toggle inclusion of blob objects"
-msgstr "réad blob neamhbhailí %s"
+msgstr "cuimsiú rudaí blob a thógáil"
 
 msgid "toggle inclusion of commit objects"
-msgstr ""
+msgstr "toggle áireamh rudaí tiomanta"
 
 msgid "toggle inclusion of tag objects"
-msgstr ""
+msgstr "cuimsiú rudaí clibeanna a thosc"
 
 msgid "toggle inclusion of tree objects"
-msgstr ""
+msgstr "cuimsiú rudaí crann a thógáil"
 
 msgid "toggle pruning of uninteresting paths"
-msgstr ""
+msgstr "bearradh cosáin neamh-spéisiúla a thosú"
 
 msgid "read a pattern list over stdin"
-msgstr ""
+msgstr "léigh liosta patrún thar stdin"
 
 #, c-format
 msgid "commit %s is not marked reachable"
-msgstr ""
+msgstr "nach bhfuil comhordú %s marcáilte inrochtana"
 
 msgid "too many commits marked reachable"
-msgstr ""
+msgstr "an iomarca gealltanais atá marcáilte inrochtana"
 
 msgid "could not determine MIDX preferred pack"
-msgstr ""
+msgstr "ní fhéadfaí pacáiste is fearr MIDX a chinneadh"
 
 msgid "test-tool serve-v2 [<options>]"
-msgstr ""
+msgstr "test-tool serve-v2 [<options>]"
 
 msgid "exit immediately after advertising capabilities"
-msgstr ""
+msgstr "imeacht díreach tar éis cumais fógraíochta"
 
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
-msgstr ""
+msgstr "<name><options>tá cúntóir tástála simple-ipc gníomhach [] []"
 
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
-msgstr ""
+msgstr "<name><threads>cúntóir tástála simple-ipc run-daemon [] []"
 
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
 msgstr ""
+"<name><threads><max-wait>cúntóir tástála simple-ipc tosaigh daemon [] [] []"
 
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
-msgstr ""
+msgstr "<name><max-wait>cúntóir tástála simple-ipc stad-daemon [] []"
 
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
-msgstr ""
+msgstr "<name><token>cúntóir tástála simple-ipc seol [] []"
 
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
-msgstr ""
+msgstr "<name><bytecount><byte>test-helper simple-ipc sendbytes [] [] []"
 
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
 msgstr ""
+"test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
+"[<batchsize>]"
 
 msgid "name or pathname of unix domain socket"
-msgstr ""
+msgstr "ainm nó ainm cosán soicéad fearainn unix"
 
 msgid "named-pipe name"
-msgstr ""
+msgstr "ainm píopa ainmnithe"
 
 msgid "number of threads in server thread pool"
-msgstr ""
+msgstr "líon na snáitheanna i linn snáithe freastalaí"
 
 msgid "seconds to wait for daemon to start or stop"
-msgstr ""
+msgstr "soicind chun fanacht go dtosóidh nó stopfaidh an daemon"
 
 msgid "number of bytes"
-msgstr ""
+msgstr "líon na mbetaí"
 
-#, fuzzy
 msgid "number of requests per thread"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "líon iarratais in aghaidh an snáithe"
 
 msgid "byte"
-msgstr ""
+msgstr "bith"
 
 msgid "ballast character"
-msgstr ""
+msgstr "carachtar balasta"
 
 msgid "token"
-msgstr ""
+msgstr "comhartha"
 
 msgid "command token to send to the server"
-msgstr ""
+msgstr "comhartha ordaithe le seoladh chuig an bhfreastalaí"
 
 msgid "unit-test [<options>]"
-msgstr ""
+msgstr "unit-test [<options>]"
 
 msgid "immediately exit upon the first failed test"
-msgstr ""
+msgstr "imeacht láithreach ar an gcéad tástáil theip"
 
 msgid "suite[::test]"
-msgstr ""
+msgstr "suite [::test]"
 
 msgid "run only test suite or individual test <suite[::test]>"
-msgstr ""
+msgstr "reáchtáil ach sraith tástála nó tástáil aonair <suite [::test] >"
 
 msgid "suite"
-msgstr ""
+msgstr "svuít"
 
 msgid "exclude test suite <suite>"
-msgstr ""
+msgstr "sraith tástála a eisiamh <suite>"
 
 #, c-format
 msgid "running trailer command '%s' failed"
-msgstr ""
+msgstr "theip ar an ordú leantóir '%s' a rith"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown value '%s' for key '%s'"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "luach anaithnid '%s' don eochair '%s'"
 
 #, c-format
 msgid "empty trailer token in trailer '%.*s'"
-msgstr ""
+msgstr "comhartha leantóra folamh i leantóir '%.*s'"
 
 msgid "full write to remote helper failed"
-msgstr ""
+msgstr "theip ar scríobh iomlán chuig cianchúntóir"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to find remote helper for '%s'"
-msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
+msgstr "in ann cúntóir iargúlta a aimsiú do '%s'"
 
 msgid "can't dup helper output fd"
-msgstr ""
+msgstr "ní féidir le aschur cúntóra fd a dhéanamh"
 
 #, c-format
 msgid ""
 "unknown mandatory capability %s; this remote helper probably needs newer "
 "version of Git"
 msgstr ""
+"cumas éigeantach anaithnid %s; is dócha go mbeidh leagan níos nuaí de Git ag "
+"teastáil ó"
 
 msgid "this remote helper should implement refspec capability"
-msgstr ""
+msgstr "ba cheart go gcuirfeadh an cúntóir cianda seo cumas refspec"
 
 #, c-format
 msgid "%s unexpectedly said: '%s'"
-msgstr ""
+msgstr "Dúirt %s gan choinne: '%s'"
 
 #, c-format
 msgid "%s also locked %s"
-msgstr ""
+msgstr "Glas %s freisin %s"
 
 msgid "couldn't run fast-import"
-msgstr ""
+msgstr "ní raibh in ann allmhairiú tapa a reá"
 
-#, fuzzy
 msgid "error while running fast-import"
-msgstr "earráid agus comhad pacáiste á dúnadh"
+msgstr "earráid agus iompórtáil tapa á rith"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read ref %s"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní raibh in ann tagairt %s a léamh"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown response to connect: %s"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "freagra anaithnid chun nascadh: %s"
 
 msgid "setting remote service path not supported by protocol"
-msgstr ""
+msgstr "cosán seirbhíse iargúlta a shocrú nach dtacaíonn"
 
-#, fuzzy
 msgid "invalid remote service path"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "cosán seirbhíse iargúlta"
 
 #, c-format
 msgid "can't connect to subservice %s"
-msgstr ""
+msgstr "ní féidir nasc a dhéanamh le fo-sheirbhís %s"
 
 msgid "--negotiate-only requires protocol v2"
-msgstr ""
+msgstr "--negotiate-only ag teastáil prótacal v2"
 
 msgid "'option' without a matching 'ok/error' directive"
-msgstr ""
+msgstr "'roghan' gan treoir 'ok/earráid' a mheaitseáil"
 
 #, c-format
 msgid "expected ok/error, helper said '%s'"
-msgstr ""
+msgstr "súil le ok/earráid, dúirt an cúntóir '%s'"
 
 #, c-format
 msgid "helper reported unexpected status of %s"
-msgstr ""
+msgstr "thuairiscigh cúntóir stádas gan choinne %s"
 
 #, c-format
 msgid "helper %s does not support dry-run"
-msgstr ""
+msgstr "ní thacaíonn cúntóir %s le rith tirim"
 
 #, c-format
 msgid "helper %s does not support --signed"
-msgstr ""
+msgstr "ní thacaíonn cúntóir %s le --signed"
 
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
-msgstr ""
+msgstr "ní thacaíonn cúntóir %s le --signed=if-iarrtha"
 
 #, c-format
 msgid "helper %s does not support --atomic"
-msgstr ""
+msgstr "ní thacaíonn cúntóir %s le --atomic"
 
 #, c-format
 msgid "helper %s does not support --%s"
-msgstr ""
+msgstr "ní thacaíonn cúntóir %s le --%s"
 
 #, c-format
 msgid "helper %s does not support 'push-option'"
-msgstr ""
+msgstr "ní thacaíonn cúntóir %s le 'push-rogha'"
 
 msgid "remote-helper doesn't support push; refspec needed"
-msgstr ""
+msgstr "ní thacaíonn cúntóir iargúlta le brú; teastaíonn refspec"
 
 #, c-format
 msgid "helper %s does not support '--force'"
-msgstr ""
+msgstr "ní thacaíonn cúntóir %s le '--force'"
 
 msgid "couldn't run fast-export"
-msgstr ""
+msgstr "ní raibh sé in ann onnmhairiú tapa a"
 
-#, fuzzy
 msgid "error while running fast-export"
-msgstr "earráid agus comhad pacáiste á dúnadh"
+msgstr "earráid agus easpórtáil tapa á rith"
 
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
 "Perhaps you should specify a branch.\n"
 msgstr ""
+"Níl aon réimsí i gcoiteann agus níl aon cheann sonraithe; ní dhéanann aon "
+"rud.\n"
+"B'fhéidir gur chóir duit brainse a shonrú.\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unsupported object format '%s'"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "formáid réad gan tacaíocht '%s'"
 
 #, c-format
 msgid "malformed response in ref list: %s"
-msgstr ""
+msgstr "freagra mífhoirmithe sa liosta tagartha: %s"
 
 #, c-format
 msgid "read(%s) failed"
-msgstr ""
+msgstr "theip ar léamh (%s)"
 
 #, c-format
 msgid "write(%s) failed"
-msgstr ""
+msgstr "theip ar scríobh (%s)"
 
 #, c-format
 msgid "%s thread failed"
-msgstr ""
+msgstr "Theip ar snáithe %s"
 
-#, fuzzy, c-format
+#, c-format
 msgid "%s thread failed to join: %s"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "Theip ar shnáithe %s a bheith páirteach: %s"
 
 #, c-format
 msgid "can't start thread for copying data: %s"
-msgstr ""
+msgstr "ní féidir snáithe a thosú chun sonraí a chóipeáil: %s"
 
 #, c-format
 msgid "%s process failed to wait"
-msgstr ""
+msgstr "Theip ar phróiseas %s fanacht"
 
 #, c-format
 msgid "%s process failed"
-msgstr ""
+msgstr "Theip ar phróiseas %s"
 
 msgid "can't start thread for copying data"
-msgstr ""
+msgstr "ní féidir snáithe a thosú chun sonraí a chóipe"
 
 #, c-format
 msgid "Would set upstream of '%s' to '%s' of '%s'\n"
-msgstr ""
+msgstr "Socródh sé suas sruth de '%s' go '%s' de '%s'\n"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not read bundle '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí beartán '%s' a léamh"
 
 #, c-format
 msgid "transport: invalid depth option '%s'"
-msgstr ""
+msgstr "iompar: rogha doimhneachta neamhbhailí '%s'"
 
 msgid "see protocol.version in 'git help config' for more details"
 msgstr ""
+"féach protocol.version in 'git help config' le haghaidh tuilleadh sonraí"
 
 msgid "server options require protocol version 2 or later"
-msgstr ""
+msgstr "teastaíonn leagan prótacal 2 nó níos déanaí ó roghanna"
 
 msgid "server does not support wait-for-done"
-msgstr ""
+msgstr "ní thacaíonn freastalaí le fanacht le déanamh"
 
 msgid "could not parse transport.color.* config"
-msgstr ""
+msgstr "ní fhéadfaí transport.color.* config a pháirseáil"
 
 msgid "support for protocol v2 not implemented yet"
-msgstr ""
+msgstr "tacaíocht do phrótacal v2 nach bhfuil curtha i bhfeidhm"
 
 #, c-format
 msgid "transport '%s' not allowed"
-msgstr ""
+msgstr "ní cheadaítear iompar '%s'"
 
 msgid "git-over-rsync is no longer supported"
-msgstr ""
+msgstr "ní thacaítear le git-over-rsync a thuilleadh"
 
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
 "not be found on any remote:\n"
 msgstr ""
+"Tá athruithe ar féidir leis na cosáin fo-mhodúil seo a leanas\n"
+"nach bhfuil le fáil ar aon iargúlta:\n"
 
 #, c-format
 msgid ""
@@ -21397,119 +22529,160 @@ msgid ""
 "to push them to a remote.\n"
 "\n"
 msgstr ""
+"\n"
+"Déan iarracht\n"
+"\n"
+"\tgit push --recurse-submodules=on-demand\n"
+"\n"
+"nó cd chuig an gcosán agus úsáid\n"
+"\n"
+" Brúigh git\n"
+"\n"
+"chun iad a bhrú chuig iargúlta.\n"
 
 msgid "Aborting."
-msgstr ""
+msgstr "Ag gearradh."
 
-#, fuzzy
 msgid "failed to push all needed submodules"
-msgstr "theip orthu beartáin fógraithe a fháil"
+msgstr "theip ar gach fo-mhodúl riachtanach a bhrú"
 
 msgid "bundle-uri operation not supported by protocol"
-msgstr ""
+msgstr "oibríocht bundle-uri nach dtacaíonn prótacal"
 
-#, fuzzy
 msgid "could not retrieve server-advertised bundle-uri list"
-msgstr "theip orthu beartáin fógraithe a fháil"
+msgstr "ní fhéadfaí liosta bundle-uri a fógraíodh ag freastalaí a aisghab"
 
 msgid "operation not supported by protocol"
-msgstr ""
+msgstr "oibriú nach dtacaíonn prótacal"
 
 msgid "too-short tree object"
-msgstr ""
+msgstr "réad crann ró-ghearr"
 
 msgid "malformed mode in tree entry"
-msgstr ""
+msgstr "modh mífhoirmithe i iontráil crann"
 
 msgid "empty filename in tree entry"
-msgstr ""
+msgstr "ainm comhaid folamh i iontráil crann"
 
 msgid "too-short tree file"
-msgstr ""
+msgstr "comhad crann ró-ghearr"
 
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
 "%%sPlease commit your changes or stash them before you switch branches."
 msgstr ""
+"Déanfaí d'athruithe áitiúla ar na comhaid seo a leanas a fhorscríobh trí "
+"sheiceáil:\n"
+"%%sDéan d'athruithe nó déan iad a stóráil sula n-athraíonn tú brainsí."
 
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
 "%%s"
 msgstr ""
+"Déanfaí d'athruithe áitiúla ar na comhaid seo a leanas a fhorscríobh trí "
+"sheiceáil:\n"
+"%%s"
 
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "%%sPlease commit your changes or stash them before you merge."
 msgstr ""
+"Déanfaí d'athruithe áitiúla ar na comhaid seo a leanas a fhorscríobh trí "
+"chumasc:\n"
+"%%sDo chuid athruithe a dhéanamh nó cuir isteach iad sula ndéanann tú a "
+"chumasc."
 
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
 "%%s"
 msgstr ""
+"Déanfaí d'athruithe áitiúla ar na comhaid seo a leanas a fhorscríobh trí "
+"chumasc:\n"
+"%%s"
 
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
 "%%sPlease commit your changes or stash them before you %s."
 msgstr ""
+"Déanfadh %s d'athruithe áitiúla ar na comhaid seo a leanas a fhorscríobh:\n"
+"%%sDéan do chuid athruithe nó iad a stóráil os comhair %s."
 
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
 "%%s"
 msgstr ""
+"Déanfadh %s d'athruithe áitiúla ar na comhaid seo a leanas a fhorscríobh:\n"
+"%%s"
 
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
 "%s"
 msgstr ""
+"Chaillfeadh na n-eolairí seo a leanas a nuashonrú comhaid gan rianú iontu:\n"
+"%s"
 
 #, c-format
 msgid ""
 "Refusing to remove the current working directory:\n"
 "%s"
 msgstr ""
+"Diúltú an eolaire oibre reatha a bhaint:\n"
+"%s"
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
 "%%sPlease move or remove them before you switch branches."
 msgstr ""
+"Bainfí na comhaid crann oibre gan rianú seo a leanas trí sheiceáil:\n"
+"%%sBogadh nó bain iad sula n-athraíonn tú brainsí."
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
 "%%s"
 msgstr ""
+"Bainfí na comhaid crann oibre gan rianú seo a leanas trí sheiceáil:\n"
+"%%s"
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
 "%%sPlease move or remove them before you merge."
 msgstr ""
+"Bainfí na comhaid crann oibre gan rianú seo a leanas trí chumasc:\n"
+"%%sDo thoil bog nó bain iad sula ndéanann tú a chumasc."
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
 "%%s"
 msgstr ""
+"Bainfí na comhaid crann oibre gan rianú seo a leanas trí chumasc:\n"
+"%%s"
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
 "%%sPlease move or remove them before you %s."
 msgstr ""
+"Bainfí %s na comhaid crann oibre neamhrianaithe seo a leanas:\n"
+"%%sDo thoil bog nó bain iad roimh %s."
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
 "%%s"
 msgstr ""
+"Bainfí %s na comhaid crann oibre neamhrianaithe seo a leanas:\n"
+"%%s"
 
 #, c-format
 msgid ""
@@ -21517,6 +22690,9 @@ msgid ""
 "checkout:\n"
 "%%sPlease move or remove them before you switch branches."
 msgstr ""
+"Déanfaí na comhaid crann oibre neamhrianaithe seo a leanas a fhorscríobh trí "
+"sheiceáil:\n"
+"%%sBogadh nó bain iad sula n-athraíonn tú brainsí."
 
 #, c-format
 msgid ""
@@ -21524,40 +22700,55 @@ msgid ""
 "checkout:\n"
 "%%s"
 msgstr ""
+"Déanfaí na comhaid crann oibre neamhrianaithe seo a leanas a fhorscríobh trí "
+"sheiceáil:\n"
+"%%s"
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
 "%%sPlease move or remove them before you merge."
 msgstr ""
+"Déanfaí na comhaid crann oibre neamhrianaithe seo a leanas a fhorscríobh trí "
+"chumasc:\n"
+"%%sDo thoil bog nó bain iad sula ndéanann tú cumasc."
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
 "%%s"
 msgstr ""
+"Déanfaí na comhaid crann oibre neamhrianaithe seo a leanas a fhorscríobh trí "
+"chumasc:\n"
+"%%s"
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
 "%%sPlease move or remove them before you %s."
 msgstr ""
+"Bheadh %s na comhaid crann oibre neamhrianaithe seo a leanas a fhorscríobh:\n"
+"%%sDo thoil bog nó bain iad roimh %s."
 
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
 "%%s"
 msgstr ""
+"Bheadh %s na comhaid crann oibre neamhrianaithe seo a leanas a fhorscríobh:\n"
+"%%s"
 
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
-msgstr ""
+msgstr "Tá iontráil '%s' ag forluí le '%s'. Ní féidir ceangal a dhéanamh."
 
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
 "%s"
 msgstr ""
+"Ní féidir fo-mhodúl a nuashonrú:\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -21565,12 +22756,18 @@ msgid ""
 "patterns:\n"
 "%s"
 msgstr ""
+"Níl na cosáin seo a leanas cothrom le dáta agus fágadh iad in ainneoin "
+"patrúin neamhchoitianta:\n"
+"%s"
 
 #, c-format
 msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
 "%s"
 msgstr ""
+"Tá na cosáin seo a leanas gan chumasc agus fágadh iad in ainneoin patrúin "
+"neamhchoitianta:\n"
+"%s"
 
 #, c-format
 msgid ""
@@ -21578,206 +22775,208 @@ msgid ""
 "patterns:\n"
 "%s"
 msgstr ""
+"Bhí na cosáin seo a leanas i láthair cheana féin agus dá bhrí sin níor "
+"nuashonraíodh in ainneoin\n"
+"%s"
 
 #, c-format
 msgid "Aborting\n"
-msgstr ""
+msgstr "Gearradh\n"
 
 #, c-format
 msgid ""
 "After fixing the above paths, you may want to run `git sparse-checkout "
 "reapply`.\n"
 msgstr ""
+"Tar éis duit na cosáin thuas a shocrú, b'fhéidir gur mhaith leat `git sparse-"
+"checkout reapply` a reáchtáil.\n"
 
 msgid "Updating files"
-msgstr ""
+msgstr "Comhad a nuashonrú"
 
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
 "colliding group is in the working tree:\n"
 msgstr ""
+"bhuail na cosáin seo a leanas (e.g. cosáin cás-íogair\n"
+"ar chóras comhaid cás-neamh-íogair) agus ach ceann amháin ón gcéanna\n"
+"tá grúpa imbhuailte sa chrann oibre:\n"
 
 msgid "Updating index flags"
-msgstr ""
+msgstr "Nuashonrú bratacha innéacs"
 
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
+"tá iontrálacha dúbailte ag crann oibre agus tiomantas neamhrianaithe: %s"
 
 msgid "expected flush after fetch arguments"
-msgstr ""
+msgstr "súil le sruth tar éis argóintí a fháil"
 
 msgid "invalid URL scheme name or missing '://' suffix"
-msgstr ""
+msgstr "ainm scéime URL neamhbhailí nó iarmhír ': //' in easnamh"
 
 #, c-format
 msgid "invalid %XX escape sequence"
-msgstr ""
+msgstr "seicheamh éalaithe %XX neamhbhailí"
 
 msgid "missing host and scheme is not 'file:'"
-msgstr ""
+msgstr "ní 'comhad: 'í an óstach agus an scéim atá in easnamh:"
 
 msgid "a 'file:' URL may not have a port number"
-msgstr ""
+msgstr "b'fhéidir nach mbeadh uimhir chalafoirt ag URL 'file: '"
 
 msgid "invalid characters in host name"
-msgstr ""
+msgstr "carachtair neamhbhailí in ainm ósta"
 
 msgid "invalid port number"
-msgstr ""
+msgstr "uimhir phort neamhbhail"
 
-#, fuzzy
 msgid "invalid '..' path segment"
-msgstr "sonraíocht cosáin nebhail"
+msgstr "deighleog cosáin '..' neamhbhailí"
 
-#, fuzzy, c-format
+#, c-format
 msgid "error: unable to format message: %s\n"
-msgstr "nach féidir snáithe a chruthú: %s"
+msgstr "earráid: ní féidir teachtaireacht a fhormáidiú: %s\n"
 
 msgid "usage: "
-msgstr ""
+msgstr "úsáid: "
 
 msgid "fatal: "
-msgstr ""
+msgstr "marfach: "
 
 msgid "error: "
-msgstr ""
+msgstr "earráid: "
 
 msgid "warning: "
-msgstr ""
+msgstr "rabhadh: "
 
 #, c-format
 msgid "uname() failed with error '%s' (%d)\n"
-msgstr ""
+msgstr "theip ar uname () le earráid '%s' (%d)\n"
 
-#, fuzzy
 msgid "Fetching objects"
-msgstr "Rud a sheiceáil"
+msgstr "Rudaí a fháil"
 
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
-msgstr ""
+msgstr "Ní hé '%s' ag an bpríomhchrann oibre an eolaire stórais"
 
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
-msgstr ""
+msgstr "Níl cosán iomlán chuig suíomh an chrainn oibre i gcomhad '%s'"
 
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
-msgstr ""
+msgstr "Ní comhad .git é '%s', cód earráide %d"
 
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' does not point back to '%s'"
-msgstr "Ní chuireann HEAD in iúl do bhrainse"
+msgstr "Ní dhíríonn '%s' ar ais chuig '%s'"
 
-#, fuzzy
 msgid "not a directory"
-msgstr "eolaire teimpléad"
+msgstr "ní eolaire"
 
 msgid ".git is not a file"
-msgstr ""
+msgstr "Ní comhad é .git"
 
 msgid ".git file broken"
-msgstr ""
+msgstr "comhad .git briste"
 
-#, fuzzy
 msgid ".git file incorrect"
-msgstr "comhad innéacs truaillithe"
+msgstr "comhad .git mícheart"
 
 msgid ".git file absolute/relative path mismatch"
-msgstr ""
+msgstr "comhad .git neamhoiriúnú iomlán/coibhneasta coibhneasta"
 
 msgid "not a valid path"
-msgstr ""
+msgstr "ní cosán bailí"
 
 msgid "unable to locate repository; .git is not a file"
-msgstr ""
+msgstr "in ann stór a aimsiú; ní comhad é .git"
 
 msgid "unable to locate repository; .git file does not reference a repository"
-msgstr ""
+msgstr "in ann stór a aimsiú; ní thagann comhad .git tagairt do stór"
 
 msgid "unable to locate repository; .git file broken"
-msgstr ""
+msgstr "in ann stór a aimsiú; comhad .git briste"
 
 msgid "gitdir unreadable"
-msgstr ""
+msgstr "gitdir unreadable"
 
 msgid "gitdir absolute/relative path mismatch"
-msgstr ""
+msgstr "mímheaitseáil cosán iomlán/coibhneasta gitdir"
 
 msgid "gitdir incorrect"
-msgstr ""
+msgstr "gitdir mícheart"
 
 msgid "not a valid directory"
-msgstr ""
+msgstr "ní eolaire bailí"
 
-#, fuzzy
 msgid "gitdir file does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "níl comhad gitdir ann"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to read gitdir file (%s)"
-msgstr "nach féidir crann a léamh (%s)"
+msgstr "nach féidir comhad gitdir a léamh (%s)"
 
 #, c-format
 msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
-msgstr ""
+msgstr "léamh gearr (súil leis%<PRIuMAX>bytes, léithe%<PRIuMAX>)"
 
 msgid "invalid gitdir file"
-msgstr ""
+msgstr "comhad gitdir neamhbhailí"
 
 msgid "gitdir file points to non-existent location"
-msgstr ""
+msgstr "pointeálann comhad gitdir chuig suíomh nach bhfuil ann"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to set %s in '%s'"
-msgstr "nach féidir le tiomantas %s a pharsáil"
+msgstr "nach féidir %s a shocrú i '%s'"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to unset %s in '%s'"
-msgstr "theip ar '%s' a dhínascadh"
+msgstr "nach féidir %s a dhíshocrú i '%s'"
 
 msgid "failed to set extensions.worktreeConfig setting"
-msgstr ""
+msgstr "theip ar shocrú extensions.worktreeConfig"
 
 msgid "unable to upgrade repository format to support relative worktrees"
-msgstr ""
+msgstr "in ann formáid stórais a uasghrádú chun tacú le crainn oibre coibh"
 
 msgid "unable to set extensions.relativeWorktrees setting"
-msgstr ""
+msgstr "ní féidir an socrú extensions.relativeWorktrees a shocrú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "could not setenv '%s'"
-msgstr "ní fhéadfaí %s a réiteach"
+msgstr "ní fhéadfaí '%s' a shocrú"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to create '%s'"
-msgstr "nach féidir %s a léamh"
+msgstr "ní féidir '%s' a chruthú"
 
 #, c-format
 msgid "could not open '%s' for reading and writing"
-msgstr ""
+msgstr "ní fhéadfaí '%s' a oscailt le haghaidh léamh agus scríbhneoireachta"
 
-#, fuzzy, c-format
+#, c-format
 msgid "unable to access '%s'"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "ní féidir rochtain a fháil ar '%s'"
 
-#, fuzzy
 msgid "unable to get current working directory"
-msgstr "in ann crann oibre a sheiceáil"
+msgstr "in ann eolaire oibre reatha a fháil"
 
-#, fuzzy
 msgid "unable to get random bytes"
-msgstr "nach féidir %s a léamh"
+msgstr "in ann bétaí randamacha a fháil"
 
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
-msgstr ""
+msgstr "ag iarraidh mmapáil %<PRIuMAX> thar theorainn %<PRIuMAX>"
 
 #, c-format
 msgid "mmap failed%s"
-msgstr ""
+msgstr "theip ar mmap %s"
 
 msgid "Unmerged paths:"
 msgstr "Cosáin neamh-chumasaithe:"
@@ -22242,139 +23441,149 @@ msgstr "ina theannta sin, tá athruithe neamhthiomanta i d'innéacs."
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "ní féidir %s: Tá athruithe neamhthiomanta ag d'innéacs."
 
-#, fuzzy, c-format
+#, c-format
 msgid "unknown style '%s' given for '%s'"
-msgstr "formáid stórála tagartha anaithnid '%s'"
+msgstr "stíl anaithnid '%s' a thugtar do '%s'"
 
 msgid ""
 "Error: Your local changes to the following files would be overwritten by "
 "merge"
 msgstr ""
+"Earráid: Déanfaí d'athruithe áitiúla ar na comhaid seo a leanas a "
+"fhorscríobh trí chumasc"
 
 msgid "Automated merge did not work."
-msgstr ""
+msgstr "Níor oibrigh cumaisc uathoibrithe."
 
 msgid "Should not be doing an octopus."
-msgstr ""
+msgstr "Níor chóir go mbeadh sé ag déanamh ochtair."
 
 #, sh-format
 msgid "Unable to find common commit with $pretty_name"
-msgstr ""
+msgstr "Ní féidir tiomantas coiteann a fháil le $pretty_name"
 
 #, sh-format
 msgid "Already up to date with $pretty_name"
-msgstr ""
+msgstr "Cothrom le dáta cheana féin le $pretty_name"
 
 #, sh-format
 msgid "Fast-forwarding to: $pretty_name"
-msgstr ""
+msgstr "Seoladh go tapa chuig: $pretty_name"
 
 #, sh-format
 msgid "Trying simple merge with $pretty_name"
-msgstr ""
+msgstr "Ag iarraidh cumasc simplí le $pretty_name"
 
 msgid "Simple merge did not work, trying automatic merge."
 msgstr ""
+"Níor oibrigh an cumasc simplí, táim ag iarraidh cumasc uathoibríoch a "
+"dhéanamh."
 
 #, sh-format
 msgid "usage: $dashless $USAGE"
-msgstr ""
+msgstr "úsáid: $dashless $USAGE"
 
 #, sh-format
 msgid "Cannot chdir to $cdup, the toplevel of the working tree"
-msgstr ""
+msgstr "Ní féidir a chdir go $cdup, barr an chrainn oibre"
 
 #, sh-format
 msgid "fatal: $program_name cannot be used without a working tree."
-msgstr ""
+msgstr "marfach: ní féidir $program_name a úsáid gan crann oibre."
 
-#, fuzzy
 msgid "Cannot rewrite branches: You have unstaged changes."
-msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+msgstr "Ní féidir brainsí a athscríobh: Tá athruithe gan stáitse agat."
 
-#, fuzzy, sh-format
+#, sh-format
 msgid "Cannot $action: You have unstaged changes."
-msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
+msgstr "Ní féidir $action: Tá athruithe gan stáitse agat."
 
-#, fuzzy, sh-format
+#, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
-msgstr "ní féidir %s: Tá athruithe neamhthiomanta ag d'innéacs."
+msgstr "Ní féidir $action: Tá athruithe neamhthiomanta i d'innéacs."
 
-#, fuzzy
 msgid "Additionally, your index contains uncommitted changes."
-msgstr "ina theannta sin, tá athruithe neamhthiomanta i d'innéacs."
+msgstr "Ina theannta sin, tá athruithe neamhthiomanta i d'innéacs."
 
 msgid "You need to run this command from the toplevel of the working tree."
-msgstr ""
+msgstr "Ní mór duit an t-ordú seo a reáchtáil ó bharr an chrainn oibre."
 
 msgid "Unable to determine absolute path of git directory"
-msgstr ""
+msgstr "Ní féidir cosán iomlán eolaire git a chinneadh"
 
 msgid "local zone differs from GMT by a non-minute interval\n"
-msgstr ""
+msgstr "tá eatramh neamh-nóiméid difriúil ón gcrios áitiúil\n"
 
 msgid "local time offset greater than or equal to 24 hours\n"
 msgstr ""
+"fritháireamh ama áitiúil atá níos mó ná nó cothrom le 24 uair an chloig\n"
 
 #, perl-format
 msgid "fatal: command '%s' died with exit code %d"
-msgstr ""
+msgstr "marfach: fuair an t-ordú '%s' bás le cód imeachta %d"
 
 msgid "the editor exited uncleanly, aborting everything"
-msgstr ""
+msgstr "d’imigh an t-eagarthóir go neamhghlan, ag cur deireadh le gach rud"
 
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
-msgstr ""
+msgstr "Tá leagan idirmheánach den ríomhphost a bhí á scríobh agat i '%s'.\n"
 
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
-msgstr ""
+msgstr "Cuimsíonn '%s.final' an ríomhphost comhdhéanta.\n"
 
 msgid "--dump-aliases incompatible with other options\n"
-msgstr ""
+msgstr "--dump-aliases neamhoiriúnach le roghanna eile\n"
 
 msgid "--dump-aliases and --translate-aliases are mutually exclusive\n"
-msgstr ""
+msgstr "Tá --dump-aliases agus --translate-aliases frithpháirteach\n"
 
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
 "Set sendemail.forbidSendmailVariables to false to disable this check.\n"
 msgstr ""
+"marfach: aimsíodh roghanna cumraíochta do 'sendmail'\n"
+"Tá git-send-email cumraithe leis na roghanna sendemail.* - tabhair faoi "
+"deara an 'e'.\n"
+"Socraigh sendemail.forbidSendmailVariables go bréagach chun an seiceáil seo "
+"a dhíchumasú.\n"
 
 msgid "Cannot run git format-patch from outside a repository\n"
-msgstr ""
+msgstr "Ní féidir git format-patch a rith ó lasmuigh de stórlann\n"
 
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
 msgstr ""
+"Caithfear `méid baisce' agus `athlogán' a shonrú le chéile (trí líne "
+"ordaithe nó rogha cumraíochta)\n"
 
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
-msgstr ""
+msgstr "Réimse anaithnid --suppress-cc: '%s'\n"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
-msgstr "stíl choimhlinte anaithnid '%s'"
+msgstr "Socrú --confirm anaithnid: '%s'\n"
 
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
-msgstr ""
+msgstr "rabhadh: ní thacaítear le alias sendmail le luachana: %s\n"
 
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
-msgstr ""
+msgstr "rabhadh: `:include: `níl tacaíocht: %s\n"
 
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
-msgstr ""
+msgstr "rabhadh: Ní thacaítear le hathreorú `/comhad` nó `|píopa`: %s\n"
 
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
-msgstr ""
+msgstr "rabhadh: ní aithnítear líne sendmail: %s\n"
 
 #, perl-format
 msgid ""
@@ -22384,24 +23593,34 @@ msgid ""
 "    * Saying \"./%s\" if you mean a file; or\n"
 "    * Giving --format-patch option if you mean a range.\n"
 msgstr ""
+"Tá comhad '%s' ann ach d'fhéadfadh sé a bheith ina raon na dtiomanta "
+"freisin\n"
+"chun paistí a tháirgeadh le haghaidh. Déan díbhríochnú le do thoil le do "
+"thoil\n"
+"\n"
+"    * Ag rá”. /%s” má tá comhad i gceist agat; nó\n"
+"    * Rogha --format-patch a thabhairt má tá raon i gceist agat.\n"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "Failed to opendir %s: %s"
-msgstr "Theip ar chrann %s a aimsiú."
+msgstr "Theip ar %s a oscailt: %s"
 
 msgid ""
 "\n"
 "No patch files specified!\n"
 "\n"
 msgstr ""
+"\n"
+"Níl aon chomhaid paiste sonraithe!\n"
+"\n"
 
 #, perl-format
 msgid "No subject line in %s?"
-msgstr ""
+msgstr "Níl aon líne ábhair i %s?"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "Failed to open for writing %s: %s"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "Theip ar oscailt le haghaidh scríbhneoireachta %s: %s"
 
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
@@ -22410,30 +23629,37 @@ msgid ""
 "\n"
 "Clear the body content if you don't wish to send a summary.\n"
 msgstr ""
+"Bainfear línte a thosaíonn i “GIT:”.\n"
+"Smaoinigh ar diffstat foriomlán nó tábla ábhair a áireamh\n"
+"don phaiste atá á scríobh agat.\n"
+"\n"
+"Glan ábhar an choirp mura dteastaíonn uait achoimre a sheoladh.\n"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "Failed to open %s.final: %s"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "Theip ar %s.final a oscailt: %s"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "Failed to open %s: %s"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "Theip ar %s a oscailt: %s"
 
 msgid "Summary email is empty, skipping it\n"
-msgstr ""
+msgstr "Tá ríomhphost achoimre folamh, ag scipeáil é\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
-msgstr ""
+msgstr "An bhfuil tú cinnte gur mhaith leat <%s> [Y/n] a úsáid? "
 
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
 msgstr ""
+"Is iad na comhaid seo a leanas 8bit, ach ná dearbhaíonn siad Ionchódú "
+"Aistrithe Ábhar.\n"
 
 msgid "Which 8bit encoding should I declare [UTF-8]? "
-msgstr ""
+msgstr "Cén ionchódú 8 giotán ba chóir dom a dhearbhú [UTF-8]? "
 
 #, perl-format
 msgid ""
@@ -22442,30 +23668,36 @@ msgid ""
 "has the template subject '*** SUBJECT HERE ***'. Pass --force if you really "
 "want to send.\n"
 msgstr ""
+"Diúltú a sheoladh mar gheall ar an paiste\n"
+"\t%s\n"
+"tá an teimpléad faoi réir an ábhair '*** ÁBHAR ANSEO ***'. Pasáil --force "
+"más mian leat a sheoladh i ndáiríre.\n"
 
 msgid "To whom should the emails be sent (if anyone)?"
-msgstr ""
+msgstr "Cé chuige ba chóir na ríomhphoist a sheoladh (más duine ar bith)?"
 
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
-msgstr ""
+msgstr "marfach: leathnaíonn alias '%s' chuige féin\n"
 
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
+"Aitheantas an Teachtaireachta le húsáid mar In-Reply-To don chéad ríomhphost "
+"(más ann dó)? "
 
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
-msgstr ""
+msgstr "earráid: ní féidir seoladh bailí a bhaint as: %s\n"
 
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
-msgstr ""
+msgstr "Cad atá le déanamh leis an seoladh seo? ([q]uit|[d]rop|[e]dit): "
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "CA path \"%s\" does not exist"
-msgstr "níl an stóras '%s' ann"
+msgstr "Níl cosán CA “%s” ann"
 
 msgid ""
 "    The Cc list above has been expanded by additional\n"
@@ -22479,103 +23711,120 @@ msgid ""
 "    run 'git config --global sendemail.confirm auto'.\n"
 "\n"
 msgstr ""
+"    Leathnaíodh an liosta Cc thuas trí bhreise\n"
+"    seoltaí a fhaightear sa teachtaireacht tiomanta paiste. De réir "
+"réamhshocraithe\n"
+"    spreagann ríomhphost a sheoladh sula seoltar aon uair a tharlaíonn sé "
+"seo.\n"
+"    Tá an t-iompar seo á rialú ag an sendemail.confirm\n"
+"    socrú cumraíochta.\n"
+"\n"
+"    Le haghaidh faisnéise breise, reáchtáil 'git send-email --help'.\n"
+"    Chun an t-iompar reatha a choinneáil, ach an teachtaireacht seo a "
+"scriosadh,\n"
+"    reáchtáil 'git config --global sendemail.confirm auto'.\n"
 
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr ""
+"An bhfuil tú ag iarraidh an ríomhphost seo a sheoladh? ([y]es|[n]o|[e]dit|"
+"[q]uit|[a]ll): "
 
 msgid "Send this email reply required"
-msgstr ""
+msgstr "Seol an freagra ríomhphoist riachtanach"
 
 msgid "The required SMTP server is not properly defined."
-msgstr ""
+msgstr "Níl an freastalaí SMTP riachtanach sainmhínithe i gceart."
 
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
-msgstr ""
+msgstr "Ní thacaíonn freastalaí le STARTTLS! %s"
 
 #, perl-format
 msgid "STARTTLS failed! %s"
-msgstr ""
+msgstr "Theip ar STARTTLS! %s"
 
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
+"Ní féidir SMTP a thionscnamh i gceart. Seiceáil configí agus bain úsáid as --"
+"smtp-debug."
 
 #, perl-format
 msgid "Outlook reassigned Message-ID to: %s\n"
-msgstr ""
+msgstr "Athshannaigh Outlook ID teachtaireachta chuig: %s\n"
 
 msgid "Warning: Could not retrieve Message-ID from server response.\n"
 msgstr ""
+"Rabhadh: Ní fhéadfaí teachtaireachtaí ID a aisghabháil ó fhreagairt "
+"freastalaí.\n"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "Failed to send %s\n"
-msgstr "theip ar '%s' a stáil"
+msgstr "Theip ar %s a sheoladh\n"
 
 #, perl-format
 msgid "Dry-Sent %s"
-msgstr ""
+msgstr "Seoladh tirim %s"
 
 #, perl-format
 msgid "Sent %s"
-msgstr ""
+msgstr "Seoladh %s"
 
 msgid "Dry-OK. Log says:"
-msgstr ""
+msgstr "Tirim-ceart go leor. Log deir:"
 
 msgid "OK. Log says:"
-msgstr ""
+msgstr "CEART GO LEOR. Log deir:"
 
 msgid "Result: "
-msgstr ""
+msgstr "Toradh: "
 
 msgid "Result: OK"
-msgstr ""
+msgstr "Toradh: Ceart go leor"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "can't open file %s"
-msgstr "ní féidir comhad %s '%s' a scríobh"
+msgstr "ní féidir comhad %s a oscailt"
 
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
-msgstr ""
+msgstr "(mbox) Ag cur cc: %s ó líne '%s'\n"
 
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
-msgstr ""
+msgstr "(mbox) Ag cur le: %s ó líne '%s'\n"
 
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
-msgstr ""
+msgstr "(non-mbox) Ag cur cc: %s ó líne '%s'\n"
 
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
-msgstr ""
+msgstr "(corp) Ag cur cc: %s ó líne '%s'\n"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "(%s) Could not execute '%s'"
-msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
+msgstr "(%s) Ní raibh '%s' in ann a fhorghníomhú"
 
 #, perl-format
 msgid "(%s) Malformed output from '%s'"
-msgstr ""
+msgstr "(%s) Aschur mífheidhmithe ó '%s'"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "(%s) failed to close pipe to '%s'"
-msgstr "theip ar chomhad a chóipeáil chuig '%s'"
+msgstr "Theip ar (%s) píopa a dhúnadh chuig '%s'"
 
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
-msgstr ""
+msgstr "(%s) Ag cur %s leis: %s ó: '%s'\n"
 
 msgid "cannot send message as 7bit"
-msgstr ""
+msgstr "ní féidir teachtaireacht a sheoladh mar 7bit"
 
-#, fuzzy
 msgid "invalid transfer encoding"
-msgstr "tagairt neamhbhailí: %s"
+msgstr "ionchódú aistrithe bailí"
 
 #, perl-format
 msgid ""
@@ -22583,22 +23832,27 @@ msgid ""
 "%s\n"
 "warning: no patches were sent\n"
 msgstr ""
+"marfach: %s: dhiúltaithe ag %s hook\n"
+"%s\n"
+"rabhadh: níor seoladh aon phaistí\n"
 
-#, fuzzy, perl-format
+#, perl-format
 msgid "unable to open %s: %s\n"
-msgstr "nach féidir %s a nuashonrú"
+msgstr "nach féidir %s a oscailt: %s\n"
 
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
 "warning: no patches were sent\n"
 msgstr ""
+"marfach: %s: %d níos faide ná 998 carachtar\n"
+"rabhadh: níor seoladh aon phaistí\n"
 
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
-msgstr ""
+msgstr "Scaipeáil %s le hiarmhír cúltaca '%s'.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
-msgstr ""
+msgstr "An bhfuil tú ag iarraidh %s a sheoladh i ndáiríre? [y|N]: "

--- a/po/ga.po
+++ b/po/ga.po
@@ -18,58 +18,46 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: builtin/checkout.c:47
 msgid "git checkout [<options>] <branch>"
 msgstr "git checkout [<roghanna>] <brainse>"
 
-#: builtin/checkout.c:48
 msgid "git checkout [<options>] [<branch>] -- <file>..."
 msgstr "git checkout [<roghanna>] [<brainse>] --<comhad>..."
 
-#: builtin/checkout.c:53
 msgid "git switch [<options>] [<branch>]"
 msgstr "git switch [<roghanna>] [<brainse>]"
 
-#: builtin/checkout.c:58
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [<roghanna>] [--source=<brainse>] <comhad>..."
 
-#: builtin/checkout.c:215 builtin/checkout.c:254
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "níl ár leagan ag cosán '%s'"
 
-#: builtin/checkout.c:217 builtin/checkout.c:256
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "níl a leagan ag cosán '%s'"
 
-#: builtin/checkout.c:233
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "níl gach leagan riachtanach ag cosán '%s'"
 
-#: builtin/checkout.c:288
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "níl leaganacha riachtanacha ag cosán '%s'"
 
-#: builtin/checkout.c:308
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "cosán '%s': ní féidir a chumasc"
 
-#: builtin/checkout.c:324
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Ní féidir toradh cumaisc a chur le haghaidh '%s'"
 
-#: builtin/checkout.c:328 builtin/reset.c:186
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "theip ar make_cache_entry le haghaidh cosán '%s'"
 
-#: builtin/checkout.c:442
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
@@ -77,7 +65,6 @@ msgstr[0] "Athchruthaíodh %d coimhlint chumasc"
 msgstr[1] "Athchruthaíodh %d coinbhleachtaí chumaisc"
 msgstr[2] "Athchruthaíodh %d coinbhleachtaí chumaisc"
 
-#: builtin/checkout.c:447
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
@@ -85,7 +72,6 @@ msgstr[0] "Nuashonraíodh %d cosán ó %s"
 msgstr[1] "Nuashonraíodh %d cosán ó %s"
 msgstr[2] "Nuashonraíodh %d cosán ó %s"
 
-#: builtin/checkout.c:454
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
@@ -93,71 +79,57 @@ msgstr[0] "Nuashonraíodh %d cosán ón innéacs"
 msgstr[1] "Nuashonraíodh %d cosán ón innéacs"
 msgstr[2] "Nuashonraíodh %d cosán ón innéacs"
 
-#: builtin/checkout.c:477 builtin/checkout.c:480 builtin/checkout.c:483 builtin/checkout.c:487
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "Ní féidir '%s' a úsáid le cosáin a nuashonrú"
 
-#: builtin/checkout.c:490 builtin/checkout.c:493 builtin/checkout.c:1805 builtin/checkout.c:1915
-#: builtin/checkout.c:1918 builtin/clone.c:1033 builtin/clone.c:1038 builtin/index-pack.c:2026
-#: builtin/reset.c:388 builtin/reset.c:425
 #, c-format
 msgid "options '%s' and '%s' cannot be used together"
 msgstr "ní féidir roghanna '%s' agus '%s' a úsáid le chéile"
 
-#: builtin/checkout.c:497
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
-msgstr "Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
+msgstr ""
+"Ní féidir cosáin a nuashonrú agus aistriú go brainse '%s' ag an am céanna."
 
-#: builtin/checkout.c:501
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "níl '%s' ná '%s' sonraithe"
 
-#: builtin/checkout.c:505
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "Ní mór '%s' a úsáid nuair nach sonraítear '%s'"
 
-#: builtin/checkout.c:523 builtin/checkout.c:527
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "Ní féidir '%s' nó '%s' a úsáid le %s"
 
-#: builtin/checkout.c:537
 #, c-format
 msgid "'%s', '%s', or '%s' cannot be used when checking out of a tree"
-msgstr "Ní féidir '%s', '%s', nó '%s' a úsáid agus tú ag seiceáil amach as crann"
+msgstr ""
+"Ní féidir '%s', '%s', nó '%s' a úsáid agus tú ag seiceáil amach as crann"
 
-#: builtin/checkout.c:573 builtin/checkout.c:789 builtin/reset.c:464
 msgid "index file corrupt"
 msgstr "comhad innéacs truaillithe"
 
-#: builtin/checkout.c:610 builtin/checkout.c:617
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "tá cosán '%s' neamh-chomhcheangailte"
 
-#: builtin/checkout.c:642 builtin/checkout.c:931 builtin/clone.c:693
 msgid "unable to write new index file"
 msgstr "in ann comhad innéacs nua a scríobh"
 
-#: builtin/checkout.c:802 builtin/checkout.c:1274 builtin/checkout.c:1280 builtin/reset.c:123
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "nach féidir crann a léamh (%s)"
 
-#: builtin/checkout.c:818
 msgid "you need to resolve your current index first"
 msgstr "ní mór duit d'innéacs reatha a réiteach ar dtús"
 
-#: builtin/checkout.c:835 builtin/clone.c:683
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "nach féidir le tiomantas %s a pharsáil"
 
-#: builtin/checkout.c:873
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -166,50 +138,40 @@ msgstr ""
 "ní féidir leanúint ar aghaidh le hathruithe céime sna comhaid seo a leanas:\n"
 "%s"
 
-#: builtin/checkout.c:971
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Ní féidir athbhreithniú a dhéanamh le haghaidh '%s': %s\n"
 
-#: builtin/checkout.c:1018
 msgid "HEAD is now at"
 msgstr "Tá HEAD anois ag"
 
-#: builtin/checkout.c:1022 builtin/clone.c:578 builtin/clone.c:608
 msgid "unable to update HEAD"
 msgstr "in ann HEAD a nuashonrú"
 
-#: builtin/checkout.c:1026
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Athshocraigh brainse '%s'\n"
 
-#: builtin/checkout.c:1029
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Ar '%s' cheana féin\n"
 
-#: builtin/checkout.c:1033
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Aistrigh agus athshocraigh brainse '%s'\n"
 
-#: builtin/checkout.c:1035 builtin/checkout.c:1488
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Aistrithe go brainse nua '%s'\n"
 
-#: builtin/checkout.c:1037
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Aistrithe go brainse '%s'\n"
 
-#: builtin/checkout.c:1090
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... agus %d níos mó.\n"
 
-#: builtin/checkout.c:1096
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -222,21 +184,21 @@ msgid_plural ""
 "\n"
 "%s\n"
 msgstr[0] ""
-"Rabhadh: tá %d tiomantas á fhágáil agat, gan cheangal le haon cheann de do bhrainsí:\n"
+"Rabhadh: tá %d tiomantas á fhágáil agat, gan cheangal le haon cheann de do "
+"bhrainsí:\n"
 "\n"
 "%s\n"
 msgstr[1] ""
-"Rabhadh: tá %d tiomantas á bhfágáil agat i do dhiaidh, gan aon cheangal le haon cheann de do "
-"bhrainsí:\n"
+"Rabhadh: tá %d tiomantas á bhfágáil agat i do dhiaidh, gan aon cheangal le "
+"haon cheann de do bhrainsí:\n"
 "\n"
 "%s\n"
 msgstr[2] ""
-"Rabhadh: tá %d tiomantas á bhfágáil agat i do dhiaidh, gan aon cheangal le haon cheann de do "
-"bhrainsí:\n"
+"Rabhadh: tá %d tiomantas á bhfágáil agat i do dhiaidh, gan aon cheangal le "
+"haon cheann de do bhrainsí:\n"
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1115
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -251,43 +213,39 @@ msgid_plural ""
 " git branch <new-branch-name> %s\n"
 "\n"
 msgstr[0] ""
-"Más mian leat é a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-am é seo chun é sin a "
-"dhéanamh le:\n"
+"Más mian leat é a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-"
+"am é seo chun é sin a dhéanamh le:\n"
 "\n"
 "git branch <ainm-brainse-nua> %s\n"
 msgstr[1] ""
-"Más mian leat iad a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-am é seo chun é sin a "
-"dhéanamh le:\n"
+"Más mian leat iad a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-"
+"am é seo chun é sin a dhéanamh le:\n"
 "\n"
 "git branch <ainm-brainse-nua> %s\n"
 msgstr[2] ""
-"Más mian leat iad a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-am é seo chun é sin a "
-"dhéanamh le:\n"
+"Más mian leat iad a choinneáil trí bhrainse nua a chruthú, b'fhéidir gur dea-"
+"am é seo chun é sin a dhéanamh le:\n"
 "\n"
 "git branch <ainm-brainse-nua> %s\n"
 
-#: builtin/checkout.c:1151
 msgid "internal error in revision walk"
 msgstr "earráid inmheánach i dsiúlóid"
 
-#: builtin/checkout.c:1155
 msgid "Previous HEAD position was"
 msgstr "Bhí post CEAD roimhe seo"
 
-#: builtin/checkout.c:1200 builtin/checkout.c:1482
 msgid "You are on a branch yet to be born"
 msgstr "Tá tú ar bhrainse nach rugadh fós"
 
-#: builtin/checkout.c:1293
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
 "Please use -- (and optionally --no-guess) to disambiguate"
 msgstr ""
-"D'fhéadfadh '%s' a bheith ina chomhad áitiúil agus ina bhrainse rianaithe araon.\n"
-"Úsáid le do thoil -- (agus go roghnach --no-thuairim) chun a dhíbhriú"
+"D'fhéadfadh '%s' a bheith ina chomhad áitiúil agus ina bhrainse rianaithe "
+"araon.\n"
+"Úsáid le do thoil -- (agus go roghnach --no-guess) chun a dhíbhriú"
 
-#: builtin/checkout.c:1300
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -298,64 +256,59 @@ msgid ""
 "one remote, e.g. the 'origin' remote, consider setting\n"
 "checkout.defaultRemote=origin in your config."
 msgstr ""
-"Má bhí sé i gceist agat brainse cianrianaithe a sheiceáil ar, m.sh. 'tionscnamh',\n"
-"is féidir leat é sin a dhéanamh tríd an ainm a cháiliú go hiomlán leis an rogha --track:\n"
+"Má bhí sé i gceist agat brainse cianrianaithe a sheiceáil ar, e.eg. "
+"'tionscnamh',\n"
+"is féidir leat é sin a dhéanamh tríd an ainm a cháiliú go hiomlán leis an "
+"rogha --track:\n"
 "\n"
-" seiceáil git --track bunaidh/<name>\n"
+"    git checkout --track origin/<name>\n"
 "\n"
-"<name>Más mian leat seiceálacha débhríoch a bheith agat i gcónaí is fearr leat\n"
-"iargúlta amháin, m.sh. an iargúlta 'bunús', smaoinigh ar shocrú\n"
-"checkout.defaultRemote=Bunús i do chumraíocht."
+"<name>Más mian leat seiceálacha débhríoch a bheith agat i gcónaí is fearr "
+"leat\n"
+"iargúlta amháin, e.g. an iargúlta 'bunús', smaoinigh ar shocrú\n"
+"checkout.defaultRemote=origin i do chumraíocht."
 
-#: builtin/checkout.c:1310
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "Mheaitseáil '%s' roinnt (%d) brainsí rianaithe iargúlta"
 
-#: builtin/checkout.c:1377
 msgid "only one reference expected"
 msgstr "níl ach tagairt amháin ag súil leis"
 
-#: builtin/checkout.c:1394
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "níl ach tagairt amháin ag súil leis, %d tugtha."
 
-#: builtin/checkout.c:1440
 #, c-format
 msgid "invalid reference: %s"
 msgstr "tagairt neamhbhailí: %s"
 
-#: builtin/checkout.c:1453 builtin/checkout.c:1886
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "ní crann é tagairt: %s"
 
-#: builtin/checkout.c:1504
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "táthar ag súil le brainse, faightear tag '%s'"
 
-#: builtin/checkout.c:1506
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "táthar ag súil le brainse, fuair brainse iargúlta '%s'"
 
-#: builtin/checkout.c:1508 builtin/checkout.c:1517
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "táthar ag súil le brainse, fuair '%s'"
 
-#: builtin/checkout.c:1511
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "táthar ag súil le brainse, fuair sé tiomantas '%s'"
 
-#: builtin/checkout.c:1520
-msgid "If you want to detach HEAD at the commit, try again with the --detach option."
-msgstr "Más mian leat HEAD a dhícheangal ag an tiomantas, déan iarracht arís leis an rogha --detach."
+msgid ""
+"If you want to detach HEAD at the commit, try again with the --detach option."
+msgstr ""
+"Más mian leat HEAD a dhícheangal ag an tiomantas, déan iarracht arís leis an "
+"rogha --detach."
 
-#: builtin/checkout.c:1533
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -363,7 +316,6 @@ msgstr ""
 "ní féidir brainse a athrú agus cumasc á dhéanamh\n"
 "Smaoinigh ar \"git merge --quit\" nó \"git worktree add\"."
 
-#: builtin/checkout.c:1537
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -371,7 +323,6 @@ msgstr ""
 "ní féidir brainse a athrú i lár seisiún am\n"
 "Smaoinigh ar \"git am --quit\" nó \"git worktree add\"."
 
-#: builtin/checkout.c:1541
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -379,7 +330,6 @@ msgstr ""
 "ní féidir brainse a athrú agus athbhunú á dhéanamh\n"
 "Smaoinigh ar \"git rebase --quit\" nó \"git worktree add\"."
 
-#: builtin/checkout.c:1545
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -387,7 +337,6 @@ msgstr ""
 "ní féidir brainse a athrú agus tú ag roghnú brainse nua\n"
 "Smaoinigh ar \"git cherry-pick --quit\" nó \"git worktree add\"."
 
-#: builtin/checkout.c:1549
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -395,678 +344,531 @@ msgstr ""
 "ní féidir brainse a athrú agus aisiompú á dhéanamh\n"
 "Smaoinigh ar \"git revert --quit\" nó \"git worktree add\"."
 
-#: builtin/checkout.c:1553
 msgid "you are switching branch while bisecting"
 msgstr "tá tú ag athrú brainse agus tú ag déileáil"
 
-#: builtin/checkout.c:1587
 msgid "paths cannot be used with switching branches"
 msgstr "ní féidir cosáin a úsáid le brainsí a athrú"
 
-#: builtin/checkout.c:1590 builtin/checkout.c:1594 builtin/checkout.c:1602
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "Ní féidir '%s' a úsáid le brainsí a athrú"
 
-#: builtin/checkout.c:1600
 #, c-format
 msgid "'%s' needs the paths to check out"
 msgstr "Teastaíonn '%s' na cosáin chun seiceáil"
 
-#: builtin/checkout.c:1607 builtin/checkout.c:1610 builtin/checkout.c:1613 builtin/checkout.c:1618
-#: builtin/checkout.c:1623
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "Ní féidir '%s' a úsáid le '%s'"
 
-#: builtin/checkout.c:1620
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "Ní féidir '%s' a ghlacadh <start-point>"
 
-#: builtin/checkout.c:1628
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Ní féidir brainse a aistriú go '%s' neamh-thiomanta"
 
-#: builtin/checkout.c:1633
 msgid "missing branch or commit argument"
 msgstr "brainse ar iarraidh nó argóint a dhéanamh"
 
-#: builtin/checkout.c:1678
 #, c-format
 msgid "unknown conflict style '%s'"
 msgstr "stíl choimhlinte anaithnid '%s'"
 
-#: builtin/checkout.c:1690
 msgid "suppress progress reporting"
 msgstr "cur chun cinn tuairiscithe"
 
-#: builtin/checkout.c:1694 builtin/clone.c:917 builtin/push.c:586
 msgid "force progress reporting"
 msgstr "tuairisciú dul chun cinn"
 
-#: builtin/checkout.c:1695
 msgid "perform a 3-way merge with the new branch"
 msgstr "cumasc 3 bhealach a dhéanamh leis an mbrainse nua"
 
-#: builtin/checkout.c:1696
 msgid "style"
 msgstr "stíl"
 
-#: builtin/checkout.c:1697
 msgid "conflict style (merge, diff3, or zdiff3)"
 msgstr "stíl choimhlinte (cumaisc, diff3, nó zdiff3)"
 
-#: builtin/checkout.c:1710
 msgid "detach HEAD at named commit"
 msgstr "dícheangail HEAD ag an tiomnú ainmnithe"
 
-#: builtin/checkout.c:1712
 msgid "set branch tracking configuration"
 msgstr "cumraíocht rianaithe brainse a shoc"
 
-#: builtin/checkout.c:1715
 msgid "force checkout (throw away local modifications)"
 msgstr "seiceáil fórsa (caith modhnuithe áitiúla)"
 
-#: builtin/checkout.c:1717
 msgid "new-branch"
 msgstr "brainse-nua"
 
-#: builtin/checkout.c:1717
 msgid "new unborn branch"
 msgstr "brainse nua gan breith"
 
-#: builtin/checkout.c:1719
 msgid "update ignored files (default)"
 msgstr "nuashonrú comhaid a dhéantar neamhaird orthu"
 
-#: builtin/checkout.c:1722
 msgid "do not check if another worktree is using this branch"
-msgstr "ná seiceáil an bhfuil crann oibre eile á úsáid ag baint úsáide as an mbrainse seo"
+msgstr "ná seiceáil an bhfuil crann oibre eile á úsáid ag baint úsáide as an "
+"mbrainse seo"
 
-#: builtin/checkout.c:1735
 msgid "checkout our version for unmerged files"
 msgstr "seiceáil ár leagan le haghaidh comhaid neamh-chumasaithe"
 
-#: builtin/checkout.c:1738
 msgid "checkout their version for unmerged files"
 msgstr "seiceáil a leagan le haghaidh comhaid neamh-chumasaithe"
 
-#: builtin/checkout.c:1740 builtin/reset.c:372
 msgid "select hunks interactively"
 msgstr "roghnaigh hunks idirghníomhach"
 
-#: builtin/checkout.c:1742
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "ná teorainn le speisiúintí cosáin le hiontrálacha neamhchoitianta"
 
-#: builtin/checkout.c:1801
 #, c-format
 msgid "options '-%c', '-%c', and '%s' cannot be used together"
 msgstr "ní féidir na roghanna '-%c', '-%c', agus '%s' a úsáid le chéile"
 
-#: builtin/checkout.c:1842
 msgid "--track needs a branch name"
-msgstr "Teastaíonn ainm brainse ó --track"
+msgstr "--track tá ainm brainse ag teastáil"
 
-#: builtin/checkout.c:1847
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "ainm brainse ar iarraidh; iarracht -%c"
 
-#: builtin/checkout.c:1879
 #, c-format
 msgid "could not resolve %s"
 msgstr "ní fhéadfaí %s a réiteach"
 
-#: builtin/checkout.c:1895
 msgid "invalid path specification"
 msgstr "sonraíocht cosáin nebhail"
 
-#: builtin/checkout.c:1902
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "Ní tiomantas é '%s' agus ní féidir brainse '%s' a chruthú uaidh"
 
-#: builtin/checkout.c:1906
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
-msgstr "git checkout: Ní ghlacann --detach argóint cosáin '%s'"
+msgstr "git checkout: --detach ní ghlacann argóint cosáin '%s'"
 
-#: builtin/checkout.c:1912 builtin/reset.c:391
 #, c-format
 msgid "'%s' and pathspec arguments cannot be used together"
 msgstr "Ní féidir argóintí '%s' agus pathspec a úsáid le chéile"
 
-#: builtin/checkout.c:1924 builtin/clone.c:1269 builtin/clone.c:1272 builtin/index-pack.c:2020
-#: builtin/reset.c:397 builtin/reset.c:458
 #, c-format
 msgid "the option '%s' requires '%s'"
 msgstr "tá %s ag teastáil don rogha '%s'"
 
-#: builtin/checkout.c:1931
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
 msgstr ""
-"git checkout: - ours/--a gcuid féin, --force agus --merge neamhoiriúnach nuair\n"
+"git checkout: --ours/--theirs, --force agus --merge neamhoiriúnach "
+"nuair\n"
 "seiceáil amach as an innéacs."
 
-#: builtin/checkout.c:1936
 msgid "you must specify path(s) to restore"
 msgstr "ní mór duit cosáin(í) a shonrú chun athchóiriú"
 
-#: builtin/checkout.c:1971 builtin/checkout.c:1973 builtin/checkout.c:2021 builtin/checkout.c:2023
-#: builtin/clone.c:956
 msgid "branch"
 msgstr "brainse"
 
-#: builtin/checkout.c:1972
 msgid "create and checkout a new branch"
 msgstr "brainse nua a chruthú agus a sheiceáil"
 
-#: builtin/checkout.c:1974
 msgid "create/reset and checkout a branch"
 msgstr "cruthaigh/athshocraigh agus seiceáil amach brainse"
 
-#: builtin/checkout.c:1975
 msgid "create reflog for new branch"
 msgstr "cruthú reflog do bhrainse nua"
 
-#: builtin/checkout.c:1977
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "an dara tuairim 'git check <no-such-branch>'(réamhshocraithe)"
 
-#: builtin/checkout.c:1978
 msgid "use overlay mode (default)"
 msgstr "úsáid modh forleagtha (réamhshocraithe)"
 
-#: builtin/checkout.c:2022
 msgid "create and switch to a new branch"
 msgstr "cruthú agus aistrigh go brainse nua"
 
-#: builtin/checkout.c:2024
 msgid "create/reset and switch to a branch"
 msgstr "cruthú/athshocraigh agus aistrigh go brainse"
 
-#: builtin/checkout.c:2026
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "buille faoi thuairim eile 'git switch <gan-bhrainse-den-sórt-sin>'"
 
-#: builtin/checkout.c:2028
 msgid "throw away local modifications"
 msgstr "modhnuithe áitiúla a chaitheamh"
 
-#: builtin/checkout.c:2061
 msgid "which tree-ish to checkout from"
 msgstr "cén crainn le seiceáil uaidh"
 
-#: builtin/checkout.c:2063
 msgid "restore the index"
 msgstr "an t-innéacs a chur ar ais"
 
-#: builtin/checkout.c:2065
 msgid "restore the working tree (default)"
 msgstr "an crann oibre a chur ar ais (réamhshocraithe)"
 
-#: builtin/checkout.c:2067
 msgid "ignore unmerged entries"
 msgstr "neamhaird a dhéanamh ar iontrálacha"
 
-#: builtin/checkout.c:2068
 msgid "use overlay mode"
 msgstr "úsáid modh forleagtha"
 
-#: builtin/clone.c:169
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "eolas: Ní féidir malartach a chur le haghaidh '%s': %s\n"
 
-#: builtin/clone.c:238
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "theip ar eolaire '%s' a chruthú"
 
-#: builtin/clone.c:240
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "theip ar '%s' a stáil"
 
-#: builtin/clone.c:242
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "Tá %s ann agus ní eolaire é"
 
-#: builtin/clone.c:276
 #, c-format
 msgid "'%s' is a symlink, refusing to clone with --local"
 msgstr "Is nasc comhsheasmhach é '%s', ag diúltú clónú le --local"
 
-#: builtin/clone.c:280
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "theip ar an iterator a thosú thar '%s'"
 
-#: builtin/clone.c:295
 #, c-format
 msgid "symlink '%s' exists, refusing to clone with --local"
 msgstr "tá nasc symlink '%s' ann, ag diúltú clónú le --local"
 
-#: builtin/clone.c:310
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "theip ar '%s' a dhínascadh"
 
-#: builtin/clone.c:322
 #, c-format
 msgid "hardlink cannot be checked at '%s'"
 msgstr "ní féidir crua-nasc a sheiceáil ag '%s'"
 
-#: builtin/clone.c:329
 #, c-format
 msgid "hardlink different from source at '%s'"
 msgstr "crua-nasc difriúil ó fhoinse ag '%s'"
 
-#: builtin/clone.c:334
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "theip ar nasc '%s' a chruthú"
 
-#: builtin/clone.c:338
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "theip ar chomhad a chóipeáil chuig '%s'"
 
-#: builtin/clone.c:343
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "theip ar athrá thar '%s'"
 
-#: builtin/clone.c:370
 #, c-format
 msgid "done.\n"
 msgstr "déanta.\n"
 
-#: builtin/clone.c:384
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
 "and retry with 'git restore --source=HEAD :/'\n"
 msgstr ""
 "D'éirigh le clón, ach theip ar an tseiceáil.\n"
-"Is féidir leat iniúchadh a dhéanamh ar an méid a sheiceáladh le 'git status'\n"
-"agus déan iarracht arís le 'git restore --source=head: /'\n"
+"Is féidir leat iniúchadh a dhéanamh ar an méid a sheiceáladh le 'git "
+"status'\n"
+"agus déan iarracht arís le 'git restore --source=HEAD : /'\n"
 
-#: builtin/clone.c:550
 msgid "remote did not send all necessary objects"
 msgstr "níor sheol iargúlta gach rud riachtanach"
 
-#: builtin/clone.c:566
 #, c-format
 msgid "unable to update %s"
 msgstr "nach féidir %s a nuashonrú"
 
-#: builtin/clone.c:628
 msgid "failed to initialize sparse-checkout"
 msgstr "theip ar sheiceáil éagsúil a thosú"
 
-#: builtin/clone.c:652
 msgid "remote HEAD refers to nonexistent ref, unable to checkout"
-msgstr "tagraíonn iargúlta HEAD do thagartha nach bhfuil ann, nach féidir a sheiceáil"
+msgstr ""
+"tagraíonn iargúlta HEAD do thagartha nach bhfuil ann, nach féidir a sheiceáil"
 
-#: builtin/clone.c:662
 msgid "HEAD not found below refs/heads!"
-msgstr "Ní fhaightear CEAD thíos na tagairtí/cinn!"
+msgstr "Ní fhaightear CEAD thíos na refs/heads!"
 
-#: builtin/clone.c:688
 msgid "unable to checkout working tree"
 msgstr "in ann crann oibre a sheiceáil"
 
-#: builtin/clone.c:782
 msgid "unable to write parameters to config file"
 msgstr "in ann paraiméadair a scríobh chuig comhad cumraithe"
 
-#: builtin/clone.c:849
 msgid "cannot repack to clean up"
 msgstr "ní féidir athphacáil chun glanadh"
 
-#: builtin/clone.c:851
 msgid "cannot unlink temporary alternates file"
 msgstr "ní féidir le comhad malartacha sealadacha a dhínascadh"
 
-#: builtin/clone.c:919
 msgid "don't clone shallow repository"
 msgstr "ná clóin stór éadomhain"
 
-#: builtin/clone.c:921
 msgid "don't create a checkout"
 msgstr "ná cruthaigh seiceáil"
 
-#: builtin/clone.c:922 builtin/clone.c:924
 msgid "create a bare repository"
 msgstr "stóras lom a chruthú"
 
-#: builtin/clone.c:926
 msgid "create a mirror repository (implies --bare)"
-msgstr "stóras scátháin a chruthú (tugann le tuiscint --lom)"
+msgstr "stóras scátháin a chruthú (tugann le tuiscint --bare)"
 
-#: builtin/clone.c:928
 msgid "to clone from a local repository"
 msgstr "a chlónú ó stór áitiúil"
 
-#: builtin/clone.c:930
 msgid "don't use local hardlinks, always copy"
 msgstr "ná húsáid crua-naisc áitiúla, cóipeáil i gcónaí"
 
-#: builtin/clone.c:932
 msgid "setup as shared repository"
 msgstr "socrú mar stór roinnte"
 
-#: builtin/clone.c:937
 msgid "pathspec"
 msgstr "sonraíocht chosáin"
 
-#: builtin/clone.c:938
 msgid "initialize submodules in the clone"
 msgstr "fo-mhodúil a thionscnamh sa chlón"
 
-#: builtin/clone.c:945
 msgid "number of submodules cloned in parallel"
 msgstr "líon na bhfo-mhodúil atá clónaithe go comhthreomhar"
 
-#: builtin/clone.c:946
 msgid "template-directory"
 msgstr "eolaire teimpléad"
 
-#: builtin/clone.c:947
 msgid "directory from which templates will be used"
 msgstr "eolaire as a n-úsáidfear teimpléid"
 
-#: builtin/clone.c:948 builtin/clone.c:951
 msgid "repo"
-msgstr "stór"
+msgstr "stóras"
 
-#: builtin/clone.c:949 builtin/clone.c:951
 msgid "reference repository"
 msgstr "stór tagartha"
 
-#: builtin/clone.c:953
 msgid "use --reference only while cloning"
 msgstr "bain úsáid as --reference amháin agus tú ag clónú"
 
-#: builtin/clone.c:954
 msgid "name"
 msgstr "ainm"
 
-#: builtin/clone.c:955
 msgid "use <name> instead of 'origin' to track upstream"
-msgstr "úsáid in <name>ionad 'tionscnamh' chun suas an sruth a rianú"
+msgstr "úsáid in <name> ionad 'tionscnamh' chun suas an sruth a rianú"
 
-#: builtin/clone.c:957
 msgid "checkout <branch> instead of the remote's HEAD"
-msgstr "seiceáil <brainse>in ionad CEAD an iargúlta"
+msgstr "seiceáil <brainse> in ionad CEAD an iargúlta"
 
-#: builtin/clone.c:958
 msgid "rev"
 msgstr "rev"
 
-#: builtin/clone.c:959
 msgid "clone single revision <rev> and check out"
-msgstr "clóin athbhreithni <rev>ú aonair agus seiceáil"
+msgstr "clónáil athbhreithniú aonair <rev> agus seiceáil amach"
 
-#: builtin/clone.c:960
 msgid "path"
 msgstr "cosán"
 
-#: builtin/clone.c:961
 msgid "path to git-upload-pack on the remote"
-msgstr "cosán chuig pacáiste uaslódála git-ar an iargúlta"
+msgstr "cosán chuig git-upload-pack ar an gcianrialtán"
 
-#: builtin/clone.c:962
 msgid "depth"
 msgstr "doimhneacht"
 
-#: builtin/clone.c:963
 msgid "create a shallow clone of that depth"
 msgstr "clón éadomhain den doimhneacht sin a chruthú"
 
-#: builtin/clone.c:964
 msgid "time"
 msgstr "am"
 
-#: builtin/clone.c:965
 msgid "create a shallow clone since a specific time"
 msgstr "clón éadrom a chruthú ó am ar leith"
 
-#: builtin/clone.c:966
 msgid "ref"
 msgstr "tagairt"
 
-#: builtin/clone.c:967
 msgid "deepen history of shallow clone, excluding ref"
 msgstr "stair an chlóin éadomhain a dhoimhniú, gan tagairt"
 
-#: builtin/clone.c:969
 msgid "clone only one branch, HEAD or --branch"
 msgstr "clóin ach brainse amháin, HEAD nó --branch"
 
-#: builtin/clone.c:971
 msgid "clone tags, and make later fetches not to follow them"
 msgstr "clibeanna clóin, agus tógáil níos déanaí a dhéanamh gan iad a leanúint"
 
-#: builtin/clone.c:973
 msgid "any cloned submodules will be shallow"
 msgstr "beidh aon fho-mhodúil clónaithe éadrom"
 
-#: builtin/clone.c:974
 msgid "gitdir"
 msgstr "gitdir"
 
-#: builtin/clone.c:975
 msgid "separate git dir from working tree"
 msgstr "git dir ar leithligh ó chrann oibre"
 
-#: builtin/clone.c:976
 msgid "format"
 msgstr "formáid"
 
-#: builtin/clone.c:977
 msgid "specify the reference format to use"
 msgstr "sonraigh an fhormáid tagartha le húsáid"
 
-#: builtin/clone.c:978
 msgid "key=value"
 msgstr "eochair=luach"
 
-#: builtin/clone.c:979
 msgid "set config inside the new repository"
 msgstr "socraigh cumraíocht taobh istigh den stór nua"
 
-#: builtin/clone.c:981 builtin/push.c:595
 msgid "server-specific"
 msgstr "freastalaí-shonrach"
 
-#: builtin/clone.c:981 builtin/push.c:595
 msgid "option to transmit"
 msgstr "rogha a tharchur"
 
-#: builtin/clone.c:985
 msgid "apply partial clone filters to submodules"
 msgstr "cuir scagairí clóin páirteacha i bhfeidhm"
 
-#: builtin/clone.c:987
 msgid "any cloned submodules will use their remote-tracking branch"
 msgstr "úsáidfidh aon fho-mhodúil clónaithe a mbrainse cianrianaithe"
 
-#: builtin/clone.c:989
 msgid "initialize sparse-checkout file to include only files at root"
-msgstr "comhad seiceála neamhchoitianta a thosú chun comhaid amháin a áireamh ag fréamh"
+msgstr ""
+"comhad seiceála neamhchoitianta a thosú chun comhaid amháin a áireamh ag "
+"fréamh"
 
-#: builtin/clone.c:991
 msgid "uri"
 msgstr "uri"
 
-#: builtin/clone.c:991
 msgid "a URI for downloading bundles before fetching from origin remote"
-msgstr "a URI chun cuachtaí a íoslódáil sula n-iarrtar iad ó chianchéim tionscnaimh"
+msgstr ""
+"a URI chun cuachtaí a íoslódáil sula n-iarrtar iad ó chianchéim tionscnaimh"
 
-#: builtin/clone.c:996
 msgid "git clone [<options>] [--] <repo> [<dir>]"
-msgstr "git clone [<roghanna>] [--] <stór>[<eolaire>]"
+msgstr "git clone [<roghanna>] [--] <stóras>[<eolaire>]"
 
-#: builtin/clone.c:1008
 msgid "Too many arguments."
 msgstr "An iomarca argóintí."
 
-#: builtin/clone.c:1012
 msgid "You must specify a repository to clone."
 msgstr "Ní mór duit stór a shonrú le clónú."
 
-#: builtin/clone.c:1023
 #, c-format
 msgid "unknown ref storage format '%s'"
 msgstr "formáid stórála tagartha anaithnid '%s'"
 
-#: builtin/clone.c:1052
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "níl an stóras '%s' ann"
 
-#: builtin/clone.c:1056
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "ní uimhir dhearfach é doimhneacht %s"
 
-#: builtin/clone.c:1066
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "tá cosán ceann scríbe '%s' ann cheana féin agus ní eolaire folamh é."
 
-#: builtin/clone.c:1072
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr "tá cosán stórais '%s' ann cheana féin agus ní eolaire folamh é."
 
-#: builtin/clone.c:1086
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "tá crann oibre '%s' ann cheana féin."
 
-#: builtin/clone.c:1101 builtin/clone.c:1122
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "ní fhéadfaí eolairí tosaigh de '%s' a chruthú"
 
-#: builtin/clone.c:1106
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "ní fhéadfaí crann oibre a chruthú dir '%s'"
 
-#: builtin/clone.c:1126
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Clónáil isteach i stóras lom '%s'...\n"
 
-#: builtin/clone.c:1128
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Clónáil isteach '%s'...\n"
 
-#: builtin/clone.c:1157
-msgid "clone --recursive is not compatible with both --reference and --reference-if-able"
-msgstr "níl clón --recursive comhoiriúnach le --reference agus --reference-if-able araon"
+msgid ""
+"clone --recursive is not compatible with both --reference and --reference-if-"
+"able"
+msgstr ""
+"níl clón --recursive comhoiriúnach le --reference agus --reference-if-able"
 
-#: builtin/clone.c:1288
+
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "Ní ainm iargúlta bailí é '%s'"
 
-#: builtin/clone.c:1323
 msgid "--depth is ignored in local clones; use file:// instead."
-msgstr "Déantar neamhaird ar --deep i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+msgstr "--depth déantar neamhaird de i gclóin áitiúla; bain úsáid as comhad:// ina ionad."
 
-#: builtin/clone.c:1325
 msgid "--shallow-since is ignored in local clones; use file:// instead."
-msgstr "Déantar neamhaird ar --shallow-since i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+msgstr "--shallow-since déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// ina ionad."
 
-#: builtin/clone.c:1327
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
-msgstr ""
-"Déantar neamhaird ar --shallow-exclusive i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+msgstr "--shallow-exclude déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// ina ionad."
 
-#: builtin/clone.c:1329
 msgid "--filter is ignored in local clones; use file:// instead."
-msgstr "Déantar neamhaird ar --filter i gclóin áitiúla; bain úsáid as comhad://ina ionad sin."
+msgstr "--filter déantar neamhaird de i gclóin áitiúla; bain úsáid as file:// ina ionad."
 
-#: builtin/clone.c:1332
 msgid "source repository is shallow, reject to clone."
 msgstr "tá stóras foinse éadrom, diúltaigh clóin."
 
-#: builtin/clone.c:1334
 msgid "source repository is shallow, ignoring --local"
 msgstr "tá stóras foinse éadrom, ag neamhaird a dhéanamh ar --local"
 
-#: builtin/clone.c:1339
 msgid "--local is ignored"
-msgstr "Déantar neamhaird a dhéanamh ar --local"
+msgstr "--local déantar neamhaird de"
 
-#: builtin/clone.c:1355
 msgid "cannot clone from filtered bundle"
 msgstr "ní féidir clónú ó bhearta scagtha"
 
-#: builtin/clone.c:1463 builtin/clone.c:1494
 msgid "failed to initialize the repo, skipping bundle URI"
 msgstr "theip ar an repo a thionscnamh, ag scipeáil URI beartán"
 
-#: builtin/clone.c:1465
 #, c-format
 msgid "failed to fetch objects from bundle URI '%s'"
 msgstr "theip ar rudaí a fháil ó URI '%s'"
 
-#: builtin/clone.c:1497
 msgid "failed to fetch advertised bundles"
 msgstr "theip orthu beartáin fógraithe a fháil"
 
-#: builtin/clone.c:1530 builtin/clone.c:1597
 msgid "remote transport reported error"
 msgstr "earráid tuairiscithe ar iompar"
 
-#: builtin/clone.c:1541
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Níor aimsíodh brainse iargúlta %s i suas sruth %s"
 
-#: builtin/clone.c:1546
 #, c-format
 msgid "Remote revision %s not found in upstream %s"
 msgstr "Ní aimsíodh athbhreithniú iargúlta %s i suas sruth %s"
 
-#: builtin/clone.c:1557
 msgid "You appear to have cloned an empty repository."
 msgstr "Is cosúil gur chlónaigh tú stór folamh."
 
-#: builtin/index-pack.c:245
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "mímheaitseáil cineál réad ag %s"
 
-#: builtin/index-pack.c:265
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "nár bhfuair sé réad ag súil leis %s"
 
-#: builtin/index-pack.c:268
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "réad %s: súil leis an gcineál %s, aimsíodh %s"
 
-#: builtin/index-pack.c:286
 msgid "Checking objects"
 msgstr "Rud a sheiceáil"
 
-#: builtin/index-pack.c:319
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
@@ -1074,64 +876,50 @@ msgstr[0] "ní féidir %d beart a líonadh"
 msgstr[1] "ní féidir %d beart a líonadh"
 msgstr[2] "ní féidir %d beart a líonadh"
 
-#: builtin/index-pack.c:329
 msgid "early EOF"
 msgstr "luath EOF"
 
-#: builtin/index-pack.c:330
 msgid "read error on input"
 msgstr "earráid léigh ar ionchur"
 
-#: builtin/index-pack.c:342
 msgid "used more bytes than were available"
 msgstr "úsáideadh níos mó bytes ná mar a bhí ar fáil"
 
-#: builtin/index-pack.c:349
 msgid "pack too large for current definition of off_t"
 msgstr "pacáiste ró-mhór le haghaidh sainmhíniú reatha ar off_t"
 
-#: builtin/index-pack.c:354
 #, c-format
 msgid "pack exceeds maximum allowed size (%s)"
 msgstr "sáraíonn an pacáiste an méid uasta ceadaithe (%s)"
 
-#: builtin/index-pack.c:387
 msgid "pack signature mismatch"
 msgstr "mímheaitseáil sínithe pacáiste"
 
-#: builtin/index-pack.c:390
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "leagan pacáiste %<PRIu32> gan tacaíocht"
 
-#: builtin/index-pack.c:407
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "tá réad lochtach sa phacáiste ag an bhfritháireamh %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:513
 #, c-format
 msgid "inflate returned %d"
 msgstr "infleáil ar ais %d"
 
-#: builtin/index-pack.c:563
 msgid "offset value overflow for delta base object"
 msgstr "ró-shreabhadh luacha a fhritháireamh do réad"
 
-#: builtin/index-pack.c:571
 msgid "delta base offset is out of bound"
 msgstr "tá fhritháireamh bonn delta as ceangailte"
 
-#: builtin/index-pack.c:579
 #, c-format
 msgid "unknown object type %d"
 msgstr "cineál réad anaithnid %d"
 
-#: builtin/index-pack.c:610
 msgid "cannot pread pack file"
 msgstr "ní féidir comhad pacáiste a roghnú"
 
-#: builtin/index-pack.c:612
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
@@ -1139,92 +927,71 @@ msgstr[0] "deireadh roimh am comhaid phacáiste, %<PRIuMAX> beart ar iarraidh"
 msgstr[1] "deireadh roimh am comhaid phacáiste, %<PRIuMAX> beart ar iarraidh"
 msgstr[2] "deireadh roimh am comhaid phacáiste, %<PRIuMAX> beart ar iarraidh"
 
-#: builtin/index-pack.c:638
 msgid "serious inflate inconsistency"
 msgstr "neamhchomhsheasmhacht tromchúiseach"
 
-#: builtin/index-pack.c:783 builtin/index-pack.c:789 builtin/index-pack.c:814
-#: builtin/index-pack.c:915 builtin/index-pack.c:925
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "FUARTHAS IMBHALL SHA1 LE %s!"
 
-#: builtin/index-pack.c:786
 #, c-format
 msgid "unable to read %s"
 msgstr "nach féidir %s a léamh"
 
-#: builtin/index-pack.c:913
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "ní féidir faisnéis réad atá ann cheana %s a léamh"
 
-#: builtin/index-pack.c:922
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "ní féidir réad %s atá ann cheana a léamh"
 
-#: builtin/index-pack.c:936
 #, c-format
 msgid "invalid blob object %s"
 msgstr "réad blob neamhbhailí %s"
 
-#: builtin/index-pack.c:939 builtin/index-pack.c:958
 msgid "fsck error in packed object"
 msgstr "earráid fsck i réad pacáilte"
 
-#: builtin/index-pack.c:955
 #, c-format
 msgid "invalid %s"
 msgstr "%s neamhbhailí"
 
-#: builtin/index-pack.c:960
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Níl gach réad leanbh de %s inrochtana"
 
-#: builtin/index-pack.c:1023 builtin/index-pack.c:1070
 msgid "failed to apply delta"
 msgstr "theip ar delta a chur i bhfeidhm"
 
-#: builtin/index-pack.c:1264
 msgid "Receiving objects"
 msgstr "Rudaí a fháil"
 
-#: builtin/index-pack.c:1264
 msgid "Indexing objects"
 msgstr "Rudaí innéacsála"
 
-#: builtin/index-pack.c:1300
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "tá an pacáiste truaillithe (neamhoiriúnú SHA1)"
 
-#: builtin/index-pack.c:1305
 msgid "cannot fstat packfile"
 msgstr "ní féidir le pacáiste fstat"
 
-#: builtin/index-pack.c:1308
 msgid "pack has junk at the end"
 msgstr "tá bruscar ag an bpacáiste ag an deireadh"
 
-#: builtin/index-pack.c:1320
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "mearbhall níos faide ná imní i parse_pack_objects()"
 
-#: builtin/index-pack.c:1344
 msgid "Resolving deltas"
 msgstr "Deltas a réiteach"
 
-#: builtin/index-pack.c:1355
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "nach féidir snáithe a chruthú: %s"
 
-#: builtin/index-pack.c:1388
 msgid "confusion beyond insanity"
 msgstr "mearbhall níos faide ná mar gheall"
 
-#: builtin/index-pack.c:1394
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
@@ -1232,12 +999,10 @@ msgstr[0] "críochnaithe le %d réad áitiúil"
 msgstr[1] "críochnaithe le %d réad áitiúil"
 msgstr[2] "críochnaithe le %d réad áitiúil"
 
-#: builtin/index-pack.c:1406
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Seicsum eireaball gan choinne do %s (éilliú diosca?)"
 
-#: builtin/index-pack.c:1410
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
@@ -1245,66 +1010,53 @@ msgstr[0] "tá %d delta gan réiteach sa phacáiste"
 msgstr[1] "tá %d deiltí gan réiteach sa phacáiste"
 msgstr[2] "tá %d deiltí gan réiteach sa phacáiste"
 
-#: builtin/index-pack.c:1434
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "nach féidir réad cuibheangailte a dhíscaoileadh (%d)"
 
-#: builtin/index-pack.c:1530
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "tá réad áitiúil %s truaillithe"
 
-#: builtin/index-pack.c:1552
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "ní chríochnaíonn ainm pacáiste '%s' le '.%s'"
 
-#: builtin/index-pack.c:1576
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "ní féidir comhad %s '%s' a scríobh"
 
-#: builtin/index-pack.c:1584
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "ní féidir comhad %s scríofa '%s' a dhúnadh"
 
-#: builtin/index-pack.c:1601
 #, c-format
 msgid "unable to rename temporary '*.%s' file to '%s'"
 msgstr "in ann athainmniú sealadach '*.%s' comhad chuig '%s'"
 
-#: builtin/index-pack.c:1624
 msgid "error while closing pack file"
 msgstr "earráid agus comhad pacáiste á dúnadh"
 
-#: builtin/index-pack.c:1676
 #, c-format
 msgid "bad pack.indexVersion=%<PRIu32>"
 msgstr "droch-pack.indexVersion=%<PRIu32>"
 
-#: builtin/index-pack.c:1682
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "líon neamhbhailí na snáitheanna sonraithe (%d)"
 
-#: builtin/index-pack.c:1685 builtin/index-pack.c:1965
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "gan tacaíocht do shnáitheanna, ag déanamh neamhaird ar %s"
 
-#: builtin/index-pack.c:1751
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Ní féidir comhad pacáiste atá ann cheana '%s' a oscailt"
 
-#: builtin/index-pack.c:1753
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Ní féidir comhad idx pacáiste atá ann cheana a oscailt do '%s'"
 
-#: builtin/index-pack.c:1801
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
@@ -1312,7 +1064,6 @@ msgstr[0] "neamh-delta: %d réad"
 msgstr[1] "neamh-delta: %d réad"
 msgstr[2] "neamh-delta: %d réad"
 
-#: builtin/index-pack.c:1808
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
@@ -1320,79 +1071,64 @@ msgstr[0] "fad slabhra = %d: %lu réad"
 msgstr[1] "fad slabhra = %d: %lu réada"
 msgstr[2] "fad slabhra = %d: %lu réada"
 
-#: builtin/index-pack.c:1850
 msgid "could not start pack-objects to repack local links"
 msgstr "ní fhéadfaí pacáiste-earraí a thosú chun naisc áitiúla a athphacáil"
 
-#: builtin/index-pack.c:1855
 msgid "failed to feed local object to pack-objects"
 msgstr "theip ar réad áitiúil a bheathú ar rudaí pacáiste"
 
-#: builtin/index-pack.c:1868
 msgid "index-pack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
-"index-pack: Ag súil le línte aitheantais réada heicsidheachúlach iomlán ó pack-objects amháin."
+"index-pack: Ag súil le línte aitheantais réada heicsidheachúlach iomlán ó "
+"pack-objects amháin."
 
-#: builtin/index-pack.c:1879
 msgid "could not finish pack-objects to repack local links"
 msgstr "ní fhéadfaí pacáistí a chríochnú chun naisc áitiúla a athphacáil"
 
-#: builtin/index-pack.c:1921
 msgid "Cannot come back to cwd"
 msgstr "Ní féidir teacht ar ais chuig cwd"
 
-#: builtin/index-pack.c:1972
 #, c-format
 msgid "bad --pack_header: %s"
 msgstr "droch --pack_header: %s"
 
-#: builtin/index-pack.c:1991 builtin/index-pack.c:1995
 #, c-format
 msgid "bad %s"
 msgstr "droch %s"
 
-#: builtin/index-pack.c:2001
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algartam hais anaithnid '%s'"
 
-#: builtin/index-pack.c:2022
 msgid "--promisor cannot be used with a pack name"
-msgstr "Ní féidir --promisor a úsáid le hainm pacáiste"
+msgstr "--promisor ní féidir é a úsáid le hainm pacáiste"
 
-#: builtin/index-pack.c:2024
 msgid "--stdin requires a git repository"
-msgstr "Teastaíonn stór git ag teastáil ó --stdin"
+msgstr "--stdin teastaíonn stórlann git"
 
-#: builtin/index-pack.c:2050
 msgid "--verify with no packfile name given"
-msgstr "- fíorú gan aon ainm pacáiste a thugtar"
+msgstr "--verify gan ainm comhaid pacáiste tugtha"
 
-#: builtin/index-pack.c:2117
 msgid "fsck error in pack objects"
-msgstr "earráid fsck i rudaí pacáiste"
+msgstr "fsck earráid i rudaí pacáiste"
 
-#: builtin/push.c:26
 msgid "git push [<options>] [<repository> [<refspec>...]]"
 msgstr "git push [<roghanna>] [<stóras> [<refspec>...]]"
 
-#: builtin/push.c:112
 msgid "tag shorthand without <tag>"
 msgstr "gearrthand clib gan <tag>"
 
-#: builtin/push.c:120
 msgid "--delete only accepts plain target ref names"
-msgstr "Ní ghlacann --delete ach le spriocainmneacha tagartha simplí"
+msgstr "--delete ní ghlacann sé ach le hainmneacha tagartha sprice simplí"
 
-#: builtin/push.c:162
 msgid ""
 "\n"
 "To choose either option permanently, see push.default in 'git help config'.\n"
 msgstr ""
 "\n"
-"Chun ceachtar rogha a roghnú go buan, féach push.default i 'git help config'.\n"
+"Chun ceachtar rogha a roghnú go buan, féach push.default i 'git help "
+"config'.\n"
 
-#: builtin/push.c:166
 msgid ""
 "\n"
 "To avoid automatically configuring an upstream branch when its name\n"
@@ -1401,10 +1137,10 @@ msgid ""
 msgstr ""
 "\n"
 "Chun brainse suas srutha a chumrú go huathoibríoch a sheachaint nuair a\n"
-"ní mheaitseoidh sé leis an mbrainse áitiúil, féach an rogha 'simplí' de branch.autoSetupMerge\n"
+"ní mheaitseoidh sé leis an mbrainse áitiúil, féach an rogha 'simplí' de "
+"branch.autoSetupMerge\n"
 "i 'git help config'.\n"
 
-#: builtin/push.c:172
 #, c-format
 msgid ""
 "The upstream branch of your current branch does not match\n"
@@ -1429,7 +1165,6 @@ msgstr ""
 "    git push %s HEAD\n"
 "%s%s"
 
-#: builtin/push.c:188
 #, c-format
 msgid ""
 "You are not currently on a branch.\n"
@@ -1444,7 +1179,6 @@ msgstr ""
 "\n"
 " git push %s HEAD:<ainm-na-brainse-cianda>\n"
 
-#: builtin/push.c:204
 msgid ""
 "\n"
 "To have this happen automatically for branches without a tracking\n"
@@ -1452,9 +1186,8 @@ msgid ""
 msgstr ""
 "\n"
 "Chun é seo a tharlóidh go huathoibríoch do bhrainsí gan rianú\n"
-"suas sruth, féach 'Push.AutoSetUpRemote' i 'git help config'.\n"
+"suas sruth, féach 'push.autoSetupRemote' i 'git help config'.\n"
 
-#: builtin/push.c:210
 #, c-format
 msgid ""
 "The current branch %s has no upstream branch.\n"
@@ -1464,21 +1197,22 @@ msgid ""
 "%s"
 msgstr ""
 "Níl brainse suas srutha ag an mbrainse reatha %s.\n"
-"Chun an brainse reatha a bhrú agus an iargúlta a shocrú mar thuas an sruth, bain úsáid as\n"
+"Chun an brainse reatha a bhrú agus an iargúlta a shocrú mar thuas an sruth, "
+"bain úsáid as\n"
 "\n"
 "    git push --set-upstream %s %s\n"
 "%s"
 
-#: builtin/push.c:221
 #, c-format
 msgid "The current branch %s has multiple upstream branches, refusing to push."
-msgstr "Tá brainsí iolracha suas srutha ag an mbrainse reatha %s, ag diúltú brú."
+msgstr ""
+"Tá brainsí iolracha suas srutha ag an mbrainse reatha %s, ag diúltú brú."
 
-#: builtin/push.c:239
-msgid "You didn't specify any refspecs to push, and push.default is \"nothing\"."
-msgstr "Níor shonraigh tú aon refspec le brú, agus is é push.default “rud ar bith”."
+msgid ""
+"You didn't specify any refspecs to push, and push.default is \"nothing\"."
+msgstr ""
+"Níor shonraigh tú aon refspec le brú, agus is é push.default “rud ar bith”."
 
-#: builtin/push.c:265
 #, c-format
 msgid ""
 "You are pushing to remote '%s', which is not the upstream of\n"
@@ -1489,19 +1223,19 @@ msgstr ""
 "do bhrainse reatha '%s', gan insint liom cad ba cheart a bhrú\n"
 "chun an brainse iargúlta a nuashonrú."
 
-#: builtin/push.c:288
 msgid ""
 "Updates were rejected because the tip of your current branch is behind\n"
 "its remote counterpart. If you want to integrate the remote changes,\n"
 "use 'git pull' before pushing again.\n"
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
-"Diúltaíodh nuashonruithe toisc go bhfuil barr do bhrainse reatha taobh thiar de\n"
-"a mhacasamhail iargúlta. Más mian leat na hathruithe iargúlta a chomhtháthú,\n"
+"Diúltaíodh nuashonruithe toisc go bhfuil barr do bhrainse reatha taobh thiar "
+"de\n"
+"a mhacasamhail iargúlta. Más mian leat na hathruithe iargúlta a "
+"chomhtháthú,\n"
 "bain úsáid as 'git pull' sula mbrú arís.\n"
 "Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
 
-#: builtin/push.c:294
 msgid ""
 "Updates were rejected because a pushed branch tip is behind its remote\n"
 "counterpart. If you want to integrate the remote changes, use 'git pull'\n"
@@ -1509,11 +1243,11 @@ msgid ""
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
 "Diúltaíodh nuashonruithe toisc go bhfuil barr brainse brúite taobh thiar dá\n"
-"comhghleacaí. Más mian leat na hathruithe iargúlta a chomhtháthú, bain úsáid as 'git pull'\n"
+"comhghleacaí. Más mian leat na hathruithe iargúlta a chomhtháthú, bain úsáid "
+"as 'git pull'\n"
 "sula ndéantar é a bhrú arís.\n"
 "Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
 
-#: builtin/push.c:300
 msgid ""
 "Updates were rejected because the remote contains work that you do not\n"
 "have locally. This is usually caused by another repository pushing to\n"
@@ -1521,27 +1255,29 @@ msgid ""
 "'git pull' before pushing again.\n"
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
-"Diúltaíodh nuashonruithe toisc go bhfuil obair nach ndéanann tú san iargúlta\n"
+"Diúltaíodh nuashonruithe toisc go bhfuil obair nach ndéanann tú san "
+"iargúlta\n"
 "a bheith agat go háitiúil. De ghnáth bíonn stór eile ag brú chuig seo\n"
-"an tagairt chéanna. Más mian leat na hathruithe iargúlta a chomhtháthú, bain úsáid as\n"
+"an tagairt chéanna. Más mian leat na hathruithe iargúlta a chomhtháthú, bain "
+"úsáid as\n"
 "'git tarraing' sula ndéantar é a bhrú arís.\n"
 "Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
 
-#: builtin/push.c:307
 msgid "Updates were rejected because the tag already exists in the remote."
-msgstr "Diúltaíodh nuashonruithe toisc go bhfuil an clib ann cheana féin sa iargúlta."
+msgstr ""
+"Diúltaíodh nuashonruithe toisc go bhfuil an clib ann cheana féin sa iargúlta."
 
-#: builtin/push.c:310
 msgid ""
 "You cannot update a remote ref that points at a non-commit object,\n"
 "or update a remote ref to make it point at a non-commit object,\n"
 "without using the '--force' option.\n"
 msgstr ""
-"Ní féidir leat tagairt iargúlta a nuashonrú a chuireann in iúl ar réad neamh-thiomanta,\n"
-"nó tagairt iargúlta a nuashonrú chun é a chur in iúl ar réad neamh-thiomanta,\n"
+"Ní féidir leat tagairt iargúlta a nuashonrú a chuireann in iúl ar réad neamh-"
+"thiomanta,\n"
+"nó tagairt iargúlta a nuashonrú chun é a chur in iúl ar réad neamh-"
+"thiomanta,\n"
 "gan an rogha '--force' a úsáid.\n"
 
-#: builtin/push.c:315
 msgid ""
 "Updates were rejected because the tip of the remote-tracking branch has\n"
 "been updated since the last checkout. If you want to integrate the\n"
@@ -1553,120 +1289,96 @@ msgstr ""
 "athruithe iargúlta, bain úsáid as 'git pull' sula mbrú arís.\n"
 "Féach an 'Nóta faoi fast-forward 'i 'git push --help' le haghaidh sonraí."
 
-#: builtin/push.c:385
 #, c-format
 msgid "Pushing to %s\n"
 msgstr "Ag brú chuig %s\n"
 
-#: builtin/push.c:392
 #, c-format
 msgid "failed to push some refs to '%s'"
 msgstr "theip ar roinnt réimsí a bhrú chuig '%s'"
 
-#: builtin/push.c:458
-msgid "recursing into submodule with push.recurseSubmodules=only; using on-demand instead"
+msgid ""
+"recursing into submodule with push.recurseSubmodules=only; using on-demand "
+"instead"
 msgstr ""
-"athfhillteach isteach i bhfo-mhodúl le push.RecursesubModules=amháin; ag baint úsáide as ar-"
-"éileamh ina ionad"
+"athfhillteach isteach i bhfo-mhodúl le push.RecursesubModules=only; ag "
+"baint úsáide as ar-éileamh ina ionad"
 
-#: builtin/push.c:515
 #, c-format
 msgid "invalid value for '%s'"
 msgstr "luach neamhbhailí do '%s'"
 
-#: builtin/push.c:563
 msgid "repository"
 msgstr "stóras"
 
-#: builtin/push.c:564
 msgid "push all branches"
 msgstr "brúigh gach brainse"
 
-#: builtin/push.c:566
 msgid "mirror all refs"
 msgstr "scáthán gach ceann"
 
-#: builtin/push.c:568
 msgid "delete refs"
 msgstr "scrios réimsí"
 
-#: builtin/push.c:569
 msgid "push tags (can't be used with --all or --branches or --mirror)"
-msgstr "clibeanna brú (ní féidir iad a úsáid le --all nó --crainsí nó --scáthán)"
+msgstr "clibeanna brú (ní féidir iad a úsáid le --all nó --branches nó --mirror)"
 
-#: builtin/push.c:570
 msgid "dry run"
 msgstr "rith tirim"
 
-#: builtin/push.c:571
 msgid "machine-readable output"
 msgstr "aschur inléite meaisín"
 
-#: builtin/push.c:572
 msgid "force updates"
 msgstr "nuashonruithe fórsa"
 
-#: builtin/push.c:573
 msgid "<refname>:<expect>"
 msgstr "<refname>:<expect>"
 
-#: builtin/push.c:574
 msgid "require old value of ref to be at this value"
 msgstr "a cheangal go mbeadh seanluach an tagartha ag an luach seo"
 
-#: builtin/push.c:577
 msgid "require remote updates to be integrated locally"
 msgstr "éilíonn go ndéanfaí nuashonruithe iargúlta"
 
-#: builtin/push.c:580
 msgid "control recursive pushing of submodules"
 msgstr "brú athfhillteach ar fho-mhodúil a rialú"
 
-#: builtin/push.c:581
 msgid "use thin pack"
 msgstr "bain úsáid as pacáiste tanaí"
 
-#: builtin/push.c:582 builtin/push.c:583
 msgid "receive pack program"
 msgstr "clár pacáiste a fháil"
 
-#: builtin/push.c:584
 msgid "set upstream for git pull/status"
 msgstr "socraigh suas sruth le haghaidh tarraing/stádas git"
 
-#: builtin/push.c:587
 msgid "prune locally removed refs"
 msgstr "gearradh a bhaintear go háitiúil"
 
-#: builtin/push.c:589
 msgid "bypass pre-push hook"
 msgstr "seachbhóthar crúca réamh"
 
-#: builtin/push.c:590
 msgid "push missing but relevant tags"
 msgstr "clibeanna atá ar iarraidh ach ábhartha a"
 
-#: builtin/push.c:592
 msgid "GPG sign the push"
 msgstr "Síníonn GPG an brú"
 
-#: builtin/push.c:594
 msgid "request atomic transaction on remote side"
 msgstr "iarraidh idirbheart adamach ar an taobh iargúl"
 
-#: builtin/push.c:613
 msgid "--delete doesn't make sense without any refs"
-msgstr "--ní bhíonn ciall ag scriosadh gan aon ghearradh"
+msgstr "--delete níl ciall leis gan aon réiteoirí"
 
-#: builtin/push.c:631
 #, c-format
 msgid "bad repository '%s'"
 msgstr "droch-stóras '%s'"
 
-#: builtin/push.c:632
 msgid ""
 "No configured push destination.\n"
-"Either specify the URL from the command-line or configure a remote repository using\n"
+"Either specify the URL from the command-line or configure a remote "
+"repository using\n"
 "\n"
 "    git remote add <name> <url>\n"
 "\n"
@@ -1675,7 +1387,8 @@ msgid ""
 "    git push <name>\n"
 msgstr ""
 "Gan aon cheann scríbe brúite cumraithe.\n"
-"Sonraigh an URL ón líne ordaithe nó cumraigh stór iargúlta ag baint úsáide as\n"
+"Sonraigh an URL ón líne ordaithe nó cumraigh stór iargúlta ag baint úsáide "
+"as\n"
 "\n"
 "    git remote add <name> <url>\n"
 "\n"
@@ -1683,158 +1396,127 @@ msgstr ""
 "\n"
 "    git push <ainm>\n"
 
-#: builtin/push.c:650
 msgid "--all can't be combined with refspecs"
-msgstr "--ní féidir gach rud a chomhcheangal le refspecs"
+msgstr "--all ní féidir é a chomhcheangal le refspecs"
 
-#: builtin/push.c:654
 msgid "--mirror can't be combined with refspecs"
-msgstr "--ní féidir scáthán a chomhcheangal le refspecs"
+msgstr "--mirror ní féidir é a chomhcheangal le refspecs"
 
-#: builtin/push.c:662
 msgid "push options must not have new line characters"
 msgstr "ní chóir go mbeadh carachtair líne nua ag roghanna brú"
 
-#: builtin/reset.c:45
-msgid "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
-msgstr "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
+msgid ""
+"git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
+msgstr ""
+"git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 
-#: builtin/reset.c:46
 msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
 msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
 
-#: builtin/reset.c:47
-msgid "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
-msgstr "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
+msgid ""
+"git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
+msgstr ""
+"git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 
-#: builtin/reset.c:48
 msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
 msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
 
-#: builtin/reset.c:54
 msgid "mixed"
 msgstr "measctha"
 
-#: builtin/reset.c:54
 msgid "soft"
 msgstr "bog"
 
-#: builtin/reset.c:54
 msgid "hard"
 msgstr "crua"
 
-#: builtin/reset.c:54
 msgid "merge"
 msgstr "cumaisc"
 
-#: builtin/reset.c:54
 msgid "keep"
 msgstr "coinnigh"
 
-#: builtin/reset.c:104
 msgid "You do not have a valid HEAD."
 msgstr "Níl CEANN bailí agat."
 
-#: builtin/reset.c:106
 msgid "Failed to find tree of HEAD."
 msgstr "Theip ar chrann HEAD a aimsiú."
 
-#: builtin/reset.c:112
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Theip ar chrann %s a aimsiú."
 
-#: builtin/reset.c:141
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "Tá HEAD anois ag %s"
 
-#: builtin/reset.c:242
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Ní féidir athshocrú %s a dhéanamh i lár cumaisc."
 
-#: builtin/reset.c:350
 msgid "be quiet, only report errors"
 msgstr "bí ciúin, ní thuairiscigh ach earráidí"
 
-#: builtin/reset.c:352
 msgid "skip refreshing the index after reset"
 msgstr "scipeáil an t-innéacs a athnuachan tar éis"
 
-#: builtin/reset.c:354
 msgid "reset HEAD and index"
 msgstr "athshocraigh HEAD agus innéacs"
 
-#: builtin/reset.c:357
 msgid "reset only HEAD"
 msgstr "athshocraigh CEAD amháin"
 
-#: builtin/reset.c:360 builtin/reset.c:363
 msgid "reset HEAD, index and working tree"
 msgstr "athshocraigh HEAD, innéacs agus crann oibre"
 
-#: builtin/reset.c:366
 msgid "reset HEAD but keep local changes"
 msgstr "athshocraigh HEAD ach coinnigh athruithe áiti"
 
-#: builtin/reset.c:374
 msgid "record only the fact that removed paths will be added later"
 msgstr "ní thaifeadadh ach an fíric go gcuirfear cosáin bainte leis níos déanaí"
 
-#: builtin/reset.c:408
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Theip ar '%s' a réiteach mar athbhreithniú bailí."
 
-#: builtin/reset.c:411 builtin/reset.c:419
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Ní fhéadfaí réad '%s' a pháirseáil."
 
-#: builtin/reset.c:416
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Theip ar '%s' a réiteach mar chrann bailí."
 
-#: builtin/reset.c:437
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
-msgstr "<paths>Tá - measctha le cosáin míshuanta; bain úsáid as 'git reset -- 'ina ionad sin."
+msgstr "--mixed le cosáin imithe i léig; bain úsáid as 'git reset -- <cosáin>' ina ionad."
 
-#: builtin/reset.c:439
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Ní féidir %s a athshocrú le cosáin."
 
-#: builtin/reset.c:454
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "Ní cheadaítear athshocrú %s i stóras lom"
 
-#: builtin/reset.c:488
 msgid "Unstaged changes after reset:"
 msgstr "Athruithe gan stáitse tar éis athshocrú:"
 
-#: builtin/reset.c:491
 #, c-format
 msgid ""
 "It took %.2f seconds to refresh the index after reset.  You can use\n"
 "'--no-refresh' to avoid this."
 msgstr ""
-"Thóg sé %.2f soicind an t-innéacs a athnuachan tar éis athshocrú. Is féidir leat úsáid a bhaint "
-"as\n"
-"'--no-athnuachan' chun é seo a sheachaint."
+"Thóg sé %.2f soicind an t-innéacs a athnuachan tar éis athshocrú. Is féidir "
+"leat úsáid a bhaint as\n"
+"'--no-refresh' chun é seo a sheachaint."
 
-#: builtin/reset.c:509
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Ní fhéadfaí comhad innéacs a athshocrú chun athbhreithniú '%s'."
 
-#: builtin/reset.c:514
 msgid "Could not write new index file."
 msgstr "Ní fhéadfaí comhad innéacs nua a scríobh."
 
-#: remote.c:308
 #, c-format
 msgid ""
 "reading remote from \"%s/%s\", which is nominated for removal.\n"
@@ -1857,55 +1539,46 @@ msgstr ""
 "Mura féidir leat, cuir in iúl dúinn le do thoil cén fáth a gcaithfidh tú\n"
 "é a úsáid fós trí ríomhphost a sheoladh chuig <git@vger.kernel.org>."
 
-#: remote.c:469
 #, c-format
 msgid "config remote shorthand cannot begin with '/': %s"
 msgstr "ní féidir le '/' tosú le gearrthánach iargúlta config: %s"
 
-#: remote.c:515
 msgid "more than one receivepack given, using the first"
-msgstr "níos mó ná pacáiste glacadóra amháin a thugtar, ag baint úsáide as an gcéad"
+msgstr ""
+"níos mó ná pacáiste glacadóra amháin a thugtar, ag baint úsáide as an gcéad"
 
-#: remote.c:523
 msgid "more than one uploadpack given, using the first"
-msgstr "níos mó ná pacáiste uaslódála amháin tugtha, ag baint úsáide as an gcéad"
+msgstr ""
+"níos mó ná pacáiste uaslódála amháin tugtha, ag baint úsáide as an gcéad"
 
-#: remote.c:558
 #, c-format
 msgid "unrecognized followRemoteHEAD value '%s' ignored"
 msgstr "neamhaird a dhéanamh ar luach FollowRemoteHead '%s' gan aithint"
 
-#: remote.c:732
 #, c-format
 msgid "unrecognized value transfer.credentialsInUrl: '%s'"
-msgstr "aistriú luacha neamhaitheantaí.CredentialsInURL: '%s'"
+msgstr "aistriú luacha transfer.credentialsInUrl: '%s'"
 
-#: remote.c:748 remote.c:750
 #, c-format
 msgid "URL '%s' uses plaintext credentials"
 msgstr "Úsáideann URL '%s' dhintiúir téacs simplí"
 
-#: remote.c:853
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Ní féidir %s agus %s a fháil chuig %s"
 
-#: remote.c:857
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "Is gnách go rianann %s %s, ní %s"
 
-#: remote.c:861
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "Rianann %s %s agus %s araon"
 
-#: remote.c:1147
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "src refspec %s ní mheaitseálann aon"
 
-#: remote.c:1152
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr "meaitseálann src refspec %s níos mó ná ceann amháin"
@@ -1914,7 +1587,6 @@ msgstr "meaitseálann src refspec %s níos mó ná ceann amháin"
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1167
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -1928,17 +1600,17 @@ msgid ""
 "Neither worked, so we gave up. You must fully qualify the ref."
 msgstr ""
 "Ní ainm athainmnithe iomlán é an ceann scríbe a sholáthair tú (i.e., \n"
-"ag tosú le \"refs/\"). Rinneamar iarracht buille faoi thuairim a thabhairt faoi cad a bhí i gceist "
-"agat le:\n"
+"ag tosú le \"refs/\"). Rinneamar iarracht buille faoi thuairim a thabhairt "
+"faoi cad a bhí i gceist agat le:\n"
 "\n"
 "- Ag lorg tagartha a mheaitseálann '%s' ar an taobh iargúlta.\n"
 "- Ag seiceáil an bhfuil an <src> atá á bhrú ('%s') ina thagairt \n"
 "  i \"refs/{heads,tags}/\". Más ea, cuirimid réimír comhfhreagrach r\n"
 "  efs/{heads,tags}/ leis ar an taobh iargúlta.\n"
 "\n"
-"Níor oibrigh ceachtar acu, mar sin thugamar suas. Caithfidh tú an tagairt a cháiliú go hiomlán."
+"Níor oibrigh ceachtar acu, mar sin thugamar suas. Caithfidh tú an tagairt a "
+"cháiliú go hiomlán."
 
-#: remote.c:1187
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -1949,7 +1621,6 @@ msgstr ""
 "An raibh i gceist agat brainse nua a chruthú trí bhrú chuig\n"
 "'%s:refs/heads/%s'?"
 
-#: remote.c:1192
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -1960,7 +1631,6 @@ msgstr ""
 "An raibh i gceist agat clib nua a chruthú trí bhrú chuig\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1197
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -1971,7 +1641,6 @@ msgstr ""
 "An raibh sé i gceist agat crann nua a chlibeáil trí bhrú chuig\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1202
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -1982,107 +1651,87 @@ msgstr ""
 "An raibh sé i gceist agat blob nua a chlibeáil trí bhrú chuig\n"
 "'%s:refs/tags/%s'?"
 
-#: remote.c:1242
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "Ní féidir %s a réiteach chuig an mbrainse"
 
-#: remote.c:1253
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "ní féidir '%s' a scriosadh: níl tagairt iargúlta ann"
 
-#: remote.c:1265
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr "meaitseálann dst refspec %s níos mó ná ceann amháin"
 
-#: remote.c:1276
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr "faigheann dst ref %s ó níos mó ná src amháin"
 
-#: remote.c:1806 remote.c:1913
 msgid "HEAD does not point to a branch"
 msgstr "Ní chuireann HEAD in iúl do bhrainse"
 
-#: remote.c:1815
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "aon bhrainse den sórt sin: '%s'"
 
-#: remote.c:1818
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "níl aon chumrú suas srutha le haghaidh brainse '%s'"
 
-#: remote.c:1824
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "brainse suas srutha '%s' nach stóráiltear mar bhrainse cianrianaithe"
 
-#: remote.c:1839
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
-msgstr "níl aon bhrainse rianaithe áitiúil ag ceann scríbe brúite '%s' ar iargúlta '%s'"
+msgstr ""
+"níl aon bhrainse rianaithe áitiúil ag ceann scríbe brúite '%s' ar iargúlta "
+"'%s'"
 
-#: remote.c:1854
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "níl aon iargúlta ag brainse '%s' chun brú"
 
-#: remote.c:1864
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "ní chuimsíonn '%s' brú refspections do '%s'"
 
-#: remote.c:1877
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "níl aon cheann scríbe ag brú (is é 'rud ar bith' push.default)"
 
-#: remote.c:1899
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "ní féidir brú 'simplí' a réiteach chuig ceann scríbe amháin"
 
-#: remote.c:2034
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "ní raibh in ann tagairt iargúlta %s a fháil"
 
-#: remote.c:2047
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ag neamhaird den tagairt ghreannmhar '%s' go háitiúil"
 
-#: remote.c:2135
 msgid "revision walk setup failed"
 msgstr "theip ar socrú siúlóid ath"
 
-#: remote.c:2216
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Tá do bhrainse bunaithe ar '%s', ach tá an suas sruth imithe.\n"
 
-#: remote.c:2220
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr " (bain úsáid as \"git branch --unset-upstream\" chun é a dheisiú)\n"
 
-#: remote.c:2223
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Tá do bhrainse cothrom le dáta le '%s'.\n"
 
-#: remote.c:2227
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Tagraíonn do bhrainse agus '%s' do thiomnuithe difriúla.\n"
 
-#: remote.c:2230
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr " (bain úsáid as \"%s\" le haghaidh sonraí)\n"
 
-#: remote.c:2234
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
@@ -2090,26 +1739,26 @@ msgstr[0] "Tá do bhrainse chun tosaigh ar '%s' le tiomantas %d.\n"
 msgstr[1] "Tá do bhrainse chun tosaigh ar '%s' le tiomantais %d.\n"
 msgstr[2] "Tá do bhrainse chun tosaigh ar '%s' le tiomantais %d.\n"
 
-#: remote.c:2240
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr " (bain úsáid as “git push” chun do thiomanta áitiúla a fhoilsiú)\n"
 
-#: remote.c:2243
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
-msgid_plural "Your branch is behind '%s' by %d commits, and can be fast-forwarded.\n"
+msgid_plural ""
+"Your branch is behind '%s' by %d commits, and can be fast-forwarded.\n"
 msgstr[0] ""
-"Tá do bhrainse taobh thiar de '%s' faoi %d tiomantas, agus is féidir é a luasghéarú ar aghaidh.\n"
+"Tá do bhrainse taobh thiar de '%s' faoi %d tiomantas, agus is féidir é a "
+"luasghéarú ar aghaidh.\n"
 msgstr[1] ""
-"Tá do bhrainse taobh thiar de '%s' faoi %d tiomnuithe, agus is féidir é a luasghéarú ar aghaidh.\n"
+"Tá do bhrainse taobh thiar de '%s' faoi %d tiomnuithe, agus is féidir é a "
+"luasghéarú ar aghaidh.\n"
 msgstr[2] ""
-"Tá do bhrainse taobh thiar de '%s' faoi %d tiomnuithe, agus is féidir é a luasghéarú ar aghaidh.\n"
+"Tá do bhrainse taobh thiar de '%s' faoi %d tiomnuithe, agus is féidir é a "
+"luasghéarú ar aghaidh.\n"
 
-#: remote.c:2251
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr " (bain úsáid as “git pull” chun do bhrainse áitiúil a nuashonrú)\n"
 
-#: remote.c:2254
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -2127,151 +1776,135 @@ msgstr[2] ""
 "Tá do bhrainse agus '%s' scartha óna chéile,\n"
 "agus tá %d agus %d tiomnuithe difriúla acu faoi seach.\n"
 
-#: remote.c:2265
-msgid "  (use \"git pull\" if you want to integrate the remote branch with yours)\n"
-msgstr " (bain úsáid as “git pull” más mian leat an brainse iargúlta a chomhtháthú le leatsa)\n"
+msgid ""
+"  (use \"git pull\" if you want to integrate the remote branch with yours)\n"
+msgstr ""
+" (bain úsáid as “git pull” más mian leat an brainse iargúlta a chomhtháthú "
+"le leatsa)\n"
 
-#: remote.c:2464
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "ní féidir ainm réad a bhfuil súil leis '%s' a pharsáil"
 
-#: remote.c:2757
 #, c-format
 msgid "cannot strip one component off url '%s'"
 msgstr "ní féidir comhpháirt amháin a bhaint as url '%s'"
 
-#: wt-status.c:178
 msgid "Unmerged paths:"
 msgstr "Cosáin neamh-chumasaithe:"
 
-#: wt-status.c:207 wt-status.c:239
 msgid "  (use \"git restore --staged <file>...\" to unstage)"
-msgstr " (bain úsáid as “git restore --stage <comhad>...” chun an stáitse a dhíchur)"
+msgstr ""
+" (bain úsáid as “git restore --staged <comhad>...” chun an stáitse a dhíchur)"
 
-#: wt-status.c:210 wt-status.c:242
 #, c-format
 msgid "  (use \"git restore --source=%s --staged <file>...\" to unstage)"
-msgstr " (bain úsáid as \"git restore --source=%s --staged <comhad>...\" chun an stáitse a dhí-ardú)"
+msgstr ""
+" (bain úsáid as \"git restore --source=%s --staged <comhad>...\" chun an "
+"stáitse a dhí-ardú)"
 
-#: wt-status.c:213 wt-status.c:245
 msgid "  (use \"git rm --cached <file>...\" to unstage)"
-msgstr " (bain úsáid as “git rm --cached <comhad>...” chun an stáitse a dhíchur)"
+msgstr ""
+" (bain úsáid as “git rm --cached <comhad>...” chun an stáitse a dhíchur)"
 
-#: wt-status.c:217
 msgid "  (use \"git add <file>...\" to mark resolution)"
 msgstr " (bain úsáid as “git add <comhad>...” chun réiteach a mharcáil)"
 
-#: wt-status.c:219 wt-status.c:223
 msgid "  (use \"git add/rm <file>...\" as appropriate to mark resolution)"
-msgstr " (bain úsáid \"git add/rm <comhad>...\" de réir mar is cuí chun réiteach a mharcáil)"
+msgstr ""
+" (bain úsáid \"git add/rm <comhad>...\" de réir mar is cuí chun réiteach a "
+"mharcáil)"
 
-#: wt-status.c:221
 msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr " (bain úsáid as “git rm <comhad>...” chun réiteach a mharcáil)"
 
-#: wt-status.c:231 wt-status.c:1174
 msgid "Changes to be committed:"
 msgstr "Athruithe atá le déanamh:"
 
-#: wt-status.c:254 wt-status.c:1183
 msgid "Changes not staged for commit:"
 msgstr "Athruithe nach ndearnadh a chur ar stáitse le haghaidh tiomantais:"
 
-#: wt-status.c:258
 msgid "  (use \"git add <file>...\" to update what will be committed)"
-msgstr "  (bain úsáid as “git add <comhad>...” chun an méid a bheidh tiomanta a nuashonrú)"
+msgstr ""
+"  (bain úsáid as “git add <comhad>...” chun an méid a bheidh tiomanta a "
+"nuashonrú)"
 
-#: wt-status.c:260
 msgid "  (use \"git add/rm <file>...\" to update what will be committed)"
-msgstr "  (bain úsáid as “git add/rm <comhad>...” chun an méid a bheidh tiomanta a nuashonrú)"
+msgstr ""
+"  (bain úsáid as “git add/rm <comhad>...” chun an méid a bheidh tiomanta a "
+"nuashonrú)"
 
-#: wt-status.c:261
-msgid "  (use \"git restore <file>...\" to discard changes in working directory)"
-msgstr " (bain úsáid as “git restore <comhad>...” chun athruithe ar eolaire oibre a dhiúscairt)"
+msgid ""
+"  (use \"git restore <file>...\" to discard changes in working directory)"
+msgstr ""
+" (bain úsáid as “git restore <comhad>...” chun athruithe ar eolaire oibre a "
+"dhiúscairt)"
 
-#: wt-status.c:263
 msgid "  (commit or discard the untracked or modified content in submodules)"
-msgstr " (an t-ábhar neamhrianaithe nó modhnaithe i bhfo-mhodúil a thiomsú nó a dhiúscairt)"
+msgstr ""
+" (an t-ábhar neamhrianaithe nó modhnaithe i bhfo-mhodúil a thiomsú nó a "
+"dhiúscairt)"
 
-#: wt-status.c:274
 #, c-format
 msgid "  (use \"git %s <file>...\" to include in what will be committed)"
-msgstr " (bain úsáid as “git %s <comhad>...” chun an méid a bheidh tiomanta san áireamh)"
+msgstr ""
+" (bain úsáid as “git %s <comhad>...” chun an méid a bheidh tiomanta san "
+"áireamh)"
 
-#: wt-status.c:286
 msgid "both deleted:"
 msgstr "scriosta an dá cheann:"
 
-#: wt-status.c:288
 msgid "added by us:"
 msgstr "curtha leis againn:"
 
-#: wt-status.c:290
 msgid "deleted by them:"
 msgstr "scriosta ag siad:"
 
-#: wt-status.c:292
 msgid "added by them:"
 msgstr "a chuir siad leis:"
 
-#: wt-status.c:294
 msgid "deleted by us:"
 msgstr "scriosta againn:"
 
-#: wt-status.c:296
 msgid "both added:"
 msgstr "chuir an bheirt leis:"
 
-#: wt-status.c:298
 msgid "both modified:"
 msgstr "an dá cheann modhnaithe:"
 
-#: wt-status.c:308
 msgid "new file:"
 msgstr "comhad nua:"
 
-#: wt-status.c:310
 msgid "copied:"
 msgstr "cóipeáilte:"
 
-#: wt-status.c:312
 msgid "deleted:"
 msgstr "scriosta:"
 
-#: wt-status.c:314
 msgid "modified:"
 msgstr "modhnaithe:"
 
-#: wt-status.c:316
 msgid "renamed:"
 msgstr "athainmnithe:"
 
-#: wt-status.c:318
 msgid "typechange:"
 msgstr "cineál cineál:"
 
-#: wt-status.c:320
 msgid "unknown:"
 msgstr "anaithnid:"
 
-#: wt-status.c:322
 msgid "unmerged:"
 msgstr "gan chumasc:"
 
-#: wt-status.c:402
 msgid "new commits, "
 msgstr "tiomantais nua, "
 
-#: wt-status.c:404
 msgid "modified content, "
 msgstr "ábhar modhnaithe, "
 
-#: wt-status.c:406
 msgid "untracked content, "
 msgstr "ábhar neamhrianaithe, "
 
-#: wt-status.c:1000
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
@@ -2279,15 +1912,12 @@ msgstr[0] "Tá %d iontráil i do stash faoi láthair"
 msgstr[1] "Tá %d iontrálacha ar do stash faoi láthair"
 msgstr[2] "Tá %d iontrálacha ar do stash faoi láthair"
 
-#: wt-status.c:1031
 msgid "Submodules changed but not updated:"
 msgstr "Fo-mhodúil athraithe ach gan nuashonrú:"
 
-#: wt-status.c:1033
 msgid "Submodule changes to be committed:"
 msgstr "Athruithe fo-mhodúil atá le tiomantas:"
 
-#: wt-status.c:1118
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -2295,7 +1925,6 @@ msgstr ""
 "Ná déan an líne thuas a mhodhnú ná a bhaint.\n"
 "Déanfar neamhaird ar gach rud thíos é."
 
-#: wt-status.c:1214
 #, c-format
 msgid ""
 "\n"
@@ -2303,63 +1932,54 @@ msgid ""
 "You can use '--no-ahead-behind' to avoid this.\n"
 msgstr ""
 "\n"
-"Thóg sé %.2f soicind chun luachanna na brainse chun tosaigh/taobh thiar a ríomh.\n"
+"Thóg sé %.2f soicind chun luachanna na brainse chun tosaigh/taobh thiar a "
+"ríomh.\n"
 "Is féidir leat '--no-ahead-behind' a úsáid chun seo a sheachaint.\n"
 
-#: wt-status.c:1246
 msgid "You have unmerged paths."
 msgstr "Tá cosáin neamh-chumasaithe agat."
 
-#: wt-status.c:1249
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr " (coinbhleachtaí a shocrú agus reáchtáil “git commit”)"
 
-#: wt-status.c:1251
 msgid "  (use \"git merge --abort\" to abort the merge)"
-msgstr " (bain úsáid as “git merge --abort” chun an cumaisc a chur ar deireadh)"
+msgstr ""
+" (bain úsáid as “git merge --abort” chun an cumaisc a chur ar deireadh)"
 
-#: wt-status.c:1255
 msgid "All conflicts fixed but you are still merging."
 msgstr "Socraíodh gach coinbhleacht ach tá tú fós ag cumasc."
 
-#: wt-status.c:1258
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (bain úsáid as “git commit” chun cumasc a thabhairt i gcrích)"
 
-#: wt-status.c:1269
 msgid "You are in the middle of an am session."
 msgstr "Tá tú i lár seisiún am."
 
-#: wt-status.c:1272
 msgid "The current patch is empty."
 msgstr "Tá an paiste reatha folamh."
 
-#: wt-status.c:1277
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (déan coinbhleachtaí a shocrú agus ansin rith “git am --continue”)"
 
-#: wt-status.c:1279
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr " (bain úsáid as “git am --skip” chun an paiste seo a scipeáil)"
 
-#: wt-status.c:1282
-msgid "  (use \"git am --allow-empty\" to record this patch as an empty commit)"
+msgid ""
+"  (use \"git am --allow-empty\" to record this patch as an empty commit)"
 msgstr ""
-" (bain úsáid as “git am --allow-empty” chun an paiste seo a thaifeadadh mar thiomantas folamh)"
+" (bain úsáid as “git am --allow-empty” chun an paiste seo a thaifeadadh mar "
+"thiomantas folamh)"
 
-#: wt-status.c:1284
 msgid "  (use \"git am --abort\" to restore the original branch)"
-msgstr " (bain úsáid as “git am --abort” chun an bhrainse bunaidh a chur ar ais)"
+msgstr ""
+" (bain úsáid as “git am --abort” chun an bhrainse bunaidh a chur ar ais)"
 
-#: wt-status.c:1430
 msgid "git-rebase-todo is missing."
 msgstr "tá git-rebase-todo ar iarraidh."
 
-#: wt-status.c:1432
 msgid "No commands done."
 msgstr "Níl aon orduithe déanta."
 
-#: wt-status.c:1435
 #, c-format
 msgid "Last command done (%<PRIuMAX> command done):"
 msgid_plural "Last commands done (%<PRIuMAX> commands done):"
@@ -2367,16 +1987,13 @@ msgstr[0] "An chéad ordú eile le déanamh (%<PRIuMAX>ordú atá fágtha):"
 msgstr[1] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
 msgstr[2] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
 
-#: wt-status.c:1447
 #, c-format
 msgid "  (see more in file %s)"
 msgstr " (féach tuilleadh i gcomhad %s)"
 
-#: wt-status.c:1454
 msgid "No commands remaining."
 msgstr "Níl aon orduithe fágtha."
 
-#: wt-status.c:1457
 #, c-format
 msgid "Next command to do (%<PRIuMAX> remaining command):"
 msgid_plural "Next commands to do (%<PRIuMAX> remaining commands):"
@@ -2384,293 +2001,257 @@ msgstr[0] "An chéad ordú eile le déanamh (%<PRIuMAX> an t-ordú atá fágtha)
 msgstr[1] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
 msgstr[2] "Na chéad orduithe eile le déanamh (%<PRIuMAX> orduithe atá fágtha):"
 
-#: wt-status.c:1465
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
-msgstr " (bain úsáid as “git rebase --edit-todo” chun féachaint agus eagar a chur in eagar)"
+msgstr ""
+" (bain úsáid as “git rebase --edit-todo” chun féachaint agus eagar a chur in "
+"eagar)"
 
-#: wt-status.c:1477
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Tá tú ag athbhunú brainse '%s' faoi láthair ar '%s'."
 
-#: wt-status.c:1482
 msgid "You are currently rebasing."
 msgstr "Tá tú ag athbhunú faoi láthair."
 
-#: wt-status.c:1495
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
-msgstr " (déan coinbhleachtaí a shocrú agus ansin rith “git rebase --continue”)"
+msgstr ""
+" (déan coinbhleachtaí a shocrú agus ansin rith “git rebase --continue”)"
 
-#: wt-status.c:1497
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr " (bain úsáid as “git rebase --skip” chun an paiste seo a scipeáil)"
 
-#: wt-status.c:1499
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
-msgstr " (bain úsáid as “git rebase --abort” chun an bhrainse bunaidh a sheiceáil)"
+msgstr ""
+" (bain úsáid as “git rebase --abort” chun an bhrainse bunaidh a sheiceáil)"
 
-#: wt-status.c:1506
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr " (gach coinbhleacht socraithe: reáchtáil “git rebase --continue”)"
 
-#: wt-status.c:1510
 #, c-format
-msgid "You are currently splitting a commit while rebasing branch '%s' on '%s'."
-msgstr "Tá tiomantas á roinnt agat faoi láthair agus tú ag athbhunú brainse '%s' ar '%s'."
+msgid ""
+"You are currently splitting a commit while rebasing branch '%s' on '%s'."
+msgstr ""
+"Tá tiomantas á roinnt agat faoi láthair agus tú ag athbhunú brainse '%s' ar "
+"'%s'."
 
-#: wt-status.c:1515
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Tá tú ag roinnt tiomantas faoi láthair le linn athbhunaithe."
 
-#: wt-status.c:1518
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
-msgstr " (Nuair a bheidh d'eolaire oibre glan, reáchtáil “git rebase --continue”)"
+msgstr ""
+" (Nuair a bheidh d'eolaire oibre glan, reáchtáil “git rebase --continue”)"
 
-#: wt-status.c:1522
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
-msgstr "Tá tú ag eagarthóireacht faoi láthair agus tú ag athbhunú brainse '%s' ar '%s'."
+msgstr ""
+"Tá tú ag eagarthóireacht faoi láthair agus tú ag athbhunú brainse '%s' ar "
+"'%s'."
 
-#: wt-status.c:1527
 msgid "You are currently editing a commit during a rebase."
 msgstr "Tá tú ag eagarthóireacht tiomanta faoi láthair le linn athbhunaithe."
 
-#: wt-status.c:1530
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr " (bain úsáid as “git commit --amend” chun an tiomantas reatha a leasú)"
 
-#: wt-status.c:1532
-msgid "  (use \"git rebase --continue\" once you are satisfied with your changes)"
-msgstr " (bain úsáid as “git rebase --continue” nuair a bheidh tú sásta le d'athruithe)"
+msgid ""
+"  (use \"git rebase --continue\" once you are satisfied with your changes)"
+msgstr ""
+" (bain úsáid as “git rebase --continue” nuair a bheidh tú sásta le "
+"d'athruithe)"
 
-#: wt-status.c:1543
 msgid "Cherry-pick currently in progress."
 msgstr "Cherry-pick atá ar siúl faoi láthair."
 
-#: wt-status.c:1546
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Tá tiomantas %s ag piocadh silíní faoi láthair."
 
-#: wt-status.c:1553
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr " (coinbhleachtaí a shocrú agus reáchtáil “git cherry-pick --continue”)"
 
-#: wt-status.c:1556
 msgid "  (run \"git cherry-pick --continue\" to continue)"
-msgstr " (reáchtáil “git cherry-pick - lean” chun leanúint ar aghaidh)"
+msgstr " (reáchtáil “git cherry-pick --continue ” chun leanúint ar aghaidh)"
 
-#: wt-status.c:1559
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr " (gach coinbhleacht socraithe: reáchtáil “git cherry-pick --continue”)"
 
-#: wt-status.c:1561
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
-msgstr " (bain úsáid as “git cherry-pick --skip” chun an paiste seo a scipeáil)"
+msgstr ""
+" (bain úsáid as “git cherry-pick --skip” chun an paiste seo a scipeáil)"
 
-#: wt-status.c:1563
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
-msgstr " (bain úsáid as “git cherry-pick --abort” chun an oibríocht pioc silíní a chealú)"
+msgstr ""
+" (bain úsáid as “git cherry-pick --abort” chun an oibríocht pioc silíní a "
+"chealú)"
 
-#: wt-status.c:1573
 msgid "Revert currently in progress."
 msgstr "Ar ais atá ar siúl faoi láthair."
 
-#: wt-status.c:1576
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Tá tiomantas %s á chur ar ais faoi láthair."
 
-#: wt-status.c:1582
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr " (déan coinbhleachtaí a shocrú agus rith “git revert --continue”)"
 
-#: wt-status.c:1585
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr " (reáchtáil “git revert --continue” chun leanúint ar aghaidh)"
 
-#: wt-status.c:1588
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr " (gach coinbhleacht socraithe: reáchtáil “git revert --continue”)"
 
-#: wt-status.c:1590
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr " (bain úsáid as “git revert --skip” chun an paiste seo a scipeáil)"
 
-#: wt-status.c:1592
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
-msgstr " (bain úsáid as “git revert --abort” chun an oibríocht aisghabhála a chealú)"
+msgstr ""
+" (bain úsáid as “git revert --abort” chun an oibríocht aisghabhála a chealú)"
 
-#: wt-status.c:1602
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Tá tú ag déileáil faoi láthair, tosaigh tú ó bhrainse '%s'."
 
-#: wt-status.c:1606
 msgid "You are currently bisecting."
 msgstr "Tá tú ag déileáil faoi láthair."
 
-#: wt-status.c:1609
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
-msgstr " (bain úsáid as “git bisect reset” chun filleadh ar an mbrainse bunaidh)"
+msgstr ""
+" (bain úsáid as “git bisect reset” chun filleadh ar an mbrainse bunaidh)"
 
-#: wt-status.c:1620
 msgid "You are in a sparse checkout."
 msgstr "Tá tú i seiceáil neamhchoitianta."
 
-#: wt-status.c:1623
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
-msgstr "Tá tú i seiceáil neamhchoitianta le %d%% de na comhaid rianaithe i láthair."
+msgstr ""
+"Tá tú i seiceáil neamhchoitianta le %d%% de na comhaid rianaithe i láthair."
 
-#: wt-status.c:1871
 msgid "On branch "
 msgstr "Ar bhrainse "
 
-#: wt-status.c:1878
 msgid "interactive rebase in progress; onto "
 msgstr "athbhunú idirghníomhach atá ar siúl; ar "
 
-#: wt-status.c:1880
 msgid "rebase in progress; onto "
 msgstr "athbhunú atá ar siúl; ar "
 
-#: wt-status.c:1885
 msgid "HEAD detached at "
 msgstr "HEAD scoite ag "
 
-#: wt-status.c:1887
 msgid "HEAD detached from "
 msgstr "CEANN scartha ó "
 
-#: wt-status.c:1890
 msgid "Not currently on any branch."
 msgstr "Níl sé ar aon bhrainse faoi láthair."
 
-#: wt-status.c:1907
 msgid "Initial commit"
 msgstr "Tiomantas tosaigh"
 
-#: wt-status.c:1908
 msgid "No commits yet"
 msgstr "Níl aon gealltanais fós"
 
-#: wt-status.c:1922
 msgid "Untracked files"
 msgstr "Comhaid neamhrianaithe"
 
-#: wt-status.c:1924
 msgid "Ignored files"
 msgstr "Comhaid neamhaird"
 
-#: wt-status.c:1929
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files,\n"
 "but the results were cached, and subsequent runs may be faster."
 msgstr ""
 "Thóg sé %.2f soicind comhaid gan rianú a áireamh,\n"
-"ach cuireadh na torthaí a chosc, agus d'fhéadfadh rith ina dhiaidh sin a bheith níos gasta."
+"ach cuireadh na torthaí a chosc, agus d'fhéadfadh rith ina dhiaidh sin a "
+"bheith níos gasta."
 
-#: wt-status.c:1934
 #, c-format
 msgid "It took %.2f seconds to enumerate untracked files."
 msgstr "Thóg sé %.2f soicind comhaid gan rianú a áireamh."
 
-#: wt-status.c:1938
 msgid "See 'git help status' for information on how to improve this."
-msgstr "Féach 'git help status' le haghaidh faisnéise maidir le conas é seo a fheabhsú."
+msgstr ""
+"Féach 'git help status' le haghaidh faisnéise maidir le conas é seo a "
+"fheabhsú."
 
-#: wt-status.c:1942
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Comhaid neamhrianaithe nár liostaíodh %s"
 
-#: wt-status.c:1944
 msgid " (use -u option to show untracked files)"
 msgstr " (bain úsáid as an rogha -u chun comhaid neamhrianaithe a thaispeáint)"
 
-#: wt-status.c:1950
 msgid "No changes"
 msgstr "Gan aon athruithe"
 
-#: wt-status.c:1955
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
-msgstr "níl aon athruithe curtha le tiomantas (bain úsáid as “git add” agus/nó “git commit -a”)\n"
+msgstr ""
+"níl aon athruithe curtha le tiomantas (bain úsáid as “git add” agus/nó “git "
+"commit -a”)\n"
 
-#: wt-status.c:1959
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "níl aon athruithe curtha le tiomantas\n"
 
-#: wt-status.c:1963
 #, c-format
-msgid "nothing added to commit but untracked files present (use \"git add\" to track)\n"
+msgid ""
+"nothing added to commit but untracked files present (use \"git add\" to "
+"track)\n"
 msgstr ""
-"ní chuirtear aon rud le tiomantas ach comhaid neamhrianaithe i láthair (bain úsáid as “git add” "
-"chun rianú)\n"
+"ní chuirtear aon rud le tiomantas ach comhaid neamhrianaithe i láthair (bain "
+"úsáid as “git add” chun rianú)\n"
 
-#: wt-status.c:1967
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "ní chuir aon rud le tiomantas ach comhaid neamhrianaithe i láthair\n"
 
-#: wt-status.c:1971
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
-msgstr "aon rud le tiomantas (comhaid a chruthú/cóipeáil agus bain úsáid as “git add” chun rianú)\n"
+msgstr ""
+"aon rud le tiomantas (comhaid a chruthú/cóipeáil agus bain úsáid as “git "
+"add” chun rianú)\n"
 
-#: wt-status.c:1975 wt-status.c:1981
 #, c-format
 msgid "nothing to commit\n"
 msgstr "aon rud le tiomantas\n"
 
-#: wt-status.c:1978
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
-msgstr "aon rud le tiomantas (bain úsáid as -u chun comhaid neamhrianaithe a thaispeáint)\n"
+msgstr ""
+"aon rud le tiomantas (bain úsáid as -u chun comhaid neamhrianaithe a "
+"thaispeáint)\n"
 
-#: wt-status.c:1983
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "aon rud le tiomantas, crann oibre glan\n"
 
-#: wt-status.c:2088
 msgid "No commits yet on "
 msgstr "Níl aon gealltanas ar aghaidh go fóill "
 
-#: wt-status.c:2092
 msgid "HEAD (no branch)"
 msgstr "CEAD (gan aon bhrainse)"
 
-#: wt-status.c:2122
 msgid "gone"
 msgstr "imithe"
 
-#: wt-status.c:2124
 msgid "different"
 msgstr "difriúil"
 
-#: wt-status.c:2126 wt-status.c:2134
 msgid "behind "
 msgstr "taobh thiar "
 
-#: wt-status.c:2129 wt-status.c:2132
 msgid "ahead "
 msgstr "chun tosaigh "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2674
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "ní féidir %s: Tá athruithe gan stáitse agat."
 
-#: wt-status.c:2680
 msgid "additionally, your index contains uncommitted changes."
 msgstr "ina theannta sin, tá athruithe neamhthiomanta i d'innéacs."
 
-#: wt-status.c:2682
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "ní féidir %s: Tá athruithe neamhthiomanta ag d'innéacs."


### PR DESCRIPTION
This commit introduces an initial Irish (Gaeilge) translation for Git, added as `po/ga.po`.

The file was created and translated manually. Validation was done using Poedit to ensure there are no syntax errors or formatting issues.
