### PR TITLE
l10n: update zh_CN translations

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,6 +1,7 @@
 # Chinese translations for Git package
 # Git 软件包的简体中文翻译.
 # Copyright (C) 2012,2013 Jiang Xin <worldhello.net AT gmail.com>
+# Copyright (C) 2021-2023 Fangyi Zhou <me@fangyi.io>
 # This file is distributed under the same license as the Git package.
 # Contributors:
 #   - Fangyi Zhou <me AT fangyi.io>
@@ -16,15 +17,15 @@
 #   - Zhuang Ya <zhuangya AT me.com>
 #   - Teng Long <dyroneteng AT gmail.com>
 #
-#  Git glossary for Chinese translators
+# Git glossary for Chinese translators
 #
 #   English                          |  Chinese
 #   ---------------------------------+--------------------------------------
-#   3-way merge                      |  三方合并
+#   3-way merge                      |  三路合并
 #   abbreviate                       |  简写（的 SHA-1 值）
 #   alternate object database        |  备用对象库
 #   attribute source                 |  属性来源
-#   amend                            |  修补
+#   amend                            |  修订
 #   ancestor                         |  祖先，祖先提交
 #   annotated tag                    |  附注标签
 #   bare repository                  |  纯仓库
@@ -33,9 +34,9 @@
 #   blob object                      |  数据对象
 #   bloom filter                     |  布隆过滤器
 #   branch                           |  分支
-#   bundle                           |  归档包
+#   bundle                           |  捆绑包
 #   bypass                           |  绕过
-#   cache                            |  索引（的别称）
+#   cache                            |  缓存（索引的别称）
 #   chain                            |  （提交）链
 #   changeset                        |  变更集
 #   checkout                         |  检出
@@ -48,7 +49,7 @@
 #   commit object                    |  提交对象
 #   commit-graph                     |  提交图
 #   commit-ish (also committish)     |  提交号
-#   cone                             |  锥形（稀疏检出模型）；锥（稀疏检出）
+#   cone                             |  锥形模式（稀疏检出）；锥（稀疏检出）
 #   conflict                         |  冲突
 #   core Git                         |  核心 Git 工具
 #   cover letter                     |  附函
@@ -59,28 +60,29 @@
 #   dirty                            |  脏（的工作区）
 #   dumb HTTP protocol               |  哑 HTTP 协议
 #   enlistment                       |  登记（在 scalar 中使用）
-#   evil merge                       |  坏合并（合并引入了父提交没有的修改）
+#   evil merge                       |  恶意合并（合并引入了额外变更，即父提交没有的修改）
 #   fast-forward                     |  快进
 #   fetch                            |  获取
 #   file system                      |  文件系统
 #   fork                             |  派生
 #   Git archive                      |  仓库（对于 arch 用户）
 #   gitfile                          |  gitfile（仓库链接文件）
-#   grafts                           |  （提交）移植
+#   grafts                           |  （提交）嫁接
 #   hash                             |  哈希值
 #   HEAD                             |  HEAD（头指针，亦即当前分支）
 #   head                             |  头、分支
 #   head ref                         |  分支
 #   header                           |  头信息
 #   hook                             |  钩子
-#   hunk                             |  补丁片段
 #   index                            |  索引
 #   index entry                      |  索引条目
 #   loose object                     |  松散对象
 #   loose refs                       |  松散引用
-#   magic                            |  神奇前缀（路径规格支持的一种前缀表达式）
-#   master                           |  master（默认分支名）
+#   magic                            |  魔法前缀（路径规格支持的一种前缀表达式）
+#   master                           |  master（传统默认分支名，将被 main 替代）
 #   merge                            |  合并
+#   merge-base                       |  合并基线
+#   note                             |  注解
 #   object                           |  对象
 #   object database                  |  对象库
 #   object identifier                |  对象标识符
@@ -95,11 +97,12 @@
 #   parent                           |  父提交
 #   partial clone                    |  部分克隆
 #   patch                            |  补丁
+#   patch hunk                       |  补丁块
 #   pathspec                         |  路径规格
 #   pattern                          |  模式
 #   pickaxe                          |  挖掘
-#   plumbing                         |  管件（Git 底层核心命令的别称）
-#   porcelain                        |  瓷件（Git 上层封装命令的别称）
+#   plumbing                         |  管件（Git 底层命令的别称）
+#   porcelain                        |  瓷件（Git 高层命令的别称）
 #   precious-objects repo            |  珍品仓库
 #   preferred pack                   |  首选包（多包索引中引入的首选包概念）
 #   promisor                         |  承诺者
@@ -130,7 +133,7 @@
 #   squash                           |  挤压
 #   stage                            |  n. 暂存区（即索引）; v. 暂存
 #   stale                            |  过期的
-#   stash                            |  n. 贮藏区; v. 贮藏
+#   stash                            |  n. 储藏区; v. 储藏
 #   submodule                        |  子模组
 #   symref                           |  符号引用
 #   tag                              |  n. 标签; v. 打标签
@@ -146,10 +149,22 @@
 #   unpack                           |  解包
 #   unreachable object               |  不可达对象
 #   unstage                          |  取消暂存
-#   upstream                         |  上游
-#   upstream branch                  |  上游分支
+#   upstream                         |  上游（分支/仓库）
 #   working tree                     |  工作区
-# Fangyi Zhou <me@fangyi.io>, 2021-2023.
+#
+#  Preferred Chinese Terms
+#
+#   - 默认 (not 缺省)
+#   - 其他 (not 其它)
+#   - 作为 (not 做为)
+#   - 当作 (not 当做)
+#   - 登录 (not 登陆)
+#   - 账户 (not 帐户)
+#   - 密码 (not 口令)
+#   - 撤销 (not 撤消)
+#   - 吗？ (not 么？)   # 疑问助词
+#   - 无法 (not 不能)：客观。客观障碍、技术限制、物理规律，非主观
+#   - 不能 (not 无法)：主观。能力不足、规则限制、逻辑冲突、设计限制、意愿拒绝
 #
 msgid ""
 msgstr ""
@@ -178,7 +193,7 @@ msgstr "嗯（%s）？"
 
 #: add-interactive.c builtin/merge.c builtin/rebase.c reset.c sequencer.c
 msgid "could not read index"
-msgstr "不能读取索引"
+msgstr "无法读取索引"
 
 #: add-interactive.c
 msgid "binary"
@@ -199,11 +214,11 @@ msgstr "更新"
 #: add-interactive.c
 #, c-format
 msgid "could not stage '%s'"
-msgstr "不能暂存 '%s'"
+msgstr "无法暂存 '%s'"
 
 #: add-interactive.c builtin/stash.c reset.c sequencer.c
 msgid "could not write index"
-msgstr "不能写入索引"
+msgstr "无法写入索引"
 
 #: add-interactive.c
 #, c-format
@@ -215,7 +230,7 @@ msgstr[1] "更新了 %d 个路径\n"
 #: add-interactive.c
 #, c-format
 msgid "note: %s is untracked now.\n"
-msgstr "说明：%s 现已成为未跟踪的。\n"
+msgstr "注意：%s 现在未被跟踪。\n"
 
 #: add-interactive.c apply.c builtin/checkout.c builtin/reset.c
 #, c-format
@@ -228,7 +243,7 @@ msgstr "还原"
 
 #: add-interactive.c
 msgid "Could not parse HEAD^{tree}"
-msgstr "不能解析 HEAD^{tree}"
+msgstr "无法解析 HEAD^{tree}"
 
 #: add-interactive.c
 #, c-format
@@ -274,7 +289,7 @@ msgstr "补丁更新"
 
 #: add-interactive.c
 msgid "Review diff"
-msgstr "检视 diff"
+msgstr "查看差异"
 
 #: add-interactive.c
 msgid "show paths with changes"
@@ -350,11 +365,11 @@ msgstr "请选择"
 
 #: add-interactive.c
 msgid "staged"
-msgstr "缓存"
+msgstr "已暂存"
 
 #: add-interactive.c
 msgid "unstaged"
-msgstr "未缓存"
+msgstr "未暂存"
 
 #: add-interactive.c apply.c builtin/am.c builtin/bugreport.c builtin/clone.c
 #: builtin/diagnose.c builtin/fetch.c builtin/hook.c builtin/merge.c
@@ -364,7 +379,7 @@ msgstr "路径"
 
 #: add-interactive.c
 msgid "could not refresh index"
-msgstr "不能刷新索引"
+msgstr "无法刷新索引"
 
 #: add-interactive.c builtin/clean.c
 #, c-format
@@ -379,12 +394,12 @@ msgstr "暂存模式变更 [y,n,q,a,d%s,?]? "
 #: add-patch.c
 #, c-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
-msgstr "暂存删除动作 [y,n,q,a,d%s,?]? "
+msgstr "暂存删除变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
-msgstr "暂存添加动作 [y,n,q,a,d%s,?]? "
+msgstr "暂存新增变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
@@ -414,28 +429,28 @@ msgstr ""
 #: add-patch.c
 #, c-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
-msgstr "贮藏模式变更 [y,n,q,a,d%s,?]? "
+msgstr "储藏模式变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
-msgstr "贮藏删除动作 [y,n,q,a,d%s,?]? "
+msgstr "储藏删除变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
-msgstr "贮藏添加动作 [y,n,q,a,d%s,?]? "
+msgstr "储藏新增变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
-msgstr "贮藏该块 [y,n,q,a,d%s,?]? "
+msgstr "储藏该块 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
-msgstr "如果补丁能正确地应用，编辑块将立即标记为贮藏。"
+msgstr "如果补丁能正确地应用，编辑块将立即标记为储藏。"
 
 #: add-patch.c
 msgid ""
@@ -445,11 +460,11 @@ msgid ""
 "a - stash this hunk and all later hunks in the file\n"
 "d - do not stash this hunk or any of the later hunks in the file\n"
 msgstr ""
-"y - 贮藏该块\n"
-"n - 不要贮藏该块\n"
-"q - 退出。不贮藏该块及后面的全部块\n"
-"a - 贮藏该块和本文件中后面的全部块\n"
-"d - 不贮藏该块和本文件中后面的全部块\n"
+"y - 储藏该块\n"
+"n - 不要储藏该块\n"
+"q - 退出。不储藏该块及后面的全部块\n"
+"a - 储藏该块和本文件中后面的全部块\n"
+"d - 不储藏该块和本文件中后面的全部块\n"
 
 #: add-patch.c
 #, c-format
@@ -459,12 +474,12 @@ msgstr "取消暂存模式变更 [y,n,q,a,d%s,?]? "
 #: add-patch.c
 #, c-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
-msgstr "取消暂存删除动作 [y,n,q,a,d%s,?]? "
+msgstr "取消暂存删除变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
-msgstr "取消暂存添加动作 [y,n,q,a,d%s,?]? "
+msgstr "取消暂存新增变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
@@ -475,7 +490,7 @@ msgstr "取消暂存该块 [y,n,q,a,d%s,?]? "
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
-msgstr "如果补丁能正确地应用，编辑块将立即标记为未暂存。"
+msgstr "如果补丁能正确地应用，编辑块将立即标记为取消暂存。"
 
 #: add-patch.c
 msgid ""
@@ -539,12 +554,12 @@ msgstr "从工作区中丢弃模式变更 [y,n,q,a,d%s,?]? "
 #: add-patch.c
 #, c-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
-msgstr "从工作区中丢弃删除动作 [y,n,q,a,d%s,?]? "
+msgstr "从工作区中丢弃删除变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
-msgstr "从工作区中丢弃添加动作 [y,n,q,a,d%s,?]? "
+msgstr "从工作区中丢弃新增变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
@@ -579,12 +594,12 @@ msgstr "从索引和工作区中丢弃模式变更 [y,n,q,a,d%s,?]? "
 #: add-patch.c
 #, c-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
-msgstr "从索引和工作区中丢弃删除动作 [y,n,q,a,d%s,?]? "
+msgstr "从索引和工作区中丢弃删除变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
-msgstr "从索引和工作区中丢弃添加动作 [y,n,q,a,d%s,?]? "
+msgstr "从索引和工作区中丢弃新增变更 [y,n,q,a,d%s,?]? "
 
 #: add-patch.c
 #, c-format
@@ -680,11 +695,11 @@ msgstr "无法解析数据块头信息 '%.*s'"
 
 #: add-patch.c
 msgid "could not parse diff"
-msgstr "不能解析差异信息"
+msgstr "无法解析差异信息"
 
 #: add-patch.c
 msgid "could not parse colored diff"
-msgstr "不能解析彩色差异信息"
+msgstr "无法解析彩色差异信息"
 
 #: add-patch.c
 #, c-format
@@ -707,7 +722,7 @@ msgid ""
 "expected context line #%d in\n"
 "%.*s"
 msgstr ""
-"预期上下文行 #%d 于\n"
+"预期上下文行 #%d 位于\n"
 "%.*s"
 
 #: add-patch.c
@@ -720,7 +735,7 @@ msgid ""
 msgstr ""
 "块不重叠：\n"
 "%.*s\n"
-"\t不是结尾于：\n"
+"\t未以以下内容结尾：\n"
 "%.*s"
 
 #: add-patch.c
@@ -746,7 +761,7 @@ msgid ""
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
 "aborted and the hunk is left unchanged.\n"
 msgstr ""
-"如果不能干净地应用，您将有机会重新编辑。如果该块的全部内容删除，则\n"
+"如果无法干净地应用，您将有机会重新编辑。如果该块的全部内容删除，则\n"
 "此次编辑被终止，该块不会被修改。\n"
 
 #: add-patch.c
@@ -766,15 +781,15 @@ msgstr "'git apply --cached' 失败"
 #: add-patch.c
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
-msgstr "您的编辑块不能被应用。重新编辑（选择 \"no\" 丢弃！） [y/n]? "
+msgstr "您的编辑块无法被应用。重新编辑（选择 \"no\" 丢弃！） [y/n]? "
 
 #: add-patch.c
 msgid "The selected hunks do not apply to the index!"
-msgstr "选中的块不能应用到索引！"
+msgstr "选中的块无法应用到索引！"
 
 #: add-patch.c
 msgid "Apply them to the worktree anyway? "
-msgstr "无论如何都要应用到工作区么？"
+msgstr "仍要应用到工作区吗？"
 
 #: add-patch.c
 msgid "Nothing was applied.\n"
@@ -813,15 +828,15 @@ msgstr "预期只有一个字母，得到 '%s'"
 
 #: add-patch.c
 msgid "No other hunk"
-msgstr "没有其它块"
+msgstr "没有其他块"
 
 #: add-patch.c
 msgid "No other undecided hunk"
-msgstr "没有其它未决定的块"
+msgstr "没有其他未决定的块"
 
 #: add-patch.c
 msgid "No other hunks to goto"
-msgstr "没有其它可供跳转的块"
+msgstr "没有其他可供跳转的块"
 
 #: add-patch.c
 msgid "go to which hunk (<ret> to see more)? "
@@ -845,7 +860,7 @@ msgstr[1] "对不起，只有 %d 个可用块。"
 
 #: add-patch.c
 msgid "No other hunks to search"
-msgstr "没有其它可供查找的块"
+msgstr "没有其他可供查找的块"
 
 #: add-patch.c
 msgid "search for regex? "
@@ -862,7 +877,7 @@ msgstr "没有和给定模式相匹配的块"
 
 #: add-patch.c
 msgid "Sorry, cannot split this hunk"
-msgstr "对不起，不能拆分这个块"
+msgstr "对不起，无法拆分这个块"
 
 #: add-patch.c
 #, c-format
@@ -871,7 +886,7 @@ msgstr "拆分为 %d 块。"
 
 #: add-patch.c
 msgid "Sorry, cannot edit this hunk"
-msgstr "对不起，不能编辑这个块"
+msgstr "对不起，无法编辑这个块"
 
 #: add-patch.c
 #, c-format
@@ -922,7 +937,7 @@ msgstr "无法拉取，因为您有未合并的文件。"
 
 #: advice.c
 msgid "Reverting is not possible because you have unmerged files."
-msgstr "无法回退，因为您有未合并的文件。"
+msgstr "无法还原，因为您有未合并的文件。"
 
 #: advice.c
 msgid "Rebasing is not possible because you have unmerged files."
@@ -1049,7 +1064,7 @@ msgid ""
 "* Use \"git add --sparse <paths>\" to update the index\n"
 "* Use \"git sparse-checkout reapply\" to apply the sparsity rules"
 msgstr ""
-"为了修正这些的路径的稀疏性，请运行下列命令：\n"
+"为了修正这些路径的稀疏性，请运行下列命令：\n"
 "* 使用 \"git add --sparse <路径>\" 来更新索引\n"
 "* 使用 \"git sparse-checkout reapply\" 来应用稀疏规则"
 
@@ -1116,7 +1131,7 @@ msgstr "regexec 返回 %d，输入为：%s"
 #: apply.c
 #, c-format
 msgid "unable to find filename in patch at line %d"
-msgstr "不能在补丁的第 %d 行找到文件名"
+msgstr "无法在补丁的第 %d 行找到文件名"
 
 #: apply.c
 #, c-format
@@ -1225,7 +1240,7 @@ msgstr "无法读取符号链接 %s"
 #: apply.c
 #, c-format
 msgid "unable to open or read %s"
-msgstr "不能打开或读取 %s"
+msgstr "无法打开或读取 %s"
 
 #: apply.c
 #, c-format
@@ -1250,7 +1265,7 @@ msgid ""
 "while searching for:\n"
 "%.*s"
 msgstr ""
-"当查询：\n"
+"在搜索：\n"
 "%.*s"
 
 #: apply.c
@@ -1261,12 +1276,12 @@ msgstr "缺失 '%s' 的二进制补丁数据"
 #: apply.c
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
-msgstr "不能反向应用一个缺少到 '%s' 的反向数据块的二进制补丁"
+msgstr "无法反向应用一个缺少到 '%s' 的反向数据块的二进制补丁"
 
 #: apply.c
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
-msgstr "不能在 '%s' 上应用没有完整索引行的二进制补丁"
+msgstr "无法在 '%s' 上应用没有完整索引行的二进制补丁"
 
 #: apply.c
 #, c-format
@@ -1302,7 +1317,7 @@ msgstr "打补丁失败：%s:%ld"
 #: apply.c builtin/mv.c
 #, c-format
 msgid "cannot checkout %s"
-msgstr "不能检出 %s"
+msgstr "无法检出 %s"
 
 #: apply.c midx.c pack-mtimes.c pack-revindex.c setup.c
 #, c-format
@@ -1312,7 +1327,7 @@ msgstr "无法读取 %s"
 #: apply.c
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
-msgstr "读取位于符号链接中的 '%s'"
+msgstr "从 '%s' 读取时越过符号链接"
 
 #: apply.c
 #, c-format
@@ -1331,12 +1346,12 @@ msgstr "%s：和索引不匹配"
 
 #: apply.c
 msgid "repository lacks the necessary blob to perform 3-way merge."
-msgstr "仓库缺乏执行三方合并所必需的数据对象。"
+msgstr "仓库缺乏执行三路合并所必需的数据对象。"
 
 #: apply.c
 #, c-format
 msgid "Performing three-way merge...\n"
-msgstr "执行三方合并...\n"
+msgstr "执行三路合并...\n"
 
 #: apply.c
 #, c-format
@@ -1346,12 +1361,12 @@ msgstr "无法读取 '%s' 的当前内容"
 #: apply.c
 #, c-format
 msgid "Failed to perform three-way merge...\n"
-msgstr "无法执行三方合并...\n"
+msgstr "无法执行三路合并...\n"
 
 #: apply.c
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
-msgstr "应用补丁到 '%s' 存在冲突。\n"
+msgstr "应用补丁到 '%s' 时发生冲突。\n"
 
 #: apply.c
 #, c-format
@@ -1361,7 +1376,7 @@ msgstr "成功应用补丁到 '%s'。\n"
 #: apply.c
 #, c-format
 msgid "Falling back to direct application...\n"
-msgstr "回落到直接应用...\n"
+msgstr "改为直接应用...\n"
 
 #: apply.c
 msgid "removal patch leaves file contents"
@@ -1405,7 +1420,7 @@ msgstr "%2$s 的新模式（%1$o）和 %4$s 的旧模式（%3$o）不匹配"
 #: apply.c
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
-msgstr "受影响的文件 '%s' 位于符号链接中"
+msgstr "受影响的文件 '%s' 位于符号链接之外"
 
 #: apply.c
 #, c-format
@@ -1435,32 +1450,32 @@ msgstr "sha1 信息缺失或无效（%s）。"
 #: apply.c
 #, c-format
 msgid "could not add %s to temporary index"
-msgstr "不能在临时索引中添加 %s"
+msgstr "无法在临时索引中添加 %s"
 
 #: apply.c
 #, c-format
 msgid "could not write temporary index to %s"
-msgstr "不能把临时索引写入到 %s"
+msgstr "无法把临时索引写入到 %s"
 
 #: apply.c
 #, c-format
 msgid "unable to remove %s from index"
-msgstr "不能从索引中移除 %s"
+msgstr "无法从索引中移除 %s"
 
 #: apply.c
 #, c-format
 msgid "corrupt patch for submodule %s"
-msgstr "子模组 %s 损坏的补丁"
+msgstr "针对子模组 %s 的补丁已损坏"
 
 #: apply.c
 #, c-format
 msgid "unable to stat newly created file '%s'"
-msgstr "不能对新建文件 '%s' 调用 stat"
+msgstr "无法对新建文件 '%s' 调用 stat"
 
 #: apply.c
 #, c-format
 msgid "unable to create backing store for newly created file %s"
-msgstr "不能为新建文件 %s 创建后端存储"
+msgstr "无法为新建文件 %s 创建后端存储"
 
 #: apply.c
 #, c-format
@@ -1480,7 +1495,7 @@ msgstr "关闭文件 '%s'"
 #: apply.c
 #, c-format
 msgid "unable to write file '%s' mode %o"
-msgstr "不能写文件 '%s' 权限 %o"
+msgstr "无法写文件 '%s' 权限 %o"
 
 #: apply.c
 #, c-format
@@ -1495,37 +1510,37 @@ msgstr "内部错误"
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
-msgstr[0] "应用 %%s 个补丁，其中 %d 个被拒绝..."
-msgstr[1] "应用 %%s 个补丁，其中 %d 个被拒绝..."
+msgstr[0] "应用补丁 %%s，其中 %d 个被拒绝..."
+msgstr[1] "应用补丁 %%s，其中 %d 个被拒绝..."
 
 #: apply.c
 #, c-format
 msgid "cannot open %s"
-msgstr "不能打开 %s"
+msgstr "无法打开 %s"
 
 #: apply.c rerere.c
 #, c-format
 msgid "cannot unlink '%s'"
-msgstr "不能删除 '%s'"
+msgstr "无法删除 '%s'"
 
 #: apply.c
 #, c-format
 msgid "Hunk #%d applied cleanly."
-msgstr "第 #%d 个片段成功应用。"
+msgstr "第 #%d 个块成功应用。"
 
 #: apply.c
 #, c-format
 msgid "Rejected hunk #%d."
-msgstr "拒绝第 #%d 个片段。"
+msgstr "拒绝第 #%d 个块。"
 
 #: apply.c
 #, c-format
 msgid "Skipped patch '%s'."
-msgstr "略过补丁 '%s'。"
+msgstr "跳过补丁 '%s'。"
 
 #: apply.c
 msgid "No valid patches in input (allow with \"--allow-empty\")"
-msgstr "输入中没有合法的补丁 （使用 \"--allow-empty\" 来允许）"
+msgstr "输入中没有合法补丁（可用 \"--allow-empty\" 允许）"
 
 #: apply.c t/helper/test-cache-tree.c
 msgid "unable to read index file"
@@ -1534,14 +1549,14 @@ msgstr "无法读取索引文件"
 #: apply.c
 #, c-format
 msgid "can't open patch '%s': %s"
-msgstr "不能打开补丁 '%s'：%s"
+msgstr "无法打开补丁 '%s'：%s"
 
 #: apply.c
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
-msgstr[0] "抑制下仍有 %d 个空白字符误用"
-msgstr[1] "抑制下仍有 %d 个空白字符误用"
+msgstr[0] "已抑制 %d 个空白字符错误"
+msgstr[1] "已抑制 %d 个空白字符错误"
 
 #: apply.c
 #, c-format
@@ -1563,11 +1578,11 @@ msgstr "无法写入新索引文件"
 
 #: apply.c
 msgid "don't apply changes matching the given path"
-msgstr "不要应用与给出路径向匹配的变更"
+msgstr "不要应用与给定路径相匹配的变更"
 
 #: apply.c
 msgid "apply changes matching the given path"
-msgstr "应用与给出路径向匹配的变更"
+msgstr "应用与给定路径相匹配的变更"
 
 #: apply.c builtin/am.c
 msgid "num"
@@ -1579,7 +1594,7 @@ msgstr "从传统的 diff 路径中移除指定数量的前导斜线"
 
 #: apply.c
 msgid "ignore additions made by the patch"
-msgstr "忽略补丁中的添加的文件"
+msgstr "忽略补丁新增的内容"
 
 #: apply.c
 msgid "instead of applying the patch, output diffstat for the input"
@@ -1619,7 +1634,7 @@ msgstr "还应用此补丁（与 --stat/--summary/--check 选项同时使用）"
 
 #: apply.c
 msgid "attempt three-way merge, fall back on normal patch if that fails"
-msgstr "尝试三路合并，如果失败则回落至正常补丁模式"
+msgstr "尝试三路合并，如果失败则回落到普通补丁模式"
 
 #: apply.c builtin/merge-file.c
 msgid "for conflicts, use our version"
@@ -1635,7 +1650,7 @@ msgstr "如果冲突，使用联合版本"
 
 #: apply.c
 msgid "build a temporary index based on embedded index information"
-msgstr "创建一个临时索引基于嵌入的索引信息"
+msgstr "基于嵌入的索引信息创建临时索引"
 
 #: apply.c builtin/checkout-index.c
 msgid "paths are separated with NUL character"
@@ -1652,7 +1667,7 @@ msgstr "动作"
 
 #: apply.c
 msgid "detect new or modified lines that have whitespace errors"
-msgstr "检查新增和修改的行中间的空白字符滥用"
+msgstr "检测新增或修改的行是否存在空白错误"
 
 #: apply.c
 msgid "ignore changes in whitespace when finding context"
@@ -1668,19 +1683,19 @@ msgstr "无需至少一行上下文"
 
 #: apply.c
 msgid "leave the rejected hunks in corresponding *.rej files"
-msgstr "将拒绝的补丁片段保存在对应的 *.rej 文件中"
+msgstr "将被拒绝的块保存在对应的 *.rej 文件中"
 
 #: apply.c
 msgid "allow overlapping hunks"
-msgstr "允许重叠的补丁片段"
+msgstr "允许重叠的块"
 
 #: apply.c
 msgid "tolerate incorrectly detected missing new-line at the end of file"
-msgstr "允许不正确的文件末尾换行符"
+msgstr "容忍误判的文件末尾缺失换行符"
 
 #: apply.c
 msgid "do not trust the line counts in the hunk headers"
-msgstr "不信任补丁片段的头信息中的行号"
+msgstr "不信任块头信息中的行数"
 
 #: apply.c builtin/am.c
 msgid "root"
@@ -1701,7 +1716,7 @@ msgstr "--ours、--theirs 和 --union 需要 --3way"
 #: archive-tar.c archive-zip.c
 #, c-format
 msgid "cannot stream blob %s"
-msgstr "不能打开数据对象 %s"
+msgstr "无法流式传输数据对象 %s"
 
 #: archive-tar.c archive-zip.c
 #, c-format
@@ -1759,12 +1774,12 @@ msgstr "git archive --remote <仓库> [--exec <命令>] --list"
 #: archive.c builtin/fast-import.c builtin/gc.c builtin/notes.c builtin/tag.c
 #, c-format
 msgid "cannot read '%s'"
-msgstr "不能读取 '%s'"
+msgstr "无法读取 '%s'"
 
 #: archive.c
 #, c-format
 msgid "pathspec '%s' matches files outside the current directory"
-msgstr "路径规格 '%s' 匹配了当前目录外的文件'"
+msgstr "路径规格 '%s' 匹配了当前目录外的文件"
 
 #: archive.c builtin/add.c builtin/rm.c
 #, c-format
@@ -1881,7 +1896,7 @@ msgstr "仓库"
 
 #: archive.c builtin/archive.c
 msgid "retrieve the archive from remote repository <repo>"
-msgstr "从远程仓库（<仓库>）提取归档文件"
+msgstr "从远程仓库 <仓库> 提取归档文件"
 
 #: archive.c builtin/archive.c builtin/difftool.c builtin/notes.c
 msgid "command"
@@ -1929,7 +1944,7 @@ msgstr "%.*s 不是一个有效的属性名"
 
 #: attr.c
 msgid "unable to add additional attribute"
-msgstr "不能添加额外属性"
+msgstr "无法添加额外属性"
 
 #: attr.c
 #, c-format
@@ -1946,7 +1961,7 @@ msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
 msgstr ""
-"负值模版在 git attributes 中被忽略\n"
+"否定模式在 git attributes 中被忽略\n"
 "当字符串确实要以感叹号开始时，使用 '\\!'。"
 
 #: attr.c
@@ -1981,7 +1996,7 @@ msgstr "无法对 %s 执行 stat"
 #: builtin/pack-objects.c combine-diff.c object-file.c rerere.c
 #, c-format
 msgid "unable to read %s"
-msgstr "不能读 %s"
+msgstr "无法读取 %s"
 
 #: bisect.c
 #, c-format
@@ -2004,7 +2019,7 @@ msgid ""
 "The merge base %s is bad.\n"
 "This means the bug has been fixed between %s and [%s].\n"
 msgstr ""
-"合并基线 %s 是坏的。\n"
+"合并基线 %s 是有问题的。\n"
 "这意味着介于 %s 和 [%s] 之间的 bug 已经被修复。\n"
 
 #: bisect.c
@@ -2043,14 +2058,14 @@ msgid ""
 "So we cannot be sure the first %s commit is between %s and %s.\n"
 "We continue anyway."
 msgstr ""
-"介于 %s 和 [%s] 的合并基线一定被忽略了。\n"
+"介于 %s 和 [%s] 的合并基线必须被跳过。\n"
 "所以我们无法确认第一个 %s 提交是否介于 %s 和 %s 之间。\n"
-"我们仍旧继续。"
+"我们仍然继续。"
 
 #: bisect.c
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
-msgstr "二分查找中：合并基线必须是经过测试的\n"
+msgstr "二分查找中：合并基线必须经过测试\n"
 
 #: bisect.c
 #, c-format
@@ -2060,17 +2075,17 @@ msgstr "需要一个 %s 版本"
 #: bisect.c
 #, c-format
 msgid "could not create file '%s'"
-msgstr "不能创建文件 '%s'"
+msgstr "无法创建文件 '%s'"
 
 #: bisect.c builtin/notes.c
 #, c-format
 msgid "unable to start 'show' for object '%s'"
-msgstr "不能为对象 '%s' 开始 'show'"
+msgstr "无法对对象 '%s' 启动 'show'"
 
 #: bisect.c builtin/merge.c
 #, c-format
 msgid "could not read file '%s'"
-msgstr "不能读取文件 '%s'"
+msgstr "无法读取文件 '%s'"
 
 #: bisect.c
 msgid "reading bisect refs failed"
@@ -2134,7 +2149,7 @@ msgstr "在 %2$s 中无此路径 %1$s"
 #: blame.c
 #, c-format
 msgid "cannot read blob %s for path %s"
-msgstr "不能为路径 %2$s 读取数据对象 %1$s"
+msgstr "无法为路径 %2$s 读取数据对象 %1$s"
 
 #: branch.c
 msgid ""
@@ -2173,7 +2188,7 @@ msgid ""
 "the remote tracking information by invoking:"
 msgstr ""
 "\n"
-"在修复错误后，您可以通过执行以下命令来尝试修改远程跟踪分支："
+"在修复错误后，您可以通过执行以下命令来尝试修复远程跟踪信息："
 
 #: branch.c
 #, c-format
@@ -2188,7 +2203,7 @@ msgstr "要求从 '%s' 继承跟踪信息，但是没有设置合并配置"
 #: branch.c
 #, c-format
 msgid "not tracking: ambiguous information for ref '%s'"
-msgstr "不在跟踪中：引用 '%s' 有歧义的信息"
+msgstr "未跟踪：引用 '%s' 的信息含糊不清"
 
 #  译者：为保证在输出中对齐，注意调整句中空格！
 #. #-#-#-#-#  branch.c.po  #-#-#-#-#
@@ -2222,11 +2237,11 @@ msgid ""
 "different remotes' fetch refspecs map into different\n"
 "tracking namespaces."
 msgstr ""
-"有多个远程的获取引用规格映射到了追踪引用 '%s'：\n"
+"有多个远程的获取引用规格映射到了跟踪引用 '%s'：\n"
 "%s\n"
 "这一般是个配置错误。\n"
 "\n"
-"如果要支持设置追踪分支，请保证不同远程的获取引用规格映射至不同的追踪命名空"
+"如果要支持设置跟踪分支，请保证不同远程的获取引用规格映射至不同的跟踪命名空"
 "间。"
 
 #: branch.c
@@ -2302,13 +2317,13 @@ msgid ""
 "You may try updating the submodules using 'git checkout --no-recurse-"
 "submodules %s && git submodule update --init'"
 msgstr ""
-"你可以用 'git checkout --no-recurse-submodules %s && git submodule update --"
+"您可以用 'git checkout --no-recurse-submodules %s && git submodule update --"
 "init' 来尝试更新子模组"
 
 #: branch.c
 #, c-format
 msgid "submodule '%s': cannot create branch '%s'"
-msgstr "子模组 '%s'：不能创建分支 '%s'"
+msgstr "子模组 '%s'：无法创建分支 '%s'"
 
 #: branch.c
 #, c-format
@@ -2322,7 +2337,7 @@ msgstr "git add [<选项>] [--] <路径规格>..."
 #: builtin/add.c
 #, c-format
 msgid "cannot chmod %cx '%s'"
-msgstr "不能 chmod %cx '%s'"
+msgstr "无法 chmod %cx '%s'"
 
 #: builtin/add.c
 msgid "Unstaged changes after refreshing the index:"
@@ -2330,7 +2345,7 @@ msgstr "刷新索引之后尚未被暂存的变更："
 
 #: builtin/add.c
 msgid "could not read the index"
-msgstr "不能读取索引"
+msgstr "无法读取索引"
 
 #: builtin/add.c
 msgid "editing patch failed"
@@ -2339,16 +2354,16 @@ msgstr "编辑补丁失败"
 #: builtin/add.c read-cache.c
 #, c-format
 msgid "could not stat '%s'"
-msgstr "不能对 '%s' 调用 stat"
+msgstr "无法对 '%s' 调用 stat"
 
 #: builtin/add.c
 msgid "empty patch. aborted"
-msgstr "空补丁。异常终止"
+msgstr "空补丁。已中止"
 
 #: builtin/add.c
 #, c-format
 msgid "could not apply '%s'"
-msgstr "不能应用 '%s'"
+msgstr "无法应用 '%s'"
 
 #: builtin/add.c
 msgid "The following paths are ignored by one of your .gitignore files:\n"
@@ -2358,13 +2373,13 @@ msgstr "下列路径根据您的一个 .gitignore 文件而被忽略：\n"
 #: builtin/prune-packed.c builtin/pull.c builtin/push.c builtin/remote.c
 #: builtin/rm.c builtin/send-pack.c builtin/sparse-checkout.c
 msgid "dry run"
-msgstr "演习"
+msgstr "试运行"
 
 #: builtin/add.c builtin/check-ignore.c builtin/commit.c
 #: builtin/count-objects.c builtin/fsck.c builtin/log.c builtin/mv.c
 #: builtin/read-tree.c builtin/refs.c
 msgid "be verbose"
-msgstr "冗长输出"
+msgstr "输出更详细"
 
 #: builtin/add.c
 msgid "interactive picking"
@@ -2392,11 +2407,11 @@ msgstr "对已跟踪文件（暗含 -u）重新归一换行符"
 
 #: builtin/add.c
 msgid "record only the fact that the path will be added later"
-msgstr "只记录，该路径稍后再添加"
+msgstr "只记录该路径稍后将被添加"
 
 #: builtin/add.c
 msgid "add changes from all tracked and untracked files"
-msgstr "添加所有改变的已跟踪文件和未跟踪文件"
+msgstr "添加所有已跟踪和未跟踪文件的变更"
 
 #: builtin/add.c
 msgid "ignore paths removed in the working tree (same as --no-all)"
@@ -2408,11 +2423,11 @@ msgstr "不添加，只刷新索引"
 
 #: builtin/add.c
 msgid "just skip files which cannot be added because of errors"
-msgstr "跳过因出错不能添加的文件"
+msgstr "跳过因出错无法添加的文件"
 
 #: builtin/add.c
 msgid "check if - even missing - files are ignored in dry run"
-msgstr "检查在演习模式下文件（即使不存在）是否被忽略"
+msgstr "检查试运行时文件（即使不存在）是否被忽略"
 
 #: builtin/add.c builtin/mv.c builtin/rm.c
 msgid "allow updating entries outside of the sparse-checkout cone"
@@ -2424,7 +2439,7 @@ msgstr "覆盖列表里文件的可执行位"
 
 #: builtin/add.c
 msgid "warn when adding an embedded repository"
-msgstr "创建一个嵌入式仓库时给予警告"
+msgstr "添加嵌入式仓库时给予警告"
 
 #: builtin/add.c
 #, c-format
@@ -2443,7 +2458,7 @@ msgid ""
 "\n"
 "See \"git help submodule\" for more information."
 msgstr ""
-"您在当前仓库中添加了另一个Git仓库。克隆外层的仓库将不包含嵌入仓库的\n"
+"您在当前仓库中添加了另一个 Git 仓库。外层仓库的克隆将不包含嵌入式仓库的\n"
 "内容，并且不知道该如何获取它。如果您要添加一个子模组，使用：\n"
 "\n"
 "\tgit submodule add <url> %s\n"
@@ -2508,7 +2523,7 @@ msgstr "无法写新的索引文件"
 #: builtin/am.c builtin/mailinfo.c mailinfo.c
 #, c-format
 msgid "bad action '%s' for '%s'"
-msgstr "'%2$s' 的错误动作 '%1$s'"
+msgstr "用于 '%2$s' 的动作 '%1$s' 无效"
 
 #: builtin/am.c builtin/blame.c builtin/fetch.c builtin/pack-objects.c
 #: builtin/pull.c builtin/revert.c diff-merges.c diff.c environment.c
@@ -2520,16 +2535,16 @@ msgstr "'%s' 的值无效：'%s'"
 #: builtin/am.c builtin/commit.c builtin/merge.c sequencer.c
 #, c-format
 msgid "could not read '%s'"
-msgstr "不能读取 '%s'"
+msgstr "无法读取 '%s'"
 
 #: builtin/am.c
 msgid "could not parse author script"
-msgstr "不能解析作者脚本"
+msgstr "无法解析作者脚本"
 
 #: builtin/am.c builtin/replace.c commit.c sequencer.c
 #, c-format
 msgid "could not parse %s"
-msgstr "不能解析 %s"
+msgstr "无法解析 %s"
 
 #: builtin/am.c
 #, c-format
@@ -2632,15 +2647,15 @@ msgstr "无效的身份标识：%.*s"
 #: builtin/am.c builtin/checkout.c builtin/clone.c commit-graph.c
 #, c-format
 msgid "unable to parse commit %s"
-msgstr "不能解析提交 %s"
+msgstr "无法解析提交 %s"
 
 #: builtin/am.c
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
-msgstr "仓库缺乏必要的数据对象以进行三方合并。"
+msgstr "仓库缺乏必要的数据对象，无法回落到三路合并。"
 
 #: builtin/am.c
 msgid "Using index info to reconstruct a base tree..."
-msgstr "使用索引来重建一个（三方合并的）基础目录树..."
+msgstr "使用索引来重建一个（三路合并的）基础目录树..."
 
 #: builtin/am.c
 msgid ""
@@ -2652,7 +2667,7 @@ msgstr ""
 
 #: builtin/am.c
 msgid "Falling back to patching base and 3-way merge..."
-msgstr "回落到基础版本上打补丁及进行三方合并..."
+msgstr "回落到在基础版本上打补丁并进行三路合并..."
 
 #: builtin/am.c
 msgid "Failed to merge in the changes."
@@ -2695,7 +2710,7 @@ msgstr "无法写入索引文件"
 #: builtin/am.c
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
-msgstr "脏索引：不能应用补丁（脏文件：%s）"
+msgstr "脏索引：无法应用补丁（脏文件：%s）"
 
 #: builtin/am.c
 #, c-format
@@ -2740,7 +2755,7 @@ msgid ""
 "already introduced the same changes; you might want to skip this patch."
 msgstr ""
 "没有变更 —— 您是不是忘了执行 'git add'？\n"
-"如果没有什么要添加到暂存区的，则很可能是其它提交已经引入了相同的变更。\n"
+"如果没有什么要添加到暂存区的，则很可能是其他提交已经引入了相同的变更。\n"
 "您也许想要跳过这个补丁。"
 
 #: builtin/am.c
@@ -2751,13 +2766,13 @@ msgid ""
 "You might run `git rm` on a file to accept \"deleted by them\" for it."
 msgstr ""
 "在您的索引中仍存在未合并的路径。\n"
-"您应该对已经冲突解决的每一个文件执行 'git add' 来标记已经完成。 \n"
+"您应该对已经冲突解决的每一个文件执行 'git add' 来标记已经完成。\n"
 "您可以对 \"由他们删除\" 的文件执行 `git rm` 命令。"
 
 #: builtin/am.c builtin/reset.c
 #, c-format
 msgid "Could not parse object '%s'."
-msgstr "不能解析对象 '%s'。"
+msgstr "无法解析对象 '%s'。"
 
 #: builtin/am.c
 msgid "failed to clean index"
@@ -2796,7 +2811,7 @@ msgstr "老的参数 —— 无作用"
 
 #: builtin/am.c
 msgid "allow fall back on 3way merging if needed"
-msgstr "如果必要，允许使用三方合并。"
+msgstr "如有需要，允许回落到三路合并"
 
 #: builtin/am.c builtin/init-db.c builtin/prune-packed.c builtin/repack.c
 #: builtin/stash.c
@@ -2859,7 +2874,7 @@ msgstr "补丁的格式"
 
 #: builtin/am.c
 msgid "override error message when patch failure occurs"
-msgstr "打补丁失败时显示的错误信息"
+msgstr "覆盖打补丁失败时的错误信息"
 
 #: builtin/am.c
 msgid "continue applying patches after resolving a conflict"
@@ -2895,7 +2910,7 @@ msgstr "把空补丁记录为空提交"
 
 #: builtin/am.c
 msgid "lie about committer date"
-msgstr "将作者日期作为提交日期"
+msgstr "伪造提交者日期"
 
 #: builtin/am.c
 msgid "use current timestamp for author date"
@@ -2904,7 +2919,7 @@ msgstr "用当前时间作为作者日期"
 #: builtin/am.c builtin/commit-tree.c builtin/commit.c builtin/merge.c
 #: builtin/pull.c builtin/rebase.c builtin/revert.c builtin/tag.c
 msgid "key-id"
-msgstr "key-id"
+msgstr "密钥 ID"
 
 #: builtin/am.c builtin/rebase.c
 msgid "GPG-sign commits"
@@ -2941,7 +2956,7 @@ msgid ""
 "Stray %s directory found.\n"
 "Use \"git am --abort\" to remove it."
 msgstr ""
-"发现了错误的 %s 目录。\n"
+"发现了残留的 %s 目录。\n"
 "使用 \"git am --abort\" 删除它。"
 
 #: builtin/am.c
@@ -2958,7 +2973,7 @@ msgstr "git apply [<选项>] [<补丁>...]"
 
 #: builtin/archive.c diagnose.c
 msgid "could not redirect output"
-msgstr "不能重定向输出"
+msgstr "无法重定向输出"
 
 #: builtin/archive.c
 msgid "git archive: expected ACK/NAK, got a flush packet"
@@ -3030,17 +3045,17 @@ msgstr "git bisect run <命令> [<参数>...]"
 #: builtin/bisect.c
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
-msgstr "不能以 '%2$s' 模式打开文件 '%1$s'"
+msgstr "无法以 '%2$s' 模式打开文件 '%1$s'"
 
 #: builtin/bisect.c
 #, c-format
 msgid "could not write to file '%s'"
-msgstr "不能写入文件 '%s'"
+msgstr "无法写入文件 '%s'"
 
 #: builtin/bisect.c
 #, c-format
 msgid "cannot open file '%s' for reading"
-msgstr "不能打开文件 '%s' 来读取"
+msgstr "无法打开文件 '%s' 来读取"
 
 #: builtin/bisect.c
 #, c-format
@@ -3050,12 +3065,12 @@ msgstr "'%s' 不是一个有效的术语"
 #: builtin/bisect.c
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
-msgstr "不能使用内置命令 '%s' 作为术语"
+msgstr "无法使用内置命令 '%s' 作为术语"
 
 #: builtin/bisect.c
 #, c-format
 msgid "can't change the meaning of the term '%s'"
-msgstr "不能修改术语 '%s' 的含义"
+msgstr "无法修改术语 '%s' 的含义"
 
 #: builtin/bisect.c
 msgid "please use two different terms"
@@ -3075,12 +3090,12 @@ msgstr "'%s' 不是一个有效的提交"
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
-msgstr "不能检出原始 HEAD '%s'。尝试 'git bisect reset <提交>'。"
+msgstr "无法检出原始 HEAD '%s'。尝试 'git bisect reset <提交>'。"
 
 #: builtin/bisect.c
 #, c-format
 msgid "Bad bisect_write argument: %s"
-msgstr "坏的 bisect_write 参数：%s"
+msgstr "错误的 bisect_write 参数：%s"
 
 #: builtin/bisect.c
 #, c-format
@@ -3128,7 +3143,7 @@ msgstr "在只有一个 %s 提交的情况下二分查找"
 #.
 #: builtin/bisect.c
 msgid "Are you sure [Y/n]? "
-msgstr "您确认么[Y/n]？ "
+msgstr "您确认吗 [Y/n]？ "
 
 #: builtin/bisect.c
 msgid "status: waiting for both good and bad commits\n"
@@ -3186,7 +3201,7 @@ msgstr "'%s' 看起来不是一个有效的版本"
 
 #: builtin/bisect.c
 msgid "bad HEAD - I need a HEAD"
-msgstr "坏的 HEAD - 我需要一个 HEAD"
+msgstr "无效的 HEAD - 需要一个 HEAD"
 
 #: builtin/bisect.c
 #, c-format
@@ -3195,7 +3210,7 @@ msgstr "检出 '%s' 失败。尝试 'git bisect start <有效分支>'。"
 
 #: builtin/bisect.c
 msgid "bad HEAD - strange symbolic ref"
-msgstr "坏的 HEAD - 奇怪的符号引用"
+msgstr "无效的 HEAD - 奇怪的符号引用"
 
 #: builtin/bisect.c
 #, c-format
@@ -3212,7 +3227,7 @@ msgstr "您需要执行 \"git bisect start\" 来开始\n"
 #.
 #: builtin/bisect.c
 msgid "Do you want me to do it for you [Y/n]? "
-msgstr "您想让我为您这样做么[Y/n]？ "
+msgstr "您想让我为您这样做吗[Y/n]？ "
 
 #: builtin/bisect.c
 msgid "Please call `--bisect-state` with at least one argument"
@@ -3226,12 +3241,12 @@ msgstr "'git bisect %s' 只能带一个参数。"
 #: builtin/bisect.c
 #, c-format
 msgid "Bad rev input: %s"
-msgstr "坏的版本输入：%s"
+msgstr "错误的版本输入：%s"
 
 #: builtin/bisect.c
 #, c-format
 msgid "Bad rev input (not a commit): %s"
-msgstr "坏的版本输入（不是提交）：%s"
+msgstr "错误的版本输入（不是提交）：%s"
 
 #: builtin/bisect.c
 msgid "We are not bisecting."
@@ -3240,12 +3255,12 @@ msgstr "我们没有在二分查找。"
 #: builtin/bisect.c
 #, c-format
 msgid "'%s'?? what are you talking about?"
-msgstr "'%s'?? 您在说什么?"
+msgstr "'%s'？？您在说什么？"
 
 #: builtin/bisect.c
 #, c-format
 msgid "cannot read file '%s' for replaying"
-msgstr "不能读取文件 '%s' 来重放"
+msgstr "无法读取文件 '%s' 来重放"
 
 #: builtin/bisect.c
 #, c-format
@@ -3278,7 +3293,7 @@ msgstr "无法打开文件 '%s' 进行写入"
 
 #: builtin/bisect.c
 msgid "bisect run cannot continue any more"
-msgstr "二分查找不能继续运行"
+msgstr "二分查找无法继续运行"
 
 #: builtin/bisect.c
 msgid "bisect run success"
@@ -3341,7 +3356,7 @@ msgstr "<版本选项> 的文档记录在 git-rev-list(1) 中"
 #: builtin/blame.c
 #, c-format
 msgid "expecting a color: %s"
-msgstr "期望一个颜色：%s"
+msgstr "期望是颜色：%s"
 
 #: builtin/blame.c
 msgid "must end with a color"
@@ -3363,7 +3378,7 @@ msgstr ""
 #: builtin/blame.c
 #, c-format
 msgid "cannot find revision %s to ignore"
-msgstr "不能找到要忽略的版本 %s"
+msgstr "无法找到要忽略的版本 %s"
 
 #: builtin/blame.c
 msgid "show blame entries as we find them, incrementally"
@@ -3405,7 +3420,7 @@ msgstr "显示为一个适合机器读取的格式"
 
 #: builtin/blame.c
 msgid "show porcelain format with per-line commit information"
-msgstr "为每一行显示机器适用的提交信息"
+msgstr "以 porcelain 格式显示每行的提交信息"
 
 #: builtin/blame.c
 msgid "use the same output mode as git-annotate (Default: off)"
@@ -3453,7 +3468,7 @@ msgstr "忽略来自 <文件> 中的版本"
 
 #: builtin/blame.c
 msgid "color redundant metadata from previous line differently"
-msgstr "使用颜色间隔输出与前一行不同的重复元信息"
+msgstr "用不同颜色标示与前一行重复的元信息"
 
 #: builtin/blame.c
 msgid "color lines by age"
@@ -3469,7 +3484,7 @@ msgstr "使用来自 <文件> 的修订集而不是调用 git-rev-list"
 
 #: builtin/blame.c
 msgid "use <file>'s contents as the final image"
-msgstr "使用 <文件> 的内容作为最终的镜像"
+msgstr "使用 <文件> 的内容作为最终结果"
 
 #: builtin/blame.c
 msgid "score"
@@ -3493,7 +3508,7 @@ msgstr "只处理在 <开始>,<结束> 范围内的行，或者函数：<函数�
 
 #: builtin/blame.c
 msgid "--progress can't be used with --incremental or porcelain formats"
-msgstr "--progress 不能和 --incremental 或机器内部格式一起使用"
+msgstr "--progress 不能和 --incremental 或 porcelain 格式一起使用"
 
 #. TRANSLATORS: This string is used to tell us the
 #. maximum display width for a relative timestamp in
@@ -3542,7 +3557,7 @@ msgstr "git branch [<选项>] (-m | -M) [<旧分支>] <新分支>"
 
 #: builtin/branch.c
 msgid "git branch [<options>] (-c | -C) [<old-branch>] <new-branch>"
-msgstr "git branch [<选项>] (-c | -C) [<老分支>] <新分支>"
+msgstr "git branch [<选项>] (-c | -C) [<旧分支>] <新分支>"
 
 #: builtin/branch.c
 msgid "git branch [<options>] [-r | -a] [--points-at]"
@@ -3598,7 +3613,7 @@ msgstr "不能将 -a 和 -d 同时使用"
 #: builtin/branch.c
 #, c-format
 msgid "cannot delete branch '%s' used by worktree at '%s'"
-msgstr "无法强制更新被工作区 '%2$s' 所使用的分支 '%1$s'"
+msgstr "无法删除被工作区 '%2$s' 使用的分支 '%1$s'"
 
 #: builtin/branch.c
 #, c-format
@@ -3617,7 +3632,7 @@ msgstr ""
 #: builtin/branch.c
 #, c-format
 msgid "branch '%s' not found"
-msgstr "分支 '%s' 未发现"
+msgstr "分支 '%s' 未找到"
 
 #: builtin/branch.c
 #, c-format
@@ -3631,11 +3646,11 @@ msgstr "已删除分支 %s（曾为 %s）。\n"
 
 #: builtin/branch.c builtin/tag.c
 msgid "unable to parse format string"
-msgstr "不能解析格式化字符串"
+msgstr "无法解析格式化字符串"
 
 #: builtin/branch.c
 msgid "could not resolve HEAD"
-msgstr "不能解析 HEAD 提交"
+msgstr "无法解析 HEAD"
 
 #: builtin/branch.c
 #, c-format
@@ -3650,12 +3665,12 @@ msgstr "分支 %s 正被变基到 %s"
 #: builtin/branch.c
 #, c-format
 msgid "branch %s is being bisected at %s"
-msgstr "分支 %s 正被二分查找于 %s"
+msgstr "分支 %s 正在 %s 处进行二分查找"
 
 #: builtin/branch.c
 #, c-format
 msgid "HEAD of working tree %s is not updated"
-msgstr "工作区 %s 的 HEAD 指向没有被更新"
+msgstr "工作区 %s 的 HEAD 未更新"
 
 #: builtin/branch.c
 #, c-format
@@ -3712,7 +3727,7 @@ msgid ""
 msgstr ""
 "请编辑分支的描述\n"
 "  %s\n"
-"以 '%s' 开头的行将被过滤。\n"
+"以 '%s' 开头的行将被移除。\n"
 
 #: builtin/branch.c
 msgid "Generic options"
@@ -3764,7 +3779,7 @@ msgstr "只打印不包含该提交的分支"
 
 #: builtin/branch.c
 msgid "Specific git-branch actions:"
-msgstr "具体的 git-branch 动作："
+msgstr "具体的 git-branch 操作："
 
 #: builtin/branch.c
 msgid "list both remote-tracking and local branches"
@@ -3812,7 +3827,7 @@ msgstr "创建分支的引用日志"
 
 #: builtin/branch.c
 msgid "edit the description for the branch"
-msgstr "标记分支的描述"
+msgstr "编辑分支的描述"
 
 #: builtin/branch.c
 msgid "force creation, move/rename, deletion"
@@ -3840,7 +3855,7 @@ msgstr "只打印指向该对象的分支"
 
 #: builtin/branch.c builtin/for-each-ref.c builtin/tag.c
 msgid "sorting and filtering are case insensitive"
-msgstr "排序和过滤属于大小写不敏感"
+msgstr "排序和过滤不区分大小写"
 
 #: builtin/branch.c builtin/ls-files.c
 msgid "recurse through submodules"
@@ -3857,7 +3872,7 @@ msgstr "无法将 HEAD 解析为有效引用"
 
 #: builtin/branch.c builtin/clone.c
 msgid "HEAD not found below refs/heads!"
-msgstr "HEAD 没有位于 /refs/heads 之下！"
+msgstr "HEAD 没有位于 refs/heads 之下！"
 
 #: builtin/branch.c
 msgid ""
@@ -3876,11 +3891,11 @@ msgstr "必须提供分支名"
 
 #: builtin/branch.c
 msgid "cannot give description to detached HEAD"
-msgstr "不能向分离头指针提供描述"
+msgstr "无法向分离头指针提供描述"
 
 #: builtin/branch.c
 msgid "cannot edit description of more than one branch"
-msgstr "不能为一个以上的分支编辑描述"
+msgstr "无法为一个以上的分支编辑描述"
 
 #: builtin/branch.c
 msgid "cannot copy the current branch while not on any"
@@ -3924,7 +3939,7 @@ msgstr "为取消上游设置操作提供了太多的参数"
 
 #: builtin/branch.c
 msgid "could not unset upstream of HEAD when it does not point to any branch"
-msgstr "无法取消 HEAD 的上游设置因为它没有指向一个分支"
+msgstr "无法取消 HEAD 的上游设置，因为它没有指向任何分支"
 
 #: builtin/branch.c
 #, c-format
@@ -3967,9 +3982,9 @@ msgid ""
 "              [(-s | --suffix) <format> | --no-suffix]\n"
 "              [--diagnose[=<mode>]]"
 msgstr ""
-"git bugreport [-o | --output-directory <文件>]\n"
+"git bugreport [-o | --output-directory <路径>]\n"
 "              [(-s | --suffix) <格式> | --no-suffix]\n"
-"              [--diagnose[=<模式>]"
+"              [--diagnose[=<模式>]]"
 
 #: builtin/bugreport.c
 msgid ""
@@ -4000,7 +4015,7 @@ msgstr ""
 "\n"
 "您所期望的与实际发生的有什么不同？\n"
 "\n"
-"您想要补充的其它内容：\n"
+"您想要补充的其他内容：\n"
 "\n"
 "请检查下面错误报告中余下的内容。\n"
 "您可以删除任何您不想共享的内容。\n"
@@ -4031,12 +4046,12 @@ msgstr "未知参数 `%s'"
 #: builtin/bugreport.c builtin/diagnose.c
 #, c-format
 msgid "could not create leading directories for '%s'"
-msgstr "不能为 '%s' 创建先导目录"
+msgstr "无法为 '%s' 创建上级目录"
 
 #: builtin/bugreport.c builtin/diagnose.c
 #, c-format
 msgid "unable to create diagnostics archive %s"
-msgstr "不能创建诊断归档包 %s"
+msgstr "无法创建诊断归档包 %s"
 
 #: builtin/bugreport.c
 msgid "System Info"
@@ -4082,11 +4097,11 @@ msgstr "需要一个 <文件> 参数"
 
 #: builtin/bundle.c builtin/pack-objects.c
 msgid "do not show progress meter"
-msgstr "不显示进度表"
+msgstr "不显示进度条"
 
 #: builtin/bundle.c builtin/pack-objects.c
 msgid "show progress meter"
-msgstr "显示进度表"
+msgstr "显示进度条"
 
 #: builtin/bundle.c
 msgid "historical; same as --progress"
@@ -4098,28 +4113,28 @@ msgstr "老的参数；无作用"
 
 #: builtin/bundle.c
 msgid "specify bundle format version"
-msgstr "指定归档包的格式版本"
+msgstr "指定捆绑包的格式版本"
 
 #: builtin/bundle.c
 msgid "Need a repository to create a bundle."
-msgstr "需要一个仓库来创建归档包。"
+msgstr "需要一个仓库来创建捆绑包。"
 
 #: builtin/bundle.c
 msgid "do not show bundle details"
-msgstr "不显示归档包的细节"
+msgstr "不显示捆绑包的细节"
 
 #: builtin/bundle.c bundle.c
 msgid "need a repository to verify a bundle"
-msgstr "需要一个仓库来校验一个归档包"
+msgstr "需要一个仓库来校验一个捆绑包"
 
 #: builtin/bundle.c
 #, c-format
 msgid "%s is okay\n"
-msgstr "%s 可以\n"
+msgstr "%s 没问题\n"
 
 #: builtin/bundle.c
 msgid "Need a repository to unbundle."
-msgstr "需要一个仓库来解开归档包。"
+msgstr "需要一个仓库来解开捆绑包。"
 
 #: builtin/bundle.c
 msgid "Unbundling objects"
@@ -4128,7 +4143,7 @@ msgstr "解包对象中"
 #: builtin/cat-file.c
 #, c-format
 msgid "cannot read object %s '%s'"
-msgstr "不能读取对象 %s '%s'"
+msgstr "无法读取对象 %s '%s'"
 
 #: builtin/cat-file.c
 msgid "flush is only for --buffer mode"
@@ -4199,7 +4214,7 @@ msgstr "美观地打印 <对象> 的内容"
 
 #: builtin/cat-file.c
 msgid "Emit [broken] object attributes"
-msgstr "输出 [坏的] 对象属性"
+msgstr "输出 [损坏的] 对象属性"
 
 #: builtin/cat-file.c
 msgid "show object type (one of 'blob', 'tree', 'commit', 'tag', ...)"
@@ -4227,11 +4242,11 @@ msgstr "类似于 --batch，但不输出 <内容>"
 
 #: builtin/cat-file.c
 msgid "stdin is NUL-terminated"
-msgstr "标准输入以 NUL 字符分隔"
+msgstr "标准输入以 NUL 字符终止"
 
 #: builtin/cat-file.c
 msgid "stdin and stdout is NUL-terminated"
-msgstr "标准输入和标准输出以 NUL 字符分隔"
+msgstr "标准输入和标准输出以 NUL 字符终止"
 
 #: builtin/cat-file.c
 msgid "read commands from stdin"
@@ -4277,7 +4292,7 @@ msgstr "数据对象|树"
 
 #: builtin/cat-file.c
 msgid "use a <path> for (--textconv | --filters); Not with 'batch'"
-msgstr "(--textconv | --filters) 使用 <路径>；而不是 'batch'"
+msgstr "为 (--textconv | --filters) 使用 <路径>；不能与 'batch' 同用"
 
 #: builtin/cat-file.c
 msgid "objects filter only supported in batch mode"
@@ -4442,7 +4457,7 @@ msgstr "git checkout-index [<选项>] [--] [<文件>...]"
 
 #: builtin/checkout-index.c
 msgid "stage should be between 1 and 3 or all"
-msgstr "索引值应该取值 1 到 3 或者 all"
+msgstr "暂存区编号应为 1 到 3 或 all"
 
 #: builtin/checkout-index.c
 msgid "check out all files in the index"
@@ -4458,7 +4473,7 @@ msgstr "强制覆盖现有的文件"
 
 #: builtin/checkout-index.c
 msgid "no warning for existing files and files not in index"
-msgstr "存在或不在索引中的文件都没有警告"
+msgstr "对已存在文件和不在索引中的文件不发出警告"
 
 #: builtin/checkout-index.c
 msgid "don't checkout new files"
@@ -4519,7 +4534,7 @@ msgstr "路径 '%s' 没有必需的版本"
 #: builtin/checkout.c
 #, c-format
 msgid "path '%s': cannot merge"
-msgstr "path '%s'：无法合并"
+msgstr "路径 '%s'：无法合并"
 
 #: builtin/checkout.c
 #, c-format
@@ -4555,7 +4570,7 @@ msgstr "'%s' 不能在更新路径时使用"
 #: builtin/checkout.c
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
-msgstr "不能同时更新路径并切换到分支'%s'。"
+msgstr "不能同时更新路径并切换到分支 '%s'。"
 
 #: builtin/checkout.c
 #, c-format
@@ -4598,13 +4613,13 @@ msgid ""
 "cannot continue with staged changes in the following files:\n"
 "%s"
 msgstr ""
-"不能继续，下列文件有暂存的修改：\n"
+"无法继续，下列文件有暂存的修改：\n"
 "%s"
 
 #: builtin/checkout.c
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
-msgstr "不能对 '%s' 执行 reflog 操作：%s\n"
+msgstr "无法对 '%s' 执行 reflog 操作：%s\n"
 
 #: builtin/checkout.c
 msgid "HEAD is now at"
@@ -4612,7 +4627,7 @@ msgstr "HEAD 目前位于"
 
 #: builtin/checkout.c builtin/clone.c
 msgid "unable to update HEAD"
-msgstr "不能更新 HEAD"
+msgstr "无法更新 HEAD"
 
 #: builtin/checkout.c
 #, c-format
@@ -4643,7 +4658,7 @@ msgstr "切换到分支 '%s'\n"
 #: builtin/checkout.c
 #, c-format
 msgid " ... and %d more.\n"
-msgstr " ... 及其它 %d 个。\n"
+msgstr " ... 及其他 %d 个。\n"
 
 #: builtin/checkout.c
 #, c-format
@@ -4730,8 +4745,8 @@ msgstr ""
 "\n"
 "    git checkout --track origin/<名称>\n"
 "\n"
-"如果您总是喜欢使用模糊的简短分支名 <名称>，而不喜欢如 'origin' 的远程\n"
-"名称，可以在配置中设置 checkout.defaultRemote=origin。"
+"如果您希望在检出模糊的简短分支名 <名称> 时总是偏好某个远程（如 'origin'），\n"
+"可以在配置中设置 checkout.defaultRemote=origin。"
 
 #: builtin/checkout.c
 #, c-format
@@ -4780,7 +4795,7 @@ msgstr "期望一个分支，得到提交 '%s'"
 #: builtin/checkout.c
 msgid ""
 "If you want to detach HEAD at the commit, try again with the --detach option."
-msgstr "如果你在本提交分离头指针，使用 --detach 选项重试。"
+msgstr "如果您想在该提交处分离 HEAD，请使用 --detach 选项重试。"
 
 #: builtin/checkout.c
 msgid ""
@@ -4853,7 +4868,7 @@ msgstr "'%s' 不带 <起始点>"
 #: builtin/checkout.c
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
-msgstr "不能切换分支到一个非提交 '%s'"
+msgstr "无法切换分支到一个非提交 '%s'"
 
 #: builtin/checkout.c
 msgid "missing branch or commit argument"
@@ -4866,7 +4881,7 @@ msgstr "未知的冲突风格 '%s'"
 
 #: builtin/checkout.c
 msgid "perform a 3-way merge with the new branch"
-msgstr "和新的分支执行三方合并"
+msgstr "和新的分支执行三路合并"
 
 #: builtin/checkout.c builtin/log.c builtin/range-diff.c parse-options.h
 msgid "style"
@@ -4890,7 +4905,7 @@ msgstr "新分支"
 
 #: builtin/checkout.c
 msgid "new unborn branch"
-msgstr "新的未诞生的分支"
+msgstr "新的尚未诞生分支"
 
 #: builtin/checkout.c builtin/merge.c
 msgid "update ignored files (default)"
@@ -4910,12 +4925,12 @@ msgstr "对尚未合并的文件检出他们的版本"
 
 #: builtin/checkout.c
 msgid "do not limit pathspecs to sparse entries only"
-msgstr "对路径不做稀疏检出的限制"
+msgstr "对路径规格不只限于稀疏条目"
 
 #: builtin/checkout.c
 #, c-format
 msgid "options '-%c', '-%c', and '%s' cannot be used together"
-msgstr "选项 '-%c'、'-%c' 和 ‘%s' 不能同时使用"
+msgstr "选项 '-%c'、'-%c' 和 '%s' 不能同时使用"
 
 #: builtin/checkout.c
 msgid "--track needs a branch name"
@@ -4938,12 +4953,12 @@ msgstr "无效的路径规格"
 #: builtin/checkout.c
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
-msgstr "'%s' 不是一个提交，不能基于它创建分支 '%s'"
+msgstr "'%s' 不是一个提交，无法基于它创建分支 '%s'"
 
 #: builtin/checkout.c
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
-msgstr "git checkout：--detach 不能接收路径参数 '%s'"
+msgstr "git checkout：--detach 不接收路径参数 '%s'"
 
 #: builtin/checkout.c
 msgid ""
@@ -4999,7 +5014,7 @@ msgstr "丢弃本地修改"
 
 #: builtin/checkout.c
 msgid "which tree-ish to checkout from"
-msgstr "要检出哪一个树"
+msgstr "要从哪个树对象检出"
 
 #: builtin/checkout.c
 msgid "restore the index"
@@ -5022,7 +5037,7 @@ msgid ""
 "git clean [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] "
 "[<pathspec>...]"
 msgstr ""
-"git clean [-d] [-f] [-i] [-n] [-q] [-e <模式>] [-x | -X] [--] <路径规格>..."
+"git clean [-d] [-f] [-i] [-n] [-q] [-e <模式>] [-x | -X] [--] [<路径规格>...]"
 
 #: builtin/clean.c builtin/sparse-checkout.c
 #, c-format
@@ -5037,22 +5052,22 @@ msgstr "将删除 %s\n"
 #: builtin/clean.c
 #, c-format
 msgid "Skipping repository %s\n"
-msgstr "忽略仓库 %s\n"
+msgstr "跳过仓库 %s\n"
 
 #: builtin/clean.c
 #, c-format
 msgid "Would skip repository %s\n"
-msgstr "将忽略仓库 %s\n"
+msgstr "将跳过仓库 %s\n"
 
 #: builtin/clean.c midx.c
 #, c-format
 msgid "failed to remove %s"
-msgstr "无法删除 '%s'"
+msgstr "无法删除 %s"
 
 #: builtin/clean.c
 #, c-format
 msgid "could not lstat %s\n"
-msgstr "不能对 %s 调用 lstat\n"
+msgstr "无法对 %s 调用 lstat\n"
 
 #: builtin/clean.c
 msgid "Refusing to remove current working directory\n"
@@ -5104,7 +5119,7 @@ msgstr "嗯（%s）？\n"
 #: builtin/clean.c
 #, c-format
 msgid "Input ignore patterns>> "
-msgstr "输入模版以排除条目>> "
+msgstr "输入忽略模式>> "
 
 #: builtin/clean.c
 #, c-format
@@ -5132,7 +5147,7 @@ msgid ""
 "?                   - help for prompt selection"
 msgstr ""
 "clean               - 开始清理\n"
-"filter by pattern   - 通过模版排除要删除的条目\n"
+"filter by pattern   - 通过模式排除要删除的条目\n"
 "select by numbers   - 通过数字选择要删除的条目\n"
 "ask each            - 针对删除逐一询问（就像 \"rm -i\"）\n"
 "quit                - 停止删除并退出\n"
@@ -5190,7 +5205,7 @@ msgstr "clean.requireForce 设置为 true 且未提供 -f 选项：拒绝执行�
 #: builtin/clone.c
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
-msgstr "info：不能为 '%s' 添加一个备用：%s\n"
+msgstr "info：无法为 '%s' 添加一个备用：%s\n"
 
 #: builtin/clone.c builtin/diff.c builtin/rm.c grep.c setup.c
 #, c-format
@@ -5269,7 +5284,7 @@ msgstr "远程没有发送所有必需的对象"
 #: builtin/clone.c
 #, c-format
 msgid "unable to update %s"
-msgstr "不能更新 %s"
+msgstr "无法更新 %s"
 
 #: builtin/clone.c
 msgid "failed to initialize sparse-checkout"
@@ -5281,7 +5296,7 @@ msgstr "远程 HEAD 指向一个不存在的引用，无法检出"
 
 #: builtin/clone.c
 msgid "unable to checkout working tree"
-msgstr "不能检出工作区"
+msgstr "无法检出工作区"
 
 #: builtin/clone.c
 msgid "unable to write parameters to config file"
@@ -5341,7 +5356,7 @@ msgstr "模板目录"
 
 #: builtin/clone.c builtin/init-db.c
 msgid "directory from which templates will be used"
-msgstr "模板目录将被使用"
+msgstr "将从该目录使用模板"
 
 #: builtin/clone.c builtin/submodule--helper.c
 msgid "reference repository"
@@ -5391,7 +5406,7 @@ msgstr "引用"
 
 #: builtin/clone.c builtin/fetch.c builtin/pull.c
 msgid "deepen history of shallow clone, excluding ref"
-msgstr "深化浅克隆的历史，除了给定的引用"
+msgstr "深化浅克隆的历史，不包含指定引用"
 
 #: builtin/clone.c builtin/submodule--helper.c
 msgid "clone only one branch, HEAD or --branch"
@@ -5403,15 +5418,15 @@ msgstr "克隆标签，并在后续获取时不跟随它们"
 
 #: builtin/clone.c
 msgid "any cloned submodules will be shallow"
-msgstr "子模组将以浅下载模式克隆"
+msgstr "所有被克隆的子模组都将是浅克隆"
 
 #: builtin/clone.c builtin/init-db.c
 msgid "gitdir"
-msgstr "git目录"
+msgstr "git 目录"
 
 #: builtin/clone.c builtin/init-db.c
 msgid "separate git dir from working tree"
-msgstr "git目录和工作区分离"
+msgstr "将 git 目录与工作区分离"
 
 #: builtin/clone.c builtin/init-db.c builtin/submodule--helper.c
 msgid "specify the reference format to use"
@@ -5419,7 +5434,7 @@ msgstr "指定要使用的引用格式"
 
 #: builtin/clone.c
 msgid "key=value"
-msgstr "key=value"
+msgstr "键=值"
 
 #: builtin/clone.c
 msgid "set config inside the new repository"
@@ -5428,7 +5443,7 @@ msgstr "在新仓库中设置配置信息"
 #: builtin/clone.c builtin/fetch.c builtin/ls-remote.c builtin/pull.c
 #: builtin/push.c builtin/send-pack.c
 msgid "server-specific"
-msgstr "server-specific"
+msgstr "服务端特定"
 
 #: builtin/clone.c builtin/fetch.c builtin/ls-remote.c builtin/pull.c
 #: builtin/push.c builtin/send-pack.c
@@ -5445,15 +5460,15 @@ msgstr "任何克隆的子模组将使用它们的远程跟踪分支"
 
 #: builtin/clone.c
 msgid "initialize sparse-checkout file to include only files at root"
-msgstr "初始化稀疏检出文件，只包含根目录文件"
+msgstr "初始化稀疏检出文件，只包含根目录中的文件"
 
 #: builtin/clone.c
 msgid "uri"
-msgstr "uri"
+msgstr "URI"
 
 #: builtin/clone.c
 msgid "a URI for downloading bundles before fetching from origin remote"
-msgstr "用于在从 origin 远程获取之前下载归档包的 URI"
+msgstr "用于在从 origin 远程获取之前下载捆绑包的 URI"
 
 #: builtin/clone.c
 msgid "git clone [<options>] [--] <repo> [<dir>]"
@@ -5501,12 +5516,12 @@ msgstr "工作区 '%s' 已经存在。"
 #: builtin/clone.c builtin/difftool.c builtin/log.c builtin/worktree.c
 #, c-format
 msgid "could not create leading directories of '%s'"
-msgstr "不能为 '%s' 创建先导目录"
+msgstr "无法为 '%s' 创建上级目录"
 
 #: builtin/clone.c
 #, c-format
 msgid "could not create work tree dir '%s'"
-msgstr "不能创建工作区目录 '%s'"
+msgstr "无法创建工作区目录 '%s'"
 
 #: builtin/clone.c
 #, c-format
@@ -5559,20 +5574,20 @@ msgstr "--local 被忽略"
 
 #: builtin/clone.c
 msgid "cannot clone from filtered bundle"
-msgstr "无法从经过过滤的归档包克隆"
+msgstr "无法从经过过滤的捆绑包克隆"
 
 #: builtin/clone.c
 msgid "failed to initialize the repo, skipping bundle URI"
-msgstr "无法初始化仓库，跳过归档包 URI"
+msgstr "无法初始化仓库，跳过捆绑包 URI"
 
 #: builtin/clone.c
 #, c-format
 msgid "failed to fetch objects from bundle URI '%s'"
-msgstr "无法从归档包 URI '%s' 获取对象"
+msgstr "无法从捆绑包 URI '%s' 获取对象"
 
 #: builtin/clone.c
 msgid "failed to fetch advertised bundles"
-msgstr "无法获取公布的归档包"
+msgstr "无法获取公布的捆绑包"
 
 #: builtin/clone.c
 msgid "remote transport reported error"
@@ -5581,7 +5596,7 @@ msgstr "远程传输报告错误"
 #: builtin/clone.c
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
-msgstr "远程分支 %s 在上游 %s 未发现"
+msgstr "远程分支 %s 在上游 %s 未找到"
 
 #: builtin/clone.c
 #, c-format
@@ -5646,7 +5661,7 @@ msgid ""
 msgstr ""
 "git commit-graph write [--object-dir <目录>] [--append]\n"
 "                       [--split[=<策略>]] [--reachable | --stdin-packs | --"
-"stdin-commits] \n"
+"stdin-commits]\n"
 "                       [--changed-paths] [--[no-]max-new-filters <n>] [--"
 "[no-]progress]\n"
 "                       <切分选项>"
@@ -5662,7 +5677,7 @@ msgstr "保存图形的对象目录"
 
 #: builtin/commit-graph.c
 msgid "if the commit-graph is split, only verify the tip file"
-msgstr "如果提交图被拆分，只验证头一个文件"
+msgstr "如果提交图被拆分，只验证顶端文件"
 
 #: builtin/commit-graph.c
 #, c-format
@@ -5708,7 +5723,7 @@ msgstr "从标准输入中的提交开始扫描"
 
 #: builtin/commit-graph.c
 msgid "include all commits already in the commit-graph file"
-msgstr "包含 commit-graph 文件中已有所有提交"
+msgstr "包含 commit-graph 文件中已有的所有提交"
 
 #: builtin/commit-graph.c
 msgid "enable computation for changed paths"
@@ -5751,7 +5766,7 @@ msgid ""
 "git commit-tree [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
 "                [(-F <file>)...] <tree>"
 msgstr ""
-"git commit-tree [(-p <父提交>)...] [-S[<私钥 ID>]] [(-m <消息>)...]\n"
+"git commit-tree [(-p <父提交>)...] [-S[<密钥 ID>]] [(-m <消息>)...]\n"
 "                [(-F <文件>)...] <树>"
 
 #: builtin/commit-tree.c
@@ -5798,7 +5813,7 @@ msgstr "从文件中读取提交说明"
 #: builtin/commit-tree.c builtin/commit.c builtin/merge.c builtin/pull.c
 #: builtin/revert.c
 msgid "GPG sign commit"
-msgstr "GPG 提交签名"
+msgstr "GPG 签名提交"
 
 #: builtin/commit-tree.c
 msgid "must give exactly one tree"
@@ -5827,7 +5842,7 @@ msgstr ""
 "           [--allow-empty-message] [--no-verify] [-e] [--author=<作者>]\n"
 "           [--date=<日期>] [--cleanup=<模式>] [--[no-]status]\n"
 "           [-i | -o] [--pathspec-from-file=<文件> [--pathspec-file-nul]]\n"
-"           [(--trailer <键>[(=|:)<值>])...] [-S[<私钥 ID>]]\n"
+"           [(--trailer <键>[(=|:)<值>])...] [-S[<密钥 ID>]]\n"
 "           [--] [<路径规格>...]"
 
 #: builtin/commit.c
@@ -5840,8 +5855,8 @@ msgid ""
 "it empty. You can repeat your command with --allow-empty, or you can\n"
 "remove the commit entirely with \"git reset HEAD^\".\n"
 msgstr ""
-"您要修补最近的提交，但这么做会让它成为空提交。您可以重复您的命令并带上\n"
-"--allow-empty 选项，或者您可用命令 \"git reset HEAD^\" 整个删除该提交。\n"
+"您要修订最近的提交，但这么做会让它成为空提交。您可以重复您的命令并带上\n"
+"--allow-empty 选项，或者您可用命令 \"git reset HEAD^\" 彻底删除该提交。\n"
 
 #: builtin/commit.c
 msgid ""
@@ -5896,11 +5911,11 @@ msgstr "无法解包 HEAD 树对象"
 
 #: builtin/commit.c
 msgid "No paths with --include/--only does not make sense."
-msgstr "参数 --include/--only 不跟路径没有意义。"
+msgstr "在未指定路径时使用 --include/--only 没有意义。"
 
 #: builtin/commit.c
 msgid "unable to create temporary index"
-msgstr "不能创建临时索引"
+msgstr "无法创建临时索引"
 
 #: builtin/commit.c
 msgid "interactive add failed"
@@ -5912,7 +5927,7 @@ msgstr "无法更新临时索引"
 
 #: builtin/commit.c
 msgid "Failed to update main cache tree"
-msgstr "不能更新树的主缓存"
+msgstr "无法更新主缓存树"
 
 #: builtin/commit.c
 msgid "cannot do a partial commit during a merge."
@@ -5962,7 +5977,7 @@ msgstr "无法选择一个未被当前提交说明使用的注释字符"
 #: builtin/commit.c
 #, c-format
 msgid "could not lookup commit '%s'"
-msgstr "不能查询提交 '%s'"
+msgstr "无法查询提交 '%s'"
 
 #: builtin/commit.c builtin/shortlog.c
 #, c-format
@@ -5971,12 +5986,12 @@ msgstr "（正从标准输入中读取日志信息）\n"
 
 #: builtin/commit.c
 msgid "could not read log from standard input"
-msgstr "不能从标准输入中读取日志信息"
+msgstr "无法从标准输入中读取日志信息"
 
 #: builtin/commit.c
 #, c-format
 msgid "could not read log file '%s'"
-msgstr "不能读取日志文件 '%s'"
+msgstr "无法读取日志文件 '%s'"
 
 #: builtin/commit.c
 #, c-format
@@ -5985,11 +6000,11 @@ msgstr "选项 '%s' 和 '%s:%s' 不能同时使用"
 
 #: builtin/commit.c
 msgid "could not read SQUASH_MSG"
-msgstr "不能读取 SQUASH_MSG"
+msgstr "无法读取 SQUASH_MSG"
 
 #: builtin/commit.c
 msgid "could not read MERGE_MSG"
-msgstr "不能读取 MERGE_MSG"
+msgstr "无法读取 MERGE_MSG"
 
 #: builtin/commit.c bundle.c rerere.c sequencer.c
 #, c-format
@@ -5998,7 +6013,7 @@ msgstr "无法打开 '%s'"
 
 #: builtin/commit.c
 msgid "could not write commit template"
-msgstr "不能写提交模版"
+msgstr "无法写提交模板"
 
 #: builtin/commit.c
 #, c-format
@@ -6113,11 +6128,11 @@ msgstr "无效的未跟踪文件参数 '%s'"
 
 #: builtin/commit.c
 msgid "You are in the middle of a merge -- cannot reword."
-msgstr "您正处于一个合并过程中 -- 无法改写说明。"
+msgstr "您正处于一个合并过程中 -- 不能改写说明。"
 
 #: builtin/commit.c
 msgid "You are in the middle of a cherry-pick -- cannot reword."
-msgstr "您正处于一个拣选过程中 -- 无法改写说明。"
+msgstr "您正处于一个拣选过程中 -- 不能改写说明。"
 
 #: builtin/commit.c
 #, c-format
@@ -6131,19 +6146,19 @@ msgstr "改写说明选项 '%s' 和 '%s' 不能同时使用"
 
 #: builtin/commit.c
 msgid "You have nothing to amend."
-msgstr "您没有可修补的提交。"
+msgstr "您没有可修订的提交。"
 
 #: builtin/commit.c
 msgid "You are in the middle of a merge -- cannot amend."
-msgstr "您正处于一个合并过程中 -- 无法修补提交。"
+msgstr "您正处于一个合并过程中 -- 不能修订提交。"
 
 #: builtin/commit.c
 msgid "You are in the middle of a cherry-pick -- cannot amend."
-msgstr "您正处于一个拣选过程中 -- 无法修补提交。"
+msgstr "您正处于一个拣选过程中 -- 不能修订提交。"
 
 #: builtin/commit.c
 msgid "You are in the middle of a rebase -- cannot amend."
-msgstr "您正处于一个变基过程中 -- 无法修补提交。"
+msgstr "您正处于一个变基过程中 -- 不能修订提交。"
 
 #: builtin/commit.c
 msgid "--reset-author can be used only with -C, -c or --amend."
@@ -6157,7 +6172,7 @@ msgstr "未知选项：--fixup=%s:%s"
 #: builtin/commit.c
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
-msgstr "路径  '%s ...' 和 -a 选项同时使用没有意义"
+msgstr "路径 '%s ...' 和 -a 选项同时使用没有意义"
 
 #: builtin/commit.c
 msgid "show status concisely"
@@ -6169,7 +6184,7 @@ msgstr "显示分支信息"
 
 #: builtin/commit.c
 msgid "show stash information"
-msgstr "显示贮藏区信息"
+msgstr "显示储藏信息"
 
 #: builtin/commit.c
 msgid "compute full ahead/behind values"
@@ -6223,7 +6238,7 @@ msgstr "不检测重命名"
 
 #: builtin/commit.c
 msgid "detect renames, optionally set similarity index"
-msgstr "检测重命名，可以设置索引相似度"
+msgstr "检测重命名，可设置相似度索引"
 
 #: builtin/commit.c
 msgid "Unsupported combination of ignored and untracked-files arguments"
@@ -6283,7 +6298,7 @@ msgstr "[(amend|reword):]提交"
 #: builtin/commit.c
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
-msgstr "使用自动挤压格式的提交说明对指定的提交进行修正、修补或改写说明"
+msgstr "使用自动挤压格式的提交说明对指定的提交进行修正、修订或改写说明"
 
 #: builtin/commit.c
 msgid "use autosquash formatted message to squash specified commit"
@@ -6360,7 +6375,7 @@ msgstr "绕过 post-rewrite 钩子"
 
 #: builtin/commit.c
 msgid "ok to record an empty change"
-msgstr "允许一个空提交"
+msgstr "允许记录空变更"
 
 #: builtin/commit.c
 msgid "ok to record a change with an empty message"
@@ -6368,7 +6383,7 @@ msgstr "允许空的提交说明"
 
 #: builtin/commit.c sequencer.c
 msgid "could not parse HEAD commit"
-msgstr "不能解析 HEAD 提交"
+msgstr "无法解析 HEAD 提交"
 
 #: builtin/commit.c
 #, c-format
@@ -6377,22 +6392,22 @@ msgstr "损坏的 MERGE_HEAD 文件（%s）"
 
 #: builtin/commit.c
 msgid "could not read MERGE_MODE"
-msgstr "不能读取 MERGE_MODE"
+msgstr "无法读取 MERGE_MODE"
 
 #: builtin/commit.c
 #, c-format
 msgid "could not read commit message: %s"
-msgstr "不能读取提交说明：%s"
+msgstr "无法读取提交说明：%s"
 
 #: builtin/commit.c
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
-msgstr "终止提交因为提交说明为空。\n"
+msgstr "由于提交说明为空，终止提交。\n"
 
 #: builtin/commit.c
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
-msgstr "终止提交；您未更改来自模版的提交说明。\n"
+msgstr "终止提交；您未更改来自模板的提交说明。\n"
 
 #: builtin/commit.c
 #, c-format
@@ -6543,7 +6558,7 @@ msgstr "显示选项"
 
 #: builtin/config.c
 msgid "terminate values with NUL byte"
-msgstr "终止值是 NUL 字节"
+msgstr "以 NUL 字节终止值"
 
 #: builtin/config.c
 msgid "show variable names only"
@@ -6568,7 +6583,7 @@ msgstr "未能识别的 --type 参数，%s"
 
 #: builtin/config.c
 msgid "only one type at a time"
-msgstr "一次只能一个类型"
+msgstr "一次只能指定一个类型"
 
 #: builtin/config.c
 #, c-format
@@ -6578,7 +6593,7 @@ msgstr "错误的参数个数，应该为 %d 个"
 #: builtin/config.c
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
-msgstr "错误的参数个数，应该为从 %d 个到 %d 个"
+msgstr "错误的参数个数，应为 %d 到 %d 个"
 
 #: builtin/config.c
 #, c-format
@@ -6606,7 +6621,7 @@ msgstr "无法解析默认颜色值"
 
 #: builtin/config.c
 msgid "not in a git directory"
-msgstr "不在 git 仓库中"
+msgstr "不在 git 目录中"
 
 #: builtin/config.c
 msgid "writing to stdin is not supported"
@@ -6625,9 +6640,9 @@ msgid ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 msgstr ""
-"# This is Git's per-user configuration file.\n"
+"# 这是 Git 的用户级配置文件。\n"
 "[user]\n"
-"# Please adapt and uncomment the following lines:\n"
+"# 请根据需要修改并取消注释以下行：\n"
 "#\tname = %s\n"
 "#\temail = %s\n"
 
@@ -6662,7 +6677,7 @@ msgstr ""
 
 #: builtin/config.c
 msgid "Other"
-msgstr "其它"
+msgstr "其他"
 
 #: builtin/config.c
 msgid "respect include directives on lookup"
@@ -6715,7 +6730,7 @@ msgstr "缺少条目时使用默认值"
 
 #: builtin/config.c
 msgid "--fixed-value only applies with 'value-pattern'"
-msgstr "--fixed-value 仅适用于有 '值模式'"
+msgstr "--fixed-value 仅适用于 '值模式'"
 
 #: builtin/config.c
 msgid "--default= cannot be used with --all or --url="
@@ -6782,7 +6797,7 @@ msgstr "不支持编辑数据对象"
 #: builtin/config.c
 #, c-format
 msgid "cannot create configuration file %s"
-msgstr "不能创建配置文件 %s"
+msgstr "无法创建配置文件 %s"
 
 #: builtin/config.c
 msgid "Action"
@@ -6885,7 +6900,7 @@ msgstr ""
 
 #: builtin/count-objects.c
 msgid "print sizes in human readable format"
-msgstr "以用户可读的格式显示大小"
+msgstr "以人类可读的格式显示大小"
 
 #: builtin/credential-cache--daemon.c
 #, c-format
@@ -6948,7 +6963,7 @@ msgstr "附注的"
 #: builtin/describe.c
 #, c-format
 msgid "annotated tag %s not available"
-msgstr "附注标签 %s 无效"
+msgstr "附注标签 %s 不可用"
 
 #: builtin/describe.c
 #, c-format
@@ -6968,7 +6983,7 @@ msgstr "没有精确匹配到引用或标签，继续搜索进行描述\n"
 #: builtin/describe.c
 #, c-format
 msgid "finished search at %s\n"
-msgstr "完成搜索 %s\n"
+msgstr "在 %s 处完成搜索\n"
 
 #: builtin/describe.c
 #, c-format
@@ -7037,7 +7052,7 @@ msgstr "使用任意引用"
 
 #: builtin/describe.c
 msgid "use any tag, even unannotated"
-msgstr "使用任意标签，即使未附带注释"
+msgstr "使用任意标签，即使未附注"
 
 #: builtin/describe.c
 msgid "always use long format"
@@ -7111,12 +7126,12 @@ msgstr "指定诊断信息归档包的内容"
 #: builtin/diff-pairs.c
 #, c-format
 msgid "unable to parse mode: %s"
-msgstr "不能解析模式：%s"
+msgstr "无法解析模式：%s"
 
 #: builtin/diff-pairs.c
 #, c-format
 msgid "unable to parse object id: %s"
-msgstr "不能解析对象 ID：%s"
+msgstr "无法解析对象 ID：%s"
 
 #: builtin/diff-pairs.c
 msgid "git diff-pairs -z [<diff-options>]"
@@ -7215,7 +7230,7 @@ msgstr "无法处理的对象 '%s'。"
 #: builtin/diff.c
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
-msgstr "%s...%s：多条合并基线，使用 %s"
+msgstr "%s...%s：多个合并基线，使用 %s"
 
 #: builtin/difftool.c
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
@@ -7251,12 +7266,12 @@ msgstr "两个文件都被修改：'%s' 和 '%s'。"
 
 #: builtin/difftool.c
 msgid "working tree file has been left."
-msgstr "工作区文件被留了下来。"
+msgstr "工作区文件已保留。"
 
 #: builtin/difftool.c sequencer.c
 #, c-format
 msgid "could not copy '%s' to '%s'"
-msgstr "不能拷贝 '%s' 至 '%s'"
+msgstr "无法拷贝 '%s' 至 '%s'"
 
 #: builtin/difftool.c
 #, c-format
@@ -7384,8 +7399,7 @@ msgstr "无法在提交 %s 中找到提交者"
 msgid ""
 "encountered commit-specific encoding %.*s in commit %s; use --reencode=[yes|"
 "no] to handle it"
-msgstr ""
-"在提交 %3$s 中遇到提交特定编码 %2$.*1$s；使用 --reencode=[yes|no] 来处理"
+msgstr "遇到提交特定编码 %.*s 的提交为 %s；使用 --reencode=[yes|no] 来处理"
 
 #: builtin/fast-export.c
 #, c-format
@@ -7542,7 +7556,7 @@ msgstr "如果文件存在，从该文件导入标记"
 
 #: builtin/fast-export.c
 msgid "fake a tagger when tags lack one"
-msgstr "当标签缺少标记人字段时，假装提供一个"
+msgstr "当标签缺少打标签者时，伪造一个"
 
 #: builtin/fast-export.c
 msgid "output full tree for each commit"
@@ -7570,7 +7584,7 @@ msgstr "匿名输出"
 
 #: builtin/fast-export.c
 msgid "from:to"
-msgstr "from:to"
+msgstr "从:到"
 
 #: builtin/fast-export.c
 msgid "convert <from> to <to> in anonymized output"
@@ -7578,7 +7592,7 @@ msgstr "在匿名输出中将 <from> 转换为 <to>"
 
 #: builtin/fast-export.c
 msgid "reference parents which are not in fast-export stream by object id"
-msgstr "引用父对象 ID 不在 fast-export 流中"
+msgstr "通过对象 ID 引用不在 fast-export 流中的父对象"
 
 #: builtin/fast-export.c
 msgid "show original object ids of blobs/commits"
@@ -7586,7 +7600,7 @@ msgstr "显示数据对象/提交的原始对象 ID"
 
 #: builtin/fast-export.c
 msgid "label tags with mark ids"
-msgstr "对带有标记 ID 的标签做标记"
+msgstr "用标记 ID 标注标签"
 
 #: builtin/fast-import.c
 #, c-format
@@ -7703,7 +7717,7 @@ msgstr "未更新 %s（新的分支顶端 %s 不包含 %s）"
 #: sequencer.c
 #, c-format
 msgid "unable to create leading directories of %s"
-msgstr "不能为 %s 创建先导目录"
+msgstr "无法为 %s 创建上级目录"
 
 #: builtin/fast-import.c
 #, c-format
@@ -7852,7 +7866,7 @@ msgstr "目录不能指定为 'inline'：%s"
 #: builtin/fast-import.c
 #, c-format
 msgid "%s not found: %s"
-msgstr "未找到%s：%s"
+msgstr "未找到 %s：%s"
 
 #: builtin/fast-import.c
 msgid "tree"
@@ -7870,7 +7884,7 @@ msgstr "路径 %s 不在分支中"
 
 #: builtin/fast-import.c
 msgid "can't add a note on empty branch."
-msgstr "不能在空分支上添加注释。"
+msgstr "无法在空分支上添加注解。"
 
 #: builtin/fast-import.c
 #, c-format
@@ -7970,7 +7984,7 @@ msgstr ""
 
 #: builtin/fast-import.c
 msgid "expected committer but didn't get one"
-msgstr "预期提交者但未获取"
+msgstr "预期提交者但未获得"
 
 #: builtin/fast-import.c
 msgid "encountered signed commit; use --signed-commits=<mode> to handle it"
@@ -8193,7 +8207,7 @@ msgstr "流过早结束"
 #: builtin/fetch-pack.c
 #, c-format
 msgid "Lockfile created but not reported: %s"
-msgstr "Lockfile 已创建但未报告：%s"
+msgstr "锁文件已创建但未报告：%s"
 
 #: builtin/fetch.c
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
@@ -8227,7 +8241,7 @@ msgstr "来自 %.*s\n"
 #: builtin/fetch.c
 #, c-format
 msgid "object %s not found"
-msgstr "对象 %s 未发现"
+msgstr "对象 %s 未找到"
 
 #: builtin/fetch.c
 msgid "[up to date]"
@@ -8247,11 +8261,11 @@ msgstr "[标签更新]"
 
 #: builtin/fetch.c
 msgid "unable to update local ref"
-msgstr "不能更新本地引用"
+msgstr "无法更新本地引用"
 
 #: builtin/fetch.c
 msgid "would clobber existing tag"
-msgstr "会破坏现有的标签"
+msgstr "会覆盖现有的标签"
 
 #: builtin/fetch.c
 msgid "[new tag]"
@@ -8276,7 +8290,7 @@ msgstr "非快进"
 #: builtin/fetch.c builtin/grep.c sequencer.c
 #, c-format
 msgid "cannot open '%s'"
-msgstr "不能打开 '%s'"
+msgstr "无法打开 '%s'"
 
 #: builtin/fetch.c
 msgid ""
@@ -8330,7 +8344,7 @@ msgstr "选项 \"%s\" 的值 \"%s\" 对于 %s 是无效的"
 #: builtin/fetch.c
 #, c-format
 msgid "option \"%s\" is ignored for %s"
-msgstr "选项 \"%s\" 为 %s 所忽略"
+msgstr "选项 \"%s\" 对 %s 将被忽略"
 
 #: builtin/fetch.c odb.c
 #, c-format
@@ -8353,7 +8367,7 @@ msgid ""
 msgstr ""
 "运行 'git remote set-head %s %s' 同步变更，或通过配置选项\n"
 "'remote.%s.followRemoteHEAD' 设置为其他值以屏蔽此提示。具体可通过\n"
-"运行命令 'git config remote.%s.followRemoteHEAD warn-if-not-branch-%s'\n"
+"运行命令 'git config set remote.%s.followRemoteHEAD warn-if-not-branch-%s'\n"
 "以禁用该警告，直到远程将 HEAD 更改为其他内容。"
 
 #: builtin/fetch.c
@@ -8388,7 +8402,7 @@ msgid ""
 "some local refs could not be updated; try running\n"
 " 'git remote prune %s' to remove any old, conflicting branches"
 msgstr ""
-"一些本地引用不能被更新；尝试运行\n"
+"一些本地引用无法被更新；尝试运行\n"
 " 'git remote prune %s' 来删除旧的、有冲突的分支"
 
 #: builtin/fetch.c
@@ -8435,7 +8449,7 @@ msgstr "正在获取 %s\n"
 #: builtin/fetch.c
 #, c-format
 msgid "could not fetch %s"
-msgstr "不能获取 %s"
+msgstr "无法获取 %s"
 
 #: builtin/fetch.c
 #, c-format
@@ -8498,11 +8512,11 @@ msgstr "修改引用规格以将所有引用放入 refs/prefetch/"
 
 #: builtin/fetch.c builtin/pull.c
 msgid "prune remote-tracking branches no longer on remote"
-msgstr "清除远程已经不存在的分支的跟踪分支"
+msgstr "清除远程已不存在的远程跟踪分支"
 
 #: builtin/fetch.c
 msgid "prune local tags no longer on remote and clobber changed tags"
-msgstr "清除远程不存在的本地标签，并且替换变更标签"
+msgstr "清除远程已不存在的本地标签，并覆盖已变更的标签"
 
 #  译者：可选值，不能翻译
 #: builtin/fetch.c builtin/pull.c
@@ -8549,7 +8563,7 @@ msgstr "在子模组路径输出的前面加上此目录"
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
-msgstr "递归获取子模组的缺省值（比配置文件优先级低）"
+msgstr "递归获取子模组的默认值（比配置文件优先级低）"
 
 #: builtin/fetch.c builtin/pull.c
 msgid "accept refs that update .git/shallow"
@@ -8606,7 +8620,7 @@ msgstr "对于一个完整的仓库，参数 --unshallow 没有意义"
 #: builtin/fetch.c
 #, c-format
 msgid "failed to fetch bundles from '%s'"
-msgstr "无法从 '%s' 获取归档包"
+msgstr "无法从 '%s' 获取捆绑包"
 
 #: builtin/fetch.c
 msgid "fetch --all does not take a repository argument"
@@ -8678,19 +8692,19 @@ msgstr "从文件中读取"
 
 #: builtin/for-each-ref.c
 msgid "quote placeholders suitably for shells"
-msgstr "引用占位符适用于 shells"
+msgstr "为 shell 适当引用占位符"
 
 #: builtin/for-each-ref.c
 msgid "quote placeholders suitably for perl"
-msgstr "引用占位符适用于 perl"
+msgstr "为 perl 适当引用占位符"
 
 #: builtin/for-each-ref.c
 msgid "quote placeholders suitably for python"
-msgstr "引用占位符适用于 python"
+msgstr "为 python 适当引用占位符"
 
 #: builtin/for-each-ref.c
 msgid "quote placeholders suitably for Tcl"
-msgstr "引用占位符适用于 Tcl"
+msgstr "为 Tcl 适当引用占位符"
 
 #: builtin/for-each-ref.c
 msgid "show only <n> matched refs"
@@ -8828,18 +8842,18 @@ msgstr "悬空 %s %s"
 
 #: builtin/fsck.c
 msgid "could not create lost-found"
-msgstr "不能创建 lost-found"
+msgstr "无法创建 lost-found"
 
 #: builtin/fsck.c builtin/gc.c builtin/rebase.c rebase-interactive.c rerere.c
 #: sequencer.c
 #, c-format
 msgid "could not write '%s'"
-msgstr "不能写入 '%s'"
+msgstr "无法写入 '%s'"
 
 #: builtin/fsck.c
 #, c-format
 msgid "could not finish '%s'"
-msgstr "不能完成 '%s'"
+msgstr "无法完成 '%s'"
 
 #: builtin/fsck.c
 #, c-format
@@ -8917,7 +8931,7 @@ msgstr "%s：对象损坏或丢失：%s"
 #: builtin/fsck.c
 #, c-format
 msgid "%s: object could not be parsed: %s"
-msgstr "%s：不能解析对象：%s"
+msgstr "%s：无法解析对象：%s"
 
 #: builtin/fsck.c
 #, c-format
@@ -9095,7 +9109,7 @@ msgstr "无法初始化健康检查线程"
 #: builtin/fsmonitor--daemon.c
 #, c-format
 msgid "could not cd home '%s'"
-msgstr "不能切换至家目录 '%s'"
+msgstr "无法切换至家目录 '%s'"
 
 #: builtin/fsmonitor--daemon.c
 #, c-format
@@ -9167,7 +9181,7 @@ msgstr "无法解析 '%s' 值 '%s'"
 #: builtin/gc.c setup.c
 #, c-format
 msgid "cannot stat '%s'"
-msgstr "不能对 '%s' 调用 stat"
+msgstr "无法对 '%s' 调用 stat"
 
 #: builtin/gc.c
 #, c-format
@@ -9213,7 +9227,7 @@ msgstr "强制执行 gc 即使另外一个 gc 正在执行"
 
 #: builtin/gc.c
 msgid "repack all other packs except the largest pack"
-msgstr "除了最大的包之外，对所有其它包文件重新打包"
+msgstr "除了最大的包之外，对所有其他包文件重新打包"
 
 #: builtin/gc.c builtin/repack.c
 msgid "pack prefix to store a pack containing pruned objects"
@@ -9335,7 +9349,7 @@ msgstr "'%s' 不是一个有效的任务"
 #: builtin/gc.c
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
-msgstr "任务 '%s' 不能被多次选择"
+msgstr "任务 '%s' 无法被多次选择"
 
 #: builtin/gc.c
 msgid "run tasks based on the state of the repository"
@@ -9343,7 +9357,7 @@ msgstr "基于仓库状态来运行任务"
 
 #: builtin/gc.c
 msgid "perform maintenance in the background"
-msgstr "在后台执行运维"
+msgstr "在后台执行维护"
 
 #: builtin/gc.c
 msgid "frequency"
@@ -9355,7 +9369,7 @@ msgstr "基于频率运行任务"
 
 #: builtin/gc.c
 msgid "do not report progress or other information over stderr"
-msgstr "不通过标准错误报告进度或其它信息"
+msgstr "不通过标准错误报告进度或其他信息"
 
 #: builtin/gc.c
 msgid "task"
@@ -9584,7 +9598,7 @@ msgstr "只在单词边界匹配模式"
 
 #: builtin/grep.c
 msgid "process binary files as text"
-msgstr "把二进制文件当做文本处理"
+msgstr "把二进制文件当作文本处理"
 
 #: builtin/grep.c
 msgid "don't match patterns in binary files"
@@ -9692,7 +9706,7 @@ msgstr "使用 <n> 个工作线程"
 
 #: builtin/grep.c
 msgid "shortcut for -C NUM"
-msgstr "快捷键 -C 数字"
+msgstr "-C NUM 的快捷方式"
 
 #: builtin/grep.c
 msgid "show a line with the function name before matches"
@@ -9724,7 +9738,7 @@ msgstr "只显示匹配所有模式的文件中的匹配"
 
 #: builtin/grep.c
 msgid "pager"
-msgstr "分页"
+msgstr "分页器"
 
 #: builtin/grep.c
 msgid "show matching files in the pager"
@@ -9749,7 +9763,7 @@ msgstr "--no-index 或 --untracked 不能和版本同时使用"
 #: builtin/grep.c
 #, c-format
 msgid "unable to resolve revision: %s"
-msgstr "不能解析版本：%s"
+msgstr "无法解析版本：%s"
 
 #: builtin/grep.c
 msgid "--untracked not supported with --recurse-submodules"
@@ -9831,7 +9845,7 @@ msgstr "在 --all 中显示别名"
 
 #: builtin/help.c
 msgid "exclude guides"
-msgstr "排除向导"
+msgstr "排除指南"
 
 #: builtin/help.c
 msgid "show man page"
@@ -10032,7 +10046,7 @@ msgstr "解压缩返回 %d"
 
 #: builtin/index-pack.c
 msgid "offset value overflow for delta base object"
-msgstr "偏移值覆盖了 delta 基准对象"
+msgstr "delta 基准对象的偏移值溢出"
 
 #: builtin/index-pack.c
 msgid "delta base offset is out of bound"
@@ -10066,12 +10080,12 @@ msgstr "发现 %s 出现 SHA1 冲突！"
 #: builtin/index-pack.c
 #, c-format
 msgid "cannot read existing object info %s"
-msgstr "不能读取现存对象信息 %s"
+msgstr "无法读取现存对象信息 %s"
 
 #: builtin/index-pack.c
 #, c-format
 msgid "cannot read existing object %s"
-msgstr "不能读取现存对象 %s"
+msgstr "无法读取现存对象 %s"
 
 #: builtin/index-pack.c
 #, c-format
@@ -10106,11 +10120,11 @@ msgstr "索引对象中"
 
 #: builtin/index-pack.c
 msgid "pack is corrupted (SHA1 mismatch)"
-msgstr "包冲突（SHA1 不匹配）"
+msgstr "包已损坏（SHA1 不匹配）"
 
 #: builtin/index-pack.c
 msgid "cannot fstat packfile"
-msgstr "不能对包文件调用 fstat"
+msgstr "无法对包文件调用 fstat"
 
 #: builtin/index-pack.c
 msgid "pack has junk at the end"
@@ -10127,7 +10141,7 @@ msgstr "处理 delta 中"
 #: builtin/index-pack.c builtin/pack-objects.c
 #, c-format
 msgid "unable to create thread: %s"
-msgstr "不能创建线程：%s"
+msgstr "无法创建线程：%s"
 
 #: builtin/index-pack.c
 msgid "confusion beyond insanity"
@@ -10155,7 +10169,7 @@ msgstr[1] "包有 %d 个未解决的 delta"
 #: builtin/index-pack.c
 #, c-format
 msgid "unable to deflate appended object (%d)"
-msgstr "不能压缩附加对象（%d）"
+msgstr "无法压缩附加对象（%d）"
 
 #: builtin/index-pack.c
 #, c-format
@@ -10180,7 +10194,7 @@ msgstr "无法关闭已写入的 %s 文件 '%s'"
 #: builtin/index-pack.c
 #, c-format
 msgid "unable to rename temporary '*.%s' file to '%s'"
-msgstr "不能重命名临时文件 '*.%s' 为 '%s'"
+msgstr "无法重命名临时文件 '*.%s' 为 '%s'"
 
 #: builtin/index-pack.c
 msgid "error while closing pack file"
@@ -10244,7 +10258,7 @@ msgstr "错误的 --pack_header：%s"
 #: builtin/index-pack.c
 #, c-format
 msgid "bad %s"
-msgstr "错误选项 %s"
+msgstr "错误的 %s"
 
 #: builtin/index-pack.c builtin/init-db.c setup.c
 #, c-format
@@ -10253,7 +10267,7 @@ msgstr "未知的哈希算法 '%s'"
 
 #: builtin/index-pack.c
 msgid "--promisor cannot be used with a pack name"
-msgstr "--promisor 无法与包名称一起使用"
+msgstr "--promisor 不能与包名称一起使用"
 
 #: builtin/index-pack.c
 msgid "--stdin requires a git repository"
@@ -10299,7 +10313,7 @@ msgstr "覆盖初始分支名称"
 
 #: builtin/init-db.c builtin/verify-pack.c
 msgid "hash"
-msgstr "hash"
+msgstr "哈希"
 
 #: builtin/init-db.c builtin/show-index.c builtin/verify-pack.c
 msgid "specify the hash algorithm to use"
@@ -10308,12 +10322,12 @@ msgstr "指定要使用的哈希算法"
 #: builtin/init-db.c
 #, c-format
 msgid "cannot mkdir %s"
-msgstr "不能创建目录 %s"
+msgstr "无法创建目录 %s"
 
 #: builtin/init-db.c
 #, c-format
 msgid "cannot chdir to %s"
-msgstr "不能切换目录到 %s"
+msgstr "无法切换目录到 %s"
 
 #: builtin/init-db.c
 #, c-format
@@ -10325,11 +10339,11 @@ msgstr "不允许 %s（或 --work-tree=<目录>）而没有指定 %s（或 --git
 #: builtin/init-db.c
 #, c-format
 msgid "Cannot access work tree '%s'"
-msgstr "不能访问工作区 '%s'"
+msgstr "无法访问工作区 '%s'"
 
 #: builtin/init-db.c
 msgid "--separate-git-dir incompatible with bare repository"
-msgstr "--separate-git-dir 不能用于纯仓库"
+msgstr "--separate-git-dir 和纯仓库不兼容"
 
 #: builtin/interpret-trailers.c
 msgid ""
@@ -10344,7 +10358,7 @@ msgstr ""
 #: builtin/interpret-trailers.c wrapper.c
 #, c-format
 msgid "could not stat %s"
-msgstr "不能对 %s 调用 stat"
+msgstr "无法对 %s 调用 stat"
 
 #: builtin/interpret-trailers.c
 #, c-format
@@ -10358,21 +10372,21 @@ msgstr "文件 %s 用户不可写"
 
 #: builtin/interpret-trailers.c
 msgid "could not open temporary file"
-msgstr "不能打开临时文件"
+msgstr "无法打开临时文件"
 
 #: builtin/interpret-trailers.c
 #, c-format
 msgid "could not read input file '%s'"
-msgstr "不能读取输入文件 '%s'"
+msgstr "无法读取输入文件 '%s'"
 
 #: builtin/interpret-trailers.c builtin/mktag.c imap-send.c
 msgid "could not read from stdin"
-msgstr "不能自标准输入读取"
+msgstr "无法自标准输入读取"
 
 #: builtin/interpret-trailers.c
 #, c-format
 msgid "could not rename temporary file to %s"
-msgstr "不能重命名临时文件为 %s"
+msgstr "无法重命名临时文件为 %s"
 
 #: builtin/interpret-trailers.c
 msgid "edit files in place"
@@ -10503,7 +10517,7 @@ msgstr "跟踪 <文件> 中 <开始>,<结束> 范围内的行或函数 :<函数�
 
 #: builtin/log.c
 msgid "-L<range>:<file> cannot be used with pathspec"
-msgstr "-L<范围>:<文件> 不能和路径表达式共用"
+msgstr "-L<范围>:<文件> 不能和路径规格共用"
 
 #: builtin/log.c
 msgid ""
@@ -10596,7 +10610,7 @@ msgstr "无法将 '%s' 解析为一个有效引用"
 
 #: builtin/log.c
 msgid "could not find exact merge base"
-msgstr "不能找到准确的合并基线"
+msgstr "无法找到准确的合并基线"
 
 #: builtin/log.c
 msgid ""
@@ -10622,7 +10636,7 @@ msgstr "基线提交不应该出现在版本列表中"
 
 #: builtin/log.c
 msgid "cannot get patch id"
-msgstr "无法得到补丁 id"
+msgstr "无法得到补丁 ID"
 
 #: builtin/log.c
 msgid "failed to infer range-diff origin of current series"
@@ -10667,7 +10681,7 @@ msgstr "补丁以 <n> 开始编号，而不是1"
 
 #: builtin/log.c
 msgid "reroll-count"
-msgstr "重制-计数"
+msgstr "重制次数"
 
 #: builtin/log.c
 msgid "mark the series as Nth re-roll"
@@ -10723,7 +10737,7 @@ msgstr "不包含已在上游提交中的补丁"
 
 #: builtin/log.c
 msgid "show patch format instead of default (patch + stat)"
-msgstr "显示纯补丁格式而非默认的（补丁+状态）"
+msgstr "显示纯补丁格式而非默认的（补丁+统计）"
 
 #: builtin/log.c
 msgid "Messaging"
@@ -10731,7 +10745,7 @@ msgstr "邮件发送"
 
 #: builtin/log.c
 msgid "header"
-msgstr "header"
+msgstr "头信息"
 
 #: builtin/log.c
 msgid "add email header"
@@ -10755,7 +10769,7 @@ msgstr "标识"
 
 #: builtin/log.c
 msgid "set From address to <ident> (or committer ident if absent)"
-msgstr "将 From 地址设置为 <标识>（如若不提供，则用提交者 ID 做为地址）"
+msgstr "将 From 地址设置为 <标识>（如若不提供，则用提交者 ID 作为地址）"
 
 #: builtin/log.c
 msgid "message-id"
@@ -10849,7 +10863,7 @@ msgstr "--remerge-diff 无意义"
 #: builtin/log.c builtin/submodule--helper.c rerere.c submodule.c
 #, c-format
 msgid "could not create directory '%s'"
-msgstr "不能创建目录 '%s'"
+msgstr "无法创建目录 '%s'"
 
 #: builtin/log.c
 msgid "--interdiff requires --cover-letter or single patch"
@@ -10898,7 +10912,7 @@ msgstr "git cherry [-v] [<上游> [<头> [<限制>]]]"
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
-msgstr "不能找到跟踪的远程分支，请手工指定 <上游>。\n"
+msgstr "无法找到跟踪的远程分支，请手工指定 <上游>。\n"
 
 #: builtin/ls-files.c builtin/ls-tree.c
 #, c-format
@@ -10939,7 +10953,7 @@ msgstr "显示已修改的文件"
 
 #: builtin/ls-files.c
 msgid "show other files in the output"
-msgstr "显示其它文件"
+msgstr "显示其他文件"
 
 #: builtin/ls-files.c
 msgid "show ignored files in the output"
@@ -11041,7 +11055,7 @@ msgstr "不打印远程 URL"
 
 #: builtin/ls-remote.c builtin/rebase.c
 msgid "exec"
-msgstr "exec"
+msgstr "可执行命令"
 
 #: builtin/ls-remote.c
 msgid "path of git-upload-pack on the remote host"
@@ -11069,7 +11083,7 @@ msgstr "参考 url.<base>.insteadOf 设置"
 
 #: builtin/ls-remote.c
 msgid "exit with exit code 2 if no matching refs are found"
-msgstr "若未找到匹配的引用则以退出码2退出"
+msgstr "若未找到匹配的引用则以退出码 2 退出"
 
 #: builtin/ls-remote.c
 msgid "show underlying ref in addition to the object pointed by it"
@@ -11203,11 +11217,11 @@ msgstr "查找一个多路合并的祖先提交"
 
 #: builtin/merge-base.c
 msgid "list revs not reachable from others"
-msgstr "显示不能被其他访问到的版本"
+msgstr "显示无法被其他访问到的版本"
 
 #: builtin/merge-base.c
 msgid "is the first one ancestor of the other?"
-msgstr "第一个是其他的祖先提交么？"
+msgstr "第一个是其他的祖先提交吗？"
 
 #: builtin/merge-base.c
 msgid "find where <commit> forked from reflog of <ref>"
@@ -11256,12 +11270,12 @@ msgstr "对象 '%s' 不存在"
 
 #: builtin/merge-file.c
 msgid "Could not write object file"
-msgstr "不能写入对象文件"
+msgstr "无法写入对象文件"
 
 #: builtin/merge-recursive.c
 #, c-format
 msgid "could not parse object '%s'"
-msgstr "不能解析对象 '%s'"
+msgstr "无法解析对象 '%s'"
 
 #: builtin/merge-recursive.c
 #, c-format
@@ -11272,7 +11286,7 @@ msgstr[1] "无法处理 %d 条以上的基线。忽略 %s。"
 
 #: builtin/merge-recursive.c
 msgid "not handling anything other than two heads merge."
-msgstr "不能处理两个头合并之外的任何操作。"
+msgstr "无法处理两个头合并之外的任何操作。"
 
 #: builtin/merge-recursive.c
 #, c-format
@@ -11343,7 +11357,7 @@ msgstr "指定用于合并的合并基线"
 
 #: builtin/merge-tree.c builtin/merge.c builtin/pull.c
 msgid "option=value"
-msgstr "option=value"
+msgstr "选项=值"
 
 #: builtin/merge-tree.c builtin/merge.c builtin/pull.c
 msgid "option for selected merge strategy"
@@ -11379,7 +11393,7 @@ msgstr "选项 `%s' 需要一个值"
 #: builtin/merge.c
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
-msgstr "不能找到合并策略 '%s'。\n"
+msgstr "无法找到合并策略 '%s'。\n"
 
 #: builtin/merge.c
 #, c-format
@@ -11429,7 +11443,7 @@ msgstr "允许快进（默认）"
 
 #: builtin/merge.c builtin/pull.c
 msgid "abort if fast-forward is not possible"
-msgstr "如果不能快进就放弃合并"
+msgstr "如果无法快进就放弃合并"
 
 #: builtin/merge.c builtin/pull.c
 msgid "verify that the named commit has a valid GPG signature"
@@ -11471,11 +11485,11 @@ msgstr "绕过 pre-merge-commit 和 commit-msg 钩子"
 
 #: builtin/merge.c
 msgid "could not run stash."
-msgstr "不能运行贮藏。"
+msgstr "无法运行储藏。"
 
 #: builtin/merge.c
 msgid "stash failed"
-msgstr "贮藏失败"
+msgstr "储藏失败"
 
 #: builtin/merge.c
 msgid "read-tree failed"
@@ -11511,7 +11525,7 @@ msgstr "坏的 branch.%s.mergeoptions 字符串：%s"
 
 #: builtin/merge.c merge-ort-wrappers.c
 msgid "Unable to write index."
-msgstr "不能写入索引。"
+msgstr "无法写入索引。"
 
 #: builtin/merge.c
 msgid "Not handling anything other than two heads merge."
@@ -11520,12 +11534,12 @@ msgstr "未处理两个头合并之外的任何操作。"
 #: builtin/merge.c builtin/sparse-checkout.c
 #, c-format
 msgid "unable to write %s"
-msgstr "不能写 %s"
+msgstr "无法写 %s"
 
 #: builtin/merge.c
 #, c-format
 msgid "Could not read from '%s'"
-msgstr "不能从 '%s' 读取"
+msgstr "无法从 '%s' 读取"
 
 #: builtin/merge.c
 #, c-format
@@ -11592,12 +11606,12 @@ msgstr "环境 '%2$s' 中存在坏的取值 '%1$s'"
 #: builtin/merge.c editor.c read-cache.c wrapper.c
 #, c-format
 msgid "could not close '%s'"
-msgstr "不能关闭 '%s'"
+msgstr "无法关闭 '%s'"
 
 #: builtin/merge.c
 #, c-format
 msgid "not something we can merge in %s: %s"
-msgstr "不能在 %s 中合并：%s"
+msgstr "无法在 %s 中合并：%s"
 
 #: builtin/merge.c
 msgid "--abort expects no arguments"
@@ -11654,7 +11668,7 @@ msgstr "到空分支的非快进式提交没有意义"
 #: builtin/merge.c
 #, c-format
 msgid "%s - not something we can merge"
-msgstr "%s - 不能被合并"
+msgstr "%s - 无法被合并"
 
 #: builtin/merge.c
 msgid "Can merge only exactly one commit into empty head"
@@ -11682,7 +11696,7 @@ msgstr "尝试非常小的索引内合并...\n"
 #: builtin/merge.c
 #, c-format
 msgid "Nope.\n"
-msgstr "无。\n"
+msgstr "不行。\n"
 
 #: builtin/merge.c
 #, c-format
@@ -11717,7 +11731,7 @@ msgstr "自动合并进展顺利，按要求在提交前停止\n"
 #: builtin/merge.c
 #, c-format
 msgid "When finished, apply stashed changes with `git stash pop`\n"
-msgstr "在完成后，使用 `git stash pop` 应用贮藏的变更\n"
+msgstr "在完成后，使用 `git stash pop` 应用储藏的变更\n"
 
 #: builtin/mktag.c
 #, c-format
@@ -11732,7 +11746,7 @@ msgstr "错误：标签输入未通过 fsck：%s"
 #: builtin/mktag.c
 #, c-format
 msgid "could not read tagged object '%s'"
-msgstr "不能读取被标记的对象 '%s'"
+msgstr "无法读取被标记的对象 '%s'"
 
 #: builtin/mktag.c
 #, c-format
@@ -11836,7 +11850,7 @@ msgstr "目录 %s 在索引中并且不是子模组？"
 
 #: builtin/mv.c
 msgid "Please stage your changes to .gitmodules or stash them to proceed"
-msgstr "请将您的修改暂存到 .gitmodules 中或贮藏后再继续"
+msgstr "请将您的修改暂存到 .gitmodules 中或储藏后再继续"
 
 #: builtin/mv.c
 #, c-format
@@ -11845,7 +11859,7 @@ msgstr "%.*s 在索引中"
 
 #: builtin/mv.c
 msgid "force move/rename even if target exists"
-msgstr "强制移动/重命令，即使目标存在"
+msgstr "强制移动/重命名，即使目标存在"
 
 #: builtin/mv.c
 msgid "skip move/rename errors"
@@ -11863,7 +11877,7 @@ msgstr "检查 '%s' 到 '%s' 的重命名\n"
 
 #: builtin/mv.c
 msgid "bad source"
-msgstr "坏的源"
+msgstr "错误的源"
 
 #: builtin/mv.c
 msgid "destination exists"
@@ -11871,7 +11885,7 @@ msgstr "目标已存在"
 
 #: builtin/mv.c
 msgid "can not move directory into itself"
-msgstr "不能将目录移动到自身"
+msgstr "无法将目录移动到自身"
 
 #: builtin/mv.c
 msgid "destination already exists"
@@ -11896,7 +11910,7 @@ msgstr "覆盖 '%s'"
 
 #: builtin/mv.c
 msgid "Cannot overwrite"
-msgstr "不能覆盖"
+msgstr "无法覆盖"
 
 #: builtin/mv.c
 msgid "multiple sources for the same target"
@@ -11972,7 +11986,7 @@ msgstr "标注标准输入的文字"
 
 #: builtin/name-rev.c
 msgid "allow to print `undefined` names (default)"
-msgstr "允许打印 `未定义` 的名称（默认）"
+msgstr "允许打印 `undefined` 的名称（默认）"
 
 #: builtin/name-rev.c
 msgid "dereference tags in the input (internal use)"
@@ -12017,7 +12031,7 @@ msgstr "git notes [--ref <注解引用>] show [<对象>]"
 #: builtin/notes.c
 msgid ""
 "git notes [--ref <notes-ref>] merge [-v | -q] [-s <strategy>] <notes-ref>"
-msgstr "git notes [--ref <注解引用>] merge [-v | -q] [-s <策略> ] <注解引用>"
+msgstr "git notes [--ref <注解引用>] merge [-v | -q] [-s <策略>] <注解引用>"
 
 #: builtin/notes.c
 msgid "git notes [--ref <notes-ref>] remove [<object>...]"
@@ -12085,7 +12099,7 @@ msgstr "为下面的对象写/编辑说明："
 
 #: builtin/notes.c
 msgid "could not read 'show' output"
-msgstr "不能读取 'show' 的输出"
+msgstr "无法读取 'show' 的输出"
 
 #: builtin/notes.c
 #, c-format
@@ -12098,7 +12112,7 @@ msgstr "请通过 -m 或 -F 选项为注解提供内容"
 
 #: builtin/notes.c
 msgid "unable to write note object"
-msgstr "不能写注解对象"
+msgstr "无法写注解对象"
 
 #: builtin/notes.c
 #, c-format
@@ -12108,7 +12122,7 @@ msgstr "注解内容被留在 %s 中"
 #: builtin/notes.c builtin/tag.c
 #, c-format
 msgid "could not open or read '%s'"
-msgstr "不能打开或读取 '%s'"
+msgstr "无法打开或读取 '%s'"
 
 #: builtin/notes.c
 #, c-format
@@ -12123,7 +12137,7 @@ msgstr "无法读取对象 '%s'。"
 #: builtin/notes.c
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
-msgstr "不能从非数据对象 '%s' 中读取注解数据。"
+msgstr "无法从非数据对象 '%s' 中读取注解数据。"
 
 #: builtin/notes.c
 #, c-format
@@ -12136,7 +12150,7 @@ msgstr "无法把注解从 '%s' 拷贝到 '%s'"
 #: builtin/notes.c
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
-msgstr "拒绝向 %2$s（在 refs/notes/ 之外）%1$s注解"
+msgstr "拒绝向 %2$s（在 refs/notes/ 之外）%1$s 注解"
 
 #: builtin/notes.c
 #, c-format
@@ -12149,7 +12163,7 @@ msgstr "注解内容作为一个字符串"
 
 #: builtin/notes.c
 msgid "note contents in a file"
-msgstr "注解内容到一个文件中"
+msgstr "注解内容在一个文件中"
 
 #: builtin/notes.c
 msgid "reuse and edit specified note object"
@@ -12157,7 +12171,7 @@ msgstr "重用和编辑指定的注解对象"
 
 #: builtin/notes.c
 msgid "edit note message in editor"
-msgstr "在编辑器中编辑注释说明"
+msgstr "在编辑器中编辑注解说明"
 
 #: builtin/notes.c
 msgid "reuse specified note object"
@@ -12165,7 +12179,7 @@ msgstr "重用指定的注解对象"
 
 #: builtin/notes.c
 msgid "allow storing empty note"
-msgstr "允许保存空白注释"
+msgstr "允许保存空注解"
 
 #: builtin/notes.c
 msgid "replace existing notes"
@@ -12177,7 +12191,7 @@ msgstr "<分段符>"
 
 #: builtin/notes.c
 msgid "insert <paragraph-break> between paragraphs"
-msgstr "在段落之间插入<分段符>"
+msgstr "在段落之间插入 <分段符>"
 
 #: builtin/notes.c
 msgid "remove unnecessary whitespace"
@@ -12188,7 +12202,7 @@ msgstr "删除不必要的空白字符"
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
-msgstr "不能添加注解。发现对象 %s 已存在注解。使用 '-f' 覆盖现存注解"
+msgstr "无法添加注解。发现对象 %s 已存在注解。使用 '-f' 覆盖现存注解"
 
 #: builtin/notes.c
 #, c-format
@@ -12217,12 +12231,12 @@ msgstr "参数太少"
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
-msgstr "不能拷贝注解。发现对象 %s 已存在注解。使用 '-f' 覆盖现存注解"
+msgstr "无法拷贝注解。发现对象 %s 已存在注解。使用 '-f' 覆盖现存注解"
 
 #: builtin/notes.c
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
-msgstr "源对象 %s 缺少注解。不能拷贝。"
+msgstr "源对象 %s 缺少注解。无法拷贝。"
 
 #: builtin/notes.c
 #, c-format
@@ -12294,7 +12308,7 @@ msgstr "通过提交未合并的注解来完成注解合并"
 
 #: builtin/notes.c
 msgid "Aborting notes merge resolution"
-msgstr "中止注解合并的方案"
+msgstr "中止注解合并的解决过程"
 
 #: builtin/notes.c
 msgid "abort notes merge"
@@ -12330,7 +12344,7 @@ msgid ""
 "'git notes merge --commit', or abort the merge with 'git notes merge --"
 "abort'.\n"
 msgstr ""
-"自动合并说明失败。修改 %s 中的冲突并且使用命令 'git notes merge --commit' 提"
+"自动注解合并失败。修改 %s 中的冲突并且使用命令 'git notes merge --commit' 提"
 "交结果，或者使用命令 'git notes merge --abort' 终止合并。\n"
 
 #: builtin/notes.c builtin/tag.c
@@ -12391,7 +12405,7 @@ msgstr ""
 "                 [--revs [--unpacked | --all]] [--keep-pack=<包名>]\n"
 "                 [--cruft] [--cruft-expiration=<时间>]\n"
 "                 [--stdout [--filter=<过滤规格>] | <基线名称>]\n"
-"                 [--shallow] [--keep-true-parents] [--[no-]sparse]\"\n"
+"                 [--shallow] [--keep-true-parents] [--[no-]sparse]\n"
 "                 [--name-hash-version=<n>] [--path-walk] < <对象列表>"
 
 #: builtin/pack-objects.c
@@ -12470,7 +12484,7 @@ msgstr "禁用 bitmap 写入，因为一些对象将不会被打包"
 #: builtin/pack-objects.c
 #, c-format
 msgid "delta base offset overflow in pack for %s"
-msgstr "%s 压缩中 delta 基准偏移越界"
+msgstr "包 %s 中 delta 基准偏移溢出"
 
 #: builtin/pack-objects.c
 #, c-format
@@ -12572,7 +12586,7 @@ msgstr "包文件 %s 是承诺者，但已给出 --exclude-promisor-objects"
 #: builtin/pack-objects.c
 #, c-format
 msgid "could not find pack '%s'"
-msgstr "不能找到包 '%s'"
+msgstr "无法找到包 '%s'"
 
 #: builtin/pack-objects.c
 #, c-format
@@ -12611,7 +12625,7 @@ msgstr ""
 
 #: builtin/pack-objects.c reachable.c
 msgid "could not load cruft pack .mtimes"
-msgstr "不能载入废弃包 .mtimes"
+msgstr "无法载入废弃包 .mtimes"
 
 #: builtin/pack-objects.c
 msgid "cannot open pack index"
@@ -12638,7 +12652,7 @@ msgstr "不是一个版本 '%s'"
 #: builtin/pack-objects.c builtin/rev-parse.c
 #, c-format
 msgid "bad revision '%s'"
-msgstr "坏的版本 '%s'"
+msgstr "错误的版本 '%s'"
 
 #: builtin/pack-objects.c
 msgid "unable to add recent objects"
@@ -12788,7 +12802,7 @@ msgstr "忽略配有 .keep 文件的包"
 
 #: builtin/pack-objects.c
 msgid "ignore this pack"
-msgstr "忽略该 pack"
+msgstr "忽略该包"
 
 #: builtin/pack-objects.c
 msgid "pack compression level"
@@ -12796,7 +12810,7 @@ msgstr "打包压缩级别"
 
 #: builtin/pack-objects.c
 msgid "do not hide commits by grafts"
-msgstr "显示被移植隐藏的提交"
+msgstr "显示被嫁接隐藏的提交"
 
 #: builtin/pack-objects.c
 msgid "use a bitmap index if available to speed up counting objects"
@@ -12889,7 +12903,7 @@ msgid ""
 "reused %<PRIu32> (from %<PRIuMAX>)"
 msgstr ""
 "总共 %<PRIu32>（差异 %<PRIu32>），复用 %<PRIu32>（差异 %<PRIu32>），包复用 "
-"%<PRIu32>（来自  %<PRIuMAX> 个包）"
+"%<PRIu32>（来自 %<PRIuMAX> 个包）"
 
 #: builtin/pack-refs.c
 msgid "git pack-refs "
@@ -13042,8 +13056,8 @@ msgstr ""
 "  git config pull.ff only       # 仅快进\n"
 "\n"
 "您可以将 \"git config\" 替换为 \"git config --global\" 以便为所有仓库设置\n"
-"缺省的配置项。您也可以在每次执行 pull 命令时添加 --rebase、--no-rebase，\n"
-"或者 --ff-only 参数覆盖缺省设置。\n"
+"默认的配置项。您也可以在每次执行 pull 命令时添加 --rebase、--no-rebase，\n"
+"或者 --ff-only 参数覆盖默认设置。\n"
 
 #: builtin/pull.c
 msgid "control for recursive fetching of submodules"
@@ -13059,7 +13073,7 @@ msgstr "使用变基操作取代合并操作以合入修改"
 
 #: builtin/pull.c builtin/revert.c
 msgid "allow fast-forward"
-msgstr "允许快进式"
+msgstr "允许快进"
 
 #: builtin/pull.c
 msgid "control use of pre-merge-commit and commit-msg hooks"
@@ -13067,7 +13081,7 @@ msgstr "控制 pre-merge-commit 和 commit-msg 钩子的使用"
 
 #: builtin/pull.c parse-options.h
 msgid "automatically stash/stash pop before and after"
-msgstr "在操作前后执行自动贮藏和弹出贮藏"
+msgstr "在操作前后执行自动储藏和弹出储藏"
 
 #: builtin/pull.c
 msgid "Options related to fetching"
@@ -13099,7 +13113,7 @@ msgstr "变基式拉取"
 
 #: builtin/pull.c builtin/rebase.c
 msgid "Please commit or stash them."
-msgstr "请提交或贮藏修改。"
+msgstr "请提交或储藏修改。"
 
 #: builtin/pull.c
 #, c-format
@@ -13146,7 +13160,7 @@ msgstr "需要指定如何调和偏离的分支。"
 
 #: builtin/pull.c
 msgid "cannot rebase with locally recorded submodule modifications"
-msgstr "本地子模组中有修改，无法变基"
+msgstr "本地子模组中有修改，不能变基"
 
 #: builtin/push.c
 msgid "git push [<options>] [<repository> [<refspec>...]]"
@@ -13361,7 +13375,7 @@ msgstr "删除引用"
 
 #: builtin/push.c
 msgid "push tags (can't be used with --all or --branches or --mirror)"
-msgstr "推送标签（不能使用 --all or --branches or --mirror）"
+msgstr "推送标签（不能与 --all、--branches 或 --mirror 同时使用）"
 
 #: builtin/push.c builtin/send-pack.c
 msgid "force updates"
@@ -13422,7 +13436,7 @@ msgstr "--delete 未接任何引用没有意义"
 #: builtin/push.c t/helper/test-bundle-uri.c
 #, c-format
 msgid "bad repository '%s'"
-msgstr "坏的仓库 '%s'"
+msgstr "错误的仓库 '%s'"
 
 #: builtin/push.c
 msgid ""
@@ -13550,11 +13564,11 @@ msgstr "读取之余再执行一个合并"
 
 #: builtin/read-tree.c
 msgid "3-way merge if no file level merging required"
-msgstr "如果没有文件级合并需要，执行三方合并"
+msgstr "如果没有文件级合并需要，执行三路合并"
 
 #: builtin/read-tree.c
 msgid "3-way merge in presence of adds and removes"
-msgstr "存在添加和删除时，也执行三方合并"
+msgstr "存在添加和删除时，也执行三路合并"
 
 #: builtin/read-tree.c
 msgid "same as -m, but discard unmerged entries"
@@ -13578,7 +13592,7 @@ msgstr "gitignore"
 
 #: builtin/read-tree.c
 msgid "allow explicitly ignored files to be overwritten"
-msgstr "允许忽略文件中设定的文件可以被覆盖"
+msgstr "允许显式忽略的文件被覆盖"
 
 #: builtin/read-tree.c
 msgid "don't check the working tree after merging"
@@ -13621,7 +13635,7 @@ msgstr ""
 #: builtin/rebase.c sequencer.c
 #, c-format
 msgid "could not read '%s'."
-msgstr "不能读取 '%s'。"
+msgstr "无法读取 '%s'。"
 
 #: builtin/rebase.c
 #, c-format
@@ -13762,7 +13776,7 @@ msgstr "变基到给定的分支而非上游"
 
 #: builtin/rebase.c
 msgid "use the merge-base of upstream and branch as the current base"
-msgstr "使用上游和分支的合并基线做为当前基线"
+msgstr "使用上游和分支的合并基线作为当前基线"
 
 #: builtin/rebase.c
 msgid "allow pre-rebase hook to run"
@@ -13938,7 +13952,7 @@ msgstr "动作 --edit-todo 只能用在交互式变基过程中。"
 
 #: builtin/rebase.c
 msgid "Cannot read HEAD"
-msgstr "不能读取 HEAD"
+msgstr "无法读取 HEAD"
 
 #: builtin/rebase.c
 msgid ""
@@ -14008,7 +14022,7 @@ msgstr "无效的上游 '%s'"
 
 #: builtin/rebase.c
 msgid "Could not create new root commit"
-msgstr "不能创建新的根提交"
+msgstr "无法创建新的根提交"
 
 #: builtin/rebase.c
 #, c-format
@@ -14022,7 +14036,7 @@ msgstr "没有这样的引用：%s"
 
 #: builtin/rebase.c
 msgid "Could not resolve HEAD to a commit"
-msgstr "不能解析 HEAD 至一个提交"
+msgstr "无法解析 HEAD 至一个提交"
 
 #: builtin/rebase.c
 #, c-format
@@ -14156,7 +14170,7 @@ msgstr "git reflog exists <引用>"
 
 #: builtin/reflog.c
 msgid "git reflog write <ref> <old-oid> <new-oid> <message>"
-msgstr "git reflog write <引用> <旧oid> <新oid> <消息>"
+msgstr "git reflog write <引用> <旧OID> <新OID> <消息>"
 
 #: builtin/reflog.c
 msgid ""
@@ -14294,7 +14308,7 @@ msgstr "新对象 '%s' 不存在"
 #: builtin/reflog.c
 #, c-format
 msgid "cannot start transaction: %s"
-msgstr "不能启动事务：%s"
+msgstr "无法启动事务：%s"
 
 #: builtin/reflog.c
 #, c-format
@@ -14316,7 +14330,7 @@ msgstr "git refs verify [--strict] [--verbose]"
 
 #: builtin/refs.c
 msgid "git refs exists <ref>"
-msgstr "git reflog exists <引用>"
+msgstr "git refs exists <引用>"
 
 #: builtin/refs.c
 msgid "git refs optimize "
@@ -14353,7 +14367,7 @@ msgstr "'git refs verify' 不接受任何参数"
 
 #: builtin/refs.c
 msgid "git refs list "
-msgstr "git reflog list"
+msgstr "git refs list "
 
 #: builtin/refs.c
 msgid "'git refs exists' requires a reference"
@@ -14452,7 +14466,7 @@ msgstr "更新 %s 中"
 #: builtin/remote.c
 #, c-format
 msgid "Could not fetch %s"
-msgstr "不能获取 %s"
+msgstr "无法获取 %s"
 
 #: builtin/remote.c
 msgid ""
@@ -14543,12 +14557,12 @@ msgstr "（删除）"
 #: builtin/remote.c
 #, c-format
 msgid "could not set '%s'"
-msgstr "不能设置 '%s'"
+msgstr "无法设置 '%s'"
 
 #: builtin/remote.c config.c
 #, c-format
 msgid "could not unset '%s'"
-msgstr "不能取消设置 '%s'"
+msgstr "无法取消设置 '%s'"
 
 #: builtin/remote.c
 #, c-format
@@ -14559,7 +14573,7 @@ msgid ""
 msgstr ""
 "配置（%s）remote.pushDefault 位于：\n"
 "\t%s:%d\n"
-"现在在为不存在的远程名 '%s' 命名"
+"现在指向不存在的远程名 '%s'"
 
 #: builtin/remote.c
 msgid ""
@@ -14585,7 +14599,7 @@ msgstr "没有此远程仓库：'%s'"
 #: builtin/remote.c
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
-msgstr "不能重命名配置小节 '%s' 到 '%s'"
+msgstr "无法重命名配置小节 '%s' 到 '%s'"
 
 #: builtin/remote.c
 msgid "Renaming remote references"
@@ -14625,7 +14639,7 @@ msgstr[1] "注意：refs/remotes/ 层级之外的一些分支未被移除。要�
 #: builtin/remote.c
 #, c-format
 msgid "Could not remove config section '%s'"
-msgstr "不能移除配置小节 '%s'"
+msgstr "无法移除配置小节 '%s'"
 
 #: builtin/remote.c
 #, c-format
@@ -14651,7 +14665,7 @@ msgstr " ???"
 #: builtin/remote.c
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
-msgstr "无效的 branch.%s.merge，不能变基到一个以上的分支"
+msgstr "无效的 branch.%s.merge，无法变基到一个以上的分支"
 
 #: builtin/remote.c
 #, c-format
@@ -14681,7 +14695,7 @@ msgstr "与远程 %s 合并"
 #: builtin/remote.c
 #, c-format
 msgid "%-*s    and with remote %s\n"
-msgstr "%-*s    以及和远程 %s\n"
+msgstr "%-*s    以及与远程 %s\n"
 
 #: builtin/remote.c
 msgid "create"
@@ -14854,7 +14868,7 @@ msgstr "不是一个有效引用：%s"
 #: builtin/remote.c
 #, c-format
 msgid "Could not set up %s"
-msgstr "不能设置 %s"
+msgstr "无法设置 %s"
 
 #: builtin/remote.c
 #, c-format
@@ -14903,7 +14917,7 @@ msgstr "返回所有 URL 地址"
 
 #: builtin/remote.c
 msgid "manipulate push URLs"
-msgstr "操作推送 URLS"
+msgstr "管理推送 URL"
 
 #: builtin/remote.c
 msgid "add URL"
@@ -14911,7 +14925,7 @@ msgstr "添加 URL"
 
 #: builtin/remote.c
 msgid "delete URLs"
-msgstr "删除 URLS"
+msgstr "删除 URL"
 
 #: builtin/remote.c
 msgid "--add --delete doesn't make sense"
@@ -14920,7 +14934,7 @@ msgstr "--add --delete 无意义"
 #: builtin/remote.c
 #, c-format
 msgid "Invalid old URL pattern: %s"
-msgstr "无效的旧 URL 匹配模版：%s"
+msgstr "无效的旧 URL 匹配模板：%s"
 
 #: builtin/remote.c
 #, c-format
@@ -15016,7 +15030,7 @@ msgstr "向 git-pack-objects 传递参数 --delta-islands"
 
 #: builtin/repack.c
 msgid "with -A, do not loosen objects older than this"
-msgstr "使用 -A，不要将早于给定时间的对象过期"
+msgstr "使用 -A，不要将早于给定时间的对象变为松散对象"
 
 #: builtin/repack.c
 msgid "with -a, repack unreachable objects"
@@ -15056,7 +15070,7 @@ msgstr "不要对该包文件重新打包"
 
 #: builtin/repack.c
 msgid "find a geometric progression with factor <N>"
-msgstr "使用因子 <n> 查找几何级数"
+msgstr "使用因子 <N> 查找几何级数"
 
 #: builtin/repack.c
 msgid "write a multi-pack index of the resulting packs"
@@ -15226,12 +15240,12 @@ msgstr "在替换的提交中签名将被移除！"
 #: builtin/replace.c
 #, c-format
 msgid "could not write replacement commit for: '%s'"
-msgstr "不能为 '%s' 写替换提交"
+msgstr "无法为 '%s' 写替换提交"
 
 #: builtin/replace.c
 #, c-format
 msgid "graft for '%s' unnecessary"
-msgstr "对 '%s' 移植没有必要"
+msgstr "对 '%s' 嫁接没有必要"
 
 #: builtin/replace.c
 #, c-format
@@ -15244,7 +15258,7 @@ msgid ""
 "could not convert the following graft(s):\n"
 "%s"
 msgstr ""
-"不能转换下列移植：\n"
+"无法转换下列嫁接：\n"
 "%s"
 
 #: builtin/replace.c
@@ -15265,7 +15279,7 @@ msgstr "修改一个提交的父提交"
 
 #: builtin/replace.c
 msgid "convert existing graft file"
-msgstr "转换现存的移植文件"
+msgstr "转换现存的嫁接文件"
 
 #: builtin/replace.c
 msgid "replace the ref if it exists"
@@ -15336,7 +15350,7 @@ msgstr "--advance 的参数必须是引用"
 msgid ""
 "cannot advance target with multiple sources because ordering would be ill-"
 "defined"
-msgstr "不能使用多个源推进目标，因为无法明确如何排序"
+msgstr "无法使用多个源推进目标，因为无法明确如何排序"
 
 #: builtin/replay.c
 #, c-format
@@ -15394,7 +15408,7 @@ msgstr "目前还不支持从根提交向下重放！"
 
 #: builtin/replay.c
 msgid "replaying merge commits is not supported yet!"
-msgstr "目前还不支持重放到合并提交！"
+msgstr "目前还不支持重放合并提交！"
 
 #: builtin/replay.c
 #, c-format
@@ -15458,7 +15472,7 @@ msgstr "远程"
 
 #: builtin/repo.c
 msgid "Others"
-msgstr "其它"
+msgstr "其他"
 
 #: builtin/repo.c
 msgid "Reachable objects"
@@ -15522,7 +15536,7 @@ msgstr "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<提交>]
 
 #: builtin/reset.c
 msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
-msgstr "git reset [-q] [<树对象>] [--] <路径表达式>..."
+msgstr "git reset [-q] [<树对象>] [--] <路径规格>..."
 
 #: builtin/reset.c
 msgid ""
@@ -15531,7 +15545,7 @@ msgstr "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<树对象>
 
 #: builtin/reset.c
 msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
-msgstr "git reset --patch [<树对象>] [--] [<路径表达式>...]"
+msgstr "git reset --patch [<树对象>] [--] [<路径规格>...]"
 
 #: builtin/reset.c
 msgid "mixed"
@@ -15623,13 +15637,13 @@ msgstr "--mixed 带路径已弃用，而是用 'git reset -- <路径>'。"
 #: builtin/reset.c
 #, c-format
 msgid "Cannot do %s reset with paths."
-msgstr "不能带路径进行%s重置。"
+msgstr "无法带路径进行%s重置。"
 
 #  译者：汉字之间无空格，故删除%s前后空格
 #: builtin/reset.c
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
-msgstr "不能对纯仓库进行%s重置"
+msgstr "不允许对纯仓库进行%s重置"
 
 #: builtin/reset.c
 msgid "Unstaged changes after reset:"
@@ -15645,11 +15659,11 @@ msgstr "在重置后花了 %.2f 秒来刷新索引。使用 '--no-refresh' 以�
 #: builtin/reset.c
 #, c-format
 msgid "Could not reset index file to revision '%s'."
-msgstr "不能重置索引文件至版本 '%s'。"
+msgstr "无法重置索引文件至版本 '%s'。"
 
 #: builtin/reset.c
 msgid "Could not write new index file."
-msgstr "不能写入新的索引文件。"
+msgstr "无法写入新的索引文件。"
 
 #: builtin/rev-list.c
 #, c-format
@@ -15727,7 +15741,7 @@ msgstr "--resolve-git-dir 需要一个参数"
 #: builtin/rev-parse.c
 #, c-format
 msgid "not a gitdir '%s'"
-msgstr "不是一个git目录 '%s'"
+msgstr "不是一个 git 目录 '%s'"
 
 #: builtin/rev-parse.c
 msgid "--git-path requires an argument"
@@ -15774,7 +15788,7 @@ msgstr "该操作必须在一个工作区中运行"
 
 #: builtin/rev-parse.c
 msgid "Could not read the index"
-msgstr "不能读取索引"
+msgstr "无法读取索引"
 
 #: builtin/rev-parse.c
 #, c-format
@@ -15816,15 +15830,15 @@ msgstr "%s：%s 不能和 %s 同时使用"
 
 #: builtin/revert.c
 msgid "end revert or cherry-pick sequence"
-msgstr "终止反转或拣选操作"
+msgstr "结束还原或拣选操作"
 
 #: builtin/revert.c
 msgid "resume revert or cherry-pick sequence"
-msgstr "继续反转或拣选操作"
+msgstr "继续还原或拣选操作"
 
 #: builtin/revert.c
 msgid "cancel revert or cherry-pick sequence"
-msgstr "取消反转或拣选操作"
+msgstr "取消还原或拣选操作"
 
 #: builtin/revert.c
 msgid "skip current commit and continue"
@@ -15956,7 +15970,7 @@ msgstr "没有提供路径规格。我应该删除哪些文件？"
 
 #: builtin/rm.c
 msgid "please stage your changes to .gitmodules or stash them to proceed"
-msgstr "请将您的修改暂存到 .gitmodules 中或贮藏后再继续"
+msgstr "请将您的修改暂存到 .gitmodules 中或储藏后再继续"
 
 #: builtin/rm.c
 #, c-format
@@ -15966,7 +15980,7 @@ msgstr "未提供 -r 选项不会递归删除 '%s'"
 #: builtin/rm.c
 #, c-format
 msgid "git rm: unable to remove %s"
-msgstr "git rm：不能删除 %s"
+msgstr "git rm：无法删除 %s"
 
 #: builtin/send-pack.c
 msgid ""
@@ -16124,11 +16138,11 @@ msgstr "以对象名字命名提交"
 
 #: builtin/show-branch.c
 msgid "show possible merge bases"
-msgstr "显示可能合并的基线"
+msgstr "显示可能的合并基线"
 
 #: builtin/show-branch.c
 msgid "show refs unreachable from any other ref"
-msgstr "显示没有任何引用的的引用"
+msgstr "显示任何其他引用都不可达的引用"
 
 #: builtin/show-branch.c
 msgid "show commits in topological order"
@@ -16178,8 +16192,8 @@ msgstr "无此引用 %s"
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
-msgstr[0] "不能处理 %d 个以上的版本。"
-msgstr[1] "不能处理 %d 个以上的版本。"
+msgstr[0] "无法处理 %d 个以上的版本。"
+msgstr[1] "无法处理 %d 个以上的版本。"
 
 #: builtin/show-branch.c
 #, c-format
@@ -16189,7 +16203,7 @@ msgstr "'%s' 不是一个有效的引用。"
 #: builtin/show-branch.c
 #, c-format
 msgid "cannot find commit %s (%s)"
-msgstr "不能找到提交 %s（%s）"
+msgstr "无法找到提交 %s（%s）"
 
 #: builtin/show-index.c
 msgid "hash-algorithm"
@@ -16249,7 +16263,7 @@ msgstr "显示 HEAD 引用，即使被过滤掉"
 
 #: builtin/show-ref.c
 msgid "dereference tags into object IDs"
-msgstr "转换标签到对象 ID"
+msgstr "将标签解引用为对象 ID"
 
 #: builtin/show-ref.c
 msgid "only show SHA1 hash using <n> digits"
@@ -16298,7 +16312,7 @@ msgstr "无法为稀疏检出文件创建目录"
 #: builtin/sparse-checkout.c
 #, c-format
 msgid "unable to fdopen %s"
-msgstr "不能 fdopen %s"
+msgstr "无法 fdopen %s"
 
 #: builtin/sparse-checkout.c
 msgid "failed to initialize worktree config"
@@ -16454,11 +16468,11 @@ msgstr "输入和输出的文件使用 NUL 字符终结"
 
 #: builtin/sparse-checkout.c
 msgid "when used with --rules-file interpret patterns as cone mode patterns"
-msgstr "通过 --rules-file 选项传递的模型将被作为锥形（稀疏检出模型）进行解析"
+msgstr "通过 --rules-file 选项传递的模式将被作为锥形模式（稀疏检出）进行解析"
 
 #: builtin/sparse-checkout.c
 msgid "use patterns in <file> instead of the current ones."
-msgstr "从 <文件> 参数中读取模式，而不是从标准输入"
+msgstr "使用 <文件> 中的模式替代当前模式。"
 
 #: builtin/stash.c
 msgid "git stash list [<log-options>]"
@@ -16470,23 +16484,23 @@ msgid ""
 "options>] [<stash>]"
 msgstr ""
 "git stash show [-u | --include-untracked | --only-untracked] [<差异选项>] [<"
-"贮存>]"
+"储藏>]"
 
 #: builtin/stash.c
 msgid "git stash drop [-q | --quiet] [<stash>]"
-msgstr "git stash drop [-q | --quiet] [<贮存>]"
+msgstr "git stash drop [-q | --quiet] [<储藏>]"
 
 #: builtin/stash.c
 msgid "git stash pop [--index] [-q | --quiet] [<stash>]"
-msgstr "git stash pop [--index] [-q | --quiet] [<贮存>]"
+msgstr "git stash pop [--index] [-q | --quiet] [<储藏>]"
 
 #: builtin/stash.c
 msgid "git stash apply [--index] [-q | --quiet] [<stash>]"
-msgstr "git stash apply [--index] [-q | --quiet] [<贮存>]"
+msgstr "git stash apply [--index] [-q | --quiet] [<储藏>]"
 
 #: builtin/stash.c
 msgid "git stash branch <branchname> [<stash>]"
-msgstr "git stash branch <分支名> [<stash>]"
+msgstr "git stash branch <分支名> [<储藏>]"
 
 #: builtin/stash.c
 msgid "git stash store [(-m | --message) <message>] [-q | --quiet] <commit>"
@@ -16503,7 +16517,7 @@ msgid ""
 msgstr ""
 "git stash [push [-p | --patch] [-S | --staged] [-k | --[no-]keep-index] [-q "
 "| --quiet]\n"
-"          [-u | --include-untracked] [-a | --all] [(-m | --message <消息>]\n"
+"          [-u | --include-untracked] [-a | --all] [(-m | --message) <消息>]\n"
 "          [--pathspec-from-file=<文件> [--pathspec-file-nul]]\n"
 "          [--] [<路径规格>...]]"
 
@@ -16523,7 +16537,7 @@ msgstr "git stash create [<消息>]"
 
 #: builtin/stash.c
 msgid "git stash export (--print | --to-ref <ref>) [<stash>...]"
-msgstr "git stash export (--print | --to-ref <引用>) [<贮藏>...]"
+msgstr "git stash export (--print | --to-ref <引用>) [<储藏>...]"
 
 #: builtin/stash.c
 msgid "git stash import <commit>"
@@ -16532,11 +16546,11 @@ msgstr "git stash import <提交>"
 #: builtin/stash.c
 #, c-format
 msgid "'%s' is not a stash-like commit"
-msgstr "'%s' 不像是一个贮藏提交"
+msgstr "'%s' 不像是一个储藏提交"
 
 #: builtin/stash.c
 msgid "No stash entries found."
-msgstr "未发现贮藏条目。"
+msgstr "未发现储藏条目。"
 
 #: builtin/stash.c
 #, c-format
@@ -16565,7 +16579,7 @@ msgstr ""
 
 #: builtin/stash.c
 msgid "cannot apply a stash in the middle of a merge"
-msgstr "无法在合并过程中应用贮藏"
+msgstr "无法在合并过程中应用储藏"
 
 #: builtin/stash.c
 #, c-format
@@ -16578,7 +16592,7 @@ msgstr "索引中有冲突。尝试不用 --index。"
 
 #: builtin/stash.c
 msgid "could not save index tree"
-msgstr "不能保存索引树"
+msgstr "无法保存索引树"
 
 #: builtin/stash.c
 #, c-format
@@ -16587,11 +16601,11 @@ msgstr "正在合并 %s 和 %s"
 
 #: builtin/stash.c
 msgid "Index was not unstashed."
-msgstr "索引未从贮藏中恢复。"
+msgstr "索引未从储藏中恢复。"
 
 #: builtin/stash.c
 msgid "could not restore untracked files from stash"
-msgstr "无法从贮藏条目中恢复未跟踪文件"
+msgstr "无法从储藏条目中恢复未跟踪文件"
 
 #: builtin/stash.c
 msgid "attempt to recreate the index"
@@ -16605,16 +16619,16 @@ msgstr "丢弃了 %s（%s）"
 #: builtin/stash.c
 #, c-format
 msgid "%s: Could not drop stash entry"
-msgstr "%s：无法丢弃贮藏条目"
+msgstr "%s：无法丢弃储藏条目"
 
 #: builtin/stash.c
 #, c-format
 msgid "'%s' is not a stash reference"
-msgstr "'%s' 不是一个贮藏引用"
+msgstr "'%s' 不是一个储藏引用"
 
 #: builtin/stash.c
 msgid "The stash entry is kept in case you need it again."
-msgstr "贮藏条目被保留以备您再次需要。"
+msgstr "储藏条目被保留以备您再次需要。"
 
 #: builtin/stash.c
 msgid "No branch name specified"
@@ -16630,11 +16644,11 @@ msgstr "无法解包目录树"
 
 #: builtin/stash.c
 msgid "include untracked files in the stash"
-msgstr "在贮藏中包含未跟踪文件"
+msgstr "在储藏中包含未跟踪文件"
 
 #: builtin/stash.c
 msgid "only show untracked files in the stash"
-msgstr "仅显示贮藏中的未跟踪文件"
+msgstr "仅显示储藏中的未跟踪文件"
 
 #: builtin/stash.c
 #, c-format
@@ -16643,7 +16657,7 @@ msgstr "无法用 %2$s 更新 %1$s"
 
 #: builtin/stash.c
 msgid "stash message"
-msgstr "贮藏说明"
+msgstr "储藏说明"
 
 #: builtin/stash.c
 msgid "\"git stash store\" requires one <commit> argument"
@@ -16679,7 +16693,7 @@ msgstr "无法保存当前暂存状态"
 
 #: builtin/stash.c
 msgid "Cannot record working tree state"
-msgstr "不能记录工作区状态"
+msgstr "无法记录工作区状态"
 
 #: builtin/stash.c
 msgid "Can't use --patch and --include-untracked or --all at the same time"
@@ -16699,7 +16713,7 @@ msgstr "没有要保存的本地修改"
 
 #: builtin/stash.c
 msgid "Cannot initialize stash"
-msgstr "无法初始化贮藏"
+msgstr "无法初始化储藏"
 
 #: builtin/stash.c
 msgid "Cannot save the current status"
@@ -16720,11 +16734,11 @@ msgstr "保持索引"
 
 #: builtin/stash.c
 msgid "stash staged changes only"
-msgstr "只贮藏暂存的变更"
+msgstr "只储藏暂存的变更"
 
 #: builtin/stash.c
 msgid "stash in patch mode"
-msgstr "以补丁模式贮藏"
+msgstr "以补丁模式储藏"
 
 #: builtin/stash.c
 msgid "quiet mode"
@@ -16732,7 +16746,7 @@ msgstr "静默模式"
 
 #: builtin/stash.c
 msgid "include untracked files in stash"
-msgstr "贮藏中包含未跟踪文件"
+msgstr "储藏中包含未跟踪文件"
 
 #: builtin/stash.c
 msgid "include ignore files"
@@ -16741,7 +16755,7 @@ msgstr "包含忽略的文件"
 #: builtin/stash.c
 #, c-format
 msgid "cannot parse commit %s"
-msgstr "不能解析提交 %s"
+msgstr "无法解析提交 %s"
 
 #: builtin/stash.c
 #, c-format
@@ -16765,7 +16779,7 @@ msgstr "不是提交：%s"
 #: builtin/stash.c
 #, c-format
 msgid "%s is not a valid exported stash commit"
-msgstr "%s 不是一个有效的且已导出的贮藏提交"
+msgstr "%s 不是一个有效的且已导出的储藏提交"
 
 #: builtin/stash.c
 #, c-format
@@ -16775,7 +16789,7 @@ msgstr "发现根提交 %s 包含无效数据"
 #: builtin/stash.c
 #, c-format
 msgid "found stash commit %s without expected prefix"
-msgstr "发现贮藏提交 %s 缺少预期前缀"
+msgstr "发现储藏提交 %s 缺少预期前缀"
 
 #: builtin/stash.c
 #, c-format
@@ -16785,7 +16799,7 @@ msgstr "无法解析该提交的父提交：%s"
 #: builtin/stash.c
 #, c-format
 msgid "%s does not look like a stash commit"
-msgstr "%s 看起来不像是一个贮藏提交"
+msgstr "%s 看起来不像是一个储藏提交"
 
 #: builtin/stash.c
 #, c-format
@@ -16795,7 +16809,7 @@ msgstr "无法读取提交的缓冲区：%s"
 #: builtin/stash.c
 #, c-format
 msgid "cannot save the stash for %s"
-msgstr "无法保存 %s 的贮藏"
+msgstr "无法保存 %s 的储藏"
 
 #: builtin/stash.c
 msgid "unable to write base commit"
@@ -16804,7 +16818,7 @@ msgstr "无法写入基线提交"
 #: builtin/stash.c
 #, c-format
 msgid "unable to find stash entry %s"
-msgstr "无法找到贮藏条目 %s"
+msgstr "无法找到储藏条目 %s"
 
 #: builtin/stash.c
 msgid "print the object ID instead of writing it to a ref"
@@ -16954,7 +16968,7 @@ msgstr "%s"
 #: builtin/submodule--helper.c
 #, c-format
 msgid "couldn't hash object from '%s'"
-msgstr "不能从 '%s' 创建哈希对象"
+msgstr "无法从 '%s' 创建哈希对象"
 
 #: builtin/submodule--helper.c
 #, c-format
@@ -16983,7 +16997,7 @@ msgstr "git submodule summary [<选项>] [<提交>] [--] [<路径>]"
 
 #: builtin/submodule--helper.c
 msgid "could not fetch a revision for HEAD"
-msgstr "不能为 HEAD 获取一个版本"
+msgstr "无法为 HEAD 获取一个版本"
 
 #: builtin/submodule--helper.c
 #, c-format
@@ -17037,7 +17051,7 @@ msgstr "无法移除子模组工作区 '%s'\n"
 #: builtin/submodule--helper.c
 #, c-format
 msgid "could not create empty submodule directory %s"
-msgstr "不能创建空的子模组目录 %s"
+msgstr "无法创建空的子模组目录 %s"
 
 #: builtin/submodule--helper.c
 #, c-format
@@ -17082,17 +17096,17 @@ msgstr "无法获得 git 目录 '%s' 的仓库句柄"
 #: builtin/submodule--helper.c
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
-msgstr "子模组 '%s' 不能添加仓库备选：%s"
+msgstr "子模组 '%s' 无法添加仓库备选：%s"
 
 #: builtin/submodule--helper.c
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
-msgstr "不能识别 submodule.alternateErrorStrategy 的取值 '%s'"
+msgstr "无法识别 submodule.alternateErrorStrategy 的取值 '%s'"
 
 #: builtin/submodule--helper.c
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
-msgstr "不能识别 submodule.alternateLocation 的取值 '%s'"
+msgstr "无法识别 submodule.alternateLocation 的取值 '%s'"
 
 #: builtin/submodule--helper.c submodule.c
 #, c-format
@@ -17641,7 +17655,7 @@ msgstr ""
 
 #: builtin/tag.c
 msgid "bad object type."
-msgstr "坏的对象类型。"
+msgstr "错误的对象类型。"
 
 #: builtin/tag.c
 msgid "no tag message?"
@@ -18004,7 +18018,7 @@ msgstr ""
 
 #: builtin/update-index.c
 msgid "Untracked cache disabled"
-msgstr "缓存未跟踪文件被禁用"
+msgstr "未跟踪文件缓存已禁用"
 
 #: builtin/update-index.c
 msgid ""
@@ -18017,7 +18031,7 @@ msgstr ""
 #: builtin/update-index.c
 #, c-format
 msgid "Untracked cache enabled for '%s'"
-msgstr "缓存未跟踪文件在 '%s' 启用"
+msgstr "已为 '%s' 启用未跟踪文件缓存"
 
 #: builtin/update-index.c
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
@@ -18257,7 +18271,7 @@ msgstr "无法在 '%2$s' 中取消配置 '%1$s'"
 #: builtin/worktree.c
 #, c-format
 msgid "could not create directory of '%s'"
-msgstr "不能创建目录 '%s'"
+msgstr "无法创建目录 '%s'"
 
 #: builtin/worktree.c
 msgid "initializing"
@@ -18295,7 +18309,7 @@ msgid ""
 "HEAD path: '%s'\n"
 "HEAD contents: '%s'"
 msgstr ""
-"HEAD 指向了一个无用的（或孤立的）引用。\n"
+"HEAD 指向了一个无效的（或孤立的）引用。\n"
 "HEAD 路径： '%s'\n"
 "HEAD 内容： '%s'"
 
@@ -18309,7 +18323,7 @@ msgstr ""
 
 #: builtin/worktree.c
 msgid "checkout <branch> even if already checked out in other worktree"
-msgstr "检出 <分支>，即使已经被检出到其它工作区"
+msgstr "检出 <分支>，即使已经被检出到其他工作区"
 
 #: builtin/worktree.c
 msgid "create a new branch"
@@ -18371,7 +18385,7 @@ msgstr "显示扩展的注释和原因（如果有）"
 
 #: builtin/worktree.c
 msgid "add 'prunable' annotation to worktrees older than <time>"
-msgstr "向早于 <时间> 的工作区添添加“可修剪”注释"
+msgstr "向早于 <时间> 的工作区添加“可修剪”注释"
 
 #: builtin/worktree.c
 msgid "terminate records with a NUL character"
@@ -18403,7 +18417,7 @@ msgstr "'%s' 未被锁定"
 
 #: builtin/worktree.c
 msgid "working trees containing submodules cannot be moved or removed"
-msgstr "不能移动或删除包含子模组的工作区"
+msgstr "无法移动或删除包含子模组的工作区"
 
 #: builtin/worktree.c
 msgid "force move even if worktree is dirty or locked"
@@ -18516,17 +18530,17 @@ msgstr "只对调试有用"
 #: bundle-uri.c
 #, c-format
 msgid "could not parse bundle list key %s with value '%s'"
-msgstr "不能解析归档包列表键 %s 的值 '%s'"
+msgstr "无法解析捆绑包列表键 %s 的值 '%s'"
 
 #: bundle-uri.c
 #, c-format
 msgid "bundle list at '%s' has no mode"
-msgstr "在 '%s' 的归档包列表没有模式"
+msgstr "在 '%s' 的捆绑包列表没有模式"
 
 #: bundle-uri.c
 #, c-format
 msgid "bundle list at '%s': bundle '%s' has no uri"
-msgstr "在 '%s' 的归档包列表中，归档包 '%s' 没有 URI"
+msgstr "在 '%s' 的捆绑包列表中，捆绑包 '%s' 没有 URI"
 
 #: bundle-uri.c
 msgid "failed to create temporary file"
@@ -18534,12 +18548,12 @@ msgstr "无法创建临时文件"
 
 #: bundle-uri.c
 msgid "insufficient capabilities"
-msgstr "缺乏能力"
+msgstr "能力不足"
 
 #: bundle-uri.c
 #, c-format
 msgid "file downloaded from '%s' is not a bundle"
-msgstr "下载自 '%s' 的文件不是归档包"
+msgstr "下载自 '%s' 的文件不是捆绑包"
 
 #: bundle-uri.c
 msgid "failed to store maximum creation token"
@@ -18548,7 +18562,7 @@ msgstr "无法储存最大的创建令牌"
 #: bundle-uri.c
 #, c-format
 msgid "unrecognized bundle mode from URI '%s'"
-msgstr "不可辨认的归档包模式来自 URI '%s'"
+msgstr "不可辨认的捆绑包模式来自 URI '%s'"
 
 #: bundle-uri.c
 #, c-format
@@ -18558,17 +18572,17 @@ msgstr "超过了 URI 递归限制 (%d)"
 #: bundle-uri.c
 #, c-format
 msgid "bundle '%s' has no uri"
-msgstr "归档包 '%s' 没有 URI"
+msgstr "捆绑包 '%s' 没有 URI"
 
 #: bundle-uri.c
 #, c-format
 msgid "failed to download bundle from URI '%s'"
-msgstr "无法从 URI '%s' 下载归档包"
+msgstr "无法从 URI '%s' 下载捆绑包"
 
 #: bundle-uri.c
 #, c-format
 msgid "file at URI '%s' is not a bundle or bundle list"
-msgstr "位于 URI '%s' 的文件不是归档包或归档包列表"
+msgstr "位于 URI '%s' 的文件不是捆绑包或捆绑包列表"
 
 #: bundle-uri.c
 #, c-format
@@ -18585,7 +18599,7 @@ msgstr "bundle-uri：获得了空行"
 
 #: bundle-uri.c
 msgid "bundle-uri: line is not of the form 'key=value'"
-msgstr "bundle-uri：行不是以 'key=value' 格式"
+msgstr "bundle-uri：行不是 'key=value' 格式"
 
 #: bundle-uri.c
 msgid "bundle-uri: line has empty key or value"
@@ -18594,7 +18608,7 @@ msgstr "bundle-uri：行有空的键或值"
 #: bundle.c
 #, c-format
 msgid "unrecognized bundle hash algorithm: %s"
-msgstr "未能识别的归档包哈希算法：%s"
+msgstr "未能识别的捆绑包哈希算法：%s"
 
 #: bundle.c
 #, c-format
@@ -18604,7 +18618,7 @@ msgstr "未知能力 '%s'"
 #: bundle.c
 #, c-format
 msgid "'%s' does not look like a v2 or v3 bundle file"
-msgstr "'%s' 不像是一个 v2 或 v3 版本的归档包文件"
+msgstr "'%s' 不像是一个 v2 或 v3 版本的捆绑包文件"
 
 #: bundle.c
 #, c-format
@@ -18625,37 +18639,37 @@ msgstr "一些前置提交存在于对象储存中，但未连接于本仓库的
 #, c-format
 msgid "The bundle contains this ref:"
 msgid_plural "The bundle contains these %<PRIuMAX> refs:"
-msgstr[0] "这个归档包中含有这个引用："
-msgstr[1] "这个归档包中含有 %<PRIuMAX> 个引用："
+msgstr[0] "这个捆绑包中含有这个引用："
+msgstr[1] "这个捆绑包中含有 %<PRIuMAX> 个引用："
 
 #: bundle.c
 msgid "The bundle records a complete history."
-msgstr "这个归档包记录一个完整历史。"
+msgstr "这个捆绑包记录一个完整历史。"
 
 #: bundle.c
 #, c-format
 msgid "The bundle requires this ref:"
 msgid_plural "The bundle requires these %<PRIuMAX> refs:"
-msgstr[0] "这个归档包需要这个引用："
-msgstr[1] "这个归档包需要 %<PRIuMAX> 个引用："
+msgstr[0] "这个捆绑包需要这个引用："
+msgstr[1] "这个捆绑包需要 %<PRIuMAX> 个引用："
 
 #: bundle.c
 #, c-format
 msgid "The bundle uses this hash algorithm: %s"
-msgstr "该归档包使用的哈希算法：%s"
+msgstr "该捆绑包使用的哈希算法：%s"
 
 #: bundle.c
 #, c-format
 msgid "The bundle uses this filter: %s"
-msgstr "归档包使用了过滤器：%s"
+msgstr "捆绑包使用了过滤器：%s"
 
 #: bundle.c
 msgid "unable to dup bundle descriptor"
-msgstr "无法复制归档包描述符"
+msgstr "无法复制捆绑包描述符"
 
 #: bundle.c
 msgid "Could not spawn pack-objects"
-msgstr "不能生成 pack-objects 进程"
+msgstr "无法生成 pack-objects 进程"
 
 #: bundle.c
 msgid "pack-objects died"
@@ -18669,21 +18683,21 @@ msgstr "引用 '%s' 被 rev-list 选项排除"
 #: bundle.c
 #, c-format
 msgid "unsupported bundle version %d"
-msgstr "不支持的归档包版本 %d"
+msgstr "不支持的捆绑包版本 %d"
 
 #: bundle.c
 #, c-format
 msgid "cannot write bundle version %d with algorithm %s"
-msgstr "不能写入，归档包版本 %d 不支持算法 %s"
+msgstr "无法写入，捆绑包版本 %d 不支持算法 %s"
 
 #: bundle.c
 msgid "Refusing to create empty bundle."
-msgstr "不能创建空的归档包。"
+msgstr "无法创建空的捆绑包。"
 
 #: bundle.c
 #, c-format
 msgid "cannot create '%s'"
-msgstr "不能创建 '%s'"
+msgstr "无法创建 '%s'"
 
 #: bundle.c
 msgid "index-pack died"
@@ -18820,7 +18834,7 @@ msgstr "切换分支或恢复工作区文件"
 
 #: command-list.h
 msgid "Copy files from the index to the working tree"
-msgstr "从索引拷贝文件到工作区"
+msgstr "从索引复制文件到工作区"
 
 #: command-list.h
 msgid "Find commits yet to be applied to upstream"
@@ -18952,7 +18966,7 @@ msgstr "生成一个合并提交信息"
 
 #: command-list.h
 msgid "Output information on each ref"
-msgstr "对每一个引用输出信息 "
+msgstr "对每一个引用输出信息"
 
 #: command-list.h
 msgid "Run a Git command on a list of repositories"
@@ -19004,11 +19018,11 @@ msgstr "通过 HTTP 从远程 Git 仓库下载"
 
 #: command-list.h
 msgid "Push objects over HTTP/DAV to another repository"
-msgstr "通过 HTTP/DAV 推送对象另一个仓库"
+msgstr "通过 HTTP/DAV 推送对象到另一个仓库"
 
 #: command-list.h
 msgid "Send a collection of patches from stdin to an IMAP folder"
-msgstr "从标准输入将一组补丁发送到IMAP文件夹"
+msgstr "从标准输入将一组补丁发送到 IMAP 文件夹"
 
 #: command-list.h
 msgid "Build pack index file for an existing packed archive"
@@ -19076,7 +19090,7 @@ msgstr "对于需要合并的文件执行合并"
 
 #: command-list.h
 msgid "The standard helper program to use with git-merge-index"
-msgstr "与 git-merge-index 一起使用的标准向导程序"
+msgstr "与 git-merge-index 一起使用的标准辅助程序"
 
 #: command-list.h
 msgid "Perform merge without touching index or working tree"
@@ -19109,7 +19123,7 @@ msgstr "查找给定版本的符号名称"
 
 #: command-list.h
 msgid "Add or inspect object notes"
-msgstr "添加或检查对象注释"
+msgstr "添加或检查对象注解"
 
 #: command-list.h
 msgid "Import from and submit to Perforce repositories"
@@ -19125,7 +19139,7 @@ msgstr "查找冗余的包文件"
 
 #: command-list.h
 msgid "Pack heads and tags for efficient repository access"
-msgstr "打包头和标签以实现高效的仓库访问"
+msgstr "打包分支和标签以实现高效的仓库访问"
 
 #: command-list.h
 msgid "Compute unique ID for a patch"
@@ -19149,7 +19163,7 @@ msgstr "更新远程引用和相关的对象"
 
 #: command-list.h
 msgid "Applies a quilt patchset onto the current branch"
-msgstr "将一个 quilt 补丁集应用到当前分支。"
+msgstr "将一个 quilt 补丁集应用到当前分支"
 
 #: command-list.h
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
@@ -19177,7 +19191,7 @@ msgstr "对引用的低级访问"
 
 #: command-list.h
 msgid "Manage set of tracked repositories"
-msgstr "管理已跟踪仓库"
+msgstr "管理已跟踪的仓库集合"
 
 #: command-list.h
 msgid "Pack unpacked objects in a repository"
@@ -19189,7 +19203,7 @@ msgstr "创建、列出、删除对象替换引用"
 
 #: command-list.h
 msgid "EXPERIMENTAL: Replay commits on a new base, works with bare repos too"
-msgstr "试验中：基于一个新基线重放提交，同样适用于纯仓库"
+msgstr "试验中：在新基线上重放提交，也适用于纯仓库"
 
 #: command-list.h
 msgid "Retrieve information about the repository"
@@ -19197,11 +19211,11 @@ msgstr "检索仓库信息"
 
 #: command-list.h
 msgid "Generates a summary of pending changes"
-msgstr "生成待定更改的摘要"
+msgstr "生成待处理变更的摘要"
 
 #: command-list.h
 msgid "Reuse recorded resolution of conflicted merges"
-msgstr "重用冲突合并的解决方案记录"
+msgstr "重用已记录的冲突合并解决方案"
 
 #: command-list.h
 msgid "Set `HEAD` or the index to a known state"
@@ -19213,7 +19227,7 @@ msgstr "恢复工作区文件"
 
 #: command-list.h
 msgid "Lists commit objects in reverse chronological order"
-msgstr "按时间顺序列出提交对象"
+msgstr "按时间逆序列出提交对象"
 
 #: command-list.h
 msgid "Pick out and massage parameters"
@@ -19221,7 +19235,7 @@ msgstr "选出并处理参数"
 
 #: command-list.h
 msgid "Revert some existing commits"
-msgstr "回退一些现存提交"
+msgstr "还原一些现有提交"
 
 #: command-list.h
 msgid "Remove files from the working tree and from the index"
@@ -19245,11 +19259,11 @@ msgstr "常用的 Git shell 脚本设置代码"
 
 #: command-list.h
 msgid "Restricted login shell for Git-only SSH access"
-msgstr "只允许 Git SSH 访问的受限登录shell"
+msgstr "只允许 Git SSH 访问的受限登录 shell"
 
 #: command-list.h
 msgid "Summarize 'git log' output"
-msgstr "'git log' 输出摘要"
+msgstr "汇总 'git log' 输出"
 
 #: command-list.h
 msgid "Show various types of objects"
@@ -19278,7 +19292,7 @@ msgstr "将文件内容添加到暂存区"
 
 #: command-list.h
 msgid "Stash the changes in a dirty working directory away"
-msgstr "贮藏脏工作区中的修改"
+msgstr "储藏脏工作区中的修改"
 
 #: command-list.h
 msgid "Show the working tree status"
@@ -19294,7 +19308,7 @@ msgstr "初始化、更新或检查子模组"
 
 #: command-list.h
 msgid "Bidirectional operation between a Subversion repository and Git"
-msgstr "Subersion 仓库和 Git 之间的双向操作"
+msgstr "Subversion 仓库和 Git 之间的双向操作"
 
 #: command-list.h
 msgid "Switch branches"
@@ -19326,7 +19340,7 @@ msgstr "安全地更新存储于引用中的对象名称"
 
 #: command-list.h
 msgid "Update auxiliary info file to help dumb servers"
-msgstr "更新辅助信息文件以帮助哑协议服务"
+msgstr "更新辅助信息文件以帮助哑协议服务器"
 
 #: command-list.h
 msgid "Send archive back to git-archive"
@@ -19338,15 +19352,15 @@ msgstr "将对象压缩包发送回 git-fetch-pack"
 
 #: command-list.h
 msgid "Show a Git logical variable"
-msgstr "显示一个Git逻辑变量"
+msgstr "显示一个 Git 逻辑变量"
 
 #: command-list.h
 msgid "Check the GPG signature of commits"
-msgstr "检查 GPG 提交签名"
+msgstr "检查提交的 GPG 签名"
 
 #: command-list.h
 msgid "Validate packed Git archive files"
-msgstr "校验打包的Git存仓文件"
+msgstr "校验打包的 Git 归档文件"
 
 #: command-list.h
 msgid "Check the GPG signature of tags"
@@ -19382,7 +19396,7 @@ msgstr "面向开发人员的 Git 核心教程"
 
 #: command-list.h
 msgid "Providing usernames and passwords to Git"
-msgstr "为 Git 提供用户名和口令"
+msgstr "为 Git 提供用户名和密码"
 
 #: command-list.h
 msgid "Git for CVS users"
@@ -19394,7 +19408,7 @@ msgstr "调整差异输出"
 
 #: command-list.h
 msgid "A useful minimum set of commands for Everyday Git"
-msgstr "每一天 Git 的一组有用的最小命令集合"
+msgstr "日常 Git 的一组有用的最小命令集合"
 
 #: command-list.h
 msgid "Frequently asked questions about using Git"
@@ -19402,7 +19416,7 @@ msgstr "关于使用 Git 的常见问题"
 
 #: command-list.h
 msgid "The bundle file format"
-msgstr "归档包文件格式"
+msgstr "捆绑包文件格式"
 
 #: command-list.h
 msgid "Chunk-based file formats"
@@ -19450,11 +19464,11 @@ msgstr "定义子模组属性"
 
 #: command-list.h
 msgid "Git namespaces"
-msgstr "Git 名字空间"
+msgstr "Git 命名空间"
 
 #: command-list.h
 msgid "Protocol v0 and v1 capabilities"
-msgstr "协议 v0 和 v1 能力"
+msgstr "协议 v0 和 v1 功能"
 
 #: command-list.h
 msgid "Things common to various protocols"
@@ -19466,15 +19480,15 @@ msgstr "Git 基于 HTTP 的协议"
 
 #: command-list.h
 msgid "How packs are transferred over-the-wire"
-msgstr "包在线路中传输的方式"
+msgstr "包在网络上传输的方式"
 
 #: command-list.h
 msgid "Git Wire Protocol, Version 2"
-msgstr "Git 传输协议，第二版"
+msgstr "Git 传输协议，第 2 版"
 
 #: command-list.h
 msgid "Helper programs to interact with remote repositories"
-msgstr "与远程仓库交互的助手程序"
+msgstr "与远程仓库交互的辅助程序"
 
 #: command-list.h
 msgid "Git Repository Layout"
@@ -19482,11 +19496,11 @@ msgstr "Git 仓库布局"
 
 #: command-list.h
 msgid "Specifying revisions and ranges for Git"
-msgstr "指定 Git 的版本和版本范围"
+msgstr "指定 Git 的版本和范围"
 
 #: command-list.h
 msgid "Mounting one repository inside another"
-msgstr "将一个仓库安装到另外一个仓库中"
+msgstr "将一个仓库挂载到另一个仓库中"
 
 #: command-list.h
 msgid "A tutorial introduction to Git"
@@ -19498,7 +19512,7 @@ msgstr "Git 入门教程：第二部分"
 
 #: command-list.h
 msgid "Git web interface (web frontend to Git repositories)"
-msgstr "Git web 界面（Git 仓库的 web 前端）"
+msgstr "Git Web 界面（Git 仓库的 Web 前端）"
 
 #: command-list.h
 msgid "An overview of recommended workflows with Git"
@@ -19541,7 +19555,7 @@ msgstr "提交图的变更路径的索引块太小"
 msgid ""
 "ignoring too-small changed-path chunk (%<PRIuMAX> < %<PRIuMAX>) in commit-"
 "graph file"
-msgstr "忽略提交图文件中过小的更改路径块（%<PRIuMAX> < %<PRIuMAX>）"
+msgstr "忽略提交图文件中过小的变更路径块（%<PRIuMAX> < %<PRIuMAX>）"
 
 #: commit-graph.c
 #, c-format
@@ -19655,7 +19669,7 @@ msgstr "正在计算提交图世代数字"
 
 #: commit-graph.c
 msgid "Computing commit changed paths Bloom filters"
-msgstr "计算提交变更路径的布隆过滤器"
+msgstr "正在计算提交变更路径的布隆过滤器"
 
 #: commit-graph.c
 msgid "Collecting referenced commits"
@@ -19680,7 +19694,7 @@ msgstr "为 %s 打开索引出错"
 
 #: commit-graph.c
 msgid "Finding commits for commit graph among packed objects"
-msgstr "正在打包对象中查找提交图的提交"
+msgstr "正在已打包对象中查找提交图的提交"
 
 #: commit-graph.c
 msgid "Finding extra edges in commit graph"
@@ -19703,8 +19717,8 @@ msgstr "无法为 '%s' 调整共享权限"
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
-msgstr[0] "正在用 %d 步写出提交图"
-msgstr[1] "正在用 %d 步写出提交图"
+msgstr[0] "正在用 %d 次写出提交图"
+msgstr[1] "正在用 %d 次写出提交图"
 
 #: commit-graph.c
 msgid "unable to open commit-graph chain file"
@@ -19726,7 +19740,7 @@ msgstr "无法合并提交图，其提交数分别为 %<PRIuMAX> 和 %<PRIuMAX>"
 #: commit-graph.c
 #, c-format
 msgid "cannot merge graph %s, too many commits: %<PRIuMAX>"
-msgstr "无法合并提交图 %s, 提交过多：%<PRIuMAX>"
+msgstr "无法合并提交图 %s，提交过多：%<PRIuMAX>"
 
 #: commit-graph.c
 msgid "Scanning merged commits"
@@ -19738,7 +19752,7 @@ msgstr "正在合并提交图"
 
 #: commit-graph.c
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
-msgstr "正尝试写提交图，但是 'core.commitGraph' 被禁用"
+msgstr "正在尝试写入提交图，但 'core.commitGraph' 被禁用"
 
 #: commit-graph.c
 #, c-format
@@ -19749,7 +19763,7 @@ msgstr "尝试写入提交图，但不支持 'commitGraph.changedPathsVersion' (
 
 #: commit-graph.c
 msgid "too many commits to write graph"
-msgstr "提交太多不能画图"
+msgstr "提交太多，无法写入提交图"
 
 #: commit-graph.c
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
@@ -19819,7 +19833,7 @@ msgstr "正在校验提交图中的提交"
 #: commit-reach.c sequencer.c
 #, c-format
 msgid "could not parse commit %s"
-msgstr "不能解析提交 %s"
+msgstr "无法解析提交 %s"
 
 #: commit.c
 #, c-format
@@ -19838,10 +19852,10 @@ msgid ""
 "\"git config set advice.graftFileDeprecated false\""
 msgstr ""
 "对 <GIT_DIR>/info/grafts 的支持已过时，并将在\n"
-"未来的Git版本中被移除。\n"
+"未来的 Git 版本中被移除。\n"
 "\n"
 "请使用 \"git replace --convert-graft-file\" 将\n"
-"（提交）移植转换为替换引用。\n"
+"嫁接转换为替换引用。\n"
 "\n"
 "运行 \"git config set advice.graftFileDeprecated false\"\n"
 "可关闭本消息"
@@ -19869,7 +19883,7 @@ msgstr "提交 %s 没有 GPG 签名。"
 #: commit.c
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
-msgstr "提交 %s 有一个来自 %s 的好的 GPG 签名。\n"
+msgstr "提交 %s 有一个来自 %s 的有效 GPG 签名。\n"
 
 #: commit.c
 msgid ""
@@ -19878,7 +19892,7 @@ msgid ""
 "variable i18n.commitEncoding to the encoding your project uses.\n"
 msgstr ""
 "警告：提交说明不符合 UTF-8 字符编码。\n"
-"您可以通过修补提交来改正提交说明，或者将配置变量 i18n.commitEncoding\n"
+"您可以通过修订提交来改正提交说明，或者将配置变量 i18n.commitEncoding\n"
 "设置为您项目所用的字符编码。\n"
 
 #: compat/compiler.h
@@ -19892,7 +19906,7 @@ msgstr "libc 信息不可用\n"
 #: compat/disk.h
 #, c-format
 msgid "could not determine free disk size for '%s'"
-msgstr "不能确定 '%s' 的空余磁盘空间"
+msgstr "无法确定 '%s' 的空余磁盘空间"
 
 #: compat/disk.h
 #, c-format
@@ -19902,7 +19916,7 @@ msgstr "无法获得 '%s' 的信息"
 #: compat/fsmonitor/fsm-health-win32.c
 #, c-format
 msgid "[GLE %ld] health thread could not open '%ls'"
-msgstr "[GLE %ld] 健康监测线程不能打开 '%ls'"
+msgstr "[GLE %ld] 健康监测线程无法打开 '%ls'"
 
 #: compat/fsmonitor/fsm-health-win32.c
 #, c-format
@@ -19912,7 +19926,7 @@ msgstr "[GLE %ld] 健康监测线程正在获取 '%ls' 的 BHFI"
 #: compat/fsmonitor/fsm-health-win32.c compat/fsmonitor/fsm-listen-win32.c
 #, c-format
 msgid "could not convert to wide characters: '%s'"
-msgstr "不能转换至宽字符：'%s'"
+msgstr "无法转换至宽字符：'%s'"
 
 #: compat/fsmonitor/fsm-health-win32.c
 #, c-format
@@ -19932,7 +19946,7 @@ msgstr "健康监测线程等待失败 [GLE %ld]"
 #: compat/fsmonitor/fsm-ipc-darwin.c
 #, c-format
 msgid "Invalid path: %s"
-msgstr "无效路径： %s"
+msgstr "无效路径：%s"
 
 #: compat/fsmonitor/fsm-listen-darwin.c
 msgid "Unable to create FSEventStream."
@@ -19965,7 +19979,7 @@ msgstr "ReadDirectoryChangedW 失败于 '%s' [GLE %ld]"
 #: compat/fsmonitor/fsm-listen-win32.c
 #, c-format
 msgid "GetOverlappedResult failed on '%s' [GLE %ld]"
-msgstr "GetOverlappedResult 失败于 '%s' [GLE %ld]"
+msgstr "GetOverlappedResult 在 '%s' 上失败 [GLE %ld]"
 
 #: compat/fsmonitor/fsm-listen-win32.c
 #, c-format
@@ -20000,12 +20014,12 @@ msgstr "[GLE %ld] 无法打开要读取的 '%ls'"
 #: compat/fsmonitor/fsm-path-utils-win32.c
 #, c-format
 msgid "[GLE %ld] unable to get protocol information for '%ls'"
-msgstr "[GLE %ld] 无法获取 '%ls' 的协议信息 "
+msgstr "[GLE %ld] 无法获取 '%ls' 的协议信息"
 
 #: compat/mingw.c
 #, c-format
 msgid "failed to copy SID (%ld)"
-msgstr "无法拷贝 SID (%ld)"
+msgstr "无法复制 SID (%ld)"
 
 #: compat/mingw.c
 #, c-format
@@ -20042,7 +20056,7 @@ msgstr "末尾的反斜杠"
 
 #: compat/regex/regcomp.c
 msgid "Invalid back reference"
-msgstr "无效的反向索引"
+msgstr "无效的反向引用"
 
 #: compat/regex/regcomp.c
 msgid "Unmatched [ or [^"
@@ -20167,7 +20181,7 @@ msgid ""
 "remote URLs cannot be configured in file directly or indirectly included by "
 "includeIf.hasconfig:remote.*.url"
 msgstr ""
-"远程 URL 不能在文件中配置，不管直接地还是通过 "
+"远程 URL 无法在文件中配置，不管直接地还是通过 "
 "includeIf.hasconfig:remote.*.url 间接地包含"
 
 #: config.c
@@ -20183,7 +20197,7 @@ msgstr "配置 '%.*s' 缺少环境变量名称"
 #: config.c
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
-msgstr "缺少环境变量 '%s' 于配置 '%.*s' "
+msgstr "配置 '%3$.*2$s' 缺少环境变量 '%1$s'"
 
 #: config.c
 #, c-format
@@ -20212,7 +20226,7 @@ msgstr "空的配置键名"
 #: config.c
 #, c-format
 msgid "bogus config parameter: %s"
-msgstr "伪配置参数：%s"
+msgstr "无效的配置参数：%s"
 
 #: config.c
 #, c-format
@@ -20222,7 +20236,7 @@ msgstr "%s 中格式错误"
 #: config.c
 #, c-format
 msgid "bogus count in %s"
-msgstr "%s 中错误计数"
+msgstr "%s 中计数错误"
 
 #: config.c
 #, c-format
@@ -20315,7 +20329,7 @@ msgstr "在 %3$s 中配置变量 '%2$s' 错误的取值 '%1$s'：%4$s"
 #: config.c
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
-msgstr "'%2$s' 的错误的布尔取值 '%1$s'"
+msgstr "配置变量 '%2$s' 的布尔值 '%1$s' 无效"
 
 #: config.c
 #, c-format
@@ -20340,7 +20354,7 @@ msgstr "引用 '%s' 没有指向一个数据对象"
 #: config.c
 #, c-format
 msgid "unable to resolve config blob '%s'"
-msgstr "不能解析配置对象 '%s'"
+msgstr "无法解析配置对象 '%s'"
 
 #: config.c
 msgid "unable to parse command-line config"
@@ -20435,7 +20449,7 @@ msgstr "不允许多行注释：'%s'"
 #: config.c
 #, c-format
 msgid "could not lock config file %s"
-msgstr "不能锁定配置文件 %s"
+msgstr "无法锁定配置文件 %s"
 
 #: config.c
 #, c-format
@@ -20455,7 +20469,7 @@ msgstr "对 %s 调用 fstat 失败"
 #: config.c
 #, c-format
 msgid "unable to mmap '%s'%s"
-msgstr "不能 mmap '%s'%s"
+msgstr "无法 mmap '%s'%s"
 
 #: config.c
 #, c-format
@@ -20465,12 +20479,12 @@ msgstr "对 %s 调用 chmod 失败"
 #: config.c
 #, c-format
 msgid "could not write config file %s"
-msgstr "不能写入配置文件 %s"
+msgstr "无法写入配置文件 %s"
 
 #: config.c
 #, c-format
 msgid "could not set '%s' to '%s'"
-msgstr "不能设置 '%s' 为 '%s'"
+msgstr "无法设置 '%s' 为 '%s'"
 
 #: config.c
 #, c-format
@@ -20480,7 +20494,7 @@ msgstr "无效的小节名称：%s"
 #: config.c
 #, c-format
 msgid "refusing to work with overly long line in '%s' on line %<PRIuMAX>"
-msgstr "拒绝支持内容过长的行，位于文件 '%s' 中的第 %<PRIuMAX> 行"
+msgstr "拒绝处理内容过长的行，位于文件 '%s' 中的第 %<PRIuMAX> 行"
 
 #: config.c
 #, c-format
@@ -20551,7 +20565,7 @@ msgstr "服务器给出未知的对象格式 '%s'"
 #: connect.c
 #, c-format
 msgid "error on bundle-uri response line %d: %s"
-msgstr "于 bundle-uri 响应行 %d 发生错误：%s"
+msgstr "在 bundle-uri 响应行 %d 发生错误：%s"
 
 #: connect.c
 msgid "expected flush after bundle-uri listing"
@@ -20636,11 +20650,11 @@ msgstr "已阻止奇怪的端口号 '%s'"
 #: connect.c
 #, c-format
 msgid "cannot start proxy %s"
-msgstr "不能启动代理 %s"
+msgstr "无法启动代理 %s"
 
 #: connect.c
 msgid "no path specified; see 'git help pull' for valid url syntax"
-msgstr "未指定路径，执行 'git help pull' 查看有效的 url 语法"
+msgstr "未指定路径，执行 'git help pull' 查看有效的 URL 语法"
 
 #: connect.c
 msgid "newline is forbidden in git:// hosts and repo paths"
@@ -20669,7 +20683,7 @@ msgstr "无法 fork"
 
 #: connected.c
 msgid "Could not run 'git rev-list'"
-msgstr "不能执行 'git rev-list'"
+msgstr "无法执行 'git rev-list'"
 
 #: connected.c
 msgid "failed write to rev-list"
@@ -20694,7 +20708,7 @@ msgstr "%s 中的 CRLF 将被 LF 替换"
 msgid ""
 "in the working copy of '%s', CRLF will be replaced by LF the next time Git "
 "touches it"
-msgstr "在 '%s' 的工作拷贝中，下次 Git 接触时 CRLF 将被 LF 替换"
+msgstr "在 '%s' 的工作拷贝中，下次 Git 处理时 CRLF 将被 LF 替换"
 
 #: convert.c
 #, c-format
@@ -20706,7 +20720,7 @@ msgstr "文件 %s 中的 LF 将被 CRLF 替换"
 msgid ""
 "in the working copy of '%s', LF will be replaced by CRLF the next time Git "
 "touches it"
-msgstr "在 '%s' 的工作拷贝中，下次 Git 接触时 LF 将被 CRLF 替换"
+msgstr "在 '%s' 的工作拷贝中，下次 Git 处理时 LF 将被 CRLF 替换"
 
 #: convert.c
 #, c-format
@@ -20732,7 +20746,7 @@ msgid ""
 "The file '%s' is missing a byte order mark (BOM). Please use UTF-%sBE or UTF-"
 "%sLE (depending on the byte order) as working-tree-encoding."
 msgstr ""
-"文件 '%s' 缺失一个字节顺序标记（BOM）。请使用 UTF-%sBE or UTF-%sLE（取决于字"
+"文件 '%s' 缺失一个字节顺序标记（BOM）。请使用 UTF-%sBE 或 UTF-%sLE（取决于字"
 "节序）作为工作区编码。"
 
 #: convert.c
@@ -20743,22 +20757,22 @@ msgstr "无法对 '%s' 进行从 %s 到 %s 的编码"
 #: convert.c
 #, c-format
 msgid "encoding '%s' from %s to %s and back is not the same"
-msgstr "将'%s' 的编码从 %s 到 %s 来回转换不一致"
+msgstr "将 '%s' 的编码从 %s 到 %s 来回转换不一致"
 
 #: convert.c
 #, c-format
 msgid "cannot fork to run external filter '%s'"
-msgstr "不能 fork 以执行外部过滤器 '%s'"
+msgstr "无法 fork 以执行外部过滤器 '%s'"
 
 #: convert.c
 #, c-format
 msgid "cannot feed the input to external filter '%s'"
-msgstr "不能将输入传递给外部过滤器 '%s'"
+msgstr "无法将输入传递给外部过滤器 '%s'"
 
 #: convert.c
 #, c-format
 msgid "external filter '%s' failed %d"
-msgstr "外部过滤器 '%s' 失败码 %d"
+msgstr "外部过滤器 '%s' 失败，退出码 %d"
 
 #: convert.c
 #, c-format
@@ -20820,12 +20834,12 @@ msgstr "URL 的 %s 组件中包含换行符：%s"
 #: credential.c
 #, c-format
 msgid "url has no scheme: %s"
-msgstr "URL 没有 scheme：%s"
+msgstr "URL 缺少协议：%s"
 
 #: credential.c
 #, c-format
 msgid "credential url cannot be parsed: %s"
-msgstr "不能解析凭据 URL：%s"
+msgstr "无法解析凭据 URL：%s"
 
 #: daemon.c
 #, c-format
@@ -20900,8 +20914,8 @@ msgstr[1] "%<PRIuMAX> 年"
 #, c-format
 msgid "%s, %<PRIuMAX> month ago"
 msgid_plural "%s, %<PRIuMAX> months ago"
-msgstr[0] "%s %<PRIuMAX> 个月前"
-msgstr[1] "%s %<PRIuMAX> 个月前"
+msgstr[0] "%s，%<PRIuMAX> 个月前"
+msgstr[1] "%s，%<PRIuMAX> 个月前"
 
 #: date.c
 #, c-format
@@ -20917,7 +20931,7 @@ msgstr "正在传播数据岛标记"
 #: delta-islands.c
 #, c-format
 msgid "bad tree object %s"
-msgstr "坏的树对象 %s"
+msgstr "无效的树对象 %s"
 
 #: delta-islands.c
 #, c-format
@@ -20927,12 +20941,12 @@ msgstr "未能加载 '%s' 的数据岛正则表达式：%s"
 #: delta-islands.c
 #, c-format
 msgid "island regex from config has too many capture groups (max=%d)"
-msgstr "来自 config 的数据岛正则表达式有太多的捕获组（最多 %d 个）"
+msgstr "来自配置的数据岛正则表达式有太多的捕获组（最多 %d 个）"
 
 #: delta-islands.c
 #, c-format
 msgid "Marked %d islands, done.\n"
-msgstr "已标记 %d 个数据岛，结束。\n"
+msgstr "已标记 %d 个数据岛，完成。\n"
 
 #: diagnose.c
 #, c-format
@@ -20961,7 +20975,7 @@ msgstr "无法复制标准输出"
 #: diagnose.c
 #, c-format
 msgid "could not add directory '%s' to archiver"
-msgstr "无法添加目录 '%s' 至归档器"
+msgstr "无法添加目录 '%s' 到归档器"
 
 #: diagnose.c
 msgid "failed to write archive"
@@ -20981,7 +20995,7 @@ msgstr "--merge-base 不适用于范围"
 
 #: diff-lib.c
 msgid "unable to get HEAD"
-msgstr "不能解析 HEAD"
+msgstr "无法解析 HEAD"
 
 #: diff-lib.c
 msgid "no merge base found"
@@ -21013,7 +21027,7 @@ msgstr "不是 git 仓库。使用 --no-index 比较工作区之外的两个路�
 msgid ""
 "Limiting comparison with pathspecs is only supported if both paths are "
 "directories."
-msgstr "仅当两个路径均为目录时，才支持使用路径表达式限制比较范围。"
+msgstr "仅当两个路径均为目录时，才支持使用路径规格限制比较范围。"
 
 #  译者：注意保持前导空格
 #: diff.c
@@ -21048,7 +21062,7 @@ msgstr ""
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
-msgstr "color-moved-ws：allow-indentation-change 不能与其它空白字符模式共用"
+msgstr "color-moved-ws：allow-indentation-change 不能与其他空白字符模式共用"
 
 #: diff.c
 #, c-format
@@ -21071,12 +21085,12 @@ msgstr "外部 diff 退出，停止在 %s"
 
 #: diff.c
 msgid "--follow requires exactly one pathspec"
-msgstr "--follow 明确要求只跟一个路径规格"
+msgstr "--follow 要求恰好一个路径规格"
 
 #: diff.c
 #, c-format
 msgid "pathspec magic not supported by --follow: %s"
-msgstr "--follow 不支持在路径规格中使用神奇前缀：%s"
+msgstr "--follow 不支持在路径规格中使用魔法前缀：%s"
 
 #: diff.c parse-options.c
 #, c-format
@@ -21126,7 +21140,7 @@ msgstr "ws-error-highlight=%.*s 之后未知的值"
 #: diff.c
 #, c-format
 msgid "unable to resolve '%s'"
-msgstr "不能解析 '%s'"
+msgstr "无法解析 '%s'"
 
 #: diff.c
 #, c-format
@@ -21141,12 +21155,12 @@ msgstr "%s 期望一个字符，得到 '%s'"
 #: diff.c
 #, c-format
 msgid "bad --color-moved argument: %s"
-msgstr "坏的 --color-moved 参数：%s"
+msgstr "无效的 --color-moved 参数：%s"
 
 #: diff.c
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
-msgstr "--color-moved-ws 中的无效模式 '%s' "
+msgstr "--color-moved-ws 中的无效模式 '%s'"
 
 #: diff.c
 #, c-format
@@ -21174,11 +21188,11 @@ msgstr "无法解析 --submodule 选项的参数：'%s'"
 #: diff.c
 #, c-format
 msgid "bad --word-diff argument: %s"
-msgstr "坏的 --word-diff 参数：%s"
+msgstr "无效的 --word-diff 参数：%s"
 
 #: diff.c
 msgid "Diff output format options"
-msgstr "差异输出格式化选项"
+msgstr "差异输出格式选项"
 
 #: diff.c
 msgid "generate patch"
@@ -21259,15 +21273,15 @@ msgstr "<宽度>"
 
 #: diff.c
 msgid "generate diffstat with a given width"
-msgstr "使用给定的长度生成差异统计"
+msgstr "使用给定的宽度生成差异统计"
 
 #: diff.c
 msgid "generate diffstat with a given name width"
-msgstr "使用给定的文件名长度生成差异统计"
+msgstr "使用给定的文件名宽度生成差异统计"
 
 #: diff.c
 msgid "generate diffstat with a given graph width"
-msgstr "使用给定的图形长度生成差异统计"
+msgstr "使用给定的图形宽度生成差异统计"
 
 #: diff.c
 msgid "<count>"
@@ -21308,8 +21322,7 @@ msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
 msgstr ""
-"在 --raw 或者 --numstat 中，不对路径字符转码并使用 NUL 字符做为输出字段的分隔"
-"符"
+"在 --raw 或者 --numstat 中，不对路径名转码并使用 NUL 字符作为输出字段的分隔符"
 
 #: diff.c
 msgid "<prefix>"
@@ -21317,11 +21330,11 @@ msgstr "<前缀>"
 
 #: diff.c
 msgid "show the given source prefix instead of \"a/\""
-msgstr "显示给定的源前缀取代 \"a/\""
+msgstr "显示给定的源前缀替代 \"a/\""
 
 #: diff.c
 msgid "show the given destination prefix instead of \"b/\""
-msgstr "显示给定的目标前缀取代 \"b/\""
+msgstr "显示给定的目标前缀替代 \"b/\""
 
 #: diff.c
 msgid "prepend an additional prefix to every line of output"
@@ -21365,7 +21378,7 @@ msgstr "<n>[/<m>]"
 
 #: diff.c
 msgid "break complete rewrite changes into pairs of delete and create"
-msgstr "将完全重写的变更打破为成对的删除和创建"
+msgstr "将完全重写的变更拆分为成对的删除和创建"
 
 #: diff.c
 msgid "detect renames"
@@ -21381,7 +21394,7 @@ msgstr "检测拷贝"
 
 #: diff.c
 msgid "use unmodified files as source to find copies"
-msgstr "使用未修改的文件做为发现拷贝的源"
+msgstr "使用未修改的文件作为发现拷贝的源"
 
 #: diff.c
 msgid "disable rename detection"
@@ -21389,7 +21402,7 @@ msgstr "禁用重命名探测"
 
 #: diff.c
 msgid "use empty blobs as rename source"
-msgstr "使用空的数据对象做为重命名的源"
+msgstr "使用空的数据对象作为重命名的源"
 
 #: diff.c
 msgid "continue listing the history of a file beyond renames"
@@ -21435,11 +21448,11 @@ msgstr "<正则>"
 
 #: diff.c
 msgid "ignore changes whose all lines match <regex>"
-msgstr "忽略所有行都和正则表达式匹配的变更"
+msgstr "忽略所有行都匹配 <正则> 的变更"
 
 #: diff.c
 msgid "heuristic to shift diff hunk boundaries for easy reading"
-msgstr "启发式转换差异边界以便阅读"
+msgstr "启发式调整差异块边界以便阅读"
 
 #: diff.c
 msgid "generate diff using the \"patience diff\" algorithm"
@@ -21483,7 +21496,7 @@ msgstr "在 --color-moved 下如何忽略空白字符"
 
 #: diff.c
 msgid "Other diff options"
-msgstr "其它差异选项"
+msgstr "其他差异选项"
 
 #: diff.c
 msgid "when run from subdir, exclude changes outside and show relative paths"
@@ -21491,7 +21504,7 @@ msgstr "当从子目录运行，排除目录之外的变更并显示相对路径
 
 #: diff.c
 msgid "treat all files as text"
-msgstr "把所有文件当做文本处理"
+msgstr "把所有文件当作文本处理"
 
 #: diff.c
 msgid "swap two inputs, reverse the diff"
@@ -21507,7 +21520,7 @@ msgstr "禁用本程序的所有输出"
 
 #: diff.c
 msgid "allow an external diff helper to be executed"
-msgstr "允许执行一个外置的差异助手"
+msgstr "允许执行一个外部差异辅助程序"
 
 #: diff.c
 msgid "run external text conversion filters when comparing binary files"
@@ -21535,7 +21548,7 @@ msgstr "隐藏索引中 'git add -N' 条目"
 
 #: diff.c
 msgid "treat 'git add -N' entries as real in the index"
-msgstr "将索引中 'git add -N' 条目当做真实的"
+msgstr "将索引中 'git add -N' 条目当作真实的"
 
 #: diff.c
 msgid "<string>"
@@ -21555,11 +21568,11 @@ msgstr "查找改变指定正则匹配出现次数的差异"
 
 #: diff.c
 msgid "show all changes in the changeset with -S or -G"
-msgstr "显示使用 -S 或 -G 的变更集的所有变更"
+msgstr "显示由 -S 或 -G 选中的变更集内的全部变更"
 
 #: diff.c
 msgid "treat <string> in -S as extended POSIX regular expression"
-msgstr "将 -S 的 <string> 当做扩展的 POSIX 正则表达式"
+msgstr "将 -S 的 <string> 当作扩展的 POSIX 正则表达式"
 
 #: diff.c
 msgid "control the order in which files appear in the output"
@@ -21632,7 +21645,7 @@ msgstr "无法读取排序文件 '%s'"
 
 #: diffcore-rename.c
 msgid "Performing inexact rename detection"
-msgstr "正在进行非精确的重命名探测"
+msgstr "正在进行非精确的重命名检测"
 
 #: diffcore-rotate.c
 #, c-format
@@ -21642,7 +21655,7 @@ msgstr "在差异中无此路径 '%s'"
 #: dir.c
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
-msgstr "路径规格 '%s' 未匹配任何 git 已知文件"
+msgstr "路径规格 '%s' 未匹配任何 Git 已知文件"
 
 #: dir.c
 #, c-format
@@ -21661,12 +21674,12 @@ msgstr "您的 sparse-checkout 文件可能有问题：重复的模式 '%s'"
 
 #: dir.c
 msgid "disabling cone pattern matching"
-msgstr "停用锥形模式匹配"
+msgstr "停用锥形模式（稀疏检出）匹配"
 
 #: dir.c
 #, c-format
 msgid "cannot use %s as an exclude file"
-msgstr "不能将 %s 用作排除文件"
+msgstr "无法将 %s 用作排除文件"
 
 #: dir.c
 msgid "failed to get kernel name and information"
@@ -21674,7 +21687,7 @@ msgstr "无法获得内核名称和信息"
 
 #: dir.c
 msgid "untracked cache is disabled on this system or location"
-msgstr "缓存未跟踪文件在本系统或位置中被禁用"
+msgstr "本系统或位置已禁用未跟踪文件缓存"
 
 #: dir.c
 msgid ""
@@ -21692,12 +21705,12 @@ msgstr "仓库 %s 中的索引文件损坏"
 #: dir.c
 #, c-format
 msgid "could not create directories for %s"
-msgstr "不能为 %s 创建目录"
+msgstr "无法为 %s 创建目录"
 
 #: dir.c
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
-msgstr "不能从 '%s' 迁移 git 目录到 '%s'"
+msgstr "无法从 '%s' 迁移 Git 目录到 '%s'"
 
 #: editor.c
 #, c-format
@@ -21707,12 +21720,12 @@ msgstr "提示：等待您的编辑器关闭文件...%c"
 #: editor.c sequencer.c wrapper.c
 #, c-format
 msgid "could not write to '%s'"
-msgstr "不能写入 '%s'"
+msgstr "无法写入 '%s'"
 
 #: editor.c
 #, c-format
 msgid "could not edit '%s'"
-msgstr "不能编辑 '%s'"
+msgstr "无法编辑 '%s'"
 
 #: entry.c
 msgid "Filtering content"
@@ -21721,12 +21734,12 @@ msgstr "过滤内容"
 #: entry.c
 #, c-format
 msgid "could not stat file '%s'"
-msgstr "不能对文件 '%s' 调用 stat"
+msgstr "无法对文件 '%s' 调用 stat"
 
 #: environment.c
 #, c-format
 msgid "bad git namespace path \"%s\""
-msgstr "错误的 git 名字空间路径 \"%s\""
+msgstr "错误的 git 命名空间路径 \"%s\""
 
 #: environment.c
 #, c-format
@@ -21765,7 +21778,7 @@ msgstr "忽略未知的 core.fsyncMethod 值 '%s'"
 
 #: environment.c
 msgid "core.fsyncObjectFiles is deprecated; use core.fsync instead"
-msgstr "core.fsyncObjectFiles 已经被弃用；取而代之使用 core.fsync"
+msgstr "core.fsyncObjectFiles 已经被弃用；改用 core.fsync"
 
 #: environment.c
 #, c-format
@@ -21802,7 +21815,7 @@ msgid ""
 msgstr ""
 "您正在尝试获取 %s，它位于提交图文件中，但不在对象数据库中。\n"
 "这可能是由于仓库损坏造成的。\n"
-"如果您尝试通过重新获取丢失的对象来修复此仓库损坏，请对丢失的对象使用 'git "
+"如果您尝试通过重新获取丢失的对象来修复此仓库损坏，请对缺失的对象执行 'git "
 "fetch --refetch'。"
 
 #: fetch-pack.c
@@ -21824,21 +21837,21 @@ msgstr "git fetch-pack：应为 ACK/NAK，却得到 '%s'"
 
 #: fetch-pack.c
 msgid "unable to write to remote"
-msgstr "无法写到远程"
+msgstr "无法写入远程"
 
 #: fetch-pack.c
 msgid "Server supports filter"
-msgstr "服务器支持 filter"
+msgstr "服务器支持过滤器"
 
 #: fetch-pack.c
 #, c-format
 msgid "invalid shallow line: %s"
-msgstr "无效的 shallow 信息：%s"
+msgstr "无效的 shallow 行：%s"
 
 #: fetch-pack.c
 #, c-format
 msgid "invalid unshallow line: %s"
-msgstr "无效的 unshallow 信息：%s"
+msgstr "无效的 unshallow 行：%s"
 
 #: fetch-pack.c
 #, c-format
@@ -21848,7 +21861,7 @@ msgstr "对象中出错：%s"
 #: fetch-pack.c
 #, c-format
 msgid "no shallow found: %s"
-msgstr "未发现 shallow：%s"
+msgstr "未找到 shallow：%s"
 
 #: fetch-pack.c
 #, c-format
@@ -21890,11 +21903,11 @@ msgstr "已经有 %s（%s）"
 
 #: fetch-pack.c
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
-msgstr "fetch-pack：无法派生 sideband 多路输出"
+msgstr "fetch-pack：无法派生 sideband 多路分解器"
 
 #: fetch-pack.c
 msgid "protocol error: bad pack header"
-msgstr "协议错误：坏的包头"
+msgstr "协议错误：无效的包头"
 
 #: fetch-pack.c
 #, c-format
@@ -21912,12 +21925,12 @@ msgstr "%s 失败"
 
 #: fetch-pack.c
 msgid "error in sideband demultiplexer"
-msgstr "sideband 多路输出出错"
+msgstr "sideband 多路分解器出错"
 
 #: fetch-pack.c
 #, c-format
 msgid "Server version is %.*s"
-msgstr "服务器版本 %.*s"
+msgstr "服务器版本为 %.*s"
 
 #: fetch-pack.c
 #, c-format
@@ -21926,7 +21939,7 @@ msgstr "服务器支持 %s"
 
 #: fetch-pack.c
 msgid "Server does not support shallow clients"
-msgstr "服务器不支持浅客户端"
+msgstr "服务器不支持浅克隆客户端"
 
 #: fetch-pack.c
 msgid "Server does not support --shallow-since"
@@ -22004,7 +22017,7 @@ msgstr "预期在 '%s' 之后发送 packfile"
 #: fetch-pack.c
 #, c-format
 msgid "expected no other sections to be sent after no '%s'"
-msgstr "在没有 '%s' 后不应该发送其它小节"
+msgstr "在未发送 '%s' 后不应该再发送其他小节"
 
 #: fetch-pack.c
 #, c-format
@@ -22032,11 +22045,11 @@ msgstr "git fetch-pack：预期响应结束包"
 
 #: fetch-pack.c
 msgid "no matching remote head"
-msgstr "没有匹配的远程分支"
+msgstr "没有匹配的远程头引用"
 
 #: fetch-pack.c
 msgid "unexpected 'ready' from remote"
-msgstr "来自远程的意外的 'ready'"
+msgstr "来自远程的意外 'ready'"
 
 #: fetch-pack.c
 #, c-format
@@ -22056,7 +22069,7 @@ msgstr "fsmonitor_ipc__send_query：无效路径 '%s'"
 #: fsmonitor-ipc.c
 #, c-format
 msgid "fsmonitor_ipc__send_query: unspecified error on '%s'"
-msgstr "fsmonitor_ipc__send_query：未知错误于 '%s'"
+msgstr "fsmonitor_ipc__send_query：在 '%s' 上发生未知错误"
 
 #: fsmonitor-ipc.c
 msgid "fsmonitor--daemon is not running"
@@ -22065,7 +22078,7 @@ msgstr "fsmonitor--daemon 没有运行"
 #: fsmonitor-ipc.c
 #, c-format
 msgid "could not send '%s' command to fsmonitor--daemon"
-msgstr "无法发送 '%s' 命令至 fsmonitor--daemon"
+msgstr "无法发送 '%s' 命令到 fsmonitor--daemon"
 
 #: fsmonitor-settings.c
 #, c-format
@@ -22107,8 +22120,8 @@ msgid ""
 msgstr ""
 "git [-v | --version] [-h | --help] [-C <路径>] [-c <名称>=<取值>]\n"
 "           [--exec-path[=<路径>]] [--html-path] [--man-path] [--info-path]\n"
-"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [\"--"
-"no-lazy-fetch]\n"
+"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--no-"
+"lazy-fetch]\n"
 "           [--no-optional-locks] [--no-advice] [--bare] [--git-dir=<路径>]\n"
 "           [--work-tree=<路径>] [--namespace=<名称>]\n"
 "           [--config-env=<名称>=<环境变量>] <命令> [<参数>]"
@@ -22148,7 +22161,7 @@ msgstr "应为 -c 提供一个配置字符串\n"
 #: git.c
 #, c-format
 msgid "no config key given for --config-env\n"
-msgstr "没有为 --config-env 提供配置名称\n"
+msgstr "没有为 --config-env 提供配置键名\n"
 
 #: git.c
 #, c-format
@@ -22171,8 +22184,8 @@ msgid ""
 "alias '%s' changes environment variables.\n"
 "You can use '!git' in the alias to do this"
 msgstr ""
-"别名 '%s' 修改环境变量。您可以使用在别名中\n"
-"使用 '!git'"
+"别名 '%s' 会修改环境变量。\n"
+"您可以在别名中使用 '!git' 来做到这一点"
 
 #: git.c
 #, c-format
@@ -22187,7 +22200,7 @@ msgstr "递归的别名：%s"
 #: git.c
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
-msgstr "检测到别名循环：'%s'的扩展未终止：%s"
+msgstr "检测到别名循环：'%s' 的扩展未终止：%s"
 
 #: git.c
 msgid "write failure on standard output"
@@ -22204,7 +22217,7 @@ msgstr "标准输出关闭失败"
 #: git.c
 #, c-format
 msgid "cannot handle %s as a builtin"
-msgstr "不能作为内置命令处理 %s"
+msgstr "无法作为内置命令处理 %s"
 
 #: git.c
 #, c-format
@@ -22218,7 +22231,7 @@ msgstr ""
 #: git.c
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
-msgstr "展开别名命令 '%s' 失败，'%s' 不是一个 git 命令\n"
+msgstr "展开别名命令 '%s' 失败，'%s' 不是一个 Git 命令\n"
 
 #: git.c
 #, c-format
@@ -22227,7 +22240,7 @@ msgstr "无法运行命令 '%s'：%s\n"
 
 #: gpg-interface.c
 msgid "could not create temporary file"
-msgstr "不能创建临时文件"
+msgstr "无法创建临时文件"
 
 #: gpg-interface.c
 #, c-format
@@ -22245,28 +22258,28 @@ msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
 msgstr ""
-"ssh 签名验证需要 ssh-keygen -Y find-principals/verify \n"
-"（openssh 8.2p1+ 版本可用）"
+"ssh 签名验证需要 ssh-keygen -Y find-principals/verify\n"
+"（OpenSSH 8.2p1+ 版本可用）"
 
 #: gpg-interface.c
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
-msgstr "设置了 ssh 签名吊销文件但无法找到：%s"
+msgstr "已设置 SSH 签名吊销文件但无法找到：%s"
 
 #: gpg-interface.c
 #, c-format
 msgid "bad/incompatible signature '%s'"
-msgstr "坏的/不兼容的签名 '%s‘"
+msgstr "无效/不兼容的签名 '%s'"
 
 #: gpg-interface.c
 #, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
-msgstr "无法得到密钥 '%s' 的 ssh 指纹"
+msgstr "无法得到密钥 '%s' 的 SSH 指纹"
 
 #: gpg-interface.c
 #, c-format
 msgid "failed to get the ssh fingerprint for key %s"
-msgstr "无法得到密钥 '%s' 的 ssh 指纹"
+msgstr "无法得到密钥 %s 的 SSH 指纹"
 
 #: gpg-interface.c
 msgid ""
@@ -22315,12 +22328,12 @@ msgstr "无法将 ssh 签名密钥缓冲区写入 '%s'"
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
-msgstr "ssh 签名需要 ssh-keygen -Y sign （openssh 8.2p1+ 版本可用）"
+msgstr "ssh 签名需要 ssh-keygen -Y sign（OpenSSH 8.2p1+ 版本可用）"
 
 #: gpg-interface.c
 #, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
-msgstr "无法从 '%s' 读入 ssh 签名数据"
+msgstr "无法从 '%s' 读入 SSH 签名数据"
 
 #: graph.c
 #, c-format
@@ -22371,23 +22384,23 @@ msgstr "主要的上层命令"
 
 #: help.c
 msgid "Ancillary Commands / Manipulators"
-msgstr "辅助命令/操作者"
+msgstr "辅助命令/操作类"
 
 #: help.c
 msgid "Ancillary Commands / Interrogators"
-msgstr "辅助命令/询问者"
+msgstr "辅助命令/查询类"
 
 #: help.c
 msgid "Interacting with Others"
-msgstr "与其它系统交互"
+msgstr "与其他系统交互"
 
 #: help.c
 msgid "Low-level Commands / Manipulators"
-msgstr "低级命令/操作者"
+msgstr "低级命令/操作类"
 
 #: help.c
 msgid "Low-level Commands / Interrogators"
-msgstr "低级命令/询问者"
+msgstr "低级命令/查询类"
 
 #: help.c
 msgid "Low-level Commands / Syncing Repositories"
@@ -22395,7 +22408,7 @@ msgstr "低级命令/同步仓库"
 
 #: help.c
 msgid "Low-level Commands / Internal Helpers"
-msgstr "低级命令/内部助手"
+msgstr "低级命令/内部辅助程序"
 
 #: help.c
 msgid "User-facing repository, command and file interfaces"
@@ -22440,7 +22453,7 @@ msgstr "命令别名"
 
 #: help.c
 msgid "See 'git help <command>' to read about a specific subcommand"
-msgstr "执行　'git help <command>' 来了解特定子命令"
+msgstr "执行 'git help <command>' 来了解特定子命令"
 
 #: help.c
 #, c-format
@@ -22458,7 +22471,7 @@ msgstr "git：'%s' 不是一个 git 命令。参见 'git --help'。"
 
 #: help.c
 msgid "Uh oh. Your system reports no Git commands at all."
-msgstr "唉呀，您的系统中未发现 Git 命令。"
+msgstr "哎呀，您的系统中未发现 Git 命令。"
 
 #: help.c
 #, c-format
@@ -22512,10 +22525,10 @@ msgid_plural ""
 "Did you mean one of these?"
 msgstr[0] ""
 "\n"
-"您指的是这个么？"
+"您指的是这个吗？"
 msgstr[1] ""
 "\n"
-"您指的是这其中的某一个么？"
+"您指的是这其中的某一个吗？"
 
 #: hook.c
 #, c-format
@@ -22528,7 +22541,7 @@ msgstr ""
 
 #: http-fetch.c
 msgid "not a git repository"
-msgstr "不是 git 仓库"
+msgstr "不是 Git 仓库"
 
 #: http-fetch.c
 #, c-format
@@ -22570,7 +22583,7 @@ msgstr "无法将 SSL 后端设置为 '%s'：已经设置"
 
 #: http.c
 msgid "refusing to read cookies from http.cookiefile '-'"
-msgstr "拒绝从 http.cookiefile '-' 读取 cookies"
+msgstr "拒绝从 http.cookiefile '-' 读取 Cookie"
 
 #: http.c
 msgid "ignoring http.savecookies for empty http.cookiefile"
@@ -22583,7 +22596,7 @@ msgid ""
 "  asked for: %s\n"
 "   redirect: %s"
 msgstr ""
-"不能更新重定向的 url base：\n"
+"无法更新重定向后的 URL 基址：\n"
 "     请求：%s\n"
 "   重定向：%s"
 
@@ -22623,7 +22636,7 @@ msgstr ""
 "  git config --global user.email \"you@example.com\"\n"
 "  git config --global user.name \"Your Name\"\n"
 "\n"
-"来设置您账号的缺省身份标识。\n"
+"来设置您账号的默认身份标识。\n"
 "如果仅在本仓库设置身份标识，则省略 --global 参数。\n"
 "\n"
 
@@ -22690,7 +22703,7 @@ msgstr "期望 'tree:<深度>'"
 
 #: list-objects-filter-options.c
 msgid "sparse:path filters support has been dropped"
-msgstr "sparse:path 过滤器支持已被删除"
+msgstr "sparse:path 过滤器支持已被移除"
 
 #: list-objects-filter-options.c
 #, c-format
@@ -22730,7 +22743,7 @@ msgstr "对象过滤"
 #: list-objects-filter.c
 #, c-format
 msgid "unable to access sparse blob in '%s'"
-msgstr "不能访问 '%s' 中的稀疏数据对象"
+msgstr "无法访问 '%s' 中的稀疏数据对象"
 
 #: list-objects-filter.c
 #, c-format
@@ -22765,15 +22778,15 @@ msgid ""
 msgstr ""
 "无法创建 '%s.lock'：%s。\n"
 "\n"
-"似乎另外一个 git 进程在这个仓库中运行，例如：'git commit' 命令打\n"
+"似乎另一个 Git 进程在这个仓库中运行，例如：'git commit' 命令打\n"
 "开了一个编辑器。请确认所有进程都已经关闭然后重试。如果仍然报错，\n"
-"可能之前有一个 git 进程在这个仓库中异常退出：\n"
+"可能之前有一个 Git 进程在这个仓库中异常退出：\n"
 "手动删除这个文件再继续。"
 
 #: lockfile.c
 #, c-format
 msgid "Unable to create '%s.lock': %s"
-msgstr "不能创建 '%s.lock'：%s"
+msgstr "无法创建 '%s.lock'：%s"
 
 #: log-tree.c
 msgid "unable to create temporary object directory"
@@ -22782,7 +22795,7 @@ msgstr "无法创建临时对象目录"
 #: loose.c
 #, c-format
 msgid "could not write loose object index %s"
-msgstr "不能写入松散对象索引 %s"
+msgstr "无法写入松散对象索引 %s"
 
 #: loose.c
 #, c-format
@@ -22815,17 +22828,17 @@ msgstr "无效的标记大小 '%s'，应为一个整数"
 #: merge-ort-wrappers.c
 #, c-format
 msgid "Could not parse object '%s'"
-msgstr "不能解析对象 '%s'"
+msgstr "无法解析对象 '%s'"
 
 #: merge-ort.c
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
-msgstr "无法合并子模组 %s （没有检出）"
+msgstr "无法合并子模组 %s（没有检出）"
 
 #: merge-ort.c
 #, c-format
 msgid "Failed to merge submodule %s (no merge base)"
-msgstr "无法合并子模组 %s （没有合并基线）"
+msgstr "无法合并子模组 %s（没有合并基线）"
 
 #: merge-ort.c
 #, c-format
@@ -22840,7 +22853,7 @@ msgstr "错误：无法合并子模组 %s（仓库损坏）"
 #: merge-ort.c
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
-msgstr "无法合并子模组 %s （提交未跟随合并基线）"
+msgstr "无法合并子模组 %s（提交未跟随合并基线）"
 
 #: merge-ort.c
 #, c-format
@@ -22875,7 +22888,7 @@ msgstr "错误：无法为 %s 执行内部合并"
 #: merge-ort.c
 #, c-format
 msgid "error: unable to add %s to database"
-msgstr "错误：不能添加 %s 至对象库"
+msgstr "错误：无法将 %s 添加到对象库"
 
 #: merge-ort.c
 #, c-format
@@ -22888,8 +22901,8 @@ msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
 "implicit directory rename(s) putting the following path(s) there: %s."
 msgstr ""
-"冲突（隐式目录重命名）：处于隐式目录重命名的现存文件/目录 %s，将以下路径放"
-"在：%s。"
+"冲突（隐式目录重命名）：隐式目录重命名要把以下路径放到 %s，但该处已有文件/目"
+"录：%s。"
 
 #: merge-ort.c
 #, c-format
@@ -22976,7 +22989,7 @@ msgstr "冲突（重命名/删除）：%1$s 在 %3$s 中重命名为 %2$s，但�
 #: merge-ort.c
 #, c-format
 msgid "error: cannot read object %s"
-msgstr "错误：不能读取对象 %s"
+msgstr "错误：无法读取对象 %s"
 
 #: merge-ort.c
 #, c-format
@@ -22988,7 +23001,7 @@ msgstr "错误：对象 %s 不是一个数据对象"
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
-msgstr "冲突（文件/目录）：目录已存在于 %2$s 中的 %1$s，将其移动到 %3$s。"
+msgstr "冲突（文件/目录）：目录阻挡了来自 %2$s 的 %1$s，改为将其移动到 %3$s。"
 
 #: merge-ort.c
 #, c-format
@@ -23005,8 +23018,8 @@ msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
 "of them so each can be recorded somewhere."
 msgstr ""
-"冲突（不同类型）：%s 在两侧有不同的类型，将其中之一重命名以便它们能记录在不同"
-"位置。"
+"冲突（不同类型）：%s 在两侧类型不同，已重命名其中之一，以便两者都能记录在某"
+"处。"
 
 #: merge-ort.c
 msgid "content"
@@ -23108,7 +23121,7 @@ msgstr "无法存储反向索引文件"
 #: midx-write.c
 #, c-format
 msgid "could not parse line: %s"
-msgstr "不能解析行：%s"
+msgstr "无法解析行：%s"
 
 #: midx-write.c
 #, c-format
@@ -23117,7 +23130,7 @@ msgstr "格式错误的行：%s"
 
 #: midx-write.c
 msgid "could not load pack"
-msgstr "不能载入包"
+msgstr "无法载入包"
 
 #: midx-write.c
 #, c-format
@@ -23155,7 +23168,7 @@ msgstr "无法打开首选包 %s"
 #: midx-write.c
 #, c-format
 msgid "cannot select preferred pack %s with no objects"
-msgstr "不能选择没有对象的首选包 %s"
+msgstr "无法选择没有对象的首选包 %s"
 
 #: midx-write.c
 #, c-format
@@ -23201,7 +23214,7 @@ msgstr "无法写入多包索引"
 
 #: midx-write.c
 msgid "cannot expire packs from an incremental multi-pack-index"
-msgstr "增量多包索引中的包不能过期"
+msgstr "增量多包索引中的包无法过期"
 
 #: midx-write.c
 msgid "Counting referenced objects"
@@ -23217,11 +23230,11 @@ msgstr "无法重新打包增量多包索引"
 
 #: midx-write.c
 msgid "could not start pack-objects"
-msgstr "不能开始 pack-objects"
+msgstr "无法开始 pack-objects"
 
 #: midx-write.c
 msgid "could not finish pack-objects"
-msgstr "不能结束 pack-objects"
+msgstr "无法结束 pack-objects"
 
 #: midx.c
 msgid "multi-pack-index OID fanout is of the wrong size"
@@ -23254,7 +23267,7 @@ msgstr "多包索引签名 0x%08x 和签名 0x%08x 不匹配"
 #: midx.c
 #, c-format
 msgid "multi-pack-index version %d not recognized"
-msgstr "multi-pack-index 版本 %d 不能被识别"
+msgstr "multi-pack-index 版本 %d 未被识别"
 
 #: midx.c
 #, c-format
@@ -23303,7 +23316,7 @@ msgstr "基线的 MIDX 中对象的数量过高：%<PRIuMAX>"
 #: midx.c
 #, c-format
 msgid "invalid multi-pack-index chain: line '%s' not a hash"
-msgstr "无效的多包索引链：第 '%s' 行不是哈希值"
+msgstr "无效的多包索引链：行 '%s' 不是哈希值"
 
 #: midx.c
 msgid "unable to find all multi-pack index files"
@@ -23316,7 +23329,7 @@ msgstr "无效的 MIDX 对象位置，MIDX 可能已损坏"
 #: midx.c
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
-msgstr "错的 pack-int-id：%u（共有 %u 个包）"
+msgstr "无效的 pack-int-id：%u（共有 %u 个包）"
 
 #: midx.c
 msgid "MIDX does not contain the BTMP chunk"
@@ -23325,11 +23338,11 @@ msgstr "多包索引中未包含 BTMP 块"
 #: midx.c
 #, c-format
 msgid "could not load bitmapped pack %<PRIu32>"
-msgstr "不能打开已被位图索引的包 %<PRIu32>"
+msgstr "无法加载已被位图索引的包 %<PRIu32>"
 
 #: midx.c
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
-msgstr "多包索引存储一个64位偏移，但是 off_t 太小"
+msgstr "多包索引存储一个 64 位偏移，但是 off_t 太小"
 
 #: midx.c
 msgid "multi-pack-index large offset out of bounds"
@@ -23341,7 +23354,7 @@ msgstr "多包索引文件存在，但无法解析"
 
 #: midx.c
 msgid "incorrect checksum"
-msgstr "不正确的校验码"
+msgstr "校验码不正确"
 
 #: midx.c
 msgid "Looking for referenced packfiles"
@@ -23349,7 +23362,7 @@ msgstr "正在查找引用的包文件"
 
 #: midx.c
 msgid "the midx contains no oid"
-msgstr "midx 不包含 oid"
+msgstr "MIDX 不包含 OID"
 
 #: midx.c
 msgid "Verifying OID order in multi-pack-index"
@@ -23386,17 +23399,17 @@ msgstr "oid[%d] = %s 错误的对象偏移：%<PRIx64> != %<PRIx64>"
 #: name-hash.c
 #, c-format
 msgid "unable to create lazy_dir thread: %s"
-msgstr "不能创建 lazy_dir 线程：%s"
+msgstr "无法创建 lazy_dir 线程：%s"
 
 #: name-hash.c
 #, c-format
 msgid "unable to create lazy_name thread: %s"
-msgstr "不能创建 lazy_name 线程：%s"
+msgstr "无法创建 lazy_name 线程：%s"
 
 #: name-hash.c
 #, c-format
 msgid "unable to join lazy_name thread: %s"
-msgstr "不能加入 lazy_name 线程：%s"
+msgstr "无法加入 lazy_name 线程：%s"
 
 #: notes-merge.c
 #, c-format
@@ -23405,23 +23418,23 @@ msgid ""
 "Please, use 'git notes merge --commit' or 'git notes merge --abort' to "
 "commit/abort the previous merge before you start a new notes merge."
 msgstr ""
-"您的前一次注释合并尚未结束（存在 %s）。\n"
-"在开始一个新的注释合并之前，请使用 'git notes merge --commit' 或者 'git "
+"您的前一次注解合并尚未结束（存在 %s）。\n"
+"在开始一个新的注解合并之前，请使用 'git notes merge --commit' 或者 'git "
 "notes merge --abort' 来提交/终止前一次合并。"
 
 #: notes-merge.c
 #, c-format
 msgid "You have not concluded your notes merge (%s exists)."
-msgstr "您尚未结束注释合并（存在 %s）。"
+msgstr "您尚未结束注解合并（存在 %s）。"
 
 #: notes-utils.c
 msgid "Cannot commit uninitialized/unreferenced notes tree"
-msgstr "不能提交未初始化/未引用的注解树"
+msgstr "无法提交未初始化/未引用的注解树"
 
 #: notes-utils.c
 #, c-format
 msgid "Bad notes.rewriteMode value: '%s'"
-msgstr "坏的 notes.rewriteMode 值：'%s'"
+msgstr "无效的 notes.rewriteMode 值：'%s'"
 
 #: notes-utils.c
 #, c-format
@@ -23435,16 +23448,16 @@ msgstr "拒绝向 %s（在 refs/notes/ 之外）写入注解"
 #: notes-utils.c
 #, c-format
 msgid "Bad %s value: '%s'"
-msgstr "坏的 %s 值：'%s'"
+msgstr "无效的 %s 值：'%s'"
 
 #: object-file-convert.c
 msgid "failed to decode tree entry"
-msgstr "无法解码树对象"
+msgstr "无法解码树条目"
 
 #: object-file-convert.c
 #, c-format
 msgid "failed to map tree entry for %s"
-msgstr "无法为 %s 映射树对象"
+msgstr "无法为 %s 映射树条目"
 
 #: object-file-convert.c
 #, c-format
@@ -23508,7 +23521,7 @@ msgstr "松散对象 %s（保存在 %s）已损坏"
 #: object-file.c
 #, c-format
 msgid "unable to open %s"
-msgstr "不能打开 %s"
+msgstr "无法打开 %s"
 
 #: object-file.c
 #, c-format
@@ -23544,12 +23557,12 @@ msgstr "无法创建临时文件"
 
 #: object-file.c
 msgid "unable to write loose object file"
-msgstr "不能写松散对象文件"
+msgstr "无法写入松散对象文件"
 
 #: object-file.c
 #, c-format
 msgid "unable to deflate new object %s (%d)"
-msgstr "不能压缩新对象 %s（%d）"
+msgstr "无法压缩新对象 %s（%d）"
 
 #: object-file.c
 #, c-format
@@ -23559,7 +23572,7 @@ msgstr "在对象 %s 上调用 deflateEnd 失败（%d）"
 #: object-file.c
 #, c-format
 msgid "confused by unstable object source data for %s"
-msgstr "被 %s 的不稳定对象源数据搞糊涂了"
+msgstr "由于 %s 的对象源数据不稳定而无法处理"
 
 #: object-file.c
 #, c-format
@@ -23569,7 +23582,7 @@ msgstr "写入流对象 %ld != %<PRIuMAX>"
 #: object-file.c
 #, c-format
 msgid "unable to stream deflate new object (%d)"
-msgstr "不能流式压缩新对象（%d）"
+msgstr "无法流式压缩新对象（%d）"
 
 #: object-file.c
 #, c-format
@@ -23584,7 +23597,7 @@ msgstr "无法创建目录 %s"
 #: object-file.c
 #, c-format
 msgid "cannot read object for %s"
-msgstr "不能读取对象 %s"
+msgstr "无法读取对象 %s"
 
 #: object-file.c
 #, c-format
@@ -23617,7 +23630,7 @@ msgstr "%s：无法插入数据库"
 
 #: object-file.c
 msgid "cannot add a submodule of a different hash algorithm"
-msgstr "不能添加使用不同哈希算法的子模组"
+msgstr "无法添加使用不同哈希算法的子模组"
 
 #: object-file.c
 #, c-format
@@ -23632,7 +23645,7 @@ msgstr "%s 的哈希值不匹配（预期 %s）"
 #: object-file.c
 #, c-format
 msgid "unable to mmap %s"
-msgstr "不能 mmap %s"
+msgstr "无法 mmap %s"
 
 #: object-file.c
 #, c-format
@@ -23661,7 +23674,7 @@ msgstr "无法解压缩 %s 的内容"
 #: object-name.c
 #, c-format
 msgid "%s [bad object]"
-msgstr "%s [坏的对象]"
+msgstr "%s [无效的对象]"
 
 #. TRANSLATORS: This is a line of ambiguous commit
 #. object output. E.g.:
@@ -23698,7 +23711,7 @@ msgstr "%s 标签 %s - %s"
 #: object-name.c
 #, c-format
 msgid "%s [bad tag, could not parse it]"
-msgstr "%s [坏的标签，无法解析]"
+msgstr "%s [无效的标签，无法解析]"
 
 #. TRANSLATORS: This is a line of ambiguous <type>
 #. object output. E.g. "deadbeef tree".
@@ -23719,7 +23732,7 @@ msgstr "%s 数据对象"
 #: object-name.c
 #, c-format
 msgid "short object ID %s is ambiguous"
-msgstr "短对象ID %s 存在歧义"
+msgstr "短对象 ID %s 存在歧义"
 
 #. TRANSLATORS: The argument is the list of ambiguous
 #. objects composed in show_ambiguous_object(). See
@@ -23731,7 +23744,7 @@ msgid ""
 "The candidates are:\n"
 "%s"
 msgstr ""
-"候选者有：\n"
+"候选项有：\n"
 "%s"
 
 #: object-name.c
@@ -23746,14 +23759,14 @@ msgid ""
 "examine these refs and maybe delete them. Turn this message off by\n"
 "running \"git config set advice.objectNameWarning false\""
 msgstr ""
-"Git 通常不会创建一个以40个十六进制字符结尾的引用，因为当您只提供40\n"
+"Git 通常不会创建一个以 40 个十六进制字符结尾的引用，因为当您只提供 40\n"
 "个十六进制字符时将被忽略。这些引用可能被错误地创建。例如：\n"
 "\n"
 "  git switch -c $br $(git rev-parse ...)\n"
 "\n"
-"当 \"$br\" 某种原因空白时，一个40位十六进制的引用将被创建。请检查这些\n"
+"当 \"$br\" 由于某种原因为空时，一个 40 位十六进制的引用将被创建。请检查这些\n"
 "引用，可能需要删除它们。运行 \"git config set advice.objectNameWarning\n"
-"false\" 命令关闭本消息通知。"
+"false\" 来关闭本消息通知。"
 
 #: object-name.c
 #, c-format
@@ -23814,7 +23827,7 @@ msgstr "路径 '%s' 不存在（既不在磁盘上，也不在索引中）"
 
 #: object-name.c
 msgid "relative path syntax can't be used outside working tree"
-msgstr "不能在工作区之外使用相对路径语法"
+msgstr "无法在工作区之外使用相对路径语法"
 
 #: object-name.c
 #, c-format
@@ -23844,7 +23857,7 @@ msgstr "对象 %s 有未知的类型 id %d"
 #: object.c
 #, c-format
 msgid "unable to parse object: %s"
-msgstr "不能解析对象：%s"
+msgstr "无法解析对象：%s"
 
 #: object.c
 #, c-format
@@ -23901,7 +23914,7 @@ msgstr "参考仓库 '%s' 是浅克隆"
 #: odb.c
 #, c-format
 msgid "reference repository '%s' is grafted"
-msgstr "参考仓库 '%s' 已被移植"
+msgstr "参考仓库 '%s' 已被嫁接"
 
 #: odb.c
 #, c-format
@@ -23993,7 +24006,7 @@ msgstr "位图索引中的重复条目：'%s'"
 #: pack-bitmap.c
 #, c-format
 msgid "corrupt ewah bitmap: truncated header for entry %d"
-msgstr "损坏的 EWAH 位图：条目 %d 截断的文件头"
+msgstr "损坏的 EWAH 位图：条目 %d 的文件头被截断"
 
 #: pack-bitmap.c
 #, c-format
@@ -24010,7 +24023,7 @@ msgstr "位图包索引中 XOR 偏移值无效"
 
 #: pack-bitmap.c
 msgid "cannot fstat bitmap file"
-msgstr "不能对位图文件调用 fstat"
+msgstr "无法对位图文件调用 fstat"
 
 #: pack-bitmap.c
 msgid "checksum doesn't match in MIDX and bitmap"
@@ -24023,7 +24036,7 @@ msgstr "多包位图缺少必需的反向索引"
 #: pack-bitmap.c
 #, c-format
 msgid "could not open pack %s"
-msgstr "不能打开包 %s"
+msgstr "无法打开包 %s"
 
 #: pack-bitmap.c
 msgid "corrupt bitmap lookup table: triplet position out of index"
@@ -24046,7 +24059,7 @@ msgstr "损坏的 EWAH 位图：提交 \"%s\" 位图的文件头被截断"
 #: pack-bitmap.c
 #, c-format
 msgid "unable to load pack: '%s', disabling pack-reuse"
-msgstr "无法打开包：'%s'，禁用包重用"
+msgstr "无法加载包：'%s'，禁用包重用"
 
 #: pack-bitmap.c
 msgid "unable to compute preferred pack, disabling pack-reuse"
@@ -24055,7 +24068,7 @@ msgstr "无法计算首选包，禁用包重用"
 #: pack-bitmap.c
 #, c-format
 msgid "object '%s' not found in type bitmaps"
-msgstr "对象 %s 为在类型位图中找到"
+msgstr "对象 '%s' 未在类型位图中找到"
 
 #: pack-bitmap.c
 #, c-format
@@ -24070,7 +24083,7 @@ msgstr "对象 '%s'：实际类型 '%s'，预期：'%s'"
 #: pack-bitmap.c
 #, c-format
 msgid "object not in bitmap: '%s'"
-msgstr "对象不在位图中：%s"
+msgstr "对象不在位图中：'%s'"
 
 #: pack-bitmap.c
 msgid "failed to load bitmap indexes"
@@ -24122,12 +24135,12 @@ msgstr "mtimes 文件 %s 有未知的签名"
 #: pack-mtimes.c
 #, c-format
 msgid "mtimes file %s has unsupported version %<PRIu32>"
-msgstr "mtimes 文件 %s 不支持的版本 %<PRIu32>"
+msgstr "mtimes 文件 %s 版本 %<PRIu32> 不受支持"
 
 #: pack-mtimes.c
 #, c-format
 msgid "mtimes file %s has unsupported hash id %<PRIu32>"
-msgstr "mtimes 文件 %s 有不支持的哈希 ID %<PRIu32>"
+msgstr "mtimes 文件 %s 的哈希 ID %<PRIu32> 不受支持"
 
 #: pack-mtimes.c
 #, c-format
@@ -24136,7 +24149,7 @@ msgstr "mtimes 文件 %s 损坏"
 
 #: pack-refs.c
 msgid "pack everything"
-msgstr "打包一切"
+msgstr "打包全部"
 
 #: pack-refs.c
 msgid "prune loose refs (default)"
@@ -24167,26 +24180,26 @@ msgstr "反向索引文件 %s 损坏"
 #: pack-revindex.c
 #, c-format
 msgid "reverse-index file %s has unknown signature"
-msgstr "反向索引文件 %s 有错误的签名"
+msgstr "反向索引文件 %s 有未知的签名"
 
 #: pack-revindex.c
 #, c-format
 msgid "reverse-index file %s has unsupported version %<PRIu32>"
-msgstr "反向索引文件 %s 不支持的版本 %<PRIu32>"
+msgstr "反向索引文件 %s 的版本 %<PRIu32> 不受支持"
 
 #: pack-revindex.c
 #, c-format
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
-msgstr "反向索引文件 %s 有不支持的哈希 ID %<PRIu32>"
+msgstr "反向索引文件 %s 的哈希 ID %<PRIu32> 不受支持"
 
 #: pack-revindex.c
 msgid "invalid checksum"
-msgstr "无效的校验码 %s"
+msgstr "无效的校验码"
 
 #: pack-revindex.c
 #, c-format
 msgid "invalid rev-index position at %<PRIu64>: %<PRIu32> != %<PRIu32>"
-msgstr "位于 %<PRIu64> 的无效的反向索引：%<PRIu32> != %<PRIu32>"
+msgstr "在 %<PRIu64> 的反向索引位置无效：%<PRIu32> != %<PRIu32>"
 
 #: pack-revindex.c
 msgid "multi-pack-index reverse-index chunk is the wrong size"
@@ -24198,12 +24211,12 @@ msgstr "无法确定首选包"
 
 #: pack-write.c
 msgid "cannot both write and verify reverse index"
-msgstr "无法同时写入和校验反向索引"
+msgstr "不能同时写入和校验反向索引"
 
 #: pack-write.c
 #, c-format
 msgid "could not stat: %s"
-msgstr "不能调用 stat：%s"
+msgstr "无法调用 stat：%s"
 
 #: pack-write.c
 #, c-format
@@ -24222,7 +24235,7 @@ msgstr "偏移量在包文件结束之前（损坏的 .idx？）"
 #: packfile.c
 #, c-format
 msgid "packfile %s cannot be mapped%s"
-msgstr "包文件 %s 不能被映射%s"
+msgstr "包文件 %s 无法被映射%s"
 
 #: packfile.c
 #, c-format
@@ -24287,7 +24300,7 @@ msgstr "%s 期望一个带可选 k/m/g 后缀的整数"
 #: parse-options.c
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
-msgstr "%s 期望一个非负整数和一个可选的 k/m/g 后缀"
+msgstr "%s 期望一个非负整数以及可选的 k/m/g 后缀"
 
 #: parse-options.c
 #, c-format
@@ -24321,7 +24334,7 @@ msgstr "未知开关 `%c'"
 #: parse-options.c
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
-msgstr "字符串中未知的非 ascii 字符选项：`%s'"
+msgstr "字符串中未知的非 ASCII 字符选项：`%s'"
 
 #. TRANSLATORS: The "<%s>" part of this string
 #. stands for an optional value given to a command
@@ -24454,21 +24467,21 @@ msgstr "用来初始化父项目的前缀路径"
 
 #: parse-options.h
 msgid "how to strip spaces and #comments from message"
-msgstr "设置如何删除提交说明里的空格和#注释"
+msgstr "设置如何删除提交说明里的空格和 #注释"
 
 #: parse-options.h
 msgid "read pathspec from file"
-msgstr "从文件读取路径表达式"
+msgstr "从文件读取路径规格"
 
 #: parse-options.h
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
-msgstr "使用 --pathspec-from-file，路径表达式用空字符分隔"
+msgstr "使用 --pathspec-from-file，路径规格元素用 NUL 字符分隔"
 
 #: parse.c
 #, c-format
 msgid "bad boolean environment value '%s' for '%s'"
-msgstr "对于 '%2$s' 的错误的布尔环境取值 '%1$s'"
+msgstr "环境变量 '%2$s' 的布尔值 '%1$s' 无效"
 
 #: path-walk.c
 #, c-format
@@ -24492,7 +24505,7 @@ msgstr "无法设置版本遍历"
 #: path.c
 #, c-format
 msgid "Could not make %s writable by group"
-msgstr "不能设置 %s 为组可写"
+msgstr "无法设置 %s 为组可写"
 
 #: pathspec.c
 msgid "Escape character '\\' not allowed as last character in attr value"
@@ -24519,26 +24532,26 @@ msgstr "全局的 'glob' 和 'noglob' 路径规格设置不兼容"
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
-msgstr "全局的 'literal' 路径规格设置和其它的全局路径规格设置不兼容"
+msgstr "全局的 'literal' 路径规格设置和其他的全局路径规格设置不兼容"
 
 #: pathspec.c
 msgid "invalid parameter for pathspec magic 'prefix'"
-msgstr "路径规格包含无效的神奇前缀"
+msgstr "路径规格魔法 'prefix' 的参数无效"
 
 #: pathspec.c
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
-msgstr "在路径规格 '%3$s' 中无效的神奇前缀 '%2$.*1$s'"
+msgstr "路径规格魔法前缀 '%.*s' 在 '%s' 中无效"
 
 #: pathspec.c
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
-msgstr "路径规格 '%s' 的神奇前缀结尾少了一个 ')'"
+msgstr "路径规格 '%s' 的魔法前缀结尾少了一个 ')'"
 
 #: pathspec.c
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
-msgstr "路径规格 '%2$s' 中包含未实现的神奇前缀 '%1$c'"
+msgstr "路径规格 '%2$s' 中包含未实现的魔法前缀 '%1$c'"
 
 #: pathspec.c
 #, c-format
@@ -24563,25 +24576,25 @@ msgstr "'%s'（助记符：'%c'）"
 #: pathspec.c
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
-msgstr "%s：路径规格神奇前缀不被此命令支持：%s"
+msgstr "%s：路径规格魔法前缀不被此命令支持：%s"
 
 #: pathspec.c
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
-msgstr "路径规格 '%s' 位于符号链接中"
+msgstr "路径规格 '%s' 位于符号链接之后"
 
 #: pathspec.c
 #, c-format
 msgid "line is badly quoted: %s"
-msgstr "行被错误地引用：%s"
+msgstr "行引用不正确：%s"
 
 #: pkt-line.c
 msgid "unable to write flush packet"
-msgstr "无法写 flush 包"
+msgstr "无法写入 flush 包"
 
 #: pkt-line.c
 msgid "unable to write delim packet"
-msgstr "无法写 delim 包"
+msgstr "无法写入 delim 包"
 
 #: pkt-line.c
 msgid "unable to write response end packet"
@@ -24589,11 +24602,11 @@ msgstr "无法写入响应结束数据包"
 
 #: pkt-line.c
 msgid "flush packet write failed"
-msgstr "flush 包写错误"
+msgstr "flush 包写入失败"
 
 #: pkt-line.c
 msgid "protocol error: impossibly long line"
-msgstr "协议错误：不可能的长行"
+msgstr "协议错误：行过长"
 
 #: pkt-line.c
 msgid "packet write with format failed"
@@ -24619,7 +24632,7 @@ msgstr "远端意外挂断了"
 #: pkt-line.c
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
-msgstr "协议错误：错误的行长度字符串：%.4s"
+msgstr "协议错误：错误的行长度字符：%.4s"
 
 #: pkt-line.c
 #, c-format
@@ -24642,11 +24655,11 @@ msgstr "无法创建线程 lstat：%s"
 
 #: pretty.c
 msgid "unable to parse --pretty format"
-msgstr "不能解析 --pretty 格式"
+msgstr "无法解析 --pretty 格式"
 
 #: promisor-remote.c
 msgid "lazy fetching disabled; some objects may not be available"
-msgstr "禁用延迟获取，某些对象可能不可用"
+msgstr "已禁用延迟获取，某些对象可能不可用"
 
 #: promisor-remote.c
 msgid "promisor-remote: unable to fork off fetch subprocess"
@@ -24707,7 +24720,7 @@ msgstr "未找到已接受的承诺者远程 '%s'"
 
 #: protocol-caps.c
 msgid "object-info: expected flush after arguments"
-msgstr "object-info：在参数之后应有一个 flush"
+msgstr "object-info：在参数之后应有一个 flush 包"
 
 #: prune-packed.c
 msgid "Removing duplicate objects"
@@ -24721,7 +24734,7 @@ msgstr "未能加载 %s 的伪合并正则表达式：'%s'"
 #: pseudo-merge.c
 #, c-format
 msgid "%s must be non-negative, using default"
-msgstr "%s 必须为非负整数，使用默认值"
+msgstr "%s 必须为非负值，使用默认值"
 
 #: pseudo-merge.c
 #, c-format
@@ -24747,7 +24760,7 @@ msgstr "伪合并组 '%s' 在稳定阈值之前有不稳定阈值"
 #, c-format
 msgid ""
 "pseudo-merge regex from config has too many capture groups (max=%<PRIuMAX>)"
-msgstr "来自 config 的伪合并正则表达式有太多的捕获组（最多 %<PRIuMAX> 个）"
+msgstr "来自配置的伪合并正则表达式有太多的捕获组（最多 %<PRIuMAX> 个）"
 
 #: pseudo-merge.c
 #, c-format
@@ -24781,16 +24794,16 @@ msgstr "无法读取提交 %s 的扩展伪合并表"
 
 #: range-diff.c
 msgid "could not start `log`"
-msgstr "不能启动 `log`"
+msgstr "无法启动 `log`"
 
 #: range-diff.c
 msgid "could not read `log` output"
-msgstr "不能读取 `log` 的输出"
+msgstr "无法读取 `log` 的输出"
 
 #: range-diff.c sequencer.c
 #, c-format
 msgid "could not parse commit '%s'"
-msgstr "不能解析提交 '%s'"
+msgstr "无法解析提交 '%s'"
 
 #: range-diff.c
 #, c-format
@@ -24821,12 +24834,12 @@ msgstr ""
 #: range-diff.c
 #, c-format
 msgid "could not parse log for '%s'"
-msgstr "不能解析 '%s' 的日志"
+msgstr "无法解析 '%s' 的日志"
 
 #: reachable.c
 #, c-format
 msgid "invalid extra cruft tip: '%s'"
-msgstr "无效的额外废弃提交版本：'%s'"
+msgstr "无效的额外废弃对象 tip：'%s'"
 
 #: reachable.c
 msgid "unable to enumerate additional recent objects"
@@ -24839,12 +24852,12 @@ msgstr "将不会添加文件别名 '%s'（'%s' 已经存在于索引中）"
 
 #: read-cache.c
 msgid "cannot create an empty blob in the object database"
-msgstr "不能在对象数据库中创建空的数据对象"
+msgstr "无法在对象数据库中创建空的数据对象"
 
 #: read-cache.c
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
-msgstr "%s：只能添加常规文件、符号链接或 git 目录"
+msgstr "%s：只能添加常规文件、符号链接或 Git 目录"
 
 #: read-cache.c
 #, c-format
@@ -24886,16 +24899,16 @@ msgstr ""
 #: read-cache.c
 #, c-format
 msgid "bad signature 0x%08x"
-msgstr "坏的签名 0x%08x"
+msgstr "无效的签名 0x%08x"
 
 #: read-cache.c
 #, c-format
 msgid "bad index version %d"
-msgstr "坏的索引版本 %d"
+msgstr "无效的索引版本 %d"
 
 #: read-cache.c
 msgid "bad index file sha1 signature"
-msgstr "坏的索引文件 sha1 签名"
+msgstr "无效的索引文件 SHA-1 签名"
 
 #: read-cache.c
 #, c-format
@@ -24949,7 +24962,7 @@ msgstr "%s：打开索引文件失败"
 #: read-cache.c
 #, c-format
 msgid "%s: cannot stat the open index"
-msgstr "%s：不能对打开的索引执行 stat 操作"
+msgstr "%s：无法对打开的索引执行 stat 操作"
 
 #: read-cache.c
 #, c-format
@@ -24992,7 +25005,7 @@ msgstr "无法转换为稀疏索引"
 #: read-cache.c
 #, c-format
 msgid "unable to open git dir: %s"
-msgstr "不能打开 git 目录：%s"
+msgstr "无法打开 Git 目录：%s"
 
 #: read-cache.c
 #, c-format
@@ -25002,12 +25015,12 @@ msgstr "无法删除：%s"
 #: read-cache.c
 #, c-format
 msgid "cannot fix permission bits on '%s'"
-msgstr "不能修复 '%s' 的权限位"
+msgstr "无法修复 '%s' 的权限位"
 
 #: read-cache.c
 #, c-format
 msgid "%s: cannot drop to stage #0"
-msgstr "%s：不能落到暂存区 #0"
+msgstr "%s：无法落到暂存区 #0"
 
 #: read-cache.c
 #, c-format
@@ -25065,7 +25078,7 @@ msgstr ""
 "命令:\n"
 "p, pick <提交> = 使用提交\n"
 "r, reword <提交> = 使用提交，但编辑提交说明\n"
-"e, edit <提交> = 使用提交，但停止以便修补提交\n"
+"e, edit <提交> = 使用提交，但停止以便修订提交\n"
 "s, squash <提交> = 使用提交，但挤压到前一个提交\n"
 "f, fixup [-C | -c] <提交> = 类似于 \"squash\"，但只保留前一个提交\n"
 "                   的提交说明，除非使用了 -C 参数，此情况下则只\n"
@@ -25077,9 +25090,9 @@ msgstr ""
 "l, label <label> = 为当前 HEAD 打上标记\n"
 "t, reset <label> = 重置 HEAD 到该标记\n"
 "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       创建一个合并提交，并使用原始的合并提交说明（如果没有指定\n"
-".       原始提交，使用注释部分的 oneline 作为提交说明）。使用\n"
-".       -c <提交> 可以编辑提交说明。\n"
+"        创建一个合并提交，并使用原始的合并提交说明（如果没有指定\n"
+"        原始提交，使用注释部分的 oneline 作为提交说明）。使用\n"
+"        -c <提交> 可以编辑提交说明。\n"
 "u, update-ref <引用> = 为引用 <ref> 设置一个占位符，以将该引用更新为此处的新"
 "提交。\n"
 "                      此 <引用> 在变基结束后更新。\n"
@@ -25090,8 +25103,8 @@ msgstr ""
 #, c-format
 msgid "Rebase %s onto %s (%d command)"
 msgid_plural "Rebase %s onto %s (%d commands)"
-msgstr[0] "变基 %s 到 %s（%d 个提交）"
-msgstr[1] "变基 %s 到 %s（%d 个提交）"
+msgstr[0] "变基 %s 到 %s（%d 个命令）"
+msgstr[1] "变基 %s 到 %s（%d 个命令）"
 
 #: rebase-interactive.c
 msgid ""
@@ -25136,7 +25149,7 @@ msgstr ""
 #: rebase-interactive.c
 #, c-format
 msgid "could not write '%s'."
-msgstr "不能写入 '%s'。"
+msgstr "无法写入 '%s'。"
 
 #: rebase-interactive.c
 #, c-format
@@ -25235,7 +25248,7 @@ msgstr "期望一个正数 contents:lines=%s"
 #: ref-filter.c
 #, c-format
 msgid "argument expected for %s"
-msgstr "预期参数 %s"
+msgstr "缺少 %s 的参数"
 
 #: ref-filter.c
 #, c-format
@@ -25245,7 +25258,7 @@ msgstr "预期正数参数值 %s=%s"
 #: ref-filter.c
 #, c-format
 msgid "cannot fully parse %s=%s"
-msgstr "不能完整解析 %s=%s"
+msgstr "无法完整解析 %s=%s"
 
 #: ref-filter.c
 #, c-format
@@ -25306,7 +25319,7 @@ msgstr "未知的字段名：%.*s"
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
-msgstr "不是 git 仓库，但是字段 '%.*s' 需要访问对象数据"
+msgstr "不是 Git 仓库，但是字段 '%.*s' 需要访问对象数据"
 
 #: ref-filter.c
 #, c-format
@@ -25423,7 +25436,7 @@ msgstr "选项 `%s' 必须指向一个提交"
 
 #: ref-filter.h
 msgid "key"
-msgstr "key"
+msgstr "键"
 
 #: ref-filter.h
 msgid "field name to sort on"
@@ -25526,7 +25539,7 @@ msgstr "引用 %s 的日志在 %s 之后有缺口"
 #: refs.c
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
-msgstr "引用 %s 的日志意外终止于 %s "
+msgstr "引用 %s 的日志意外终止于 %s"
 
 #: refs.c
 #, c-format
@@ -25583,7 +25596,7 @@ msgstr "'%s' 已存在，无法创建 '%s'"
 #: refs.c
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
-msgstr "无法同时处理 '%s' 和 '%s'"
+msgstr "不能同时处理 '%s' 和 '%s'"
 
 #: refs.c
 #, c-format
@@ -25728,7 +25741,7 @@ msgstr "reftable：事务失败：%s"
 #: refs/reftable-backend.c
 #, c-format
 msgid "unable to compact stack: %s"
-msgstr "无法压缩栈：%s"
+msgstr "无法压缩堆栈：%s"
 
 #: refs/reftable-backend.c
 #, c-format
@@ -25778,7 +25791,7 @@ msgstr "对象格式的未知取值：%s"
 #: remote-curl.c
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
-msgstr "%sinfo/refs 无效：这是 git 仓库么？"
+msgstr "%sinfo/refs 无效：这是 Git 仓库吗？"
 
 #: remote-curl.c
 msgid "invalid server response; expected service, got flush packet"
@@ -25829,7 +25842,7 @@ msgstr "无法倒回 rpc post 数据 - 尝试增加 http.postBuffer"
 #: remote-curl.c
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
-msgstr "remote-curl：错误的行宽字符：%.4s"
+msgstr "remote-curl：错误的行长度字符：%.4s"
 
 #: remote-curl.c
 msgid "remote-curl: unexpected response end packet"
@@ -25843,17 +25856,17 @@ msgstr "RPC 失败。%s"
 #: remote-curl.c
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
-msgstr "不能压缩请求，zlib 压缩错误 %d"
+msgstr "无法压缩请求，zlib 压缩错误 %d"
 
 #: remote-curl.c
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
-msgstr "不能压缩请求，zlib 结束错误 %d"
+msgstr "无法压缩请求，zlib 结束错误 %d"
 
 #: remote-curl.c
 #, c-format
 msgid "%d bytes of length header were received"
-msgstr "收到了 %d 字节长度的头信息"
+msgstr "收到了 %d 字节的长度头部"
 
 #: remote-curl.c
 #, c-format
@@ -25862,7 +25875,7 @@ msgstr "预期仍然需要 %d 个字节的正文"
 
 #: remote-curl.c
 msgid "dumb http transport does not support shallow capabilities"
-msgstr "哑 http 传输不支持浅克隆能力"
+msgstr "哑 HTTP 传输不支持浅克隆能力"
 
 #: remote-curl.c
 msgid "fetch failed."
@@ -25870,7 +25883,7 @@ msgstr "获取失败。"
 
 #: remote-curl.c
 msgid "cannot fetch by sha1 over smart http"
-msgstr "无法通过智能 HTTP 获取 sha1"
+msgstr "无法通过智能 HTTP 获取 SHA-1"
 
 #: remote-curl.c
 #, c-format
@@ -25880,7 +25893,7 @@ msgstr "协议错误：期望 sha/ref，却得到 '%s'"
 #: remote-curl.c
 #, c-format
 msgid "http transport does not support %s"
-msgstr "http 传输协议不支持 %s"
+msgstr "HTTP 传输协议不支持 %s"
 
 #: remote-curl.c
 msgid "protocol error: expected '<url> <path>', missing space"
@@ -25897,7 +25910,7 @@ msgstr "git-http-push 失败"
 
 #: remote-curl.c
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
-msgstr "remote-curl：用法：git remote-curl <远程> [<url>]"
+msgstr "remote-curl：用法：git remote-curl <远程> [<URL>]"
 
 #: remote-curl.c
 msgid "remote-curl: error reading command stream from git"
@@ -25905,7 +25918,7 @@ msgstr "remote-curl：错误读取来自 git 的命令流"
 
 #: remote-curl.c
 msgid "remote-curl: fetch attempted without a local repo"
-msgstr "remote-curl：尝试没有本地仓库下获取"
+msgstr "remote-curl：在没有本地仓库的情况下尝试获取"
 
 #: remote-curl.c
 #, c-format
@@ -25925,13 +25938,13 @@ msgid ""
 "If you cannot, please let us know why you still need to use it by\n"
 "sending an e-mail to <git@vger.kernel.org>."
 msgstr ""
-"正在从 \"%s/%s\" 读取远程内容，该内容被提名删除。\n"
+"正在从 \"%s/%s\" 读取远程内容，该内容被列入移除计划。\n"
 "\n"
-"如果你仍然在使用 \"remotes/\" 目录，建议迁移为基于配置远程的方式：\n"
+"如果您仍然在使用 \"remotes/\" 目录，建议迁移为基于配置远程的方式：\n"
 "\n"
 "\tgit remote rename %s %s\n"
 "\n"
-"如果你无法迁移，请发送电子邮件至 <git@vger.kernel.org> 告知我们你\n"
+"如果您无法迁移，请发送电子邮件至 <git@vger.kernel.org> 告知我们您\n"
 "仍然需要使用它的原因。"
 
 #: remote.c
@@ -25965,7 +25978,7 @@ msgstr "URL '%s' 使用明文认证信息"
 #: remote.c
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
-msgstr "不能同时获取 %s 和 %s 至 %s"
+msgstr "不能同时获取 %s 和 %s 到 %s"
 
 #: remote.c
 #, c-format
@@ -26021,7 +26034,7 @@ msgid ""
 "'%s:refs/heads/%s'?"
 msgstr ""
 "引用规格的 <src> 是一个提交对象。您是想创建一个新的分支而向\n"
-"'%s:refs/heads/%s' 推送么？"
+"'%s:refs/heads/%s' 推送吗？"
 
 #: remote.c
 #, c-format
@@ -26031,7 +26044,7 @@ msgid ""
 "'%s:refs/tags/%s'?"
 msgstr ""
 "引用规格的 <src> 是一个标签对象。您是想创建一个新的标签而向\n"
-"'%s:refs/tags/%s' 推送么？"
+"'%s:refs/tags/%s' 推送吗？"
 
 #: remote.c
 #, c-format
@@ -26041,7 +26054,7 @@ msgid ""
 "'%s:refs/tags/%s'?"
 msgstr ""
 "引用规格的 <src> 是一个树对象。您是想为这个树对象创建标签而向\n"
-"'%s:refs/tags/%s' 推送么？"
+"'%s:refs/tags/%s' 推送吗？"
 
 #: remote.c
 #, c-format
@@ -26051,7 +26064,7 @@ msgid ""
 "'%s:refs/tags/%s'?"
 msgstr ""
 "引用规格的 <src> 是一个数据对象。您是想为这个数据对象创建标签而向\n"
-"'%s:refs/tags/%s' 推送么？"
+"'%s:refs/tags/%s' 推送吗？"
 
 #: remote.c
 #, c-format
@@ -26129,7 +26142,7 @@ msgstr "无法找到远程引用 %s"
 #: remote.c
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
-msgstr "* 在本地忽略可笑的引用 '%s'"
+msgstr "* 在本地忽略异常的引用 '%s'"
 
 #: remote.c
 #, c-format
@@ -26208,12 +26221,12 @@ msgstr "无法解析期望的对象名 '%s'"
 #: remote.c
 #, c-format
 msgid "cannot strip one component off url '%s'"
-msgstr "无法从 url '%s' 剥离一个组件"
+msgstr "无法从 URL '%s' 剥离一个组件"
 
 #: repack-geometry.c
 #, c-format
 msgid "cannot open index for %s"
-msgstr "不能打开 %s 的索引"
+msgstr "无法打开 %s 的索引"
 
 #: repack-geometry.c
 #, c-format
@@ -26223,7 +26236,7 @@ msgstr "包 %s 太大，不在几何打包过程中考虑"
 #: repack-geometry.c
 #, c-format
 msgid "pack %s too large to roll up"
-msgstr "包 %s 太大导致数字溢出"
+msgstr "包 %s 太大，无法汇总"
 
 #: repack-midx.c
 #, c-format
@@ -26232,12 +26245,12 @@ msgstr "无法打开临时文件 %s 进行写入"
 
 #: repack-midx.c
 msgid "could not close refs snapshot tempfile"
-msgstr "不能关闭引用快照临时文件"
+msgstr "无法关闭引用快照临时文件"
 
 #: repack-midx.c
 #, c-format
 msgid "could not remove stale bitmap: %s"
-msgstr "无法删除过期的位图： %s"
+msgstr "无法删除过期的位图：%s"
 
 #: repack-promisor.c
 msgid "could not start pack-objects to repack promisor objects"
@@ -26253,7 +26266,7 @@ msgstr "repack：来自 pack-objects 的输入必须为完整的十六进制对�
 
 #: repack-promisor.c
 msgid "could not finish pack-objects to repack promisor objects"
-msgstr "无法完成 pack-objects 来重新打包 promisor 对象"
+msgstr "无法完成 pack-objects 来重新打包承诺者对象"
 
 #: repack-promisor.c
 msgid "could not start pack-objects to repack promisor packs"
@@ -26267,7 +26280,7 @@ msgstr "包前缀 %s 没有以对象目录 %s 开始"
 #: repack.c
 #, c-format
 msgid "renaming pack to '%s' failed"
-msgstr "重命名包至 '%s' 失败"
+msgstr "重命名包为 '%s' 失败"
 
 #: repack.c
 #, c-format
@@ -26277,12 +26290,12 @@ msgstr "pack-objects 未为包 %2$s-%3$s 写入 '%1$s' 文件"
 #: repack.c sequencer.c
 #, c-format
 msgid "could not unlink: %s"
-msgstr "不能删除：%s"
+msgstr "无法删除：%s"
 
 #: replace-object.c
 #, c-format
 msgid "bad replace ref name: %s"
-msgstr "错误的替换引用名称：%s"
+msgstr "无效的替换引用名称：%s"
 
 #: replace-object.c
 #, c-format
@@ -26310,7 +26323,7 @@ msgstr "写入 '%s' (%s) 时出错"
 #: rerere.c
 #, c-format
 msgid "could not parse conflict hunks in '%s'"
-msgstr "不能解析 '%s' 中的冲突块"
+msgstr "无法解析 '%s' 中的冲突块"
 
 #: rerere.c
 #, c-format
@@ -26340,7 +26353,7 @@ msgstr "使用之前的解决方案解决 '%s'。"
 #: rerere.c
 #, c-format
 msgid "cannot unlink stray '%s'"
-msgstr "不能删除 stray '%s'"
+msgstr "无法删除多余的 '%s'"
 
 #: rerere.c
 #, c-format
@@ -26369,15 +26382,15 @@ msgstr "忘记 '%s' 的解决方案\n"
 
 #: rerere.c
 msgid "unable to open rr-cache directory"
-msgstr "不能打开 rr-cache 目录"
+msgstr "无法打开 rr-cache 目录"
 
 #: rerere.h
 msgid "update the index with reused conflict resolution if possible"
-msgstr "如果可能，重用冲突解决更新索引"
+msgstr "如果可能，使用复用的冲突解决结果更新索引"
 
 #: reset.c
 msgid "could not determine HEAD revision"
-msgstr "不能确定 HEAD 版本"
+msgstr "无法确定 HEAD 版本"
 
 #: reset.c sequencer.c
 #, c-format
@@ -26387,7 +26400,7 @@ msgstr "无法找到 %s 指向的树"
 #: revision.c
 #, c-format
 msgid "unsupported section for hidden refs: %s"
-msgstr "不支持的隐藏引用片段： %s"
+msgstr "不支持的隐藏引用小节：%s"
 
 #: revision.c
 msgid "--exclude-hidden= passed more than once"
@@ -26401,7 +26414,7 @@ msgstr "resolve-undo 记录 `%s`，现缺失"
 #: revision.c
 #, c-format
 msgid "%s exists but is a symbolic ref"
-msgstr "%s 存在但是一个符号引用"
+msgstr "%s 存在但为符号引用"
 
 #: revision.c
 msgid ""
@@ -26427,7 +26440,7 @@ msgstr "在 --stdin 模式下的无效选项：'%s'"
 
 #: revision.c
 msgid "your current branch appears to be broken"
-msgstr "您的当前分支好像被损坏"
+msgstr "您的当前分支似乎已损坏"
 
 #: revision.c
 #, c-format
@@ -26445,7 +26458,7 @@ msgstr "-L 尚不支持 -p 和 -s 之外的差异格式"
 #: run-command.c
 #, c-format
 msgid "cannot create async thread: %s"
-msgstr "不能创建 async 线程：%s"
+msgstr "无法创建 async 线程：%s"
 
 #: scalar.c worktree.c
 #, c-format
@@ -26533,7 +26546,7 @@ msgstr "在克隆时，创建完整的工作目录"
 
 #: scalar.c
 msgid "only download metadata for the branch that will be checked out"
-msgstr "只下载要检出的分支的元信息"
+msgstr "只下载要检出的分支的元数据"
 
 #: scalar.c
 msgid "create repository within 'src' directory"
@@ -26541,7 +26554,7 @@ msgstr "在 'src' 目录中创建仓库"
 
 #: scalar.c
 msgid "specify if tags should be fetched during clone"
-msgstr "如若应在克隆期间获取标签则指定"
+msgstr "指定是否在克隆期间获取标签"
 
 #: scalar.c
 msgid "specify if background maintenance should be enabled"
@@ -26626,7 +26639,7 @@ msgstr ""
 
 #: scalar.c
 msgid "--all or <enlistment>, but not both"
-msgstr "--all 或者 <登记>，而不是两个一起"
+msgstr "--all 或 <登记>，但不能同时使用"
 
 #: scalar.c
 #, c-format
@@ -26711,7 +26724,7 @@ msgstr "-C 需要 <目录>"
 #: scalar.c
 #, c-format
 msgid "could not change to '%s'"
-msgstr "无法变更到 '%s'"
+msgstr "无法切换到 '%s'"
 
 #: scalar.c
 msgid "-c requires a <key>=<value> argument"
@@ -26734,7 +26747,7 @@ msgstr "读取远程解包状态时收到意外的 flush 包"
 #: send-pack.c
 #, c-format
 msgid "unable to parse remote unpack status: %s"
-msgstr "不能解析远程解包状态：%s"
+msgstr "无法解析远程解包状态：%s"
 
 #: send-pack.c
 #, c-format
@@ -26854,12 +26867,12 @@ msgstr ""
 #: sequencer.c
 #, c-format
 msgid "could not lock '%s'"
-msgstr "不能锁定 '%s'"
+msgstr "无法锁定 '%s'"
 
 #: sequencer.c
 #, c-format
 msgid "could not write eol to '%s'"
-msgstr "不能将换行符写入 '%s'"
+msgstr "无法将换行符写入 '%s'"
 
 #: sequencer.c
 #, c-format
@@ -26869,11 +26882,11 @@ msgstr "无法完成 '%s'"
 #: sequencer.c
 #, c-format
 msgid "your local changes would be overwritten by %s."
-msgstr "您的本地修改将被%s覆盖。"
+msgstr "您的本地修改将被 %s 覆盖。"
 
 #: sequencer.c
 msgid "commit your changes or stash them to proceed."
-msgstr "提交您的修改或贮藏后再继续。"
+msgstr "提交您的修改或储藏后再继续。"
 
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
@@ -26885,16 +26898,16 @@ msgstr "%s：无法写入新索引文件"
 
 #: sequencer.c
 msgid "unable to update cache tree"
-msgstr "不能更新缓存树"
+msgstr "无法更新缓存树"
 
 #: sequencer.c
 msgid "could not resolve HEAD commit"
-msgstr "不能解析 HEAD 提交"
+msgstr "无法解析 HEAD 提交"
 
 #: sequencer.c
 #, c-format
 msgid "no key present in '%.*s'"
-msgstr "在 '%.*s' 中没有 key"
+msgstr "在 '%.*s' 中没有键"
 
 #: sequencer.c
 #, c-format
@@ -27016,11 +27029,11 @@ msgstr "无法找到新创建的提交"
 
 #: sequencer.c
 msgid "could not parse newly created commit"
-msgstr "不能解析新创建的提交"
+msgstr "无法解析新创建的提交"
 
 #: sequencer.c
 msgid "unable to resolve HEAD after creating commit"
-msgstr "创建提交后，不能解析 HEAD"
+msgstr "创建提交后，无法解析 HEAD"
 
 #: sequencer.c
 msgid "detached HEAD"
@@ -27033,7 +27046,7 @@ msgstr "（根提交）"
 
 #: sequencer.c
 msgid "could not parse HEAD"
-msgstr "不能解析 HEAD"
+msgstr "无法解析 HEAD"
 
 #: sequencer.c
 #, c-format
@@ -27042,12 +27055,12 @@ msgstr "HEAD %s 不是一个提交！"
 
 #: sequencer.c
 msgid "unable to parse commit author"
-msgstr "不能解析提交作者"
+msgstr "无法解析提交作者"
 
 #: sequencer.c
 #, c-format
 msgid "unable to read commit message from '%s'"
-msgstr "不能从 '%s' 读取提交说明"
+msgstr "无法从 '%s' 读取提交说明"
 
 #: sequencer.c
 #, c-format
@@ -27061,12 +27074,12 @@ msgstr "损坏的作者：缺失日期信息"
 #: sequencer.c
 #, c-format
 msgid "could not update %s"
-msgstr "不能更新 %s"
+msgstr "无法更新 %s"
 
 #: sequencer.c
 #, c-format
 msgid "could not parse parent commit %s"
-msgstr "不能解析父提交 %s"
+msgstr "无法解析父提交 %s"
 
 #: sequencer.c
 #, c-format
@@ -27099,7 +27112,7 @@ msgstr "这是一个 %d 个提交的组合。"
 #: sequencer.c
 #, c-format
 msgid "cannot write '%s'"
-msgstr "不能写 '%s'"
+msgstr "无法写入 '%s'"
 
 #: sequencer.c
 msgid "need a HEAD to fixup"
@@ -27107,16 +27120,16 @@ msgstr "需要一个 HEAD 来修复"
 
 #: sequencer.c
 msgid "could not read HEAD"
-msgstr "不能读取 HEAD"
+msgstr "无法读取 HEAD"
 
 #: sequencer.c
 msgid "could not read HEAD's commit message"
-msgstr "不能读取 HEAD 的提交说明"
+msgstr "无法读取 HEAD 的提交说明"
 
 #: sequencer.c
 #, c-format
 msgid "could not read commit message of %s"
-msgstr "不能读取 %s 的提交说明"
+msgstr "无法读取 %s 的提交说明"
 
 #: sequencer.c
 msgid "your index file is unmerged."
@@ -27124,7 +27137,7 @@ msgstr "您的索引文件未完成合并。"
 
 #: sequencer.c
 msgid "cannot fixup root commit"
-msgstr "不能修复根提交"
+msgstr "无法修复根提交"
 
 #: sequencer.c
 #, c-format
@@ -27139,24 +27152,24 @@ msgstr "提交 %s 没有第 %d 个父提交"
 #: sequencer.c
 #, c-format
 msgid "cannot get commit message for %s"
-msgstr "不能得到 %s 的提交说明"
+msgstr "无法获取 %s 的提交说明"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
 #: sequencer.c
 #, c-format
 msgid "%s: cannot parse parent commit %s"
-msgstr "%s：不能解析父提交 %s"
+msgstr "%s：无法解析父提交 %s"
 
 #: sequencer.c
 #, c-format
 msgid "could not revert %s... %s"
-msgstr "不能还原 %s... %s"
+msgstr "无法还原 %s... %s"
 
 #: sequencer.c
 #, c-format
 msgid "could not apply %s... %s"
-msgstr "不能应用 %s... %s"
+msgstr "无法应用 %s... %s"
 
 #: sequencer.c
 #, c-format
@@ -27226,7 +27239,7 @@ msgid ""
 "'break' to give the control back to you so that you can\n"
 "do 'git commit --amend && git rebase --continue'."
 msgstr ""
-"'edit”' 不接受合并提交。如果您想要重放合并，\n"
+"'edit' 不接受合并提交。如果您想要重放合并，\n"
 "请在提交上使用 'merge -C'，然后使用 'break'\n"
 "将控制权交还给您，以便您可以执行\n"
 "'git commit --amend && git rebase --continue'。"
@@ -27283,11 +27296,11 @@ msgstr "没有解析提交。"
 
 #: sequencer.c
 msgid "cannot cherry-pick during a revert."
-msgstr "不能在回退中执行拣选。"
+msgstr "无法在回退中执行拣选。"
 
 #: sequencer.c
 msgid "cannot revert during a cherry-pick."
-msgstr "不能在拣选中执行回退。"
+msgstr "无法在拣选中执行回退。"
 
 #: sequencer.c
 msgid "unusable squash-onto"
@@ -27323,7 +27336,7 @@ msgstr "尝试 \"git cherry-pick (--continue | %s--abort | --quit)\""
 #: sequencer.c
 #, c-format
 msgid "could not create sequencer directory '%s'"
-msgstr "不能创建序列目录 '%s'"
+msgstr "无法创建序列目录 '%s'"
 
 #: sequencer.c
 msgid "no cherry-pick or revert in progress"
@@ -27331,16 +27344,16 @@ msgstr "拣选或还原操作并未进行"
 
 #: sequencer.c
 msgid "cannot resolve HEAD"
-msgstr "不能解析 HEAD"
+msgstr "无法解析 HEAD"
 
 #: sequencer.c
 msgid "cannot abort from a branch yet to be born"
-msgstr "不能从尚未建立的分支终止"
+msgstr "无法从尚未建立的分支终止"
 
 #: sequencer.c
 #, c-format
 msgid "cannot read '%s': %s"
-msgstr "不能读取 '%s'：%s"
+msgstr "无法读取 '%s'：%s"
 
 #: sequencer.c
 msgid "unexpected end of file"
@@ -27377,12 +27390,12 @@ msgid ""
 "have you committed already?\n"
 "try \"git %s --continue\""
 msgstr ""
-"您已经提交了么？\n"
+"您已经提交了吗？\n"
 "试试 \"git %s --continue\""
 
 #: sequencer.c
 msgid "cannot read HEAD"
-msgstr "不能读取 HEAD"
+msgstr "无法读取 HEAD"
 
 #: sequencer.c
 msgid "could not write commit message file"
@@ -27399,7 +27412,7 @@ msgid ""
 "\n"
 "  git rebase --continue\n"
 msgstr ""
-"您现在可以修补这个提交，使用\n"
+"您现在可以修订这个提交，使用\n"
 "\n"
 "  git commit --amend %s\n"
 "\n"
@@ -27410,12 +27423,12 @@ msgstr ""
 #: sequencer.c
 #, c-format
 msgid "Could not apply %s... %.*s"
-msgstr "不能应用 %s... %.*s"
+msgstr "无法应用 %s... %.*s"
 
 #: sequencer.c
 #, c-format
 msgid "Could not merge %.*s"
-msgstr "不能合并 %.*s"
+msgstr "无法合并 %.*s"
 
 #: sequencer.c
 #, c-format
@@ -27439,7 +27452,7 @@ msgstr ""
 
 #: sequencer.c
 msgid "and made changes to the index and/or the working tree.\n"
-msgstr "并且修改索引和/或工作区。\n"
+msgstr "并已修改索引和/或工作区。\n"
 
 #: sequencer.c
 #, c-format
@@ -27453,7 +27466,7 @@ msgid ""
 msgstr ""
 "执行成功：%s\n"
 "但是在索引和/或工作区中存在变更。\n"
-"提交或贮藏修改，然后运行\n"
+"提交或储藏修改，然后运行\n"
 "\n"
 "  git rebase --continue\n"
 "\n"
@@ -27465,7 +27478,7 @@ msgstr "非法的标签名称：'%.*s'"
 
 #: sequencer.c
 msgid "writing fake root commit"
-msgstr "写伪根提交"
+msgstr "正在写入伪根提交"
 
 #: sequencer.c
 msgid "writing squash-onto"
@@ -27473,7 +27486,7 @@ msgstr "写入 squash-onto"
 
 #: sequencer.c
 msgid "cannot merge without a current revision"
-msgstr "没有当前版本不能合并"
+msgstr "没有当前版本，无法合并"
 
 #: sequencer.c
 #, c-format
@@ -27483,21 +27496,21 @@ msgstr "无法解析 '%.*s'"
 #: sequencer.c
 #, c-format
 msgid "nothing to merge: '%.*s'"
-msgstr "无可用合并：'%.*s'"
+msgstr "无可合并内容：'%.*s'"
 
 #: sequencer.c
 msgid "octopus merge cannot be executed on top of a [new root]"
-msgstr "章鱼合并不能在一个新的根提交上执行"
+msgstr "章鱼合并无法在一个新的根提交上执行"
 
 #: sequencer.c
 #, c-format
 msgid "could not get commit message of '%s'"
-msgstr "不能获取 '%s' 的提交说明"
+msgstr "无法获取 '%s' 的提交说明"
 
 #: sequencer.c
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
-msgstr "甚至不能尝试合并 '%.*s'"
+msgstr "甚至无法尝试合并 '%.*s'"
 
 #: sequencer.c
 msgid "merge: Unable to write new index file"
@@ -27529,22 +27542,22 @@ msgstr ""
 
 #: sequencer.c
 msgid "Cannot autostash"
-msgstr "无法自动贮藏"
+msgstr "无法自动储藏"
 
 #: sequencer.c
 #, c-format
 msgid "Unexpected stash response: '%s'"
-msgstr "意外的贮藏响应：'%s'"
+msgstr "意外的储藏响应：'%s'"
 
 #: sequencer.c
 #, c-format
 msgid "Could not create directory for '%s'"
-msgstr "不能为 '%s' 创建目录"
+msgstr "无法为 '%s' 创建目录"
 
 #: sequencer.c
 #, c-format
 msgid "Created autostash: %s\n"
-msgstr "创建了自动贮藏：%s\n"
+msgstr "创建了自动储藏：%s\n"
 
 #: sequencer.c
 msgid "could not reset --hard"
@@ -27553,12 +27566,12 @@ msgstr "无法硬性重置（reset --hard）"
 #: sequencer.c
 #, c-format
 msgid "Applied autostash.\n"
-msgstr "已应用自动贮藏。\n"
+msgstr "已应用自动储藏。\n"
 
 #: sequencer.c
 #, c-format
 msgid "cannot store %s"
-msgstr "不能存储 %s"
+msgstr "无法存储 %s"
 
 #: sequencer.c
 #, c-format
@@ -27568,24 +27581,24 @@ msgid ""
 "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
 msgstr ""
 "%s\n"
-"您的修改在贮藏区中很安全。\n"
+"您的修改在储藏区中很安全。\n"
 "您可以在任何时候运行 \"git stash pop\" 或 \"git stash drop\"。\n"
 
 #: sequencer.c
 msgid "Applying autostash resulted in conflicts."
-msgstr "应用自动贮藏导致冲突。"
+msgstr "应用自动储藏导致冲突。"
 
 #: sequencer.c
 msgid "Autostash exists; creating a new stash entry."
-msgstr "自动贮藏已经存在；正在创建一个新的贮藏条目。"
+msgstr "自动储藏已经存在；正在创建一个新的储藏条目。"
 
 #: sequencer.c
 msgid "autostash reference is a symref"
-msgstr "自动贮藏的引用是一个符号引用"
+msgstr "自动储藏的引用是一个符号引用"
 
 #: sequencer.c
 msgid "could not detach HEAD"
-msgstr "不能分离头指针"
+msgstr "无法分离头指针"
 
 #: sequencer.c
 #, c-format
@@ -27634,16 +27647,16 @@ msgstr "未知命令 %d"
 
 #: sequencer.c
 msgid "could not read orig-head"
-msgstr "不能读取 orig-head"
+msgstr "无法读取 orig-head"
 
 #: sequencer.c
 msgid "could not read 'onto'"
-msgstr "不能读取 'onto'"
+msgstr "无法读取 'onto'"
 
 #: sequencer.c
 #, c-format
 msgid "could not update HEAD to %s"
-msgstr "不能更新 HEAD 为 %s"
+msgstr "无法更新 HEAD 为 %s"
 
 #: sequencer.c
 #, c-format
@@ -27656,7 +27669,7 @@ msgstr "不能变基：您有未暂存的变更。"
 
 #: sequencer.c
 msgid "cannot amend non-existing commit"
-msgstr "不能修补不存在的提交"
+msgstr "无法修订不存在的提交"
 
 #: sequencer.c
 #, c-format
@@ -27680,25 +27693,25 @@ msgstr ""
 #: sequencer.c
 #, c-format
 msgid "could not write file: '%s'"
-msgstr "不能写入文件：'%s'"
+msgstr "无法写入文件：'%s'"
 
 #: sequencer.c
 msgid "could not remove CHERRY_PICK_HEAD"
-msgstr "不能删除 CHERRY_PICK_HEAD"
+msgstr "无法删除 CHERRY_PICK_HEAD"
 
 #: sequencer.c
 msgid "could not commit staged changes."
-msgstr "不能提交暂存的修改。"
+msgstr "无法提交暂存的修改。"
 
 #: sequencer.c
 #, c-format
 msgid "%s: can't cherry-pick a %s"
-msgstr "%s：不能拣选一个%s"
+msgstr "%s：不能拣选一个 %s"
 
 #: sequencer.c
 #, c-format
 msgid "%s: bad revision"
-msgstr "%s：错误的版本"
+msgstr "%s：无效的版本"
 
 #: sequencer.c
 msgid "can't revert as initial commit"
@@ -27833,7 +27846,7 @@ msgstr "在 gitfile 中没有路径：%s"
 #: setup.c
 #, c-format
 msgid "not a git repository: %s"
-msgstr "不是 git 仓库：%s"
+msgstr "不是 Git 仓库：%s"
 
 #: setup.c
 #, c-format
@@ -27843,12 +27856,12 @@ msgstr "'$%s' 太大"
 #: setup.c
 #, c-format
 msgid "not a git repository: '%s'"
-msgstr "不是 git 仓库：'%s'"
+msgstr "不是 Git 仓库：'%s'"
 
 #: setup.c
 #, c-format
 msgid "cannot chdir to '%s'"
-msgstr "不能切换目录到 '%s'"
+msgstr "无法切换目录到 '%s'"
 
 #: setup.c
 #, c-format
@@ -27875,17 +27888,17 @@ msgstr ""
 
 #: setup.c
 msgid "Unable to read current working directory"
-msgstr "不能读取当前工作目录"
+msgstr "无法读取当前工作目录"
 
 #: setup.c
 #, c-format
 msgid "cannot change to '%s'"
-msgstr "不能切换到 '%s'"
+msgstr "无法切换到 '%s'"
 
 #: setup.c
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
-msgstr "不是 git 仓库（或者任何父目录）：%s"
+msgstr "不是 Git 仓库（或者任何父目录）：%s"
 
 #: setup.c
 #, c-format
@@ -27893,7 +27906,7 @@ msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
 "Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)."
 msgstr ""
-"不是 git 仓库（或者直至挂载点 %s 的任何父目录）\n"
+"不是 Git 仓库（或者直至挂载点 %s 的任何父目录）\n"
 "停止在文件系统边界（未设置 GIT_DISCOVERY_ACROSS_FILESYSTEM）。"
 
 #: setup.c
@@ -27921,42 +27934,42 @@ msgstr "setsid 失败"
 #: setup.c
 #, c-format
 msgid "cannot stat template '%s'"
-msgstr "不能对模版 '%s' 调用 stat"
+msgstr "无法对模板 '%s' 调用 stat"
 
 #: setup.c
 #, c-format
 msgid "cannot opendir '%s'"
-msgstr "不能打开目录 '%s'"
+msgstr "无法打开目录 '%s'"
 
 #: setup.c
 #, c-format
 msgid "cannot readlink '%s'"
-msgstr "不能读取链接 '%s'"
+msgstr "无法读取链接 '%s'"
 
 #: setup.c
 #, c-format
 msgid "cannot symlink '%s' '%s'"
-msgstr "不能自 '%s' 到 '%s' 创建符号链接"
+msgstr "无法从 '%s' 到 '%s' 创建符号链接"
 
 #: setup.c
 #, c-format
 msgid "cannot copy '%s' to '%s'"
-msgstr "不能拷贝 '%s' 至 '%s'"
+msgstr "无法拷贝 '%s' 至 '%s'"
 
 #: setup.c
 #, c-format
 msgid "ignoring template %s"
-msgstr "忽略模版 %s"
+msgstr "忽略模板 %s"
 
 #: setup.c
 #, c-format
 msgid "templates not found in %s"
-msgstr "没有在 %s 中找到模版"
+msgstr "没有在 %s 中找到模板"
 
 #: setup.c
 #, c-format
 msgid "not copying templates from '%s': %s"
-msgstr "没有从 '%s' 复制模版：%s"
+msgstr "没有从 '%s' 复制模板：%s"
 
 #: setup.c
 #, c-format
@@ -27971,12 +27984,12 @@ msgstr "re-init：已忽略 --initial-branch=%s"
 #: setup.c
 #, c-format
 msgid "unable to handle file type %d"
-msgstr "不能处理 %d 类型的文件"
+msgstr "无法处理 %d 类型的文件"
 
 #: setup.c
 #, c-format
 msgid "unable to move %s to %s"
-msgstr "不能移动 %s 至 %s"
+msgstr "无法移动 %s 至 %s"
 
 #: setup.c
 msgid "attempt to reinitialize repository with different hash"
@@ -27995,22 +28008,22 @@ msgstr "%s 已经存在"
 #: setup.c
 #, c-format
 msgid "Reinitialized existing shared Git repository in %s%s\n"
-msgstr "重新初始化已存在的共享 Git 仓库于 %s%s\n"
+msgstr "在 %s%s 重新初始化已存在的共享 Git 仓库\n"
 
 #: setup.c
 #, c-format
 msgid "Reinitialized existing Git repository in %s%s\n"
-msgstr "已重新初始化已存在的 Git 仓库于 %s%s\n"
+msgstr "在 %s%s 重新初始化已存在的 Git 仓库\n"
 
 #: setup.c
 #, c-format
 msgid "Initialized empty shared Git repository in %s%s\n"
-msgstr "已初始化空的共享 Git 仓库于 %s%s\n"
+msgstr "在 %s%s 初始化空的共享 Git 仓库\n"
 
 #: setup.c
 #, c-format
 msgid "Initialized empty Git repository in %s%s\n"
-msgstr "已初始化空的 Git 仓库于 %s%s\n"
+msgstr "在 %s%s 初始化空的 Git 仓库\n"
 
 #: sparse-index.c
 #, c-format
@@ -28025,19 +28038,19 @@ msgstr "拆分索引无法与稀疏索引一起使用"
 #: strbuf.c
 #, c-format
 msgid "bad %s format: element '%s' does not start with '('"
-msgstr "坏的 %s 格式：元素 '%s' 没有以 '(' 开头"
+msgstr "无效的 %s 格式：元素 '%s' 没有以 '(' 开头"
 
 #. TRANSLATORS: The first %s is a command like "ls-tree".
 #: strbuf.c
 #, c-format
 msgid "bad %s format: element '%s' does not end in ')'"
-msgstr "坏的 %s 格式：元素 '%s' 没有以 ')' 结尾"
+msgstr "无效的 %s 格式：元素 '%s' 没有以 ')' 结尾"
 
 #. TRANSLATORS: %s is a command like "ls-tree".
 #: strbuf.c
 #, c-format
 msgid "bad %s format: %%%.*s"
-msgstr "坏的 %s 格式：%%%.*s"
+msgstr "无效的 %s 格式：%%%.*s"
 
 #: strbuf.c
 #, c-format
@@ -28134,7 +28147,7 @@ msgstr "忽略可能被解析为命令行选项的 '%s'：%s"
 #: submodule-config.c
 #, c-format
 msgid "Could not update .gitmodules entry %s"
-msgstr "不能更新 .gitmodules 条目 %s"
+msgstr "无法更新 .gitmodules 条目 %s"
 
 #: submodule.c
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
@@ -28167,14 +28180,14 @@ msgstr "路径规格 '%s' 在子模组 '%.*s' 中"
 #: submodule.c
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
-msgstr "坏的 --ignore-submodules 参数：%s"
+msgstr "无效的 --ignore-submodules 参数：%s"
 
 #: submodule.c
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
 "same. Skipping it."
-msgstr "提交 %s 中位于路径 '%s' 的子模组和同名的子模组冲突。 跳过它。"
+msgstr "提交 %s 中位于路径 '%s' 的子模组和同名的子模组冲突。跳过它。"
 
 #: submodule.c
 #, c-format
@@ -28216,12 +28229,12 @@ msgstr "无法访问子模组 '%s'\n"
 #: submodule.c
 #, c-format
 msgid "Could not access submodule '%s' at commit %s\n"
-msgstr "无法访问子模组 '%s' 提交 %s\n"
+msgstr "无法访问子模组 '%s' 的提交 %s\n"
 
 #: submodule.c
 #, c-format
 msgid "Fetching submodule %s%s at commit %s\n"
-msgstr "正在获取子模组 %s%s 提交 %s\n"
+msgstr "正在获取子模组 %s%s 的提交 %s\n"
 
 #: submodule.c
 #, c-format
@@ -28235,7 +28248,7 @@ msgstr ""
 #: submodule.c
 #, c-format
 msgid "'%s' not recognized as a git repository"
-msgstr "无法将 '%s' 识别为 git 仓库"
+msgstr "无法将 '%s' 识别为 Git 仓库"
 
 #: submodule.c
 #, c-format
@@ -28265,7 +28278,7 @@ msgstr "无法在子模组 '%s' 中取消 core.worktree 的设置"
 #: submodule.c
 #, c-format
 msgid "could not recurse into submodule '%s'"
-msgstr "无法递归进子模组路径 '%s'"
+msgstr "无法递归进入子模组 '%s'"
 
 #: submodule.c
 msgid "could not reset submodule index"
@@ -28284,7 +28297,7 @@ msgstr "子模组 '%s' 无法被更新。"
 #: submodule.c
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
-msgstr "子模组 git 目录 '%s' 位于 git 目录 '%.*s' 中"
+msgstr "子模组 Git 目录 '%s' 位于 Git 目录 '%.*s' 中"
 
 #: submodule.c
 #, c-format
@@ -28305,12 +28318,12 @@ msgstr "不支持对有多个工作区的子模组 '%s' 执行 relocate_gitdir"
 #: submodule.c
 #, c-format
 msgid "could not lookup name for submodule '%s'"
-msgstr "不能查询子模组 '%s' 的名称"
+msgstr "无法查询子模组 '%s' 的名称"
 
 #: submodule.c
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
-msgstr "禁止移动 '%s' 到现存 git 目录中"
+msgstr "拒绝移动 '%s' 到现存 Git 目录中"
 
 #: submodule.c
 #, c-format
@@ -28319,7 +28332,7 @@ msgid ""
 "'%s' to\n"
 "'%s'\n"
 msgstr ""
-"将 '%s%s' 的 git 目录从\n"
+"将 '%s%s' 的 Git 目录从\n"
 "'%s' 迁移至\n"
 "'%s'\n"
 
@@ -28330,7 +28343,7 @@ msgstr "无法在 .. 中启动 ls-files"
 #: submodule.c
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
-msgstr "ls-tree 返回未知返回值 %d"
+msgstr "ls-tree 返回意外返回码 %d"
 
 #: symlinks.c
 #, c-format
@@ -28339,7 +28352,7 @@ msgstr "无法执行 lstat '%s'"
 
 #: t/helper/test-bundle-uri.c
 msgid "no remote configured to get bundle URIs from"
-msgstr "没有远程被设置为可以获取归档包 URI"
+msgstr "没有配置可用于获取 bundle URI 的远程"
 
 #: t/helper/test-bundle-uri.c
 msgid "could not get the bundle-uri list"
@@ -28404,7 +28417,7 @@ msgstr "太多提交标记为可达"
 
 #: t/helper/test-read-midx.c
 msgid "could not determine MIDX preferred pack"
-msgstr "不能确定多包索引的首选包"
+msgstr "无法确定多包索引的首选包"
 
 #: t/helper/test-serve-v2.c
 msgid "test-tool serve-v2 [<options>]"
@@ -28416,43 +28429,43 @@ msgstr "通告能力之后立即退出"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
-msgstr "test-helper simple-ipc is-active    [<名字>] [<选项>]"
+msgstr "test-helper simple-ipc is-active    [<名称>] [<选项>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
-msgstr "test-helper simple-ipc run-daemon   [<名字>] [<线程>]"
+msgstr "test-helper simple-ipc run-daemon   [<名称>] [<线程>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
-msgstr "test-helper simple-ipc start-daemon [<名字>] [<线程>] [<最大等待>]"
+msgstr "test-helper simple-ipc start-daemon [<名称>] [<线程>] [<最大等待>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
-msgstr "test-helper simple-ipc stop-daemon  [<名字>] [<最大等待>]"
+msgstr "test-helper simple-ipc stop-daemon  [<名称>] [<最大等待>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
-msgstr "test-helper simple-ipc send         [<名字>] [<令牌>]"
+msgstr "test-helper simple-ipc send         [<名称>] [<令牌>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
-msgstr "test-helper simple-ipc sendbytes    [<名字>] [<字节数>] [<字节>]"
+msgstr "test-helper simple-ipc sendbytes    [<名称>] [<字节数>] [<字节>]"
 
 #: t/helper/test-simple-ipc.c
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
 msgstr ""
-"test-helper simple-ipc multiple     [<名字>] [<线程>] [<字节计数>] [<批处理大"
+"test-helper simple-ipc multiple     [<名称>] [<线程>] [<字节计数>] [<批处理大"
 "小>]"
 
 #: t/helper/test-simple-ipc.c
 msgid "name or pathname of unix domain socket"
-msgstr "unix 域套接字的名称或路径名"
+msgstr "Unix 域套接字的名称或路径名"
 
 #: t/helper/test-simple-ipc.c
 msgid "named-pipe name"
-msgstr "命名管道的名字"
+msgstr "命名管道的名称"
 
 #: t/helper/test-simple-ipc.c
 msgid "number of threads in server thread pool"
@@ -28472,7 +28485,7 @@ msgstr "每个线程的请求数"
 
 #: t/helper/test-simple-ipc.c
 msgid "ballast character"
-msgstr "ballast character"
+msgstr "压仓字符"
 
 #: t/helper/test-simple-ipc.c
 msgid "token"
@@ -28539,7 +28552,7 @@ msgstr "无法复制助手输出文件句柄"
 msgid ""
 "unknown mandatory capability %s; this remote helper probably needs newer "
 "version of Git"
-msgstr "未知的强制能力 %s，该远程助手可能需要新版本的Git"
+msgstr "未知的强制能力 %s，该远程助手可能需要新版本的 Git"
 
 #: transport-helper.c
 msgid "this remote helper should implement refspec capability"
@@ -28557,7 +28570,7 @@ msgstr "%s 也锁定了 %s"
 
 #: transport-helper.c
 msgid "couldn't run fast-import"
-msgstr "不能执行 fast-import"
+msgstr "无法执行 fast-import"
 
 #: transport-helper.c
 msgid "error while running fast-import"
@@ -28584,7 +28597,7 @@ msgstr "无效的远程服务路径"
 #: transport-helper.c
 #, c-format
 msgid "can't connect to subservice %s"
-msgstr "不能连接到子服务 %s"
+msgstr "无法连接到子服务 %s"
 
 #: transport-helper.c transport.c
 msgid "--negotiate-only requires protocol v2"
@@ -28636,7 +28649,7 @@ msgstr "助手 %s 不支持 'push-option'"
 
 #: transport-helper.c
 msgid "remote-helper doesn't support push; refspec needed"
-msgstr "remote-heper 不支持推送，需要引用规格"
+msgstr "remote-helper 不支持推送，需要引用规格"
 
 #: transport-helper.c
 #, c-format
@@ -28693,7 +28706,7 @@ msgstr "%s 线程等待失败：%s"
 #: transport-helper.c
 #, c-format
 msgid "can't start thread for copying data: %s"
-msgstr "不能启动线程来拷贝数据：%s"
+msgstr "无法启动线程来拷贝数据：%s"
 
 #: transport-helper.c
 #, c-format
@@ -28707,7 +28720,7 @@ msgstr "%s 进程失败"
 
 #: transport-helper.c
 msgid "can't start thread for copying data"
-msgstr "不能启动线程来拷贝数据"
+msgstr "无法启动线程来拷贝数据"
 
 #: transport.c
 #, c-format
@@ -28717,7 +28730,7 @@ msgstr "将要设置 '%1$s' 的上游为 '%3$s' 的 '%2$s'\n"
 #: transport.c
 #, c-format
 msgid "could not read bundle '%s'"
-msgstr "无法读取归档包 '%s'"
+msgstr "无法读取捆绑包 '%s'"
 
 #: transport.c
 #, c-format
@@ -28738,7 +28751,7 @@ msgstr "服务器不支持 wait-for-done"
 
 #: transport.c
 msgid "could not parse transport.color.* config"
-msgstr "不能解析 transport.color.* 配置"
+msgstr "无法解析 transport.color.* 配置"
 
 #: transport.c
 msgid "support for protocol v2 not implemented yet"
@@ -28793,7 +28806,7 @@ msgstr "正在终止。"
 
 #: transport.c
 msgid "failed to push all needed submodules"
-msgstr "不能推送全部需要的子模组"
+msgstr "无法推送全部需要的子模组"
 
 #: transport.c
 msgid "bundle-uri operation not supported by protocol"
@@ -28809,7 +28822,7 @@ msgstr "协议不支持该操作"
 
 #: tree-walk.c
 msgid "too-short tree object"
-msgstr "太短的树对象"
+msgstr "树对象太短"
 
 #: tree-walk.c
 msgid "malformed mode in tree entry"
@@ -28821,7 +28834,7 @@ msgstr "树对象条目中空的文件名"
 
 #: tree-walk.c
 msgid "too-short tree file"
-msgstr "太短的树文件"
+msgstr "树文件太短"
 
 #: unpack-trees.c
 #, c-format
@@ -28830,7 +28843,7 @@ msgid ""
 "%%sPlease commit your changes or stash them before you switch branches."
 msgstr ""
 "您对下列文件的本地修改将被检出操作覆盖：\n"
-"%%s请在切换分支前提交或贮藏您的修改。"
+"%%s请在切换分支前提交或储藏您的修改。"
 
 #: unpack-trees.c
 #, c-format
@@ -28848,7 +28861,7 @@ msgid ""
 "%%sPlease commit your changes or stash them before you merge."
 msgstr ""
 "您对下列文件的本地修改将被合并操作覆盖：\n"
-"%%s请在合并前提交或贮藏您的修改。"
+"%%s请在合并前提交或储藏您的修改。"
 
 #: unpack-trees.c
 #, c-format
@@ -28866,7 +28879,7 @@ msgid ""
 "%%sPlease commit your changes or stash them before you %s."
 msgstr ""
 "您对下列文件的本地修改将被 %s 覆盖：\n"
-"%%s请在 %s 之前提交或贮藏您的修改。"
+"%%s请在 %s 之前提交或储藏您的修改。"
 
 #: unpack-trees.c
 #, c-format
@@ -29008,7 +29021,7 @@ msgstr ""
 #: unpack-trees.c
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
-msgstr "条目 '%s' 和 '%s' 重叠。无法合并。"
+msgstr "条目 '%s' 和 '%s' 重叠。无法绑定。"
 
 #: unpack-trees.c
 #, c-format
@@ -29026,7 +29039,7 @@ msgid ""
 "patterns:\n"
 "%s"
 msgstr ""
-"尽管存在稀疏检出模板，以下路径不是最新，因而保留：\n"
+"尽管存在稀疏检出模式，以下路径不是最新，因而保留：\n"
 "%s"
 
 #: unpack-trees.c
@@ -29035,7 +29048,7 @@ msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
 "%s"
 msgstr ""
-"尽管存在稀疏检出模板，以下路径处于未合并状态，因而保留：\n"
+"尽管存在稀疏检出模式，以下路径处于未合并状态，因而保留：\n"
 "%s"
 
 #: unpack-trees.c
@@ -29045,7 +29058,7 @@ msgid ""
 "patterns:\n"
 "%s"
 msgstr ""
-"尽管存在稀疏检出模板，以下路径已经存在，因而未更新：\n"
+"尽管存在稀疏检出模式，以下路径已经存在，因而未更新：\n"
 "%s"
 
 #: unpack-trees.c
@@ -29139,7 +29152,7 @@ msgstr "警告："
 #: usage.c
 #, c-format
 msgid "'%s' is nominated for removal.\n"
-msgstr "'%s' 被提名以移除。\n"
+msgstr "'%s' 已被列入移除计划。\n"
 
 #: usage.c
 #, c-format
@@ -29292,7 +29305,7 @@ msgstr "无法升级仓库格式以支持相对工作区"
 
 #: worktree.c
 msgid "unable to set extensions.relativeWorktrees setting"
-msgstr "无法设定 extensions.relativeWorktrees 的设置"
+msgstr "无法设定 extensions.relativeWorktrees 的配置"
 
 #: wrapper.c
 #, c-format
@@ -29312,11 +29325,11 @@ msgstr "无法打开 '%s' 进行读写"
 #: wrapper.c
 #, c-format
 msgid "unable to access '%s'"
-msgstr "不能访问 '%s'"
+msgstr "无法访问 '%s'"
 
 #: wrapper.c
 msgid "unable to get current working directory"
-msgstr "不能获取当前工作目录"
+msgstr "无法获取当前工作目录"
 
 #: wrapper.c
 msgid "unable to get random bytes"
@@ -29481,8 +29494,8 @@ msgstr "未跟踪的内容, "
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
-msgstr[0] "您的贮藏区当前有 %d 条记录"
-msgstr[1] "您的贮藏区当前有 %d 条记录"
+msgstr[0] "您的储藏区当前有 %d 条记录"
+msgstr[1] "您的储藏区当前有 %d 条记录"
 
 #: wt-status.c
 msgid "Submodules changed but not updated:"
@@ -29508,8 +29521,8 @@ msgid ""
 "You can use '--no-ahead-behind' to avoid this.\n"
 msgstr ""
 "\n"
-"花了 %.2f 秒才计算出分支的领先/落后范围。\n"
-"为避免，您可以使用 '--no-ahead-behind'。\n"
+"花了 %.2f 秒才计算出分支的领先/落后值。\n"
+"为避免这种情况，您可以使用 '--no-ahead-behind'。\n"
 
 #: wt-status.c
 msgid "You have unmerged paths."
@@ -29581,11 +29594,11 @@ msgstr[1] "最后完成的命令（%<PRIuMAX> 条命令被执行）："
 #: wt-status.c
 #, c-format
 msgid "  (see more in file %s)"
-msgstr "  （更多参见文件 %s）"
+msgstr "  （更多内容参见文件 %s）"
 
 #: wt-status.c
 msgid "No commands remaining."
-msgstr "未剩下任何命令。"
+msgstr "没有剩余命令。"
 
 #: wt-status.c
 #, c-format
@@ -29641,7 +29654,7 @@ msgstr "您在执行变基操作时拆分提交。"
 #  译者：注意保持前导空格
 #: wt-status.c
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
-msgstr "  （一旦您工作目录提交干净后，运行 \"git rebase --continue\"）"
+msgstr "  （一旦您的工作目录干净后，运行 \"git rebase --continue\"）"
 
 #: wt-status.c
 #, c-format
@@ -29655,7 +29668,7 @@ msgstr "您在执行变基操作时编辑提交。"
 #  译者：注意保持前导空格
 #: wt-status.c
 msgid "  (use \"git commit --amend\" to amend the current commit)"
-msgstr "  （使用 \"git commit --amend\" 修补当前提交）"
+msgstr "  （使用 \"git commit --amend\" 修订当前提交）"
 
 #  译者：注意保持前导空格
 #: wt-status.c
@@ -29699,12 +29712,12 @@ msgstr "  （使用 \"git cherry-pick --abort\" 以取消拣选操作）"
 
 #: wt-status.c
 msgid "Revert currently in progress."
-msgstr "还原操作正在行中。"
+msgstr "还原操作正在进行中。"
 
 #: wt-status.c
 #, c-format
 msgid "You are currently reverting commit %s."
-msgstr "您在执行反转提交 %s 的操作。"
+msgstr "您在执行还原提交 %s 的操作。"
 
 #  译者：注意保持前导空格
 #: wt-status.c
@@ -29729,7 +29742,7 @@ msgstr "  （使用 \"git revert --skip\" 跳过此补丁）"
 #  译者：注意保持前导空格
 #: wt-status.c
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
-msgstr "  （使用 \"git revert --abort\" 以取消反转提交操作）"
+msgstr "  （使用 \"git revert --abort\" 以取消还原操作）"
 
 #: wt-status.c
 #, c-format
@@ -29747,12 +29760,12 @@ msgstr "  （使用 \"git bisect reset\" 以回到原有分支）"
 
 #: wt-status.c
 msgid "You are in a sparse checkout."
-msgstr "您处于一个稀疏检出中。"
+msgstr "您处于稀疏检出状态。"
 
 #: wt-status.c
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
-msgstr "您处于稀疏检出状态，包含 %d%% 的跟踪文件"
+msgstr "您处于稀疏检出状态，已包含 %d%% 的跟踪文件。"
 
 #: wt-status.c
 msgid "On branch "
@@ -29800,22 +29813,22 @@ msgid ""
 "It took %.2f seconds to enumerate untracked files,\n"
 "but the results were cached, and subsequent runs may be faster."
 msgstr ""
-"枚举未追踪的文件花了 %.2f 秒，\n"
+"枚举未跟踪的文件花了 %.2f 秒，\n"
 "结果已被缓存，后续的执行会更快。"
 
 #: wt-status.c
 #, c-format
 msgid "It took %.2f seconds to enumerate untracked files."
-msgstr "枚举未追踪的文件花了 %.2f 秒。"
+msgstr "枚举未跟踪的文件花了 %.2f 秒。"
 
 #: wt-status.c
 msgid "See 'git help status' for information on how to improve this."
-msgstr "参见 'git help status' 来获取如何改善的信息。"
+msgstr "参见 'git help status' 了解如何改善。"
 
 #: wt-status.c
 #, c-format
 msgid "Untracked files not listed%s"
-msgstr "未跟踪的文件没有列出%s"
+msgstr "未跟踪的文件未列出%s"
 
 #  译者：中文字符串拼接，可删除前导空格
 #: wt-status.c
@@ -29866,11 +29879,11 @@ msgstr "无文件要提交（使用 -u 显示未跟踪的文件）\n"
 #: wt-status.c
 #, c-format
 msgid "nothing to commit, working tree clean\n"
-msgstr "无文件要提交，干净的工作区\n"
+msgstr "无文件要提交，工作区干净\n"
 
 #: wt-status.c
 msgid "No commits yet on "
-msgstr "尚无提交在 "
+msgstr "尚无提交于 "
 
 #: wt-status.c
 msgid "HEAD (no branch)"
@@ -29893,7 +29906,7 @@ msgstr "领先 "
 #: wt-status.c
 #, c-format
 msgid "cannot %s: You have unstaged changes."
-msgstr "不能%s：您有未暂存的变更。"
+msgstr "无法 %s：您有未暂存的变更。"
 
 #: wt-status.c
 msgid "additionally, your index contains uncommitted changes."
@@ -29902,7 +29915,7 @@ msgstr "另外，您的索引中包含未提交的变更。"
 #: wt-status.c
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
-msgstr "不能%s：您的索引中包含未提交的变更。"
+msgstr "不能 %s：您的索引中包含未提交的变更。"
 
 #: xdiff-interface.c
 #, c-format
@@ -29917,7 +29930,7 @@ msgstr "错误：您对下列文件的本地修改将被合并操作覆盖"
 
 #: git-merge-octopus.sh
 msgid "Automated merge did not work."
-msgstr "自动合并未生效。"
+msgstr "自动合并未成功。"
 
 #: git-merge-octopus.sh
 msgid "Should not be doing an octopus."
@@ -29955,26 +29968,26 @@ msgstr "用法：$dashless $USAGE"
 #: git-sh-setup.sh
 #, sh-format
 msgid "Cannot chdir to $cdup, the toplevel of the working tree"
-msgstr "不能切换目录到 $cdup，工作区的顶级目录"
+msgstr "无法切换到工作区的顶级目录 $cdup"
 
 #: git-sh-setup.sh
 #, sh-format
 msgid "fatal: $program_name cannot be used without a working tree."
-msgstr "致命错误：$program_name 不能在没有工作区的情况下使用"
+msgstr "致命错误：$program_name 无法在没有工作区的情况下使用"
 
 #: git-sh-setup.sh
 msgid "Cannot rewrite branches: You have unstaged changes."
-msgstr "不能重写分支：您有未暂存的变更。"
+msgstr "无法重写分支：您有未暂存的变更。"
 
 #: git-sh-setup.sh
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
-msgstr "不能 $action：您有未暂存的变更。"
+msgstr "无法 $action：您有未暂存的变更。"
 
 #: git-sh-setup.sh
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
-msgstr "不能 $action：您的索引中包含未提交的变更。"
+msgstr "无法 $action：您的索引中包含未提交的变更。"
 
 #: git-sh-setup.sh
 msgid "Additionally, your index contains uncommitted changes."
@@ -29986,11 +29999,11 @@ msgstr "您需要在工作区的顶级目录中运行这个命令。"
 
 #: git-sh-setup.sh
 msgid "Unable to determine absolute path of git directory"
-msgstr "不能确定 git 目录的绝对路径"
+msgstr "无法确定 Git 目录的绝对路径"
 
 #: git-send-email.perl
 msgid "local zone differs from GMT by a non-minute interval\n"
-msgstr "本地时间和 GMT 有不到一分钟间隔\n"
+msgstr "本地时间与 GMT 的偏移不是整数分钟\n"
 
 #: git-send-email.perl
 msgid "local time offset greater than or equal to 24 hours\n"
@@ -30014,11 +30027,11 @@ msgstr "'%s' 包含您正在编写的一个中间版本的邮件。\n"
 #: git-send-email.perl
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
-msgstr "'%s.final' 包含编辑的邮件。\n"
+msgstr "'%s.final' 包含已撰写的邮件。\n"
 
 #: git-send-email.perl
 msgid "--dump-aliases incompatible with other options\n"
-msgstr "--dump-aliases 和其它选项不兼容\n"
+msgstr "--dump-aliases 和其他选项不兼容\n"
 
 #: git-send-email.perl
 msgid "--dump-aliases and --translate-aliases are mutually exclusive\n"
@@ -30036,7 +30049,7 @@ msgstr ""
 
 #: git-send-email.perl
 msgid "Cannot run git format-patch from outside a repository\n"
-msgstr "不能在仓库之外运行 git format-patch\n"
+msgstr "无法在仓库之外运行 git format-patch\n"
 
 #: git-send-email.perl
 msgid ""
@@ -30072,7 +30085,7 @@ msgstr "警告：不支持 `/file` 或 `|pipe` 重定向：%s\n"
 #: git-send-email.perl
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
-msgstr "警告：不能识别的 sendmail 行：%s\n"
+msgstr "警告：无法识别的 sendmail 行：%s\n"
 
 #: git-send-email.perl
 #, perl-format
@@ -30155,7 +30168,7 @@ msgstr "如下文件含 8bit 内容，但没有声明一个 Content-Transfer-Enc
 
 #: git-send-email.perl
 msgid "Which 8bit encoding should I declare [UTF-8]? "
-msgstr "要声明 8bit 为什么样的编码格式 [UTF-8]？"
+msgstr "要声明哪种 8bit 编码格式 [UTF-8]？"
 
 #: git-send-email.perl
 #, perl-format
@@ -30167,11 +30180,11 @@ msgid ""
 msgstr ""
 "拒绝发送，因为补丁\n"
 "\t%s\n"
-"包含模版标题 '*** SUBJECT HERE ***'。如果确实想要发送，使用参数 --force。\n"
+"包含模板标题 '*** SUBJECT HERE ***'。如果确实想要发送，使用参数 --force。\n"
 
 #: git-send-email.perl
 msgid "To whom should the emails be sent (if anyone)?"
-msgstr "邮件将要发送给谁？"
+msgstr "邮件将要发送给谁（如果有的话）？"
 
 #: git-send-email.perl
 #, perl-format
@@ -30180,12 +30193,12 @@ msgstr "致命错误：别名 '%s' 扩展为它自己\n"
 
 #: git-send-email.perl
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
-msgstr "Message-ID 被用作第一封邮件的 In-Reply-To ？"
+msgstr "如有的话，Message-ID 要用作第一封邮件的 In-Reply-To 吗？"
 
 #: git-send-email.perl
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
-msgstr "错误：不能从 %s 中提取一个有效的邮件地址\n"
+msgstr "错误：无法从 %s 中提取一个有效的邮件地址\n"
 
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
@@ -30213,8 +30226,8 @@ msgid ""
 "\n"
 msgstr ""
 "    以上的抄送列表（Cc）已经用补丁提交信息中发现的地址进行\n"
-"    了扩展。缺省 send-email 会给出提示。这个行为可以通过\n"
-"    sendemail.confirm 配置设置。\n"
+"    了扩展。默认情况下 send-email 会给出提示。这个行为由\n"
+"    sendemail.confirm 配置控制。\n"
 "\n"
 "    更多信息，执行 'git send-email --help'。\n"
 "    要保持当前行为，但不显示此信息，运行 'git config --global\n"
@@ -30271,7 +30284,7 @@ msgstr "无法发送 %s\n"
 #: git-send-email.perl
 #, perl-format
 msgid "Dry-Sent %s"
-msgstr "演习发送 %s"
+msgstr "模拟发送 %s"
 
 #: git-send-email.perl
 #, perl-format
@@ -30280,7 +30293,7 @@ msgstr "已发送 %s"
 
 #: git-send-email.perl
 msgid "Dry-OK. Log says:"
-msgstr "演习成功。日志说："
+msgstr "模拟成功。日志说："
 
 #: git-send-email.perl
 msgid "OK. Log says:"
@@ -30302,22 +30315,22 @@ msgstr "无法打开文件 %s"
 #: git-send-email.perl
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
-msgstr "(mbox) 添加 cc：%s 自行 '%s'\n"
+msgstr "(mbox) 添加 cc：%s 来自行 '%s'\n"
 
 #: git-send-email.perl
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
-msgstr "(mbox) 添加 to：%s 自行 '%s'\n"
+msgstr "(mbox) 添加 to：%s 来自行 '%s'\n"
 
 #: git-send-email.perl
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
-msgstr "(non-mbox) 添加 cc：%s 自行 '%s'\n"
+msgstr "(non-mbox) 添加 cc：%s 来自行 '%s'\n"
 
 #: git-send-email.perl
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
-msgstr "(body) 添加 cc：%s 自行 '%s'\n"
+msgstr "(body) 添加 cc：%s 来自行 '%s'\n"
 
 #: git-send-email.perl
 #, perl-format
@@ -30327,12 +30340,12 @@ msgstr "错误：无效的 SMTP 端口 '%s'\n"
 #: git-send-email.perl
 #, perl-format
 msgid "(%s) Could not execute '%s'"
-msgstr "(%s) 不能执行 '%s'"
+msgstr "(%s) 无法执行 '%s'"
 
 #: git-send-email.perl
 #, perl-format
 msgid "(%s) Malformed output from '%s'"
-msgstr "(%s) 非法的输出信息，来自于：'%s'"
+msgstr "(%s) 来自 '%s' 的输出信息格式错误"
 
 #: git-send-email.perl
 #, perl-format
@@ -30346,7 +30359,7 @@ msgstr "(%s) 添加 %s：%s 自：'%s'\n"
 
 #: git-send-email.perl
 msgid "cannot send message as 7bit"
-msgstr "不能以 7bit 形式发送信息"
+msgstr "无法以 7bit 形式发送信息"
 
 #: git-send-email.perl
 msgid "invalid transfer encoding"
@@ -30366,7 +30379,7 @@ msgstr ""
 #: git-send-email.perl
 #, perl-format
 msgid "unable to open %s: %s\n"
-msgstr "不能打开 %s：%s\n"
+msgstr "无法打开 %s：%s\n"
 
 #: git-send-email.perl
 #, perl-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -155,7 +155,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2025-11-15 22:02+0800\n"
+"POT-Creation-Date: 2026-01-29 19:17+0800\n"
 "PO-Revision-Date: 2025-11-16 01:03+0800\n"
 "Last-Translator: Teng Long <dyroneteng@gmail.com>\n"
 "Language-Team: GitHub <https://github.com/dyrone/git/>\n"
@@ -1083,9 +1083,9 @@ msgstr "未能识别的空白字符忽略选项 '%s'"
 #: builtin/fast-export.c builtin/fetch.c builtin/help.c builtin/index-pack.c
 #: builtin/init-db.c builtin/log.c builtin/ls-files.c builtin/merge-base.c
 #: builtin/merge-tree.c builtin/merge.c builtin/rebase.c builtin/repack.c
-#: builtin/replay.c builtin/reset.c builtin/rev-parse.c builtin/show-branch.c
-#: builtin/stash.c builtin/submodule--helper.c builtin/tag.c builtin/worktree.c
-#: parse-options.c range-diff.c revision.c
+#: builtin/reset.c builtin/rev-parse.c builtin/show-branch.c builtin/stash.c
+#: builtin/submodule--helper.c builtin/tag.c builtin/worktree.c parse-options.c
+#: range-diff.c revision.c
 #, c-format
 msgid "options '%s' and '%s' cannot be used together"
 msgstr "选项 '%s' 和 '%s' 不能同时使用"
@@ -2235,8 +2235,8 @@ msgid "'%s' is not a valid branch name"
 msgstr "'%s' 不是一个有效的分支名称"
 
 #: branch.c builtin/branch.c
-msgid "See `man git check-ref-format`"
-msgstr "查阅 `man git check-ref-format`"
+msgid "See 'git help check-ref-format'"
+msgstr "参阅 'git help check-ref-format'"
 
 #: branch.c
 #, c-format
@@ -3347,6 +3347,19 @@ msgstr "期望一个颜色：%s"
 msgid "must end with a color"
 msgstr "必须以一个颜色结尾"
 
+#: builtin/blame.c diff.c merge-ort.c transport.c
+#, c-format
+msgid "unknown value for config '%s': %s"
+msgstr "配置 '%s' 未知的取值：%s"
+
+#: builtin/blame.c builtin/merge-file.c diff.c
+msgid ""
+"option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
+"\"histogram\""
+msgstr ""
+"选项 diff-algorithm 接受参数 \"myers\"、\"minimal\"、\"patience\" 和 "
+"\"histogram\""
+
 #: builtin/blame.c
 #, c-format
 msgid "cannot find revision %s to ignore"
@@ -3418,6 +3431,14 @@ msgstr "显示作者的邮箱而不是名字（默认：关闭）"
 msgid "ignore whitespace differences"
 msgstr "忽略空白差异"
 
+#: builtin/blame.c builtin/merge-file.c diff.c
+msgid "<algorithm>"
+msgstr "<算法>"
+
+#: builtin/blame.c builtin/merge-file.c diff.c
+msgid "choose a diff algorithm"
+msgstr "选择一个差异算法"
+
 #: builtin/blame.c builtin/clone.c builtin/log.c
 msgid "rev"
 msgstr "版本"
@@ -3439,8 +3460,8 @@ msgid "color lines by age"
 msgstr "依据时间着色"
 
 #: builtin/blame.c
-msgid "spend extra cycles to find better match"
-msgstr "花费额外的循环来找到更好的匹配"
+msgid "spend extra cycles to find a better match"
+msgstr "花费更多计算来找到更好的匹配"
 
 #: builtin/blame.c
 msgid "use revisions from <file> instead of calling git-rev-list"
@@ -3985,7 +4006,7 @@ msgstr ""
 "您可以删除任何您不想共享的内容。\n"
 
 #: builtin/bugreport.c builtin/commit.c builtin/fast-export.c
-#: builtin/pack-objects.c builtin/rebase.c parse-options.h
+#: builtin/pack-objects.c builtin/rebase.c builtin/replay.c parse-options.h
 msgid "mode"
 msgstr "模式"
 
@@ -4905,10 +4926,10 @@ msgstr "--track 需要一个分支名"
 msgid "missing branch name; try -%c"
 msgstr "缺少分支名，尝试 -%c"
 
-#: builtin/checkout.c
+#: builtin/checkout.c sequencer.c
 #, c-format
-msgid "could not resolve %s"
-msgstr "无法解析 %s"
+msgid "could not resolve '%s'"
+msgstr "无法解析 '%s'"
 
 #: builtin/checkout.c
 msgid "invalid path specification"
@@ -6732,10 +6753,18 @@ msgstr "--append 不能与 --value=<模式> 一起使用"
 #, c-format
 msgid ""
 "cannot overwrite multiple values with a single value\n"
-"       Use a regexp, --add or --replace-all to change %s."
+"       Use --value=<pattern>, --append or --all to change %s."
 msgstr ""
-"无法用一个值覆盖多个值\n"
-"       使用一个正则表达式、--add 或 --replace-all 来修改 %s。"
+"无法用单个值覆盖多个值\n"
+"       使用 --value=<模式>, --append 或 --all 来修改 %s。"
+
+#: builtin/config.c
+msgid "unset all multi-valued config options"
+msgstr "取消设置所有多值配置选项"
+
+#: builtin/config.c
+msgid "unset multi-valued config options with matching values"
+msgstr "取消设置匹配值的多值配置选项"
 
 #: builtin/config.c
 #, c-format
@@ -6844,6 +6873,15 @@ msgstr "--default 仅适用于 --get"
 #: builtin/config.c
 msgid "--comment is only applicable to add/set/replace operations"
 msgstr "--comment 仅适用于 add/set/replace 操作"
+
+#: builtin/config.c
+#, c-format
+msgid ""
+"cannot overwrite multiple values with a single value\n"
+"       Use a regexp, --add or --replace-all to change %s."
+msgstr ""
+"无法用一个值覆盖多个值\n"
+"       使用一个正则表达式、--add 或 --replace-all 来修改 %s。"
 
 #: builtin/count-objects.c
 msgid "print sizes in human readable format"
@@ -7351,11 +7389,6 @@ msgstr ""
 
 #: builtin/fast-export.c
 #, c-format
-msgid "encountered signed commit %s; use --signed-commits=<mode> to handle it"
-msgstr "遇到已签名提交 %s；使用 --signed-commits=<模式> 来处理"
-
-#: builtin/fast-export.c
-#, c-format
 msgid "exporting %<PRIuMAX> signature(s) for commit %s"
 msgstr "正在导出提交 %2$s 的 %1$<PRIuMAX> 个签名"
 
@@ -7363,6 +7396,19 @@ msgstr "正在导出提交 %2$s 的 %1$<PRIuMAX> 个签名"
 #, c-format
 msgid "stripping signature(s) from commit %s"
 msgstr "正在剥离提交 %s 的签名"
+
+#: builtin/fast-export.c
+#, c-format
+msgid "encountered signed commit %s; use --signed-commits=<mode> to handle it"
+msgstr "遇到已签名提交 %s；使用 --signed-commits=<模式> 来处理"
+
+#: builtin/fast-export.c
+msgid ""
+"'strip-if-invalid' is not a valid mode for git fast-export with --signed-"
+"commits=<mode>"
+msgstr ""
+"在 git fast-export 的 --signed-commits=<模式> 中，'strip-if-invalid' 不是有效"
+"模式"
 
 #: builtin/fast-export.c
 #, c-format
@@ -7380,11 +7426,6 @@ msgstr "无法读取标签 %s"
 
 #: builtin/fast-export.c
 #, c-format
-msgid "encountered signed tag %s; use --signed-tags=<mode> to handle it"
-msgstr "遇到已签名标签 %s；使用 --signed-tags=<模式> 来处理"
-
-#: builtin/fast-export.c
-#, c-format
 msgid "exporting signed tag %s"
 msgstr "正在导出已签名标签 %s"
 
@@ -7392,6 +7433,19 @@ msgstr "正在导出已签名标签 %s"
 #, c-format
 msgid "stripping signature from tag %s"
 msgstr "正在从标签 %s 中剥离签名"
+
+#: builtin/fast-export.c
+#, c-format
+msgid "encountered signed tag %s; use --signed-tags=<mode> to handle it"
+msgstr "遇到已签名标签 %s；使用 --signed-tags=<模式> 来处理"
+
+#: builtin/fast-export.c
+msgid ""
+"'strip-if-invalid' is not a valid mode for git fast-export with --signed-"
+"tags=<mode>"
+msgstr ""
+"在 git fast-export 的 --signed-tags=<模式> 中，'strip-if-invalid' 不是有效模"
+"式"
 
 #: builtin/fast-export.c
 #, c-format
@@ -7883,6 +7937,37 @@ msgstr "发现多个 %s 签名，忽略附加的签名"
 msgid "parse_one_signature() returned unknown hash algo"
 msgstr "parse_one_signature() 返回了未知的哈希算法"
 
+#: builtin/fast-import.c builtin/fsck.c
+msgid "unknown"
+msgstr "未知"
+
+#: builtin/fast-import.c
+#, c-format
+msgid ""
+"stripping invalid signature for commit '%.100s...'\n"
+"  allegedly by %s"
+msgstr ""
+"正在剥离提交 '%.100s...' 的无效签名\n"
+"  据称由 %s 提供"
+
+#: builtin/fast-import.c
+#, c-format
+msgid ""
+"stripping invalid signature for commit '%.*s'\n"
+"  allegedly by %s"
+msgstr ""
+"正在剥离提交 '%.*s' 的无效签名\n"
+"  据称由 %s 提供"
+
+#: builtin/fast-import.c
+#, c-format
+msgid ""
+"stripping invalid signature for commit\n"
+"  allegedly by %s"
+msgstr ""
+"正在剥离提交的无效签名\n"
+"  据称由 %s 提供"
+
 #: builtin/fast-import.c
 msgid "expected committer but didn't get one"
 msgstr "预期提交者但未获取"
@@ -7900,10 +7985,6 @@ msgid "importing a commit signature verbatim"
 msgstr "逐字导入提交签名"
 
 #: builtin/fast-import.c
-msgid "encountered signed tag; use --signed-tags=<mode> to handle it"
-msgstr "遇到已签名标签；使用 --signed-tags=<模式> 来处理它"
-
-#: builtin/fast-import.c
 #, c-format
 msgid "importing a tag signature verbatim for tag '%s'"
 msgstr "逐字导入标签 '%s' 的签名"
@@ -7912,6 +7993,18 @@ msgstr "逐字导入标签 '%s' 的签名"
 #, c-format
 msgid "stripping a tag signature for tag '%s'"
 msgstr "正在剥离标签 '%s' 的签名"
+
+#: builtin/fast-import.c
+msgid "encountered signed tag; use --signed-tags=<mode> to handle it"
+msgstr "遇到已签名标签；使用 --signed-tags=<模式> 来处理它"
+
+#: builtin/fast-import.c
+msgid ""
+"'strip-if-invalid' is not a valid mode for git fast-import with --signed-"
+"tags=<mode>"
+msgstr ""
+"在 git fast-import 的 --signed-tags=<模式> 中，'strip-if-invalid' 不是有效模"
+"式"
 
 #: builtin/fast-import.c
 #, c-format
@@ -8111,8 +8204,8 @@ msgid "git fetch [<options>] <group>"
 msgstr "git fetch [<选项>] <组>"
 
 #: builtin/fetch.c
-msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
-msgstr "git fetch --multiple [<选项>] [(<仓库> | <组>)...]"
+msgid "git fetch --multiple [<options>] [(<repository>|<group>)...]"
+msgstr "git fetch --multiple [<选项>] [(<仓库>|<组>)...]"
 
 #: builtin/fetch.c
 msgid "git fetch --all [<options>]"
@@ -8684,10 +8777,6 @@ msgstr "缺少 --config=<配置>"
 msgid "got bad config --config=%s"
 msgstr "发现错误的配置行 --config=%s"
 
-#: builtin/fsck.c
-msgid "unknown"
-msgstr "未知"
-
 #. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
 #: builtin/fsck.c
 #, c-format
@@ -8807,6 +8896,11 @@ msgid "%s: not a commit"
 msgstr "%s：不是一个提交"
 
 #: builtin/fsck.c
+#, c-format
+msgid "invalid parameter: expected sha1, got '%s'"
+msgstr "无效的参数：期望 sha1，得到 '%s'"
+
+#: builtin/fsck.c
 msgid "notice: No default references"
 msgstr "注意：无默认引用"
 
@@ -8837,31 +8931,6 @@ msgstr "正在检查对象目录"
 #: builtin/fsck.c
 msgid "Checking object directories"
 msgstr "正在检查对象目录"
-
-#: builtin/fsck.c
-#, c-format
-msgid "Checking %s link"
-msgstr "正在检查 %s 链接"
-
-#: builtin/fsck.c builtin/index-pack.c
-#, c-format
-msgid "invalid %s"
-msgstr "无效的 %s"
-
-#: builtin/fsck.c
-#, c-format
-msgid "%s points to something strange (%s)"
-msgstr "%s 指向奇怪的东西（%s）"
-
-#: builtin/fsck.c
-#, c-format
-msgid "%s: detached HEAD points at nothing"
-msgstr "%s：分离头指针的指向不存在"
-
-#: builtin/fsck.c
-#, c-format
-msgid "notice: %s points to an unborn branch (%s)"
-msgstr "注意：%s 指向一个尚未诞生的分支（%s）"
 
 #: builtin/fsck.c
 #, c-format
@@ -8963,16 +9032,6 @@ msgstr "检查引用数据库一致性"
 #: builtin/fsck.c builtin/index-pack.c
 msgid "Checking objects"
 msgstr "正在检查对象"
-
-#: builtin/fsck.c
-#, c-format
-msgid "%s: object missing"
-msgstr "%s：对象缺失"
-
-#: builtin/fsck.c
-#, c-format
-msgid "invalid parameter: expected sha1, got '%s'"
-msgstr "无效的参数：期望 sha1，得到 '%s'"
 
 #: builtin/fsmonitor--daemon.c
 msgid "git fsmonitor--daemon start [<options>]"
@@ -9443,6 +9502,10 @@ msgstr "无法设置维护计划"
 #: builtin/gc.c
 msgid "failed to add repo to global config"
 msgstr "无法将仓库添加到全局配置"
+
+#: builtin/gc.c
+msgid "check a specific task"
+msgstr "检查特定任务"
 
 #: builtin/gc.c
 msgid "git maintenance <subcommand> [<options>]"
@@ -10021,6 +10084,11 @@ msgstr "对打包对象 fsck 检查出错"
 
 #: builtin/index-pack.c
 #, c-format
+msgid "invalid %s"
+msgstr "无效的 %s"
+
+#: builtin/index-pack.c
+#, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "%s 的所有子对象并非都可达"
 
@@ -10194,6 +10262,10 @@ msgstr "--stdin 需要 git 仓库"
 #: builtin/index-pack.c
 msgid "--verify with no packfile name given"
 msgstr "--verify 没有提供包文件名参数"
+
+#: builtin/index-pack.c
+msgid "cannot perform queued object checks outside of a repository"
+msgstr "无法在仓库之外执行排队的对象检查"
 
 #: builtin/index-pack.c builtin/unpack-objects.c
 msgid "fsck error in pack objects"
@@ -11149,14 +11221,6 @@ msgstr ""
 "git merge-file [<选项>] [-L <名字1> [-L <初始名字> [-L <名字2>]]] <文件1> <初"
 "始文件> <文件2>"
 
-#: builtin/merge-file.c diff.c
-msgid ""
-"option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
-"\"histogram\""
-msgstr ""
-"选项 diff-algorithm 接受参数 \"myers\"、\"minimal\"、\"patience\" 和 "
-"\"histogram\""
-
 #: builtin/merge-file.c
 msgid "send results to standard output"
 msgstr "将结果发送到标准输出"
@@ -11172,14 +11236,6 @@ msgstr "使用基于 diff3 的合并"
 #: builtin/merge-file.c
 msgid "use a zealous diff3 based merge"
 msgstr "使用基于狂热 diff3（zealous diff3）的合并"
-
-#: builtin/merge-file.c diff.c
-msgid "<algorithm>"
-msgstr "<算法>"
-
-#: builtin/merge-file.c diff.c
-msgid "choose a diff algorithm"
-msgstr "选择一个差异算法"
 
 #: builtin/merge-file.c
 msgid "for conflicts, use this marker size"
@@ -12510,6 +12566,11 @@ msgstr "无法获得包 %2$s 中对象 %1$s 的类型"
 
 #: builtin/pack-objects.c
 #, c-format
+msgid "packfile %s is a promisor but --exclude-promisor-objects was given"
+msgstr "包文件 %s 是承诺者，但已给出 --exclude-promisor-objects"
+
+#: builtin/pack-objects.c
+#, c-format
 msgid "could not find pack '%s'"
 msgstr "不能找到包 '%s'"
 
@@ -12839,12 +12900,12 @@ msgid "git patch-id [--stable | --unstable | --verbatim]"
 msgstr "git patch-id [--stable | --unstable | --verbatim]"
 
 #: builtin/patch-id.c
-msgid "use the unstable patch-id algorithm"
-msgstr "使用不稳定的 patch-id 算法"
+msgid "use the unstable patch ID algorithm"
+msgstr "使用不稳定的 patch ID 算法"
 
 #: builtin/patch-id.c
-msgid "use the stable patch-id algorithm"
-msgstr "使用稳定的 patch-id 算法"
+msgid "use the stable patch ID algorithm"
+msgstr "使用稳定的 patch ID 算法"
 
 #: builtin/patch-id.c
 msgid "don't strip whitespace from the patch"
@@ -12873,50 +12934,6 @@ msgstr "不能在珍品仓库中执行清理操作"
 #: builtin/pull.c
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<选项>] [<仓库> [<引用规格>...]]"
-
-#: builtin/pull.c
-msgid "control for recursive fetching of submodules"
-msgstr "控制子模组的递归获取"
-
-#: builtin/pull.c
-msgid "Options related to merging"
-msgstr "和合并相关的选项"
-
-#: builtin/pull.c
-msgid "incorporate changes by rebasing rather than merging"
-msgstr "使用变基操作取代合并操作以合入修改"
-
-#: builtin/pull.c builtin/revert.c
-msgid "allow fast-forward"
-msgstr "允许快进式"
-
-#: builtin/pull.c
-msgid "control use of pre-merge-commit and commit-msg hooks"
-msgstr "控制 pre-merge-commit 和 commit-msg 钩子的使用"
-
-#: builtin/pull.c parse-options.h
-msgid "automatically stash/stash pop before and after"
-msgstr "在操作前后执行自动贮藏和弹出贮藏"
-
-#: builtin/pull.c
-msgid "Options related to fetching"
-msgstr "和获取相关的参数"
-
-#: builtin/pull.c
-msgid "force overwrite of local branch"
-msgstr "强制覆盖本地分支"
-
-#: builtin/pull.c
-msgid "number of submodules pulled in parallel"
-msgstr "并发拉取的子模组的数量"
-
-#: builtin/pull.c parse-options.h
-msgid "use IPv4 addresses only"
-msgstr "只使用 IPv4 地址"
-
-#: builtin/pull.c parse-options.h
-msgid "use IPv6 addresses only"
-msgstr "只使用 IPv6 地址"
 
 #: builtin/pull.c
 msgid ""
@@ -13027,6 +13044,50 @@ msgstr ""
 "您可以将 \"git config\" 替换为 \"git config --global\" 以便为所有仓库设置\n"
 "缺省的配置项。您也可以在每次执行 pull 命令时添加 --rebase、--no-rebase，\n"
 "或者 --ff-only 参数覆盖缺省设置。\n"
+
+#: builtin/pull.c
+msgid "control for recursive fetching of submodules"
+msgstr "控制子模组的递归获取"
+
+#: builtin/pull.c
+msgid "Options related to merging"
+msgstr "和合并相关的选项"
+
+#: builtin/pull.c
+msgid "incorporate changes by rebasing rather than merging"
+msgstr "使用变基操作取代合并操作以合入修改"
+
+#: builtin/pull.c builtin/revert.c
+msgid "allow fast-forward"
+msgstr "允许快进式"
+
+#: builtin/pull.c
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "控制 pre-merge-commit 和 commit-msg 钩子的使用"
+
+#: builtin/pull.c parse-options.h
+msgid "automatically stash/stash pop before and after"
+msgstr "在操作前后执行自动贮藏和弹出贮藏"
+
+#: builtin/pull.c
+msgid "Options related to fetching"
+msgstr "和获取相关的参数"
+
+#: builtin/pull.c
+msgid "force overwrite of local branch"
+msgstr "强制覆盖本地分支"
+
+#: builtin/pull.c
+msgid "number of submodules pulled in parallel"
+msgstr "并发拉取的子模组的数量"
+
+#: builtin/pull.c parse-options.h
+msgid "use IPv4 addresses only"
+msgstr "只使用 IPv4 地址"
+
+#: builtin/pull.c parse-options.h
+msgid "use IPv6 addresses only"
+msgstr "只使用 IPv6 地址"
 
 #: builtin/pull.c
 msgid "Updating an unborn branch with changes added to the index."
@@ -15255,6 +15316,11 @@ msgid "only one pattern can be given with -l"
 msgstr "只能为 -l 提供一个模式"
 
 #: builtin/replay.c
+#, c-format
+msgid "'%s' is not a valid commit-ish for %s"
+msgstr "'%s' 不是 %s 的有效提交号"
+
+#: builtin/replay.c
 msgid "need some commits to replay"
 msgstr "需要一些提交来重放"
 
@@ -15273,27 +15339,17 @@ msgid ""
 msgstr "不能使用多个源推进目标，因为无法明确如何排序"
 
 #: builtin/replay.c
-msgid ""
-"cannot implicitly determine whether this is an --advance or --onto operation"
-msgstr "不能隐式地确定这是 --advance 还是 --onto 的操作"
-
-#: builtin/replay.c
-msgid ""
-"cannot advance target with multiple source branches because ordering would "
-"be ill-defined"
-msgstr "不能使用多个源分支推进目标，因为无法明确如何排序"
-
-#: builtin/replay.c
-msgid "cannot implicitly determine correct base for --onto"
-msgstr "不能隐式地确定 --onto 正确的基线"
+#, c-format
+msgid "invalid %s value: '%s'"
+msgstr "无效的 %s 值：'%s'"
 
 #: builtin/replay.c
 msgid ""
 "(EXPERIMENTAL!) git replay ([--contained] --onto <newbase> | --advance "
-"<branch>) <revision-range>..."
+"<branch>) [--ref-action[=<mode>]] <revision-range>"
 msgstr ""
-"（试验中！）git replay ([--contained] --onto <新基线> | --advance <分支>) <版"
-"本范围>..."
+"（试验中！）git replay ([--contained] --onto <新基线> | --advance <分支>) [--"
+"ref-action[=<模式>]] <版本范围>"
 
 #: builtin/replay.c
 msgid "make replay advance given branch"
@@ -15304,8 +15360,12 @@ msgid "replay onto given commit"
 msgstr "重放到给定提交"
 
 #: builtin/replay.c
-msgid "advance all branches contained in revision-range"
-msgstr "演进版本范围中包含的所有分支"
+msgid "update all branches that point at commits in <revision-range>"
+msgstr "更新指向 <版本范围> 中提交的所有分支"
+
+#: builtin/replay.c
+msgid "control ref update behavior (update|print)"
+msgstr "控制引用更新行为（update|print）"
 
 #: builtin/replay.c
 msgid "option --onto or --advance is mandatory"
@@ -15320,16 +15380,31 @@ msgstr ""
 "一些版本遍历选项将被覆盖，如 'struct rev_info' 中的 '%s' 位将被强制设定"
 
 #: builtin/replay.c
+#, c-format
+msgid "failed to begin ref transaction: %s"
+msgstr "无法开始引用事务：%s"
+
+#: builtin/replay.c
 msgid "error preparing revisions"
 msgstr "准备版本时错误"
 
 #: builtin/replay.c
-msgid "replaying down to root commit is not supported yet!"
-msgstr "目前还不支持重放到根提交！"
+msgid "replaying down from root commit is not supported yet!"
+msgstr "目前还不支持从根提交向下重放！"
 
 #: builtin/replay.c
 msgid "replaying merge commits is not supported yet!"
 msgstr "目前还不支持重放到合并提交！"
+
+#: builtin/replay.c
+#, c-format
+msgid "failed to update ref '%s': %s"
+msgstr "无法更新引用 '%s'：%s"
+
+#: builtin/replay.c
+#, c-format
+msgid "failed to commit ref transaction: %s"
+msgstr "无法提交引用事务：%s"
 
 #: builtin/repo.c
 #, c-format
@@ -15350,8 +15425,16 @@ msgid "synonym for --format=nul"
 msgstr "和 --format=nul 同义"
 
 #: builtin/repo.c
+msgid "print all keys/values"
+msgstr "打印所有键/值"
+
+#: builtin/repo.c
 msgid "unsupported output format"
 msgstr "不支持的输出格式"
+
+#: builtin/repo.c
+msgid "--all and <key> cannot be used together"
+msgstr "--all 不能和 <key> 一起使用"
 
 #: builtin/repo.c
 msgid "References"
@@ -15392,6 +15475,14 @@ msgstr "树"
 #: builtin/repo.c
 msgid "Blobs"
 msgstr "数据对象"
+
+#: builtin/repo.c
+msgid "Inflated size"
+msgstr "展开后大小"
+
+#: builtin/repo.c
+msgid "Disk size"
+msgstr "磁盘大小"
 
 #: builtin/repo.c
 msgid "Repository structure"
@@ -17378,7 +17469,7 @@ msgstr "'%s' 已经存在于索引中"
 msgid "'%s' already exists in the index and is not a submodule"
 msgstr "'%s' 已经存在于索引中且不是一个子模组"
 
-#: builtin/submodule--helper.c read-cache.c
+#: builtin/submodule--helper.c object-file.c
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "'%s' 没有检出一个提交"
@@ -18433,6 +18524,11 @@ msgid "bundle list at '%s' has no mode"
 msgstr "在 '%s' 的归档包列表没有模式"
 
 #: bundle-uri.c
+#, c-format
+msgid "bundle list at '%s': bundle '%s' has no uri"
+msgstr "在 '%s' 的归档包列表中，归档包 '%s' 没有 URI"
+
+#: bundle-uri.c
 msgid "failed to create temporary file"
 msgstr "无法创建临时文件"
 
@@ -18458,6 +18554,11 @@ msgstr "不可辨认的归档包模式来自 URI '%s'"
 #, c-format
 msgid "exceeded bundle URI recursion limit (%d)"
 msgstr "超过了 URI 递归限制 (%d)"
+
+#: bundle-uri.c
+#, c-format
+msgid "bundle '%s' has no uri"
+msgstr "归档包 '%s' 没有 URI"
 
 #: bundle-uri.c
 #, c-format
@@ -19103,8 +19204,8 @@ msgid "Reuse recorded resolution of conflicted merges"
 msgstr "重用冲突合并的解决方案记录"
 
 #: command-list.h
-msgid "Reset current HEAD to the specified state"
-msgstr "重置当前 HEAD 到指定状态"
+msgid "Set `HEAD` or the index to a known state"
+msgstr "将 `HEAD` 或索引设置为已知状态"
 
 #: command-list.h
 msgid "Restore working tree files"
@@ -20953,11 +21054,6 @@ msgstr "color-moved-ws：allow-indentation-change 不能与其它空白字符模
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "配置变量 'diff.submodule' 未知的取值：'%s'"
-
-#: diff.c merge-ort.c transport.c
-#, c-format
-msgid "unknown value for config '%s': %s"
-msgstr "配置 '%s' 未知的取值：%s"
 
 #: diff.c
 #, c-format
@@ -23520,6 +23616,10 @@ msgid "%s: failed to insert into database"
 msgstr "%s：无法插入数据库"
 
 #: object-file.c
+msgid "cannot add a submodule of a different hash algorithm"
+msgstr "不能添加使用不同哈希算法的子模组"
+
+#: object-file.c
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s：不支持的文件类型"
@@ -25249,6 +25349,11 @@ msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
 msgstr "--format=%.*s 不能和 --python、--shell、--tcl 同时使用"
 
 #: ref-filter.c
+#, c-format
+msgid "parse_object_buffer failed on %s for %s"
+msgstr "parse_object_buffer 失败于 %2$s 的 %1$s"
+
+#: ref-filter.c
 msgid "failed to run 'describe'"
 msgstr "无法运行 'describe'"
 
@@ -25285,11 +25390,6 @@ msgstr "（非分支）"
 #, c-format
 msgid "missing object %s for %s"
 msgstr "缺失 %2$s 的对象 %1$s"
-
-#: ref-filter.c
-#, c-format
-msgid "parse_object_buffer failed on %s for %s"
-msgstr "parse_object_buffer 失败于 %2$s 的 %1$s"
 
 #: ref-filter.c
 #, c-format
@@ -25639,6 +25739,21 @@ msgstr "引用名称 %s 未找到"
 #, c-format
 msgid "refname %s is a symbolic ref, copying it is not supported"
 msgstr "引用名 %s 是一个符号引用，不支持复制"
+
+#: refs/reftable-backend.c
+#, c-format
+msgid "reftable stack for worktree '%s' is broken"
+msgstr "工作区 '%s' 的 reftable 堆栈已损坏"
+
+#: refs/reftable-backend.c
+#, c-format
+msgid "could not create iterator for worktree '%s'"
+msgstr "无法为工作区 '%s' 创建迭代器"
+
+#: refs/reftable-backend.c
+#, c-format
+msgid "could not read record for worktree '%s'"
+msgstr "无法读取工作区 '%s' 的记录"
 
 #: refspec.c
 #, c-format
@@ -26139,6 +26254,10 @@ msgstr "repack：来自 pack-objects 的输入必须为完整的十六进制对�
 #: repack-promisor.c
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr "无法完成 pack-objects 来重新打包 promisor 对象"
+
+#: repack-promisor.c
+msgid "could not start pack-objects to repack promisor packs"
+msgstr "无法启动 pack-objects 来重新打包承诺者包"
 
 #: repack.c
 #, c-format
@@ -27345,11 +27464,6 @@ msgid "illegal label name: '%.*s'"
 msgstr "非法的标签名称：'%.*s'"
 
 #: sequencer.c
-#, c-format
-msgid "could not resolve '%s'"
-msgstr "无法解析 '%s'"
-
-#: sequencer.c
 msgid "writing fake root commit"
 msgstr "写伪根提交"
 
@@ -27925,57 +28039,83 @@ msgstr "坏的 %s 格式：元素 '%s' 没有以 ')' 结尾"
 msgid "bad %s format: %%%.*s"
 msgstr "坏的 %s 格式：%%%.*s"
 
-#. TRANSLATORS: IEC 80000-13:2008 gibibyte
 #: strbuf.c
 #, c-format
-msgid "%u.%2.2u GiB"
-msgstr "%u.%2.2u GiB"
+msgid "%u.%2.2u"
+msgstr "%u.%2.2u"
 
-#. TRANSLATORS: IEC 80000-13:2008 gibibyte/second
+#. TRANSLATORS: SI decimal prefix symbol for 10^9
 #: strbuf.c
-#, c-format
-msgid "%u.%2.2u GiB/s"
-msgstr "%u.%2.2u GiB/s"
+msgid "G"
+msgstr "G"
 
-#. TRANSLATORS: IEC 80000-13:2008 mebibyte
+#. TRANSLATORS: SI decimal prefix symbol for 10^6
 #: strbuf.c
-#, c-format
-msgid "%u.%2.2u MiB"
-msgstr "%u.%2.2u MiB"
+msgid "M"
+msgstr "M"
 
-#. TRANSLATORS: IEC 80000-13:2008 mebibyte/second
+#. TRANSLATORS: SI decimal prefix symbol for 10^3
 #: strbuf.c
-#, c-format
-msgid "%u.%2.2u MiB/s"
-msgstr "%u.%2.2u MiB/s"
+msgid "k"
+msgstr "k"
 
-#. TRANSLATORS: IEC 80000-13:2008 kibibyte
+#. TRANSLATORS: IEC 80000-13:2008 gibibyte/second and gibibyte
 #: strbuf.c
-#, c-format
-msgid "%u.%2.2u KiB"
-msgstr "%u.%2.2u KiB"
+msgid "GiB/s"
+msgstr "GiB/s"
 
-#. TRANSLATORS: IEC 80000-13:2008 kibibyte/second
 #: strbuf.c
-#, c-format
-msgid "%u.%2.2u KiB/s"
-msgstr "%u.%2.2u KiB/s"
+msgid "GiB"
+msgstr "GiB"
 
-#. TRANSLATORS: IEC 80000-13:2008 byte
+#. TRANSLATORS: IEC 80000-13:2008 mebibyte/second and mebibyte
 #: strbuf.c
-#, c-format
-msgid "%u byte"
-msgid_plural "%u bytes"
-msgstr[0] "%u 字节"
-msgstr[1] "%u 字节"
+msgid "MiB/s"
+msgstr "MiB/s"
+
+#: strbuf.c
+msgid "MiB"
+msgstr "MiB"
+
+#. TRANSLATORS: IEC 80000-13:2008 kibibyte/second and kibibyte
+#: strbuf.c
+msgid "KiB/s"
+msgstr "KiB/s"
+
+#: strbuf.c
+msgid "KiB"
+msgstr "KiB"
+
+#. TRANSLATORS: IEC 80000-13:2008 byte/second and byte
+#: strbuf.c
+msgid "B/s"
+msgstr "B/s"
+
+#: strbuf.c
+msgid "B"
+msgstr "B"
 
 #. TRANSLATORS: IEC 80000-13:2008 byte/second
 #: strbuf.c
+msgid "byte/s"
+msgid_plural "bytes/s"
+msgstr[0] "字节/秒"
+msgstr[1] "字节/秒"
+
+#. TRANSLATORS: IEC 80000-13:2008 byte
+#: strbuf.c
+msgid "byte"
+msgid_plural "bytes"
+msgstr[0] "字节"
+msgstr[1] "字节"
+
+#. TRANSLATORS: The first argument is the number string. The second
+#. argument is the unit string (i.e. "12.34 MiB/s").
+#.
+#: strbuf.c
 #, c-format
-msgid "%u byte/s"
-msgid_plural "%u bytes/s"
-msgstr[0] "%u 字节/秒"
-msgstr[1] "%u 字节/秒"
+msgid "%s %s"
+msgstr "%s %s"
 
 #: submodule-config.c
 #, c-format
@@ -28329,10 +28469,6 @@ msgstr "字节数目"
 #: t/helper/test-simple-ipc.c
 msgid "number of requests per thread"
 msgstr "每个线程的请求数"
-
-#: t/helper/test-simple-ipc.c
-msgid "byte"
-msgstr "字节"
 
 #: t/helper/test-simple-ipc.c
 msgid "ballast character"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1706,7 +1706,7 @@ msgstr "不能打开数据对象 %s"
 #: archive-tar.c archive-zip.c
 #, c-format
 msgid "unsupported file mode: 0%o (SHA1: %s)"
-msgstr "不支持的文件模式：0%o (SHA1: %s)"
+msgstr "不支持的文件模式：0%o (SHA1：%s)"
 
 #: archive-tar.c archive-zip.c builtin/pack-objects.c
 #, c-format
@@ -5169,7 +5169,7 @@ msgstr "clean.requireForce 设置为 true 且未提供 -f 选项：拒绝执行�
 #: builtin/clone.c
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
-msgstr "info: 不能为 '%s' 添加一个备用：%s\n"
+msgstr "info：不能为 '%s' 添加一个备用：%s\n"
 
 #: builtin/clone.c builtin/diff.c builtin/rm.c grep.c setup.c
 #, c-format
@@ -9010,7 +9010,7 @@ msgstr "无法创建 fsmonitor cookie '%s'"
 #: builtin/fsmonitor--daemon.c
 #, c-format
 msgid "fsmonitor: cookie_result '%d' != SEEN"
-msgstr "fsmonitor: cookie_result '%d' != SEEN"
+msgstr "fsmonitor：cookie_result '%d' != SEEN"
 
 #: builtin/fsmonitor--daemon.c
 #, c-format
@@ -10144,8 +10144,8 @@ msgstr[1] "非 delta：%d 个对象"
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
-msgstr[0] "链长 = %d: %lu 对象"
-msgstr[1] "链长 = %d: %lu 对象"
+msgstr[0] "链长 = %d：%lu 对象"
+msgstr[1] "链长 = %d：%lu 对象"
 
 #: builtin/index-pack.c
 msgid "could not start pack-objects to repack local links"
@@ -10452,7 +10452,7 @@ msgstr ""
 #: builtin/log.c
 #, c-format
 msgid "git show %s: bad file"
-msgstr "git show %s: 损坏的文件"
+msgstr "git show %s：损坏的文件"
 
 #: builtin/log.c
 #, c-format
@@ -18110,7 +18110,7 @@ msgstr ""
 #: builtin/worktree.c
 #, c-format
 msgid "Removing %s/%s: %s"
-msgstr "删除 %s/%s: %s"
+msgstr "删除 %s/%s：%s"
 
 #: builtin/worktree.c
 msgid "report pruned working trees"
@@ -18472,23 +18472,23 @@ msgstr "位于 URI '%s' 的文件不是归档包或归档包列表"
 #: bundle-uri.c
 #, c-format
 msgid "bundle-uri: unexpected argument: '%s'"
-msgstr "bundle-uri: 意外的参数：'%s'"
+msgstr "bundle-uri：意外的参数：'%s'"
 
 #: bundle-uri.c
 msgid "bundle-uri: expected flush after arguments"
-msgstr "bundle-uri: 在参数之后应有一个 flush"
+msgstr "bundle-uri：在参数之后应有一个 flush"
 
 #: bundle-uri.c
 msgid "bundle-uri: got an empty line"
-msgstr "bundle-uri: 获得了空行"
+msgstr "bundle-uri：获得了空行"
 
 #: bundle-uri.c
 msgid "bundle-uri: line is not of the form 'key=value'"
-msgstr "bundle-uri: 行不是以 'key=value' 格式"
+msgstr "bundle-uri：行不是以 'key=value' 格式"
 
 #: bundle-uri.c
 msgid "bundle-uri: line has empty key or value"
-msgstr "bundle-uri: 行有空的键或值"
+msgstr "bundle-uri：行有空的键或值"
 
 #: bundle.c
 #, c-format
@@ -20980,7 +20980,7 @@ msgstr "--follow 明确要求只跟一个路径规格"
 #: diff.c
 #, c-format
 msgid "pathspec magic not supported by --follow: %s"
-msgstr "指定 --follow: %s 的同时，不支持在路径规格中使用神奇前缀"
+msgstr "--follow 不支持在路径规格中使用神奇前缀：%s"
 
 #: diff.c parse-options.c
 #, c-format
@@ -21955,12 +21955,12 @@ msgstr "服务器不允许请求未公开的对象 %s"
 #: fsmonitor-ipc.c
 #, c-format
 msgid "fsmonitor_ipc__send_query: invalid path '%s'"
-msgstr "fsmonitor_ipc__send_query: 无效路径 '%s'"
+msgstr "fsmonitor_ipc__send_query：无效路径 '%s'"
 
 #: fsmonitor-ipc.c
 #, c-format
 msgid "fsmonitor_ipc__send_query: unspecified error on '%s'"
-msgstr "fsmonitor_ipc__send_query: 未知错误于 '%s'"
+msgstr "fsmonitor_ipc__send_query：未知错误于 '%s'"
 
 #: fsmonitor-ipc.c
 msgid "fsmonitor--daemon is not running"
@@ -22465,7 +22465,7 @@ msgstr "不支持的 SSL 后端 '%s'。支持的 SSL 后端："
 #: http.c
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
-msgstr "无法设置 SSL 后端为 '%s'：cURL: cURL 没有使用 SSL 后端构建"
+msgstr "无法设置 SSL 后端为 '%s'：cURL 没有使用 SSL 后端构建"
 
 #: http.c
 #, c-format
@@ -25618,12 +25618,12 @@ msgstr "无法锁定 '%s' 引用：位于 %s，但预期为 %s"
 #: refs/reftable-backend.c
 #, c-format
 msgid "reftable: transaction prepare: %s"
-msgstr "reftable: 事务准备：%s"
+msgstr "reftable：事务准备：%s"
 
 #: refs/reftable-backend.c
 #, c-format
 msgid "reftable: transaction failure: %s"
-msgstr "reftable: 事务失败：%s"
+msgstr "reftable：事务失败：%s"
 
 #: refs/reftable-backend.c
 #, c-format
@@ -27923,7 +27923,7 @@ msgstr "坏的 %s 格式：元素 '%s' 没有以 ')' 结尾"
 #: strbuf.c
 #, c-format
 msgid "bad %s format: %%%.*s"
-msgstr "坏的 %s 格式: %%%.*s"
+msgstr "坏的 %s 格式：%%%.*s"
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
 #: strbuf.c
@@ -29956,7 +29956,7 @@ msgstr ""
 #: git-send-email.perl
 #, perl-format
 msgid "Failed to opendir %s: %s"
-msgstr "无法打开目录 %s: %s"
+msgstr "无法打开目录 %s：%s"
 
 #: git-send-email.perl
 msgid ""
@@ -29976,7 +29976,7 @@ msgstr "在 %s 中没有标题行？"
 #: git-send-email.perl
 #, perl-format
 msgid "Failed to open for writing %s: %s"
-msgstr "为写入打开 %s 失败: %s"
+msgstr "为写入打开 %s 失败：%s"
 
 #: git-send-email.perl
 msgid ""
@@ -29994,12 +29994,12 @@ msgstr ""
 #: git-send-email.perl
 #, perl-format
 msgid "Failed to open %s.final: %s"
-msgstr "无法打开 %s.final: %s"
+msgstr "无法打开 %s.final：%s"
 
 #: git-send-email.perl
 #, perl-format
 msgid "Failed to open %s: %s"
-msgstr "无法打开 %s: %s"
+msgstr "无法打开 %s：%s"
 
 #: git-send-email.perl
 msgid "Summary email is empty, skipping it\n"
@@ -30090,7 +30090,7 @@ msgstr ""
 #. at this point.
 #: git-send-email.perl
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
-msgstr "发送这封邮件？([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
+msgstr "发送这封邮件？([y]es|[n]o|[e]dit|[q]uit|[a]ll)："
 
 #: git-send-email.perl
 msgid "Send this email reply required"
@@ -30181,7 +30181,7 @@ msgstr "(non-mbox) 添加 cc：%s 自行 '%s'\n"
 #: git-send-email.perl
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
-msgstr "(body) 添加 cc: %s 自行 '%s'\n"
+msgstr "(body) 添加 cc：%s 自行 '%s'\n"
 
 #: git-send-email.perl
 #, perl-format
@@ -30196,7 +30196,7 @@ msgstr "(%s) 不能执行 '%s'"
 #: git-send-email.perl
 #, perl-format
 msgid "(%s) Malformed output from '%s'"
-msgstr "(%s) 非法的输出信息，来自于: '%s'"
+msgstr "(%s) 非法的输出信息，来自于：'%s'"
 
 #: git-send-email.perl
 #, perl-format
@@ -30206,7 +30206,7 @@ msgstr "(%s) 无法关闭管道至 '%s'"
 #: git-send-email.perl
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
-msgstr "(%s) 添加 %s: %s 自：'%s'\n"
+msgstr "(%s) 添加 %s：%s 自：'%s'\n"
 
 #: git-send-email.perl
 msgid "cannot send message as 7bit"


### PR DESCRIPTION
Git 2.53.0 的中文翻译，包含两个提交：
1. 一个用于修复 Issue #884  报告的中英文冒号不一致问题。
2. 一个包含 Git 2.53 新增的 52 条翻译。

本次翻译使用了大模型，用 [上下文 po/AGENTS.md](https://github.com/git-l10n/git-po/blob/jx/AGENTS/po/AGENTS.md) 和提示词自动翻译，人工校验发现的小问题已经修复。
