### PR TITLE
l10n: it: fix italian usage messages alignment

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -5400,7 +5400,7 @@ msgstr "uso: %s"
 #: parse-options.c:915
 #, c-format
 msgid "   or: %s"
-msgstr "  oppure: %s"
+msgstr "  o: %s"
 
 #: parse-options.c:918
 #, c-format


### PR DESCRIPTION
Fixed a misalignment in the "usage:" and "   or:" lines in the italian
help messages.
